### PR TITLE
Add toggle for MSAA 4X to menu, rename Frame Rate menu to Graphics Options

### DIFF
--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -111,7 +111,7 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
       ImGui::EndMenu();
     }
 
-    if (ImGui::BeginMenu("Frame Rate")) {
+    if (ImGui::BeginMenu("Graphics Options")) {
       ImGui::Checkbox("Enable V-Sync", &m_vsync);
       ImGui::Separator();
       ImGui::Checkbox("Framelimiter", &framelimiter);
@@ -122,6 +122,7 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
       ImGui::Separator();
       ImGui::Checkbox("Accurate Lag Mode", &experimental_accurate_lag);
       ImGui::Checkbox("Sleep in Frame Limiter", &sleep_in_frame_limiter);
+      ImGui::Checkbox("MSAA 4X",&m_msaa);
       ImGui::EndMenu();
     }
   }

--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -122,7 +122,7 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
       ImGui::Separator();
       ImGui::Checkbox("Accurate Lag Mode", &experimental_accurate_lag);
       ImGui::Checkbox("Sleep in Frame Limiter", &sleep_in_frame_limiter);
-      ImGui::Checkbox("MSAA 4X",&m_msaa);
+      ImGui::Checkbox("MSAA 4X", &m_msaa);
       ImGui::EndMenu();
     }
   }

--- a/game/graphics/opengl_renderer/debug_gui.h
+++ b/game/graphics/opengl_renderer/debug_gui.h
@@ -67,6 +67,8 @@ class OpenGlDebugGui {
   float target_fps = 60.f;
   bool experimental_accurate_lag = false;
   bool sleep_in_frame_limiter = true;
+  //Mutli sample anti-aliasing X4 enabled by default, can be toggled by menu. 
+  bool get_msaa_flag() {return m_msaa;}
 
  private:
   FrameTimeRecorder m_frame_timer;
@@ -80,5 +82,6 @@ class OpenGlDebugGui {
   char m_dump_save_name[256] = "dump.bin";
   char m_screenshot_save_name[256] = "screenshot.png";
   bool m_vsync = true;
+  bool m_msaa = true;
   float m_target_fps_text = 60.0;
 };

--- a/game/graphics/opengl_renderer/debug_gui.h
+++ b/game/graphics/opengl_renderer/debug_gui.h
@@ -67,8 +67,8 @@ class OpenGlDebugGui {
   float target_fps = 60.f;
   bool experimental_accurate_lag = false;
   bool sleep_in_frame_limiter = true;
-  //Mutli sample anti-aliasing X4 enabled by default, can be toggled by menu. 
-  bool get_msaa_flag() {return m_msaa;}
+  // Mutli sample anti-aliasing X4 enabled by default, can be toggled by menu.
+  bool get_msaa_flag() { return m_msaa; }
 
  private:
   FrameTimeRecorder m_frame_timer;

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -37,6 +37,9 @@ struct GraphicsData {
   std::condition_variable sync_cv;
   bool vsync_enabled = true;
 
+  //Msaa toggle...
+  bool msaa_enabled = true;
+
   // dma chain transfer
   std::mutex dma_mutex;
   std::condition_variable dma_cv;
@@ -434,6 +437,15 @@ static void gl_render_display(GfxDisplay* display) {
   if (req_vsync != g_gfx_data->vsync_enabled) {
     g_gfx_data->vsync_enabled = req_vsync;
     glfwSwapInterval(req_vsync);
+  }
+
+  //Turn on/off msaa, if requested.
+  bool req_msaa = g_gfx_data->debug_gui.get_msaa_flag();
+  if(req_msaa != g_gfx_data->msaa_enabled){
+    g_gfx_data->msaa_enabled = req_msaa;
+    //Turn on multisampling if requested by user, turn off otherwise.
+    if(req_msaa) glEnable(GL_MULTISAMPLE);
+    else glDisable(GL_MULTISAMPLE);
   }
 
   // actual vsync

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -37,7 +37,7 @@ struct GraphicsData {
   std::condition_variable sync_cv;
   bool vsync_enabled = true;
 
-  //Msaa toggle...
+  // Msaa toggle...
   bool msaa_enabled = true;
 
   // dma chain transfer
@@ -439,13 +439,15 @@ static void gl_render_display(GfxDisplay* display) {
     glfwSwapInterval(req_vsync);
   }
 
-  //Turn on/off msaa, if requested.
+  // Turn on/off msaa, if requested.
   bool req_msaa = g_gfx_data->debug_gui.get_msaa_flag();
-  if(req_msaa != g_gfx_data->msaa_enabled){
+  if (req_msaa != g_gfx_data->msaa_enabled) {
     g_gfx_data->msaa_enabled = req_msaa;
-    //Turn on multisampling if requested by user, turn off otherwise.
-    if(req_msaa) glEnable(GL_MULTISAMPLE);
-    else glDisable(GL_MULTISAMPLE);
+    // Turn on multisampling if requested by user, turn off otherwise.
+    if (req_msaa)
+      glEnable(GL_MULTISAMPLE);
+    else
+      glDisable(GL_MULTISAMPLE);
   }
 
   // actual vsync


### PR DESCRIPTION
Added checkbox to turn MSAA on/off. Tries to address https://github.com/open-goal/jak-project/issues/1173. However, the lag seems to still be there after unchecking the toggle - commenting out `glfwWindowHint(GLFW_SAMPLES, 4)` from line 130 of opengl.cpp seems to have a better effect, but then users can't have antialiasing even if they want it, which is less than ideal.

This is my first PR here so please let me know if I've messed anything up, I've tried to follow the style of the other files closely.
