### PR TITLE
[sprite] switch to sprite3, fix bugs

### DIFF
--- a/common/dma/gs.h
+++ b/common/dma/gs.h
@@ -362,8 +362,9 @@ class DrawMode {
     DISABLED = 0,
     SRC_DST_SRC_DST = 1,
     SRC_0_SRC_DST = 2,
-    SRC_0_FIX_DST = 3,   // fix = 128
-    SRC_DST_FIX_DST = 4  // fix = 64
+    SRC_0_FIX_DST = 3,    // fix = 128
+    SRC_DST_FIX_DST = 4,  // fix = 64
+    ZERO_SRC_SRC_DST = 5,
   };
 
   enum class AlphaTest {

--- a/game/graphics/opengl_renderer/BucketRenderer.cpp
+++ b/game/graphics/opengl_renderer/BucketRenderer.cpp
@@ -71,7 +71,9 @@ RenderMux::RenderMux(const std::string& name,
     : BucketRenderer(name, my_id), m_renderers(std::move(renderers)) {
   for (auto& r : m_renderers) {
     m_name_strs.push_back(r->name_and_id());
-    m_name_str_ptrs.push_back(m_name_strs.back().data());
+  }
+  for (auto& n : m_name_strs) {
+    m_name_str_ptrs.push_back(n.data());
   }
 }
 

--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -196,8 +196,9 @@ void OpenGLRenderer::init_bucket_renderers() {
   init_bucket_renderer<TextureUploadHandler>("pre-sprite-tex", BucketId::PRE_SPRITE_TEX);  // 65
 
   std::vector<std::unique_ptr<BucketRenderer>> sprite_renderers;
-  sprite_renderers.push_back(std::make_unique<SpriteRenderer>("sprite-renderer", BucketId::SPRITE));
+  // the first renderer added will be the default for sprite.
   sprite_renderers.push_back(std::make_unique<Sprite3>("sprite-3", BucketId::SPRITE));
+  sprite_renderers.push_back(std::make_unique<SpriteRenderer>("sprite-renderer", BucketId::SPRITE));
   init_bucket_renderer<RenderMux>("sprite", BucketId::SPRITE, std::move(sprite_renderers));  // 66
 
   init_bucket_renderer<DirectRenderer>("debug-draw-0", BucketId::DEBUG_DRAW_0, 0x20000,

--- a/game/graphics/opengl_renderer/Sprite3.h
+++ b/game/graphics/opengl_renderer/Sprite3.h
@@ -90,9 +90,11 @@ class Sprite3 : public BucketRenderer {
   struct Bucket {
     std::vector<u32> ids;
     u32 offset_in_idx_buffer = 0;
+    u64 key = -1;
   };
 
   std::map<u64, Bucket> m_sprite_buckets;
+  std::vector<Bucket*> m_bucket_list;
 
   u64 m_last_bucket_key = UINT64_MAX;
   Bucket* m_last_bucket = nullptr;

--- a/game/graphics/opengl_renderer/shaders/sprite3_3d.frag
+++ b/game/graphics/opengl_renderer/shaders/sprite3_3d.frag
@@ -17,8 +17,6 @@ void main() {
     }
     color = fragment_color * T0 * 2.0;
 
-
-
     if (color.a < alpha_min) {
         discard;
     }
@@ -27,24 +25,3 @@ void main() {
         discard;
     }
 }
-
-//out vec4 color;
-//
-//in flat vec4 fragment_color;
-//in vec3 tex_coord;
-//in flat uvec2 tex_info;
-//
-//uniform sampler2D tex_T0;
-//
-//
-//void main() {
-//    vec4 T0 = texture(tex_T0, tex_coord.xy);
-//    if (tex_info.y == 0) {
-//        T0.w = 1.0;
-//    }
-//    vec4 tex_color = fragment_color * T0 * 2.0;
-//    if (tex_color.a < 0.016) {
-//        discard;
-//    }
-//    color = tex_color;
-//}

--- a/game/graphics/opengl_renderer/shaders/sprite3_3d.vert
+++ b/game/graphics/opengl_renderer/shaders/sprite3_3d.vert
@@ -128,12 +128,12 @@ void main() {
         transformed = offset_pos_vf10 + vf12_rotated * xy0_vf19.x + vf13_rotated_trans * xy0_vf19.y;
 
     } else if (rendermode == 2) { // hud sprites
-
         transformed_pos_vf02.xyz *= Q;
         vec4 offset_pos_vf10 = transformed_pos_vf02 + (matrix == 0 ? hud_hvdf_offset : hud_hvdf_user[matrix - 1]);
 
-        scales_vf01.z = min(max(scales_vf01.z, min_scale), max_scale);
-        scales_vf01.w = min(max(scales_vf01.w, min_scale), max_scale);
+        // NOTE: no max scale for hud
+        scales_vf01.z = max(scales_vf01.z, min_scale);
+        scales_vf01.w = max(scales_vf01.w, min_scale);
 
         quat.z *= deg_to_rad;
         float sp_sin = sin(quat.z);

--- a/game/graphics/opengl_renderer/tfrag/tfrag_common.cpp
+++ b/game/graphics/opengl_renderer/tfrag/tfrag_common.cpp
@@ -36,20 +36,28 @@ DoubleDraw setup_opengl_from_draw_mode(DrawMode mode, u32 tex_unit, bool mipmap)
     glEnable(GL_BLEND);
     switch (mode.get_alpha_blend()) {
       case DrawMode::AlphaBlend::SRC_DST_SRC_DST:
+        glBlendEquation(GL_FUNC_ADD);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         break;
       case DrawMode::AlphaBlend::SRC_0_SRC_DST:
+        glBlendEquation(GL_FUNC_ADD);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE);
         break;
       case DrawMode::AlphaBlend::SRC_0_FIX_DST:
+        glBlendEquation(GL_FUNC_ADD);
         glBlendFunc(GL_ONE, GL_ONE);
         break;
       case DrawMode::AlphaBlend::SRC_DST_FIX_DST:
         // Cv = (Cs - Cd) * FIX + Cd
         // Cs * FIX * 0.5
         // Cd * FIX * 0.5
+        glBlendEquation(GL_FUNC_ADD);
         glBlendFunc(GL_CONSTANT_COLOR, GL_CONSTANT_COLOR);
         glBlendColor(0.5, 0.5, 0.5, 0.5);
+        break;
+      case DrawMode::AlphaBlend::ZERO_SRC_SRC_DST:
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+        glBlendEquation(GL_FUNC_REVERSE_SUBTRACT);
         break;
       default:
         ASSERT(false);


### PR DESCRIPTION
- Fix ordering issue in sprite3 (fixes progress menu tint and powercell sprite issue)
- Fix bug in sprite shader - the scale shouldn't be clamped to the max scale for HUD sprites
- Add blend mode for bomb shadow
- set default sprite renderer to sprite3