### PR TITLE
[graphics] Do eyes on the GPU, fix filtering and offsets

### DIFF
--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -85,6 +85,7 @@ set(RUNTIME_SOURCE
         graphics/opengl_renderer/Loader.cpp
         graphics/opengl_renderer/MercProgram.cpp
         graphics/opengl_renderer/MercRenderer.cpp
+        graphics/opengl_renderer/opengl_utils.cpp
         graphics/opengl_renderer/OpenGLRenderer.cpp
         graphics/opengl_renderer/Profiler.cpp
         graphics/opengl_renderer/Shader.cpp

--- a/game/graphics/opengl_renderer/EyeRenderer.h
+++ b/game/graphics/opengl_renderer/EyeRenderer.h
@@ -3,6 +3,7 @@
 #include <string>
 #include "game/graphics/opengl_renderer/BucketRenderer.h"
 #include "game/graphics/pipelines/opengl.h"
+#include "game/graphics/opengl_renderer/opengl_utils.h"
 
 constexpr int EYE_BASE_BLOCK = 8160;
 constexpr int NUM_EYE_PAIRS = 11;
@@ -11,12 +12,34 @@ constexpr int SINGLE_EYE_SIZE = 32;
 class EyeRenderer : public BucketRenderer {
  public:
   EyeRenderer(const std::string& name, BucketId id);
+  ~EyeRenderer();
   void render(DmaFollower& dma, SharedRenderState* render_state, ScopedProfilerNode& prof) override;
   void draw_debug_window() override;
   void init_textures(TexturePool& texture_pool) override;
 
-  template <bool DEBUG>
   void handle_eye_dma2(DmaFollower& dma, SharedRenderState* render_state, ScopedProfilerNode& prof);
+
+  struct SpriteInfo {
+    u8 a;
+    u32 uv0[2];
+    u32 uv1[2];
+    u32 xyz0[3];
+    u32 xyz1[3];
+
+    std::string print() const;
+  };
+
+  struct ScissorInfo {
+    int x0, x1;
+    int y0, y1;
+    std::string print() const;
+  };
+
+  struct EyeDraw {
+    SpriteInfo sprite;
+    ScissorInfo scissor;
+    std::string print() const;
+  };
 
  private:
   std::string m_debug;
@@ -25,13 +48,52 @@ class EyeRenderer : public BucketRenderer {
   bool m_use_bilinear = true;
   bool m_alpha_hack = true;
 
-  u32 m_left[SINGLE_EYE_SIZE * SINGLE_EYE_SIZE];
-  u32 m_right[SINGLE_EYE_SIZE * SINGLE_EYE_SIZE];
+  u32 m_temp_tex[SINGLE_EYE_SIZE * SINGLE_EYE_SIZE];
 
-  struct EyeTex {
+  bool m_use_gpu = true;
+
+  struct CpuEyeTex {
     u64 gl_tex;
     GpuTexture* gpu_tex;
     u32 tbp;
   };
-  EyeTex m_eye_textures[NUM_EYE_PAIRS * 2];
+  CpuEyeTex m_cpu_eye_textures[NUM_EYE_PAIRS * 2];
+
+  struct GpuEyeTex {
+    GpuTexture* gpu_tex;
+    u32 tbp;
+    FramebufferTexturePair fb;
+
+    // note: eye texture increased to 128x128 (originally 32x32) here.
+    GpuEyeTex() : fb(128, 128, GL_UNSIGNED_INT_8_8_8_8_REV) {}
+  } m_gpu_eye_textures[NUM_EYE_PAIRS * 2];
+
+  // xyst per vertex, 4 vertices per square, 3 draws per eye, 11 pairs of eyes, 2 eyes per pair.
+  static constexpr int VTX_BUFFER_FLOATS = 4 * 4 * 3 * NUM_EYE_PAIRS * 2;
+  float m_gpu_vertex_buffer[VTX_BUFFER_FLOATS];
+  GLuint m_vao;
+  GLuint m_gl_vertex_buffer;
+
+  struct SingleEyeDraws {
+    int lr;
+    int pair;
+
+    int tex_slot() const { return pair * 2 + lr; }
+    u32 clear_color;
+    EyeDraw iris;
+    GpuTexture* iris_tex = nullptr;
+    u64 iris_gl_tex = 0;
+
+    EyeDraw pupil;
+    GpuTexture* pupil_tex = nullptr;
+    u64 pupil_gl_tex = 0;
+
+    EyeDraw lid;
+    GpuTexture* lid_tex = nullptr;
+    u64 lid_gl_tex = 0;
+  };
+
+  std::vector<SingleEyeDraws> get_draws(DmaFollower& dma, SharedRenderState* render_state);
+  void run_cpu(const std::vector<SingleEyeDraws>& draws, SharedRenderState* render_state);
+  void run_gpu(const std::vector<SingleEyeDraws>& draws, SharedRenderState* render_state);
 };

--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -228,6 +228,7 @@ void OpenGLRenderer::init_bucket_renderers() {
     m_bucket_renderers[i]->init_textures(*m_render_state.texture_pool);
   }
   sky_cpu_blender->init_textures(*m_render_state.texture_pool);
+  sky_gpu_blender->init_textures(*m_render_state.texture_pool);
   m_render_state.loader->load_common(*m_render_state.texture_pool, "GAME");
 }
 

--- a/game/graphics/opengl_renderer/Shader.cpp
+++ b/game/graphics/opengl_renderer/Shader.cpp
@@ -76,4 +76,5 @@ ShaderLibrary::ShaderLibrary() {
   at(ShaderId::TFRAG3_NO_TEX) = {"tfrag3_no_tex"};
   at(ShaderId::SPRITE3) = {"sprite3_3d"};
   at(ShaderId::DIRECT2) = {"direct2"};
+  at(ShaderId::EYE) = {"eye"};
 }

--- a/game/graphics/opengl_renderer/Shader.h
+++ b/game/graphics/opengl_renderer/Shader.h
@@ -33,6 +33,7 @@ enum class ShaderId {
   SPRITE = 8,
   SPRITE3 = 9,
   DIRECT2 = 10,
+  EYE = 11,
   MAX_SHADERS
 };
 

--- a/game/graphics/opengl_renderer/SkyBlendCPU.h
+++ b/game/graphics/opengl_renderer/SkyBlendCPU.h
@@ -16,7 +16,12 @@ class SkyBlendCPU {
   void init_textures(TexturePool& tex_pool);
 
  private:
-  GLuint m_textures[2];  // sky, clouds
   static constexpr int m_sizes[2] = {32, 64};
   std::vector<u8> m_texture_data[2];
+
+  struct TexInfo {
+    GLuint gl;
+    u32 tbp;
+    GpuTexture* tex;
+  } m_textures[2];
 };

--- a/game/graphics/opengl_renderer/SkyBlendGPU.cpp
+++ b/game/graphics/opengl_renderer/SkyBlendGPU.cpp
@@ -66,7 +66,8 @@ void SkyBlendGPU::init_textures(TexturePool& tex_pool) {
     in.w = m_sizes[i];
     in.h = in.w;
     in.name = fmt::format("PC-SKY-GPU-{}", i);
-    tex_pool.give_texture_and_load_to_vram(in, SKY_TEXTURE_VRAM_ADDRS[i]);
+    u32 tbp = SKY_TEXTURE_VRAM_ADDRS[i];
+    m_tex_info[i] = {tex_pool.give_texture_and_load_to_vram(in, tbp), tbp};
   }
 }
 
@@ -178,6 +179,9 @@ SkyBlendStats SkyBlendGPU::do_sky_blends(DmaFollower& dma,
     // 1 draw, 2 triangles
     prof.add_draw_call(1);
     prof.add_tri(2);
+
+    render_state->texture_pool->move_existing_to_vram(m_tex_info[buffer_idx].tex,
+                                                      m_tex_info[buffer_idx].tbp);
 
     if (buffer_idx == 0) {
       if (is_first_draw) {

--- a/game/graphics/opengl_renderer/SkyBlendGPU.h
+++ b/game/graphics/opengl_renderer/SkyBlendGPU.h
@@ -26,4 +26,9 @@ class SkyBlendGPU {
   };
 
   Vertex m_vertex_data[6];
+
+  struct TexInfo {
+    GpuTexture* tex;
+    u32 tbp;
+  } m_tex_info[2];
 };

--- a/game/graphics/opengl_renderer/TextureUploadHandler.cpp
+++ b/game/graphics/opengl_renderer/TextureUploadHandler.cpp
@@ -22,7 +22,7 @@ void TextureUploadHandler::render(DmaFollower& dma,
     if (dma_tag.qwc == (128 / 16)) {
       // note: these uploads may have texture that we need for eye rendering.
       flush_uploads(uploads, render_state);
-      render_state->eye_renderer->handle_eye_dma2<false>(dma, render_state, prof);
+      render_state->eye_renderer->handle_eye_dma2(dma, render_state, prof);
     }
 
     auto data = dma.read_and_advance();

--- a/game/graphics/opengl_renderer/opengl_utils.cpp
+++ b/game/graphics/opengl_renderer/opengl_utils.cpp
@@ -1,0 +1,57 @@
+#include "opengl_utils.h"
+
+#include "common/util/Assert.h"
+
+FramebufferTexturePair::FramebufferTexturePair(int w, int h, u64 texture_format) : m_w(w), m_h(h) {
+  glGenFramebuffers(1, &m_framebuffer);
+  glGenTextures(1, &m_texture);
+
+  GLint old_framebuffer;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &old_framebuffer);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, m_framebuffer);
+  glBindTexture(GL_TEXTURE_2D, m_texture);
+
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, texture_format, nullptr);
+
+  // I don't know if we really need to do this. whatever uses this texture should figure it out.
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+
+  glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, m_texture, 0);
+  GLenum draw_buffers[1] = {GL_COLOR_ATTACHMENT0};
+  glDrawBuffers(1, draw_buffers);
+  if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+    ASSERT(false);
+  }
+
+  glBindFramebuffer(GL_FRAMEBUFFER, old_framebuffer);
+}
+
+FramebufferTexturePair::~FramebufferTexturePair() {
+  glDeleteFramebuffers(1, &m_framebuffer);
+  glDeleteTextures(1, &m_texture);
+}
+
+FramebufferTexturePairContext::FramebufferTexturePairContext(FramebufferTexturePair& fb)
+    : m_fb(&fb) {
+  glGetIntegerv(GL_VIEWPORT, m_old_viewport);
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &m_old_framebuffer);
+  glBindFramebuffer(GL_FRAMEBUFFER, m_fb->m_framebuffer);
+  glViewport(0, 0, m_fb->m_w, m_fb->m_h);
+  glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, m_fb->m_texture, 0);
+}
+
+void FramebufferTexturePairContext::switch_to(FramebufferTexturePair& fb) {
+  if (&fb != m_fb) {
+    m_fb = &fb;
+    glBindFramebuffer(GL_FRAMEBUFFER, m_fb->m_framebuffer);
+    glViewport(0, 0, m_fb->m_w, m_fb->m_h);
+    glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, m_fb->m_texture, 0);
+  }
+}
+
+FramebufferTexturePairContext::~FramebufferTexturePairContext() {
+  glViewport(m_old_viewport[0], m_old_viewport[1], m_old_viewport[2], m_old_viewport[3]);
+  glBindFramebuffer(GL_FRAMEBUFFER, m_old_framebuffer);
+}

--- a/game/graphics/opengl_renderer/opengl_utils.h
+++ b/game/graphics/opengl_renderer/opengl_utils.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "game/graphics/pipelines/opengl.h"
+
+/*!
+ * This is a wrapper around a framebuffer and texture to make it easier to render to a texture.
+ */
+class FramebufferTexturePair {
+ public:
+  FramebufferTexturePair(int w, int h, u64 texture_format);
+  ~FramebufferTexturePair();
+
+  GLuint texture() const { return m_texture; }
+
+  FramebufferTexturePair(const FramebufferTexturePair&) = delete;
+  FramebufferTexturePair& operator=(const FramebufferTexturePair&) = delete;
+
+ private:
+  friend class FramebufferTexturePairContext;
+  GLuint m_framebuffer;
+  GLuint m_texture;
+  int m_w, m_h;
+};
+
+class FramebufferTexturePairContext {
+ public:
+  FramebufferTexturePairContext(FramebufferTexturePair& fb);
+  ~FramebufferTexturePairContext();
+
+  void switch_to(FramebufferTexturePair& fb);
+
+  FramebufferTexturePairContext(const FramebufferTexturePairContext&) = delete;
+  FramebufferTexturePairContext& operator=(const FramebufferTexturePairContext&) = delete;
+
+ private:
+  FramebufferTexturePair* m_fb;
+  GLint m_old_viewport[4];
+  GLint m_old_framebuffer;
+};

--- a/game/graphics/opengl_renderer/shaders/eye.frag
+++ b/game/graphics/opengl_renderer/shaders/eye.frag
@@ -1,0 +1,10 @@
+#version 430 core
+
+out vec4 color;
+in vec2 st;
+uniform sampler2D tex_T0;
+
+void main() {
+    color = texture(tex_T0, st);
+    color.w *= 2;
+}

--- a/game/graphics/opengl_renderer/shaders/eye.vert
+++ b/game/graphics/opengl_renderer/shaders/eye.vert
@@ -1,0 +1,9 @@
+#version 430 core
+layout (location = 0) in vec4 xyst_in;
+
+out vec2 st;
+
+void main() {
+    gl_Position = vec4((xyst_in.x - 768.f) / 256.f, (xyst_in.y - 768.f) / 256.f, 0, 1);
+    st = xyst_in.zw;
+}


### PR DESCRIPTION
There are lots of advantages to doing eyes on the GPU:
- lets us increase the texture size (default is 128x128 now)
- filtering + blending works (unlike my CPU version, which didn't work right when doing both on the pupils)
- the slight offset bug is gone (I guess I don't fully understand how filtered textures work along the edges?)
- we now use the full precision of the animation. The old version had a bug where the lower 4 bits were lost.