### PR TITLE
fix envmap bugs in generic2

### DIFF
--- a/game/graphics/opengl_renderer/foreground/Generic2.h
+++ b/game/graphics/opengl_renderer/foreground/Generic2.h
@@ -42,6 +42,7 @@ class Generic2 : public BucketRenderer {
                           ScopedProfilerNode& prof,
                           DrawMode::AlphaBlend alpha,
                           bool hud);
+  void do_hud_draws(SharedRenderState* render_state, ScopedProfilerNode& prof);
   bool check_for_end_of_generic_data(DmaFollower& dma, u32 next_bucket);
   void final_vertex_update();
   bool handle_bucket_setup_dma(DmaFollower& dma, u32 next_bucket);


### PR DESCRIPTION
Fixes two envmap bugs:
- make sure we obey the fogging disable flag set in the `PRIM` register of the giftag (causes "popping" of envmap effect that's pretty obvious as you move away from the misty doors)
- disable draw reordering for HUD draws. Collecting orbs on a crate from a zoomer draws a bunch of orbs on top of each other, which doesn't look right.  As far as I know, this is the only place it happens, so we can work around by disabling the reorder on anything that uses the HUD matrix.