### PR TITLE
[graphics] fix ocean alpha and ocean near depth

### DIFF
--- a/game/graphics/opengl_renderer/DirectRenderer.cpp
+++ b/game/graphics/opengl_renderer/DirectRenderer.cpp
@@ -410,7 +410,6 @@ void DirectRenderer::update_gl_blend() {
   }
 
   if (m_my_id == BucketId::OCEAN_NEAR) {
-    glDepthMask(GL_FALSE);
     if (state.a == GsAlpha::BlendMode::SOURCE && state.b == GsAlpha::BlendMode::DEST &&
         state.c == GsAlpha::BlendMode::SOURCE && state.d == GsAlpha::BlendMode::DEST) {
       if (m_prim_gl_state.fogging_enable) {
@@ -452,7 +451,10 @@ void DirectRenderer::update_gl_test() {
     ASSERT(false);
   }
 
-  if (state.depth_writes) {
+  bool alpha_trick_to_disable = m_test_state.alpha_test_enable &&
+                                m_test_state.alpha_test == GsTest::AlphaTest::NEVER &&
+                                m_test_state.afail == GsTest::AlphaFail::FB_ONLY;
+  if (state.depth_writes && !alpha_trick_to_disable) {
     glDepthMask(GL_TRUE);
   } else {
     glDepthMask(GL_FALSE);

--- a/game/graphics/opengl_renderer/DirectRenderer2.cpp
+++ b/game/graphics/opengl_renderer/DirectRenderer2.cpp
@@ -251,35 +251,35 @@ void DirectRenderer2::setup_opengl_for_draw_mode(const Draw& draw,
       // (Cs - Cd) * As + Cd
       // Cs * As  + (1 - As) * Cd
       // s, d
-      glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ZERO);
       glBlendEquation(GL_FUNC_ADD);
     } else if (draw.mode.get_alpha_blend() == DrawMode::AlphaBlend::SRC_0_SRC_DST) {
       // (Cs - 0) * As + Cd
       // Cs * As + (1) * Cd
       // s, d
       ASSERT(draw.fix == 0);
-      glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_ONE, GL_ZERO);
       glBlendEquation(GL_FUNC_ADD);
     } else if (draw.mode.get_alpha_blend() == DrawMode::AlphaBlend::ZERO_SRC_SRC_DST) {
       // (0 - Cs) * As + Cd
       // Cd - Cs * As
       // s, d
-      glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_ONE, GL_ZERO);
       glBlendEquation(GL_FUNC_REVERSE_SUBTRACT);
     } else if (draw.mode.get_alpha_blend() == DrawMode::AlphaBlend::SRC_DST_FIX_DST) {
       // (Cs - Cd) * fix + Cd
       // Cs * fix + (1 - fx) * Cd
-      glBlendFunc(GL_CONSTANT_ALPHA, GL_ONE_MINUS_CONSTANT_ALPHA);
+      glBlendFuncSeparate(GL_CONSTANT_ALPHA, GL_ONE_MINUS_CONSTANT_ALPHA, GL_ONE, GL_ZERO);
       glBlendColor(0, 0, 0, draw.fix / 127.f);
       glBlendEquation(GL_FUNC_ADD);
     } else if (draw.mode.get_alpha_blend() == DrawMode::AlphaBlend::SRC_SRC_SRC_SRC) {
       // this is very weird...
       // Cs
-      glBlendFunc(GL_ONE, GL_ZERO);
+      glBlendFuncSeparate(GL_ONE, GL_ZERO, GL_ONE, GL_ZERO);
       glBlendEquation(GL_FUNC_ADD);
     } else if (draw.mode.get_alpha_blend() == DrawMode::AlphaBlend::SRC_0_DST_DST) {
       // (Cs - 0) * Ad + Cd
-      glBlendFunc(GL_DST_ALPHA, GL_ONE);
+      glBlendFuncSeparate(GL_DST_ALPHA, GL_ONE, GL_ONE, GL_ZERO);
       glBlendEquation(GL_FUNC_ADD);
       color_mult = 0.5;
     } else {

--- a/game/graphics/opengl_renderer/background/background_common.cpp
+++ b/game/graphics/opengl_renderer/background/background_common.cpp
@@ -37,26 +37,26 @@ DoubleDraw setup_opengl_from_draw_mode(DrawMode mode, u32 tex_unit, bool mipmap)
     switch (mode.get_alpha_blend()) {
       case DrawMode::AlphaBlend::SRC_DST_SRC_DST:
         glBlendEquation(GL_FUNC_ADD);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ZERO);
         break;
       case DrawMode::AlphaBlend::SRC_0_SRC_DST:
         glBlendEquation(GL_FUNC_ADD);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+        glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_ONE, GL_ZERO);
         break;
       case DrawMode::AlphaBlend::SRC_0_FIX_DST:
         glBlendEquation(GL_FUNC_ADD);
-        glBlendFunc(GL_ONE, GL_ONE);
+        glBlendFuncSeparate(GL_ONE, GL_ONE, GL_ONE, GL_ZERO);
         break;
       case DrawMode::AlphaBlend::SRC_DST_FIX_DST:
         // Cv = (Cs - Cd) * FIX + Cd
         // Cs * FIX * 0.5
         // Cd * FIX * 0.5
         glBlendEquation(GL_FUNC_ADD);
-        glBlendFunc(GL_CONSTANT_COLOR, GL_CONSTANT_COLOR);
+        glBlendFuncSeparate(GL_CONSTANT_COLOR, GL_CONSTANT_COLOR, GL_ONE, GL_ZERO);
         glBlendColor(0.5, 0.5, 0.5, 0.5);
         break;
       case DrawMode::AlphaBlend::ZERO_SRC_SRC_DST:
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+        glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_ONE, GL_ZERO);
         glBlendEquation(GL_FUNC_REVERSE_SUBTRACT);
         break;
       default:

--- a/game/graphics/opengl_renderer/foreground/Generic2_OpenGL.cpp
+++ b/game/graphics/opengl_renderer/foreground/Generic2_OpenGL.cpp
@@ -122,35 +122,35 @@ void Generic2::setup_opengl_for_draw_mode(const DrawMode& draw_mode,
       // (Cs - Cd) * As + Cd
       // Cs * As  + (1 - As) * Cd
       // s, d
-      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ZERO);
+      glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
       glBlendEquation(GL_FUNC_ADD);
     } else if (draw_mode.get_alpha_blend() == DrawMode::AlphaBlend::SRC_0_SRC_DST) {
       // (Cs - 0) * As + Cd
       // Cs * As + (1) * Cd
       // s, d
       ASSERT(fix == 0);
-      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_ONE, GL_ZERO);
+      glBlendFunc(GL_SRC_ALPHA, GL_ONE);
       glBlendEquation(GL_FUNC_ADD);
     } else if (draw_mode.get_alpha_blend() == DrawMode::AlphaBlend::ZERO_SRC_SRC_DST) {
       // (0 - Cs) * As + Cd
       // Cd - Cs * As
       // s, d
-      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_ONE, GL_ZERO);
+      glBlendFunc(GL_SRC_ALPHA, GL_ONE);
       glBlendEquation(GL_FUNC_REVERSE_SUBTRACT);
     } else if (draw_mode.get_alpha_blend() == DrawMode::AlphaBlend::SRC_DST_FIX_DST) {
       // (Cs - Cd) * fix + Cd
       // Cs * fix + (1 - fx) * Cd
-      glBlendFuncSeparate(GL_CONSTANT_ALPHA, GL_ONE_MINUS_CONSTANT_ALPHA, GL_ONE, GL_ZERO);
+      glBlendFunc(GL_CONSTANT_ALPHA, GL_ONE_MINUS_CONSTANT_ALPHA);
       glBlendColor(0, 0, 0, fix / 127.f);
       glBlendEquation(GL_FUNC_ADD);
     } else if (draw_mode.get_alpha_blend() == DrawMode::AlphaBlend::SRC_SRC_SRC_SRC) {
       // this is very weird...
       // Cs
-      glBlendFuncSeparate(GL_ONE, GL_ZERO, GL_ONE, GL_ZERO);
+      glBlendFunc(GL_ONE, GL_ZERO);
       glBlendEquation(GL_FUNC_ADD);
     } else if (draw_mode.get_alpha_blend() == DrawMode::AlphaBlend::SRC_0_DST_DST) {
       // (Cs - 0) * Ad + Cd
-      glBlendFuncSeparate(GL_DST_ALPHA, GL_ONE, GL_ONE, GL_ZERO);
+      glBlendFunc(GL_DST_ALPHA, GL_ONE);
       glBlendEquation(GL_FUNC_ADD);
       color_mult = 0.5f;  // HACK, should probably be 0.5
     } else {

--- a/game/graphics/opengl_renderer/foreground/Generic2_OpenGL.cpp
+++ b/game/graphics/opengl_renderer/foreground/Generic2_OpenGL.cpp
@@ -122,35 +122,35 @@ void Generic2::setup_opengl_for_draw_mode(const DrawMode& draw_mode,
       // (Cs - Cd) * As + Cd
       // Cs * As  + (1 - As) * Cd
       // s, d
-      glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ZERO);
       glBlendEquation(GL_FUNC_ADD);
     } else if (draw_mode.get_alpha_blend() == DrawMode::AlphaBlend::SRC_0_SRC_DST) {
       // (Cs - 0) * As + Cd
       // Cs * As + (1) * Cd
       // s, d
       ASSERT(fix == 0);
-      glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_ONE, GL_ZERO);
       glBlendEquation(GL_FUNC_ADD);
     } else if (draw_mode.get_alpha_blend() == DrawMode::AlphaBlend::ZERO_SRC_SRC_DST) {
       // (0 - Cs) * As + Cd
       // Cd - Cs * As
       // s, d
-      glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_ONE, GL_ZERO);
       glBlendEquation(GL_FUNC_REVERSE_SUBTRACT);
     } else if (draw_mode.get_alpha_blend() == DrawMode::AlphaBlend::SRC_DST_FIX_DST) {
       // (Cs - Cd) * fix + Cd
       // Cs * fix + (1 - fx) * Cd
-      glBlendFunc(GL_CONSTANT_ALPHA, GL_ONE_MINUS_CONSTANT_ALPHA);
+      glBlendFuncSeparate(GL_CONSTANT_ALPHA, GL_ONE_MINUS_CONSTANT_ALPHA, GL_ONE, GL_ZERO);
       glBlendColor(0, 0, 0, fix / 127.f);
       glBlendEquation(GL_FUNC_ADD);
     } else if (draw_mode.get_alpha_blend() == DrawMode::AlphaBlend::SRC_SRC_SRC_SRC) {
       // this is very weird...
       // Cs
-      glBlendFunc(GL_ONE, GL_ZERO);
+      glBlendFuncSeparate(GL_ONE, GL_ZERO, GL_ONE, GL_ZERO);
       glBlendEquation(GL_FUNC_ADD);
     } else if (draw_mode.get_alpha_blend() == DrawMode::AlphaBlend::SRC_0_DST_DST) {
       // (Cs - 0) * Ad + Cd
-      glBlendFunc(GL_DST_ALPHA, GL_ONE);
+      glBlendFuncSeparate(GL_DST_ALPHA, GL_ONE, GL_ONE, GL_ZERO);
       glBlendEquation(GL_FUNC_ADD);
       color_mult = 0.5f;  // HACK, should probably be 0.5
     } else {

--- a/game/graphics/opengl_renderer/ocean/OceanTexture.cpp
+++ b/game/graphics/opengl_renderer/ocean/OceanTexture.cpp
@@ -305,7 +305,7 @@ void OceanTexture::make_texture_with_mipmaps(SharedRenderState* render_state,
     FramebufferTexturePairContext ctxt(m_result_texture, i);
     glUniform1f(glGetUniformLocation(render_state->shaders[ShaderId::OCEAN_TEXTURE_MIPMAP].id(),
                                      "alpha_intensity"),
-                std::max(0.f, 1.f - 0.4f * i));
+                std::max(0.f, 1.f - 0.51f * i));
     glUniform1f(
         glGetUniformLocation(render_state->shaders[ShaderId::OCEAN_TEXTURE_MIPMAP].id(), "scale"),
         1.f / (1 << i));


### PR DESCRIPTION
This fixes some alpha-related issues and (as a hack) just disables writing to the z buffer for the ocean.