### PR TITLE
Input scheme quick fixes

### DIFF
--- a/game/system/newpad.cpp
+++ b/game/system/newpad.cpp
@@ -165,7 +165,7 @@ int AnalogValue(MappingInfo& /*mapping*/, Analog analog, int pad = 0) {
 
   // Map from input to output range
   return int((input - input_low) * (output_high - output_low) / (input_high - input_low) +
-    output_low);
+             output_low);
 }
 
 // map a button on a pad to a key

--- a/game/system/newpad.cpp
+++ b/game/system/newpad.cpp
@@ -132,7 +132,7 @@ int AnalogValue(MappingInfo& /*mapping*/, Analog analog, int pad = 0) {
     return 127;
   }
 
-  if (g_gamepads.gamepad_idx == -1) {
+  if (g_gamepads.gamepad_idx == -1) { // Gamepad not present - use keyboard
 
     // Movement controls mapped to WASD keys
     if (g_buffered_key_status[GLFW_KEY_W] && analog == Analog::Left_Y)
@@ -154,7 +154,7 @@ int AnalogValue(MappingInfo& /*mapping*/, Analog analog, int pad = 0) {
     if (g_buffered_key_status[GLFW_KEY_L] && analog == Analog::Right_X)
       input += 1.0f;
 
-  } else {
+  } else { // Gamepad present
     input = g_gamepad_analogs[(int)analog];
   }
 
@@ -163,6 +163,7 @@ int AnalogValue(MappingInfo& /*mapping*/, Analog analog, int pad = 0) {
   if (analog == Analog::Right_X) {
     inverted = true;
   }
+
   // GLFW provides float in range -1 to 1, caller expects 0-255
   float input_low = inverted ? 1.0f : -1.0f;
   float input_high = inverted ? -1.0f : 1.0f;

--- a/game/system/newpad.cpp
+++ b/game/system/newpad.cpp
@@ -134,6 +134,15 @@ int AnalogValue(MappingInfo& /*mapping*/, Analog analog, int pad = 0) {
 
   if (g_gamepads.gamepad_idx == -1) {
     // TODO - keyboard mapping when no pad present
+    if (g_buffered_key_status[GLFW_KEY_W] && analog == Analog::Left_Y)
+      input += -1.0f;
+    if (g_buffered_key_status[GLFW_KEY_S] && analog == Analog::Left_Y)
+      input += 1.0f;
+    if (g_buffered_key_status[GLFW_KEY_A] && analog == Analog::Left_X)
+      input += -1.0f;
+    if (g_buffered_key_status[GLFW_KEY_D] && analog == Analog::Left_X)
+      input += 1.0f;
+
   } else {
     // TODO - dead-zone support needed?
     input = g_gamepad_analogs[(int)analog];
@@ -173,15 +182,19 @@ void DefaultMapping(MappingInfo& mapping) {
     }
   }
 
-  // r1/l1
-  MapButton(mapping, Button::L1, 0, GLFW_KEY_U);
+  // R1 / L1
+  MapButton(mapping, Button::L1, 0, GLFW_KEY_Q);
   MapButton(mapping, Button::R1, 0, GLFW_KEY_I);
 
+  // R2 / L2
+  MapButton(mapping, Button::L2, 0, GLFW_KEY_1);
+  MapButton(mapping, Button::R2, 0, GLFW_KEY_O);
+
   // face buttons
-  MapButton(mapping, Button::Ecks, 0, GLFW_KEY_Z);
-  MapButton(mapping, Button::Square, 0, GLFW_KEY_X);
-  MapButton(mapping, Button::Triangle, 0, GLFW_KEY_S);
-  MapButton(mapping, Button::Circle, 0, GLFW_KEY_A);
+  MapButton(mapping, Button::Ecks, 0, GLFW_KEY_SPACE);
+  MapButton(mapping, Button::Square, 0, GLFW_KEY_F);
+  MapButton(mapping, Button::Triangle, 0, GLFW_KEY_R);
+  MapButton(mapping, Button::Circle, 0, GLFW_KEY_E);
 
   // dpad
   MapButton(mapping, Button::Up, 0, GLFW_KEY_UP);

--- a/game/system/newpad.cpp
+++ b/game/system/newpad.cpp
@@ -157,16 +157,9 @@ int AnalogValue(MappingInfo& /*mapping*/, Analog analog, int pad = 0) {
     input = g_gamepad_analogs[(int)analog];
   }
 
-  // Invert the horizontal axis of the right joystick, to match behaviour of PS joystick. The rest
-  // are already correct.
-  bool inverted = false;
-  if (analog == Analog::Right_X) {
-    inverted = true;
-  }
-
   // GLFW provides float in range -1 to 1, caller expects 0-255
-  float input_low = inverted ? 1.0f : -1.0f;
-  float input_high = inverted ? -1.0f : 1.0f;
+  const float input_low = -1.0f;
+  const float input_high = 1.0f;
   const int output_low = 0;
   const int output_high = 255;
 

--- a/game/system/newpad.cpp
+++ b/game/system/newpad.cpp
@@ -133,7 +133,8 @@ int AnalogValue(MappingInfo& /*mapping*/, Analog analog, int pad = 0) {
   }
 
   if (g_gamepads.gamepad_idx == -1) {
-    // TODO - keyboard mapping when no pad present
+
+    // Movement controls mapped to WASD keys
     if (g_buffered_key_status[GLFW_KEY_W] && analog == Analog::Left_Y)
       input += -1.0f;
     if (g_buffered_key_status[GLFW_KEY_S] && analog == Analog::Left_Y)
@@ -143,8 +144,17 @@ int AnalogValue(MappingInfo& /*mapping*/, Analog analog, int pad = 0) {
     if (g_buffered_key_status[GLFW_KEY_D] && analog == Analog::Left_X)
       input += 1.0f;
 
+    // Camera controls mapped to IJKL keys
+    if (g_buffered_key_status[GLFW_KEY_I] && analog == Analog::Right_Y)
+      input += -1.0f;
+    if (g_buffered_key_status[GLFW_KEY_K] && analog == Analog::Right_Y)
+      input += 1.0f;
+    if (g_buffered_key_status[GLFW_KEY_J] && analog == Analog::Right_X)
+      input += -1.0f;
+    if (g_buffered_key_status[GLFW_KEY_L] && analog == Analog::Right_X)
+      input += 1.0f;
+
   } else {
-    // TODO - dead-zone support needed?
     input = g_gamepad_analogs[(int)analog];
   }
 
@@ -184,11 +194,11 @@ void DefaultMapping(MappingInfo& mapping) {
 
   // R1 / L1
   MapButton(mapping, Button::L1, 0, GLFW_KEY_Q);
-  MapButton(mapping, Button::R1, 0, GLFW_KEY_I);
+  MapButton(mapping, Button::R1, 0, GLFW_KEY_O);
 
   // R2 / L2
   MapButton(mapping, Button::L2, 0, GLFW_KEY_1);
-  MapButton(mapping, Button::R2, 0, GLFW_KEY_O);
+  MapButton(mapping, Button::R2, 0, GLFW_KEY_P);
 
   // face buttons
   MapButton(mapping, Button::Ecks, 0, GLFW_KEY_SPACE);

--- a/game/system/newpad.cpp
+++ b/game/system/newpad.cpp
@@ -124,7 +124,6 @@ int IsPressed(MappingInfo& mapping, Button button, int pad = 0) {
 // returns the value of the analog axis (in the future, likely pressure sensitive if we support it?)
 // if invalid or otherwise -- returns 127 (analog stick neutral position)
 int AnalogValue(MappingInfo& /*mapping*/, Analog analog, int pad = 0) {
-
   float input = 0.0f;
 
   if (CheckPadIdx(pad) == -1) {
@@ -132,7 +131,7 @@ int AnalogValue(MappingInfo& /*mapping*/, Analog analog, int pad = 0) {
     return 127;
   }
 
-  if (g_gamepads.gamepad_idx == -1) { // Gamepad not present - use keyboard
+  if (g_gamepads.gamepad_idx == -1) {  // Gamepad not present - use keyboard
 
     // Movement controls mapped to WASD keys
     if (g_buffered_key_status[GLFW_KEY_W] && analog == Analog::Left_Y)
@@ -154,11 +153,12 @@ int AnalogValue(MappingInfo& /*mapping*/, Analog analog, int pad = 0) {
     if (g_buffered_key_status[GLFW_KEY_L] && analog == Analog::Right_X)
       input += 1.0f;
 
-  } else { // Gamepad present
+  } else {  // Gamepad present
     input = g_gamepad_analogs[(int)analog];
   }
 
-  // Invert the horizontal axis of the right joystick, to match behaviour of PS joystick. The rest are already correct.
+  // Invert the horizontal axis of the right joystick, to match behaviour of PS joystick. The rest
+  // are already correct.
   bool inverted = false;
   if (analog == Analog::Right_X) {
     inverted = true;
@@ -171,7 +171,8 @@ int AnalogValue(MappingInfo& /*mapping*/, Analog analog, int pad = 0) {
   const int output_high = 255;
 
   // Map from input to output range
-  return int((input - input_low) * (output_high - output_low) / (input_high - input_low) + output_low);
+  return int((input - input_low) * (output_high - output_low) / (input_high - input_low) +
+    output_low);
 }
 
 // map a button on a pad to a key


### PR DESCRIPTION
This adjusts the controller mapping for both gamepad and keyboard to make it more playable. Specifically:

* ~~On gamepad, the right-hand X axis is inverted, now feels correct when used with an Xbox controller. (I'm not sure if this will cause a regression if you're using a PS3 controller, or if the behaviour was incorrect on PS3 controller too - can anyone confirm?).~~
* On keyboard, analog stick movement is now implemented on WASD, and camera controls are on IJKL.
* On keyboard, buttons are now mapped in a scheme that feels somewhat playable (though controller is still preferable):
  * X: Space
  * Square: F
  * Circle: E
  * Triangle: R
  * R1: Q