### PR TITLE
ci: stop trying to cache `clang-cl` builds

### DIFF
--- a/.github/workflows/windows-workflow.yaml
+++ b/.github/workflows/windows-workflow.yaml
@@ -61,7 +61,7 @@ jobs:
         run: |
           if "${{ matrix.compiler }}" == "clang" (
             call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
-            cmake -B build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER="${{ github.workspace }}"/buildcache/bin/buildcache.exe -DCMAKE_CXX_COMPILER_LAUNCHER="${{ github.workspace }}"/buildcache/bin/buildcache.exe "-DCMAKE_C_COMPILER=C:/Program Files/LLVM/bin/clang-cl.exe" "-DCMAKE_CXX_COMPILER=C:/Program Files/LLVM/bin/clang-cl.exe" .
+            cmake -B build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" .
           ) else (
             call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
             cmake -B build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER="${{ github.workspace }}"/buildcache/bin/buildcache.exe -DCMAKE_CXX_COMPILER_LAUNCHER="${{ github.workspace }}"/buildcache/bin/buildcache.exe .


### PR DESCRIPTION
From the last comment here https://github.com/mbitsnbites/buildcache/issues/194#issuecomment-778237822 it seems to be that clang-cl with buildcache still doesn't completely work as expected.

It _seems_ to be working, but not caching anything, as mentioned above:

<details>
<summary>Logs</summary>

```
BuildCache[4768] (DEBUG) Found exe: C:\Program Files\LLVM\bin\clang-cl.exe (C:\PROGRA~1\LLVM\bin\clang-cl.exe, C:\PROGRA~1\LLVM\bin\clang-cl.exe)
BuildCache[4768] (DEBUG) Removing expired data store item "2bb81a33314c1ea562bbd46450c288df"
BuildCache[4768] (DEBUG) Program ID cache miss for C:\PROGRA~1\LLVM\bin\clang-cl.exe
BuildCache[4768] (DEBUG) Invoking: C:\PROGRA~1\LLVM\bin\clang-cl.exe --version
BuildCache[4768] (DEBUG) Filtered arguments: clang-cl.exe /nologo -TP -imsvc D:\a\jak-project\jak-project\third-party\inja -Xclang -fcxx-exceptions -Xclang -fexceptions -Xclang -std=c++17 -Xclang -mavx -Wno-c++11-narrowing -Wno-c++98-compat -W3 /O2 /Ob2 /MD /O2 /Ob2 -Wall -Wextra -std:c++17 -c --
BuildCache[4768] (INFO)  Direct mode cache miss (35c97902c5f66aa5ea5599dafc2c239e): No matching direct mode entry found
BuildCache[4768] (DEBUG) Locked D:\a\jak-project\jak-project\.buildcache\c\35\stats.json.lock
BuildCache[4768] (DEBUG) Failed to parse stats object for dir D:\a\jak-project\jak-project\.buildcache\c\35
BuildCache[4768] (DEBUG) Invoking: C:\PROGRA~1\LLVM\bin\clang-cl.exe /nologo -TP -DREPLXX_BUILDING_DLL -Dreplxx_EXPORTS -ID:\a\jak-project\jak-project\. -ID:\a\jak-project\jak-project\third-party\replxx\include -ID:\a\jak-project\jak-project\third-party\replxx\src -imsvc D:\a\jak-project\jak-project\third-party\inja -Xclang -fcxx-exceptions -Xclang -fexceptions -Xclang -std=c++17 -Xclang -D_CRT_SECURE_NO_WARNINGS -mavx -Wno-c++11-narrowing -Wno-c++98-compat -W3 /O2 /Ob2 /MD /O2 /Ob2 /DNDEBUG -Wall -Wextra -std:c++17 /FdCMakeFiles\replxx.dir\ -- D:\a\jak-project\jak-project\third-party\replxx\src\ConvertUTF.cpp /EP /showIncludes
BuildCache[4768] (DEBUG) Exception: Preprocessing command was unsuccessful.
BuildCache[4768] (DEBUG) Invoking: C:\PROGRA~1\LLVM\bin\clang-cl.exe @C:\Users\RUNNER~1\AppData\Local\Temp\nm793C.tmp
```

</details>

In any case, I can't spend days trying to get this to work -- I can't even compile the project on command line properly on windows (visual studio is doing some sort of magic to get things to work....).  Which means trial and error with 20-25minute builds, not happening.

