### PR TITLE
ci: Add an automated release process

### DIFF
--- a/.github/scripts/releases/upload-release-artifacts/.gitignore
+++ b/.github/scripts/releases/upload-release-artifacts/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.md

--- a/.github/scripts/releases/upload-release-artifacts/index.js
+++ b/.github/scripts/releases/upload-release-artifacts/index.js
@@ -74,7 +74,7 @@ glob(assetDir + `/**/*${process.env.ASSET_EXTENSION}`, {}, async (err, files) =>
     let foundDuplicate = false;
     for (var j = 0; j < releaseAssetsPre.length; j++) {
       let existingAsset = releaseAssetsPre[j];
-      if (existingAsset.name == `${path.basename(files[i])}-${release.tag_name}`) {
+      if (existingAsset.name == `opengoal-${release.tag_name}-${path.basename(files[i])}`) {
         foundDuplicate = true;
         break;
       }
@@ -88,7 +88,7 @@ glob(assetDir + `/**/*${process.env.ASSET_EXTENSION}`, {}, async (err, files) =>
       owner: "open-goal",
       repo: "jak-project",
       release_id: release.id,
-      name: `${path.basename(files[i])}-${release.tag_name}`,
+      name: `opengoal-${release.tag_name}-${path.basename(files[i])}`,
       data: assetBytes,
     });
   }

--- a/.github/scripts/releases/upload-release-artifacts/index.js
+++ b/.github/scripts/releases/upload-release-artifacts/index.js
@@ -1,0 +1,145 @@
+import { Octokit } from "@octokit/rest";
+import { throttling } from "@octokit/plugin-throttling";
+import { retry } from "@octokit/plugin-retry";
+Octokit.plugin(throttling);
+Octokit.plugin(retry);
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN,
+  userAgent: 'open-goal/jak-project',
+  log: {
+    debug: () => { },
+    info: () => { },
+    warn: console.warn,
+    error: console.error
+  },
+  throttle: {
+    onRateLimit: (retryAfter, options) => {
+      octokit.log.warn(
+        `Request quota exhausted for request ${options.method} ${options.url}`
+      );
+
+      // Retry twice after hitting a rate limit error, then give up
+      if (options.request.retryCount <= 2) {
+        console.log(`Retrying after ${retryAfter} seconds!`);
+        return true;
+      }
+    },
+    onAbuseLimit: (retryAfter, options) => {
+      // does not retry, only logs a warning
+      octokit.log.warn(
+        `Abuse detected for request ${options.method} ${options.url}`
+      );
+    },
+  }
+});
+
+let assetDir = process.env.ASSET_DIR;
+let tagToSearchFor = process.env.TAG_TO_SEARCH_FOR.split("refs/tags/")[1];
+
+console.log(`Searching in - ${assetDir}`);
+console.log(`Searching for tag - ${tagToSearchFor}`);
+
+const { data: recentReleases } = await octokit.rest.repos.listReleases({
+  owner: "open-goal",
+  repo: "jak-project",
+  per_page: 100
+});
+
+let release = undefined;
+for (var i = 0; i < recentReleases.length; i++) {
+  if (recentReleases[i].tag_name == tagToSearchFor) {
+    release = recentReleases[i];
+    break;
+  }
+}
+
+if (release == undefined) {
+  console.log(`Unable to find release with tag - ${tagToSearchFor}`);
+  process.exit(1);
+}
+
+// Upload any assets we need to, don't upload assets that are already there!
+const { data: releaseAssetsPre } = await octokit.rest.repos.listReleaseAssets({
+  owner: "open-goal",
+  repo: "jak-project",
+  release_id: release.id,
+  per_page: 100
+});
+
+import glob from 'glob';
+import * as fs from 'fs';
+import * as path from 'path';
+glob(assetDir + `/**/*${process.env.ASSET_EXTENSION}`, {}, async (err, files) => {
+  for (var i = 0; i < files.length; i++) {
+    let foundDuplicate = false;
+    for (var j = 0; j < releaseAssetsPre.length; j++) {
+      let existingAsset = releaseAssetsPre[j];
+      if (existingAsset.name == `${path.basename(files[i])}-${release.tag_name}`) {
+        foundDuplicate = true;
+        break;
+      }
+    }
+    if (foundDuplicate) {
+      continue;
+    }
+
+    var assetBytes = fs.readFileSync(files[i], null);
+    const { data: uploadAsset } = await octokit.rest.repos.uploadReleaseAsset({
+      owner: "open-goal",
+      repo: "jak-project",
+      release_id: release.id,
+      name: `${path.basename(files[i])}-${release.tag_name}`,
+      data: assetBytes,
+    });
+  }
+});
+
+// Ideally there would be a webhook event for when an artifact is added to a draft release
+// unfortunately, such a thing does not exist yet.  Therefore, we have to wait a bit
+// for the API to become consistent
+// TODO - future work - we could check previous draft releases to become eventually consistent as well
+// - draft releases should only be a temporary state, so anything that remains a draft had a problem
+await new Promise(resolve => setTimeout(resolve, 10 * 1000));
+
+// Poll the release, and check to see if it's ready to be published
+const { data: releaseAssetsPost } = await octokit.rest.repos.listReleaseAssets({
+  owner: "open-goal",
+  repo: "jak-project",
+  release_id: release.id,
+  per_page: 100
+});
+
+// Expected Assets, if we have all of them, we will publish it
+let expectedAssets = {
+  "windows-decompiler": false,
+  "windows-gk": false,
+  "windows-goalc": false,
+  "linux-decompiler": false,
+  "linux-gk": false,
+  "linux-goalc": false,
+}
+
+for (var i = 0; i < releaseAssetsPost.length; i++) {
+  let asset = releaseAssetsPost[i];
+  if (asset.name.includes("symbols")) {
+    continue;
+  }
+  for (var j = 0; j < Object.keys(expectedAssets).length; j++) {
+    let expectedNamePrefix = Object.keys(expectedAssets)[j];
+    if (asset.name.toLowerCase().includes(expectedNamePrefix)) {
+      expectedAssets[expectedNamePrefix] = true;
+      break;
+    }
+  }
+}
+
+console.log(expectedAssets);
+
+if (Object.values(expectedAssets).every(Boolean)) {
+  await octokit.rest.repos.updateRelease({
+    owner: "open-goal",
+    repo: "jak-project",
+    release_id: release.id,
+    draft: false
+  });
+}

--- a/.github/scripts/releases/upload-release-artifacts/package-lock.json
+++ b/.github/scripts/releases/upload-release-artifacts/package-lock.json
@@ -1,0 +1,559 @@
+{
+  "name": "upload-release-artifacts",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@octokit/plugin-retry": "^3.0.9",
+        "@octokit/plugin-throttling": "^3.5.2",
+        "@octokit/rest": "^18.12.0",
+        "glob": "^7.2.0"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
+      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.0",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "dependencies": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.1.0.tgz",
+      "integrity": "sha512-dWZfYvCCdjZzDYA3lIAMF72Q0jld8xidqCq5Ryw09eBJXZdcM6he0vWBTvw/b5UnGYqexxOyHWgfrsTlUJL3Gw=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.16.9",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.16.9.tgz",
+      "integrity": "sha512-gfSCMgz5scFKsR0dW4jaYsDJVt/UwCHp4dF7sHlmSekZvwzvLiOAGZ4MQkEsL5DW9hIk2W+UQkYZMTA1b6Wsqw==",
+      "dependencies": {
+        "@octokit/types": "^6.33.0"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA=="
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.12.1.tgz",
+      "integrity": "sha512-0nY3htfl6x9UkPcqv8pm9vOC/bTA7f4IMDWln13neHRdNWQvOQgZ9fRxK7BAc74rye4yVINEFi9Yb9rnGUvosA==",
+      "dependencies": {
+        "@octokit/types": "^6.33.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-3.0.9.tgz",
+      "integrity": "sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.5.2.tgz",
+      "integrity": "sha512-Eu7kfJxU8vmHqWGNszWpg+GVp2tnAfax3XQV5CkYPEE69C+KvInJXW9WajgSeW+cxYe0UVdouzCtcreGNuJo7A==",
+      "dependencies": {
+        "@octokit/types": "^6.0.1",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
+      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "18.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+      "dependencies": {
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.33.0.tgz",
+      "integrity": "sha512-0zffZ048M0UhthyPXQHLz4038Ak46nMWZXkzlXvXB/M/L1jYPBceq4iZj4qjKVrvveaJrrgKdJ9+3yUuITfcCw==",
+      "dependencies": {
+        "@octokit/openapi-types": "^11.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  },
+  "dependencies": {
+    "@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "requires": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
+      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.0",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "requires": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.1.0.tgz",
+      "integrity": "sha512-dWZfYvCCdjZzDYA3lIAMF72Q0jld8xidqCq5Ryw09eBJXZdcM6he0vWBTvw/b5UnGYqexxOyHWgfrsTlUJL3Gw=="
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.16.9",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.16.9.tgz",
+      "integrity": "sha512-gfSCMgz5scFKsR0dW4jaYsDJVt/UwCHp4dF7sHlmSekZvwzvLiOAGZ4MQkEsL5DW9hIk2W+UQkYZMTA1b6Wsqw==",
+      "requires": {
+        "@octokit/types": "^6.33.0"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA=="
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.12.1.tgz",
+      "integrity": "sha512-0nY3htfl6x9UkPcqv8pm9vOC/bTA7f4IMDWln13neHRdNWQvOQgZ9fRxK7BAc74rye4yVINEFi9Yb9rnGUvosA==",
+      "requires": {
+        "@octokit/types": "^6.33.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/plugin-retry": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-3.0.9.tgz",
+      "integrity": "sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "@octokit/plugin-throttling": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.5.2.tgz",
+      "integrity": "sha512-Eu7kfJxU8vmHqWGNszWpg+GVp2tnAfax3XQV5CkYPEE69C+KvInJXW9WajgSeW+cxYe0UVdouzCtcreGNuJo7A==",
+      "requires": {
+        "@octokit/types": "^6.0.1",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
+      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+      "requires": {
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.33.0.tgz",
+      "integrity": "sha512-0zffZ048M0UhthyPXQHLz4038Ak46nMWZXkzlXvXB/M/L1jYPBceq4iZj4qjKVrvveaJrrgKdJ9+3yUuITfcCw==",
+      "requires": {
+        "@octokit/openapi-types": "^11.1.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
+    "bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/.github/scripts/releases/upload-release-artifacts/package.json
+++ b/.github/scripts/releases/upload-release-artifacts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "upload-release-artifacts",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@octokit/plugin-retry": "^3.0.9",
+    "@octokit/plugin-throttling": "^3.5.2",
+    "@octokit/rest": "^18.12.0",
+    "glob": "^7.2.0"
+  }
+}

--- a/.github/workflows/architecture/releases.md
+++ b/.github/workflows/architecture/releases.md
@@ -1,0 +1,15 @@
+# Release Process
+
+```mermaid
+sequenceDiagram
+  Git Client->>Project Repo: Semver Tag is Pushed (ex. v1.2.5)
+  Project Repo->>Project Repo: Create a draft release
+  Project Repo->>Project Repo: Run Builds
+  loop Every build we intend to release
+    Project Repo->>Project Repo: Upload Asset to Draft Release
+    opt If All assets have been uploaded
+      Project Repo->>Project Repo: Publish the release
+    end
+  end
+  Launcher Repo->>Project Repo: Pull down latest/pinned release for it's process
+```

--- a/.github/workflows/architecture/releases.md
+++ b/.github/workflows/architecture/releases.md
@@ -2,7 +2,7 @@
 
 ```mermaid
 sequenceDiagram
-  Git Client->>Project Repo: Semver Tag is Pushed (ex. v1.2.5)
+  Project Repo->>Project Repo: New tag created via workflow dispatch
   Project Repo->>Project Repo: Create a draft release
   Project Repo->>Project Repo: Run Builds
   loop Every build we intend to release

--- a/.github/workflows/draft-new-release.yaml
+++ b/.github/workflows/draft-new-release.yaml
@@ -1,0 +1,54 @@
+name: Draft Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Semver Bump Type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  cut-release:
+    if: github.repository == 'open-goal/jak-project'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # Docs - https://github.com/mathieudutour/github-tag-action
+      # Workflows cannot trigger other workflows implicitly
+      # - https://github.community/t/github-actions-workflow-not-triggering-with-tag-push/17053/7
+      - name: Bump Version and Push Tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.BOT_PAT }}
+          tag_prefix: v
+          default_bump: ${{ github.event.inputs.bump }}
+
+      # Generate the Release Notes
+      # TODO
+      # - name: Generate Release Notes
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     COMMIT_SHA: ${{ github.SHA }}
+      #   run: |
+      #     cd ./.github/workflows/scripts/releases/generate-release-notes
+      #     npm ci
+      #     node index.js
+      #     mv ./release-notes.md ${GITHUB_WORKSPACE}/release-notes.md
+      #     ls
+
+      # Docs - https://github.com/softprops/action-gh-release
+      - name: Create a GitHub Release
+        uses: softprops/action-gh-release@v1
+        if: steps.tag_version.outputs.new_tag
+        with:
+          draft: true
+          prerelease: false
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/draft-new-release.yaml
+++ b/.github/workflows/draft-new-release.yaml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   cut-release:
-    if: github.repository == 'open-goal/jak-project'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -24,6 +23,7 @@ jobs:
       # Workflows cannot trigger other workflows implicitly
       # - https://github.community/t/github-actions-workflow-not-triggering-with-tag-push/17053/7
       - name: Bump Version and Push Tag
+        if: github.repository == 'open-goal/jak-project'
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.0
         with:
@@ -47,7 +47,7 @@ jobs:
       # Docs - https://github.com/softprops/action-gh-release
       - name: Create a GitHub Release
         uses: softprops/action-gh-release@v1
-        if: steps.tag_version.outputs.new_tag
+        if: github.repository == 'open-goal/jak-project' && steps.tag_version.outputs.new_tag
         with:
           draft: true
           prerelease: false

--- a/.github/workflows/inform-pages-repo.yaml
+++ b/.github/workflows/inform-pages-repo.yaml
@@ -14,12 +14,12 @@ on:
 jobs:
   inform:
     name: Inform Pages Repo
-    if: github.repository == 'open-goal/jak-project'
     runs-on: ubuntu-latest
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
     timeout-minutes: 10
     steps:
       - name: Send Dispatch
+        if: github.repository == 'open-goal/jak-project'
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.BOT_PAT }}

--- a/.github/workflows/inform-pages-repo.yaml
+++ b/.github/workflows/inform-pages-repo.yaml
@@ -14,7 +14,8 @@ on:
 jobs:
   inform:
     name: Inform Pages Repo
-    runs-on: ubuntu-20.04
+    if: github.repository == 'open-goal/jak-project'
+    runs-on: ubuntu-latest
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
     timeout-minutes: 10
     steps:

--- a/.github/workflows/linux-workflow.yaml
+++ b/.github/workflows/linux-workflow.yaml
@@ -101,11 +101,13 @@ jobs:
         if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler == 'clang'
         run: |
           mkdir -p ./ci-artifacts/
-          cp ./build/decompiler/decompiler ./ci-artifacts/linux-decompiler.exe.bin
+          cp ./build/decompiler/decompiler ./ci-artifacts/linux-decompiler.bin
           cp ./build/game/gk ./ci-artifacts/linux-gk.bin
           cp ./build/goalc/goalc ./ci-artifacts/linux-goalc.bin
           chmod +x ./ci-artifacts/*.bin
-          strip --strip-debug ./ci-artifacts/*.bin
+          strip --strip-debug ./ci-artifacts/linux-decompiler.bin
+          strip --strip-debug ./ci-artifacts/linux-gk.bin
+          strip --strip-debug ./ci-artifacts/linux-goalc.bin
           ls -l ./ci-artifacts/
 
       - name: Upload Assets and Potential Publish Release

--- a/.github/workflows/linux-workflow.yaml
+++ b/.github/workflows/linux-workflow.yaml
@@ -59,6 +59,7 @@ jobs:
           export CXX=clang++
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_FOR_RELEASE=ON \
             -DCMAKE_C_COMPILER_LAUNCHER="${{ github.workspace }}"/buildcache/bin/buildcache \
             -DCMAKE_CXX_COMPILER_LAUNCHER="${{ github.workspace }}"/buildcache/bin/buildcache \
             -DCODE_COVERAGE=ON -DASAN_BUILD=ON
@@ -104,6 +105,7 @@ jobs:
           cp ./build/game/gk ./ci-artifacts/linux-gk.bin
           cp ./build/goalc/goalc ./ci-artifacts/linux-goalc.bin
           chmod +x ./ci-artifacts/*.bin
+          strip --strip-debug ./ci-artifacts/*.bin
           ls -l ./ci-artifacts/
 
       - name: Upload Assets and Potential Publish Release

--- a/.github/workflows/linux-workflow.yaml
+++ b/.github/workflows/linux-workflow.yaml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*
   pull_request:
     branches:
       - master
@@ -17,13 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        config: [Debug] # TODO - Eventually we need to make a Release Config
         compiler: [clang, gcc]
-        experimental: [false]
 
-    name: ${{ matrix.config }}-${{ matrix.compiler }}
+    name: ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
     timeout-minutes: 45
 
@@ -41,47 +40,80 @@ jobs:
       - name: Checkout Submodules
         run: git submodule update --init --recursive -j 2
 
-      - name: Get Package Dependencies
+      - name: Get Common Package Dependencies
         run: sudo apt install build-essential cmake clang gcc g++ lcov make nasm libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+
+      - name: Get Clang
+        if: matrix.compiler == 'clang'
+        run: sudo apt install clang
 
       - name: Setup Buildcache
         uses: mikehardy/buildcache-action@v1.2.2
         with:
-          cache_key: ${{ matrix.os }}-${{ matrix.config }}-${{ matrix.compiler }}
+          cache_key: ${{ matrix.os }}-${{ matrix.compiler }}
 
-      - name: CMake Generation
+      - name: CMake Generation - Clang
+        if: matrix.compiler == 'clang'
         run: |
-          if [ "${{ matrix.compiler }}" == 'clang' ]; then
-            export CC=clang
-            export CXX=clang++
-            cmake -B build -DCODE_COVERAGE=ON -DASAN_BUILD=ON
-          else
-            export CC=gcc
-            export CXX=g++
-            cmake -B build \
-              -DCMAKE_C_COMPILER_LAUNCHER="${{ github.workspace }}"/buildcache/bin/buildcache \
-              -DCMAKE_CXX_COMPILER_LAUNCHER="${{ github.workspace }}"/buildcache/bin/buildcache \
-              -DCODE_COVERAGE=ON
-          fi
+          export CC=clang
+          export CXX=clang++
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER="${{ github.workspace }}"/buildcache/bin/buildcache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER="${{ github.workspace }}"/buildcache/bin/buildcache \
+            -DCODE_COVERAGE=ON -DASAN_BUILD=ON
+
+      - name: CMake Generation - GCC
+        if: matrix.compiler == 'gcc'
+        run: |
+          export CC=gcc
+          export CXX=g++
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER="${{ github.workspace }}"/buildcache/bin/buildcache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER="${{ github.workspace }}"/buildcache/bin/buildcache \
+            -DCODE_COVERAGE=ON
 
       - name: Build Project
         working-directory: ./build
-        run: |
-          make -j4
+        run: make -j4
 
       - name: Run Tests
-        run: |
-          if [ "${{ matrix.compiler }}" == 'clang' ]; then
-            ./test.sh
-          else
-            ./test_code_coverage.sh
-          fi
+        if: matrix.compiler == 'clang'
+        run: ./test.sh
+
+      - name: Run Tests - With Coverage
+        if: matrix.compiler == 'gcc'
+        run: ./test_code_coverage.sh
 
       - name: Submit Coverage Report to Codacy
-        if: ${{ matrix.compiler }} != 'clang'
+        if: ${{ matrix.compiler }} == 'gcc'
         uses: codacy/codacy-coverage-reporter-action@v1
         continue-on-error: true
         with:
           project-token: ${{ secrets.CODACY_PROJECT_KEY }}
           # lcov report
           coverage-reports: ./build/goalc-test_coverage.info
+
+      # ---- Release / Tagging related steps ----
+      - name: Prepare Build Artifacts
+        if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler != 'clang'
+        run: |
+          mkdir -p ./ci-artifacts/
+          cp ./bin/decompiler ./ci-artifacts/linux-decompiler.exe.bin
+          cp ./bin/gk ./ci-artifacts/linux-gk.bin
+          cp ./bin/goalc ./ci-artifacts/linux-goalc.bin
+          chmod +x ./ci-artifacts/*.bin
+          ls -l ./ci-artifacts/
+
+      - name: Upload Assets and Potential Publish Release
+        if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler != 'clang'
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
+          ASSET_DIR: ${{ github.WORKSPACE }}/ci-artifacts
+          ASSET_EXTENSION: bin
+          TAG_TO_SEARCH_FOR: ${{ github.REF }}
+        run: |
+          cd ./.github/workflows/scripts/releases/upload-release-artifacts
+          npm ci
+          node index.js

--- a/.github/workflows/linux-workflow.yaml
+++ b/.github/workflows/linux-workflow.yaml
@@ -97,23 +97,23 @@ jobs:
 
       # ---- Release / Tagging related steps ----
       - name: Prepare Build Artifacts
-        if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler != 'clang'
+        if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler == 'clang'
         run: |
           mkdir -p ./ci-artifacts/
-          cp ./bin/decompiler ./ci-artifacts/linux-decompiler.exe.bin
-          cp ./bin/gk ./ci-artifacts/linux-gk.bin
-          cp ./bin/goalc ./ci-artifacts/linux-goalc.bin
+          cp ./build/decompiler/decompiler ./ci-artifacts/linux-decompiler.exe.bin
+          cp ./build/game/gk ./ci-artifacts/linux-gk.bin
+          cp ./build/goalc/goalc ./ci-artifacts/linux-goalc.bin
           chmod +x ./ci-artifacts/*.bin
           ls -l ./ci-artifacts/
 
       - name: Upload Assets and Potential Publish Release
-        if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler != 'clang'
+        if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler == 'clang'
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
           ASSET_DIR: ${{ github.WORKSPACE }}/ci-artifacts
           ASSET_EXTENSION: bin
           TAG_TO_SEARCH_FOR: ${{ github.REF }}
         run: |
-          cd ./.github/workflows/scripts/releases/upload-release-artifacts
+          cd ./.github/scripts/releases/upload-release-artifacts
           npm ci
           node index.js

--- a/.github/workflows/windows-workflow.yaml
+++ b/.github/workflows/windows-workflow.yaml
@@ -80,22 +80,22 @@ jobs:
 
       # ---- Release / Tagging related steps ----
       - name: Prepare Build Artifacts
-        if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler != 'clang'
+        if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler == 'clang'
         run: |
           mkdir -p ./ci-artifacts/
-          cp ./bin/decompiler.exe ./ci-artifacts/windows-decompiler.exe
-          cp ./bin/gk.exe ./ci-artifacts/windows-gk.exe
-          cp ./bin/goalc.exe ./ci-artifacts/windows-goalc.exe
+          cp ./build/bin/decompiler.exe ./ci-artifacts/windows-decompiler.exe
+          cp ./build/bin/gk.exe ./ci-artifacts/windows-gk.exe
+          cp ./build/bin/goalc.exe ./ci-artifacts/windows-goalc.exe
           ls ./ci-artifacts/
 
       - name: Upload Assets and Potential Publish Release
-        if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler != 'clang'
+        if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler == 'clang'
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
           ASSET_DIR: ${{ github.WORKSPACE }}/ci-artifacts
           ASSET_EXTENSION: exe
           TAG_TO_SEARCH_FOR: ${{ github.REF }}
         run: |
-          cd ./.github/workflows/scripts/releases/upload-release-artifacts
+          cd ./.github/scripts/releases/upload-release-artifacts
           npm ci
           node index.js

--- a/.github/workflows/windows-workflow.yaml
+++ b/.github/workflows/windows-workflow.yaml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*
   pull_request:
     branches:
       - master
@@ -17,11 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2022]
-        config: [Release]
         compiler: [msvc, clang]
         experimental: [false]
 
-    name: ${{ matrix.config }}-${{ matrix.compiler }}
+    name: ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
@@ -35,13 +36,6 @@ jobs:
       BUILDCACHE_LOG_FILE: ${{ github.workspace }}/buildcache.log
 
     steps:
-      # NOTE - useful for debugging
-      # - name: Dump GitHub context
-      #   env:
-      #     GITHUB_CONTEXT: ${{ toJson(github) }}
-      #   run: |
-      #     echo "$GITHUB_CONTEXT"
-
       - name: Checkout Repository
         uses: actions/checkout@v2
 
@@ -54,8 +48,9 @@ jobs:
       - name: Setup Buildcache
         uses: mikehardy/buildcache-action@v1.2.2
         with:
-          cache_key: ${{ matrix.os }}-${{ matrix.config }}-${{ matrix.compiler }}
+          cache_key: ${{ matrix.os }}-${{ matrix.compiler }}
 
+      # TODO - eventually fight with this to get it to use Ninja and such
       - name: CMake Generation
         shell: cmd # ideally id like everything to be powershell but running this bat file is finicky
         run: |
@@ -82,3 +77,25 @@ jobs:
         env:
           NEXT_DIR: ${{ github.workspace }}
         run: ./build/bin/goalc-test.exe --gtest_color=yes --gtest_filter="-*MANUAL_TEST*"
+
+      # ---- Release / Tagging related steps ----
+      - name: Prepare Build Artifacts
+        if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler != 'clang'
+        run: |
+          mkdir -p ./ci-artifacts/
+          cp ./bin/decompiler.exe ./ci-artifacts/windows-decompiler.exe
+          cp ./bin/gk.exe ./ci-artifacts/windows-gk.exe
+          cp ./bin/goalc.exe ./ci-artifacts/windows-goalc.exe
+          ls ./ci-artifacts/
+
+      - name: Upload Assets and Potential Publish Release
+        if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler != 'clang'
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
+          ASSET_DIR: ${{ github.WORKSPACE }}/ci-artifacts
+          ASSET_EXTENSION: exe
+          TAG_TO_SEARCH_FOR: ${{ github.REF }}
+        run: |
+          cd ./.github/workflows/scripts/releases/upload-release-artifacts
+          npm ci
+          node index.js

--- a/.github/workflows/windows-workflow.yaml
+++ b/.github/workflows/windows-workflow.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |
           if "${{ matrix.compiler }}" == "clang" (
             call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
-            cmake -B build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" .
+            cmake -B build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DBUILD_FOR_RELEASE=ON -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" .
           ) else (
             call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
             cmake -B build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER="${{ github.workspace }}"/buildcache/bin/buildcache.exe -DCMAKE_CXX_COMPILER_LAUNCHER="${{ github.workspace }}"/buildcache/bin/buildcache.exe .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
 endif()
 
+option(BUILD_FOR_RELEASE "Build for release purposes (static everything)" OFF)
+if(BUILD_FOR_RELEASE)
+    set(BUILD_SHARED_LIBS OFF)
+else()
+    set(BUILD_SHARED_LIBS ON)
+endif()
+
 # Set default compile flags
 # optimization level can be set here. You can overwrite these in a per-project basis if you want.
 if(MSVC AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
@@ -97,7 +104,6 @@ include_directories(./)
 include_directories(SYSTEM third-party/inja)
 
 # build repl library
-option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 add_subdirectory(third-party/replxx EXCLUDE_FROM_ALL)
 
 # build common library
@@ -147,7 +153,7 @@ add_subdirectory(third-party/discord-rpc EXCLUDE_FROM_ALL)
 # NOTE: Once under CMake 3.13's policy CMP0077, override with `set()` instead
 option(ZYDIS_BUILD_TOOLS "Zydis: Build tools" OFF)
 option(ZYDIS_BUILD_EXAMPLES "Zydis: Build examples" OFF)
-option(ZYDIS_BUILD_SHARED_LIB "Zydis: Build shared library" ON)
+option(ZYDIS_BUILD_SHARED_LIB "Zydis: Build shared library" BUILD_SHARED_LIBS)
 add_subdirectory(third-party/zydis EXCLUDE_FROM_ALL)
 
 # windows memory management lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,11 @@ add_subdirectory(third-party/discord-rpc EXCLUDE_FROM_ALL)
 # NOTE: Once under CMake 3.13's policy CMP0077, override with `set()` instead
 option(ZYDIS_BUILD_TOOLS "Zydis: Build tools" OFF)
 option(ZYDIS_BUILD_EXAMPLES "Zydis: Build examples" OFF)
-option(ZYDIS_BUILD_SHARED_LIB "Zydis: Build shared library" BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS)
+    option(ZYDIS_BUILD_SHARED_LIB "Zydis: Build shared library" ON)
+else()
+    option(ZYDIS_BUILD_SHARED_LIB "Zydis: Build shared library" OFF)
+endif()
 add_subdirectory(third-party/zydis EXCLUDE_FROM_ALL)
 
 # windows memory management lib

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_library(common
-        SHARED
         audio/audio_formats.cpp
         cross_os_debug/xdbg.cpp
         cross_sockets/xsocket.cpp

--- a/decompiler/CMakeLists.txt
+++ b/decompiler/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_library(
         decomp
-        SHARED
 
         analysis/atomic_op_builder.cpp
         analysis/cfg_builder.cpp

--- a/goalc/CMakeLists.txt
+++ b/goalc/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_library(compiler
-        SHARED
         emitter/CallingConvention.cpp
         emitter/CodeTester.cpp
         emitter/ObjectFileData.cpp

--- a/third-party/fmt/CMakeLists.txt
+++ b/third-party/fmt/CMakeLists.txt
@@ -5,5 +5,8 @@ else ()
 endif (UNIX)
 
 include_directories(../)
-add_library(fmt SHARED format.cc)
-target_compile_definitions(fmt PRIVATE FMT_EXPORT INTERFACE FMT_SHARED PUBLIC FMT_SHARED)
+add_library(fmt format.cc)
+
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(fmt PRIVATE FMT_EXPORT INTERFACE FMT_SHARED PUBLIC FMT_SHARED)
+endif()

--- a/third-party/imgui/CMakeLists.txt
+++ b/third-party/imgui/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(imgui SHARED
+add_library(imgui
         imgui.cpp
         imgui_draw.cpp
         imgui_tables.cpp

--- a/third-party/lzokay/CMakeLists.txt
+++ b/third-party/lzokay/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 include(CMakePackageConfigHelpers)
 
 project(lzokay VERSION 0.1 LANGUAGES CXX)
-add_library(lzokay SHARED lzokay.hpp lzokay.cpp)
+add_library(lzokay lzokay.hpp lzokay.cpp)
 add_executable(lzokaytest test.cpp)
 target_include_directories(lzokay PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_link_libraries(lzokaytest lzokay)

--- a/third-party/mman/CMakeLists.txt
+++ b/third-party/mman/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_library(mman SHARED mman.c)
+add_library(mman mman.c)


### PR DESCRIPTION
It's a bit tedious to test these things so hopefully i didn't miss anything on the conversion from my fork back to this repo.  But this process has worked well over on pcsx2 (around 500 releases at this point, we won't be releasing nearly that much).  The test i finally got to work - https://github.com/xTVaser/jak-project/releases/tag/v0.1.3

Releases are created manually via workflow dispatch, release notes are currently not automatically generated, but should be pretty easy to do cleanly since we squash merge everything:
![image](https://user-images.githubusercontent.com/13153231/160518172-5cfa553a-89be-455f-acaf-793452bb5c07.png)

A draft release is created until all the necessary assets are uploaded:
![image](https://user-images.githubusercontent.com/13153231/160518215-b655e613-265d-4b1b-84fa-b11ba73fbad6.png)

And then it's live (ignore the naming, from a previous run, they should all be `open-goal-<windows/linux>-<decompiler/gk/goalc>.<bin/exe>`
![image](https://user-images.githubusercontent.com/13153231/160518308-6276f04d-85ef-4991-8a87-5d1548255552.png)

```mermaid
sequenceDiagram
  Project Repo->>Project Repo: New tag created via workflow dispatch
  Project Repo->>Project Repo: Create a draft release
  Project Repo->>Project Repo: Run Builds
  loop Every build we intend to release
    Project Repo->>Project Repo: Upload Asset to Draft Release
    opt If All assets have been uploaded
      Project Repo->>Project Repo: Publish the release
    end
  end
  Launcher Repo->>Project Repo: Pull down latest/pinned release for it's process
```