### PR TITLE
[graphics] use multidraws in tie/tfrag/shrub

### DIFF
--- a/decompiler/level_extractor/extract_tfrag.cpp
+++ b/decompiler/level_extractor/extract_tfrag.cpp
@@ -2043,7 +2043,8 @@ void make_tfrag3_data(std::map<u32, std::vector<GroupedDraw>>& draws,
       for (auto& strip : draw.strips) {
         tfrag3::StripDraw::VisGroup vgroup;
         vgroup.vis_idx_in_pc_bvh = strip.tfrag_id;  // associate with the tfrag for culling
-        vgroup.num = strip.verts.size() + 1;        // one for the primitive restart!
+        vgroup.num_inds = strip.verts.size() + 1;   // one for the primitive restart!
+        vgroup.num_tris = strip.verts.size() - 2;
 
         tdraw.num_triangles += strip.verts.size() - 2;
         tfrag3::StripDraw::VertexRun run;
@@ -2127,7 +2128,8 @@ void merge_groups(std::vector<tfrag3::StripDraw::VisGroup>& grps) {
   result.push_back(grps.at(0));
   for (size_t i = 1; i < grps.size(); i++) {
     if (grps[i].vis_idx_in_pc_bvh == result.back().vis_idx_in_pc_bvh) {
-      result.back().num += grps[i].num;
+      result.back().num_inds += grps[i].num_inds;
+      result.back().num_tris += grps[i].num_tris;
     } else {
       result.push_back(grps[i]);
     }

--- a/decompiler/level_extractor/extract_tie.cpp
+++ b/decompiler/level_extractor/extract_tie.cpp
@@ -2211,8 +2211,9 @@ void add_vertices_and_static_draw(tfrag3::TieTree& tree,
 
             // now we have a draw, time to add vertices
             tfrag3::StripDraw::VisGroup vgroup;
-            vgroup.vis_idx_in_pc_bvh = inst.vis_id;  // associate with the instance for culling
-            vgroup.num = strip.verts.size() + 1;     // one for the primitive restart!
+            vgroup.vis_idx_in_pc_bvh = inst.vis_id;    // associate with the instance for culling
+            vgroup.num_inds = strip.verts.size() + 1;  // one for the primitive restart!
+            vgroup.num_tris = strip.verts.size() - 2;
             draw_to_add_to->num_triangles += strip.verts.size() - 2;
             tfrag3::PackedTieVertices::MatrixGroup grp;
             grp.matrix_idx = matrix_idx;
@@ -2275,7 +2276,8 @@ void merge_groups(std::vector<tfrag3::StripDraw::VisGroup>& grps) {
   result.push_back(grps.at(0));
   for (size_t i = 1; i < grps.size(); i++) {
     if (grps[i].vis_idx_in_pc_bvh == result.back().vis_idx_in_pc_bvh) {
-      result.back().num += grps[i].num;
+      result.back().num_tris += grps[i].num_tris;
+      result.back().num_inds += grps[i].num_inds;
     } else {
       result.push_back(grps[i]);
     }

--- a/game/graphics/opengl_renderer/Loader.cpp
+++ b/game/graphics/opengl_renderer/Loader.cpp
@@ -118,17 +118,11 @@ void Loader::loader_thread() {
     for (auto& tie_tree : result->tie_trees) {
       for (auto& tree : tie_tree) {
         tree.unpack();
-        for (auto& d : tree.static_draws) {
-          d.unpack();
-        }
       }
     }
     for (auto& t_tree : result->tfrag_trees) {
       for (auto& tree : t_tree) {
         tree.unpack();
-        for (auto& d : tree.draws) {
-          d.unpack();
-        }
       }
     }
 

--- a/game/graphics/opengl_renderer/background/Shrub.h
+++ b/game/graphics/opengl_renderer/background/Shrub.h
@@ -31,7 +31,6 @@ class Shrub : public BucketRenderer {
     GLuint vertex_buffer;
     GLuint index_buffer;
     GLuint time_of_day_texture;
-    std::vector<u32> index_list;
     GLuint vao;
     u32 vert_count;
     const std::vector<tfrag3::ShrubDraw>* draws = nullptr;
@@ -39,17 +38,9 @@ class Shrub : public BucketRenderer {
     const std::vector<tfrag3::TimeOfDayColor>* colors = nullptr;
     SwizzledTimeOfDay tod_cache;
 
-    std::vector<std::array<math::Vector4f, 4>> wind_matrix_cache;
-
-    bool has_wind = false;
-    GLuint wind_vertex_index_buffer;
-    std::vector<u32> wind_vertex_index_offsets;
-
     struct {
-      u32 index_upload = 0;
       u32 verts = 0;
       u32 draws = 0;
-      u32 full_draws = 0;  // ones that have all visible
       u32 wind_draws = 0;
       Filtered<float> cull_time;
       Filtered<float> index_time;
@@ -71,7 +62,9 @@ class Shrub : public BucketRenderer {
   bool m_has_level = false;
 
   struct Cache {
-    std::vector<std::pair<int, int>> draw_idx_temp;
+    std::vector<std::pair<int, int>> multidraw_offset_per_stripdraw;
+    std::vector<GLsizei> multidraw_count_buffer;
+    std::vector<void*> multidraw_index_offset_buffer;
   } m_cache;
   TfragPcPortData m_pc_port_data;
 };

--- a/game/graphics/opengl_renderer/background/TFragment.h
+++ b/game/graphics/opengl_renderer/background/TFragment.h
@@ -46,7 +46,6 @@ class TFragment : public BucketRenderer {
  private:
   void handle_initialization(DmaFollower& dma);
 
-  std::string m_debug_string;
   bool m_child_mode = false;
   bool m_hack_test_many_levels = false;
   bool m_override_time_of_day = false;

--- a/game/graphics/opengl_renderer/background/Tfrag3.h
+++ b/game/graphics/opengl_renderer/background/Tfrag3.h
@@ -60,7 +60,6 @@ class Tfrag3 {
     tfrag3::TFragmentTreeKind kind;
     GLuint vertex_buffer = -1;
     GLuint index_buffer = -1;
-    std::vector<u32> index_list;
     GLuint time_of_day_texture;
     GLuint vao;
     u32 vert_count = 0;
@@ -84,7 +83,9 @@ class Tfrag3 {
 
   struct Cache {
     std::vector<u8> vis_temp;
-    std::vector<std::pair<int, int>> draw_idx_temp;
+    std::vector<std::pair<int, int>> multidraw_offset_per_stripdraw;
+    std::vector<GLsizei> multidraw_count_buffer;
+    std::vector<void*> multidraw_index_offset_buffer;
   } m_cache;
 
   std::string m_level_name;

--- a/game/graphics/opengl_renderer/background/Tie3.h
+++ b/game/graphics/opengl_renderer/background/Tie3.h
@@ -52,7 +52,6 @@ class Tie3 : public BucketRenderer {
     GLuint vertex_buffer;
     GLuint index_buffer;
     GLuint time_of_day_texture;
-    std::vector<u32> index_list;
     GLuint vao;
     u32 vert_count;
     const std::vector<tfrag3::StripDraw>* draws = nullptr;
@@ -69,10 +68,8 @@ class Tie3 : public BucketRenderer {
     std::vector<u32> wind_vertex_index_offsets;
 
     struct {
-      u32 index_upload = 0;
       u32 verts = 0;
       u32 draws = 0;
-      u32 full_draws = 0;  // ones that have all visible
       u32 wind_draws = 0;
       Filtered<float> cull_time;
       Filtered<float> index_time;
@@ -90,7 +87,9 @@ class Tie3 : public BucketRenderer {
 
   struct Cache {
     std::vector<u8> vis_temp;
-    std::vector<std::pair<int, int>> draw_idx_temp;
+    std::vector<std::pair<int, int>> multidraw_offset_per_stripdraw;
+    std::vector<GLsizei> multidraw_count_buffer;
+    std::vector<void*> multidraw_index_offset_buffer;
   } m_cache;
 
   std::vector<math::Vector<u8, 4>> m_color_result;

--- a/game/graphics/opengl_renderer/background/background_common.cpp
+++ b/game/graphics/opengl_renderer/background/background_common.cpp
@@ -483,82 +483,77 @@ void cull_check_all_slow(const math::Vector4f* planes,
   }
 }
 
-u32 make_all_visible_index_list(std::pair<int, int>* group_out,
-                                u32* idx_out,
-                                const std::vector<tfrag3::StripDraw>& draws) {
-  int idx_buffer_ptr = 0;
+void make_all_visible_multidraws(std::pair<int, int>* draw_ptrs_out,
+                                 GLsizei* counts_out,
+                                 void** index_offsets_out,
+                                 const std::vector<tfrag3::ShrubDraw>& draws) {
+  u64 md_idx = 0;
   for (size_t i = 0; i < draws.size(); i++) {
     const auto& draw = draws[i];
+    u64 iidx = draw.first_index_index;
     std::pair<int, int> ds;
-    ds.first = idx_buffer_ptr;
-    memcpy(&idx_out[idx_buffer_ptr], draw.unpacked.vertex_index_stream.data(),
-           draw.unpacked.vertex_index_stream.size() * sizeof(u32));
-    idx_buffer_ptr += draw.unpacked.vertex_index_stream.size();
-    ds.second = idx_buffer_ptr;
-    group_out[i] = ds;
+    ds.first = md_idx;
+    ds.second = 1;
+    counts_out[md_idx] = draw.num_indices;
+    index_offsets_out[md_idx] = (void*)(iidx * sizeof(u32));
+    md_idx++;
+    draw_ptrs_out[i] = ds;
   }
-  return idx_buffer_ptr;
 }
 
-u32 make_all_visible_index_list(std::pair<int, int>* group_out,
-                                u32* idx_out,
-                                const std::vector<tfrag3::ShrubDraw>& draws) {
-  int idx_buffer_ptr = 0;
-  for (size_t i = 0; i < draws.size(); i++) {
-    const auto& draw = draws[i];
-    std::pair<int, int> ds;
-    ds.first = idx_buffer_ptr;
-    memcpy(&idx_out[idx_buffer_ptr], draw.vertex_index_stream.data(),
-           draw.vertex_index_stream.size() * sizeof(u32));
-    idx_buffer_ptr += draw.vertex_index_stream.size();
-    ds.second = idx_buffer_ptr;
-    group_out[i] = ds;
-  }
-  return idx_buffer_ptr;
-}
-
-u32 make_index_list_from_vis_string(std::pair<int, int>* group_out,
-                                    u32* idx_out,
+u32 make_multidraws_from_vis_string(std::pair<int, int>* draw_ptrs_out,
+                                    GLsizei* counts_out,
+                                    void** index_offsets_out,
                                     const std::vector<tfrag3::StripDraw>& draws,
                                     const std::vector<u8>& vis_data) {
-  int idx_buffer_ptr = 0;
+  u64 md_idx = 0;
+  u32 num_tris = 0;
   for (size_t i = 0; i < draws.size(); i++) {
     const auto& draw = draws[i];
-    int vtx_idx = 0;
+    u64 iidx = draw.unpacked.idx_of_first_idx_in_full_buffer;
     std::pair<int, int> ds;
-    ds.first = idx_buffer_ptr;
-    bool building_run = false;
-    int run_start_out = 0;
-    int run_start_in = 0;
+    ds.first = md_idx;
+    ds.second = 0;
     for (auto& grp : draw.vis_groups) {
-      bool vis = grp.vis_idx_in_pc_bvh == 0xffffffff || vis_data[grp.vis_idx_in_pc_bvh];
-      if (building_run) {
-        if (vis) {
-          idx_buffer_ptr += grp.num;
-        } else {
-          building_run = false;
-          idx_buffer_ptr += grp.num;
-          memcpy(&idx_out[run_start_out], &draw.unpacked.vertex_index_stream[run_start_in],
-                 (idx_buffer_ptr - run_start_out) * sizeof(u32));
-        }
-      } else {
-        if (vis) {
-          building_run = true;
-          run_start_out = idx_buffer_ptr;
-          run_start_in = vtx_idx;
-          idx_buffer_ptr += grp.num;
-        } else {
-        }
+      if (grp.vis_idx_in_pc_bvh == 0xffffffff || vis_data[grp.vis_idx_in_pc_bvh]) {
+        // visible!
+        // let's use a multidraw
+        counts_out[md_idx] = grp.num_inds;
+        index_offsets_out[md_idx] = (void*)(iidx * sizeof(u32));
+        ds.second++;
+        md_idx++;
+        num_tris += grp.num_tris;
       }
-      vtx_idx += grp.num;
+      iidx += grp.num_inds;
     }
-    if (building_run) {
-      memcpy(&idx_out[run_start_out], &draw.unpacked.vertex_index_stream[run_start_in],
-             (idx_buffer_ptr - run_start_out) * sizeof(u32));
-    }
-
-    ds.second = idx_buffer_ptr;
-    group_out[i] = ds;
+    draw_ptrs_out[i] = ds;
   }
-  return idx_buffer_ptr;
+  return num_tris;
+}
+
+u32 make_all_visible_multidraws(std::pair<int, int>* draw_ptrs_out,
+                                GLsizei* counts_out,
+                                void** index_offsets_out,
+                                const std::vector<tfrag3::StripDraw>& draws) {
+  u64 md_idx = 0;
+  u32 num_tris = 0;
+  for (size_t i = 0; i < draws.size(); i++) {
+    const auto& draw = draws[i];
+    u64 iidx = draw.unpacked.idx_of_first_idx_in_full_buffer;
+    std::pair<int, int> ds;
+    ds.first = md_idx;
+    ds.second = 0;
+    for (auto& grp : draw.vis_groups) {
+      // visible!
+      // let's use a multidraw
+      counts_out[md_idx] = grp.num_inds;
+      index_offsets_out[md_idx] = (void*)(iidx * sizeof(u32));
+      ds.second++;
+      md_idx++;
+      num_tris += grp.num_tris;
+      iidx += grp.num_inds;
+    }
+    draw_ptrs_out[i] = ds;
+  }
+  return num_tris;
 }

--- a/game/graphics/opengl_renderer/background/background_common.h
+++ b/game/graphics/opengl_renderer/background/background_common.h
@@ -60,13 +60,18 @@ struct TfragPcPortData {
   u32 tree_idx;
 };
 
-u32 make_index_list_from_vis_string(std::pair<int, int>* group_out,
-                                    u32* idx_out,
+void make_all_visible_multidraws(std::pair<int, int>* draw_ptrs_out,
+                                 GLsizei* counts_out,
+                                 void** index_offsets_out,
+                                 const std::vector<tfrag3::ShrubDraw>& draws);
+
+u32 make_all_visible_multidraws(std::pair<int, int>* draw_ptrs_out,
+                                GLsizei* counts_out,
+                                void** index_offsets_out,
+                                const std::vector<tfrag3::StripDraw>& draws);
+
+u32 make_multidraws_from_vis_string(std::pair<int, int>* draw_ptrs_out,
+                                    GLsizei* counts_out,
+                                    void** index_offsets_out,
                                     const std::vector<tfrag3::StripDraw>& draws,
                                     const std::vector<u8>& vis_data);
-u32 make_all_visible_index_list(std::pair<int, int>* group_out,
-                                u32* idx_out,
-                                const std::vector<tfrag3::StripDraw>& draws);
-u32 make_all_visible_index_list(std::pair<int, int>* group_out,
-                                u32* idx_out,
-                                const std::vector<tfrag3::ShrubDraw>& draws);


### PR DESCRIPTION
Switch non-wind TIE, all tfrag, and all shrub, to use `glMultiDrawElements`.  This updates the TFRAG3 format to version 14, so you'll need to extract levels after this change.

At the starting point, the frame time is 6.3ms now, down from 7.6ms.  I think there's probably another few hundred microseconds to gain from TIE wind improvements.