### PR TITLE
Enable framelimiter by default

### DIFF
--- a/game/graphics/opengl_renderer/debug_gui.h
+++ b/game/graphics/opengl_renderer/debug_gui.h
@@ -59,7 +59,7 @@ class OpenGlDebugGui {
 
   bool get_vsync_flag() { return m_vsync; }
 
-  bool framelimiter = false;
+  bool framelimiter = true;
   float target_fps = 60.f;
   bool experimental_accurate_lag = false;
   bool sleep_in_frame_limiter = true;


### PR DESCRIPTION
Flips a bool to keep the framelimiter on at boot, this helps people with refresh rates above 60hz as this is not a problem unless  you are on a 120hz/144hz monitor. 

I'm sure these settings will be reworked eventually into an .ini file or something but this is probably a useful addition in the meantime. 