### PR TITLE
Improve `ASSERT` macro, fix linux file paths in `Taskfile` and hopefully fix the windows release

### DIFF
--- a/.github/workflows/linter-workflow.yaml
+++ b/.github/workflows/linter-workflow.yaml
@@ -21,7 +21,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Get Package Dependencies
-        run: sudo apt install clang-format clang-tidy
+        run: |
+          sudo apt install clang-format clang-tidy
+          clang-format -version
 
       - name: Check Clang-Formatting
         run: |

--- a/.github/workflows/windows-workflow.yaml
+++ b/.github/workflows/windows-workflow.yaml
@@ -85,7 +85,7 @@ jobs:
         run: |
           mkdir -p ./ci-artifacts/out
           ./.github/scripts/releases/extract_build_windows.sh ./ci-artifacts/out ./
-          7z a -tzip ./ci-artifacts/windows.zip ./ci-artfacts/out
+          7z a -tzip ./ci-artifacts/windows.zip ./ci-artifacts/out
 
       - name: Upload Assets and Potential Publish Release
         if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler == 'clang'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,19 +13,19 @@ tasks:
       - '{{.DECOMP_BIN_RELEASE_DIR}}/decompiler "./decompiler/config/jak1_ntsc_black_label.jsonc" "./iso_data" "./decompiler_out" "decompile_code=false"'
   boot-game:
     preconditions:
-      - sh: test -f {{.DECOMP_BIN_RELEASE_DIR}}/gk{{.EXE_FILE_EXTENSION}}
+      - sh: test -f {{.GK_BIN_RELEASE_DIR}}/gk{{.EXE_FILE_EXTENSION}}
         msg: "Couldn't locate runtime executable -- Have you compiled in release mode?"
     cmds:
       - "{{.GK_BIN_RELEASE_DIR}}/gk -boot -fakeiso -debug -v"
   run-game:
     preconditions:
-      - sh: test -f {{.DECOMP_BIN_RELEASE_DIR}}/gk{{.EXE_FILE_EXTENSION}}
+      - sh: test -f {{.GK_BIN_RELEASE_DIR}}/gk{{.EXE_FILE_EXTENSION}}
         msg: "Couldn't locate runtime executable -- Have you compiled in release mode?"
     cmds:
       - "{{.GK_BIN_RELEASE_DIR}}/gk -fakeiso -debug -v"
   run-game-quiet:
     preconditions:
-      - sh: test -f {{.DECOMP_BIN_RELEASE_DIR}}/gk{{.EXE_FILE_EXTENSION}}
+      - sh: test -f {{.GK_BIN_RELEASE_DIR}}/gk{{.EXE_FILE_EXTENSION}}
         msg: "Couldn't locate runtime executable -- Have you compiled in release mode?"
     cmds:
       - "{{.GK_BIN_RELEASE_DIR}}/gk -fakeiso"
@@ -33,7 +33,7 @@ tasks:
     env:
       OPENGOAL_DECOMP_DIR: "jak1/"
     preconditions:
-      - sh: test -f {{.DECOMP_BIN_RELEASE_DIR}}/goalc{{.EXE_FILE_EXTENSION}}
+      - sh: test -f {{.GOALC_BIN_RELEASE_DIR}}/goalc{{.EXE_FILE_EXTENSION}}
         msg: "Couldn't locate compiler executable -- Have you compiled in release mode?"
     cmds:
       - "{{.GOALC_BIN_RELEASE_DIR}}/goalc"

--- a/common/audio/audio_formats.cpp
+++ b/common/audio/audio_formats.cpp
@@ -289,8 +289,7 @@ void test_encode_adpcm(const std::vector<s16>& samples,
       for (int i = 0; i < 5; i++) {
         fmt::print(" [{}] {} {}\n", i, filter_errors[i], filter_shifts[i]);
       }
-      fmt::print("prev: {} {}\n", prev_block_samples[0], prev_block_samples[1]);
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("prev: {} {}", prev_block_samples[0], prev_block_samples[1]));
     }
 
     prev_block_samples[0] = samples.at(block_idx * 28 + 27);

--- a/common/custom_data/TFrag3Data.cpp
+++ b/common/custom_data/TFrag3Data.cpp
@@ -235,10 +235,9 @@ void Texture::serialize(Serializer& ser) {
 
 void Level::serialize(Serializer& ser) {
   ser.from_ptr(&version);
-  if (ser.is_loading() && version != TFRAG3_VERSION) {
-    fmt::print("version mismatch when loading tfrag3 data. Got {}, expected {}\n", version,
-               TFRAG3_VERSION);
-    ASSERT(false);
+  if (true) {
+    ASSERT_MSG(false, fmt::format("version mismatch when loading tfrag3 data. Got {}, expected {}",
+                                  version, TFRAG3_VERSION));
   }
 
   ser.from_str(&level_name);
@@ -285,9 +284,9 @@ void Level::serialize(Serializer& ser) {
 
   ser.from_ptr(&version2);
   if (ser.is_loading() && version2 != TFRAG3_VERSION) {
-    fmt::print("version mismatch when loading tfrag3 data (at end). Got {}, expected {}\n",
-               version2, TFRAG3_VERSION);
-    ASSERT(false);
+    ASSERT_MSG(false, fmt::format(
+                          "version mismatch when loading tfrag3 data (at end). Got {}, expected {}",
+                          version2, TFRAG3_VERSION));
   }
 }
 

--- a/common/custom_data/TFrag3Data.cpp
+++ b/common/custom_data/TFrag3Data.cpp
@@ -235,7 +235,7 @@ void Texture::serialize(Serializer& ser) {
 
 void Level::serialize(Serializer& ser) {
   ser.from_ptr(&version);
-  if (true) {
+  if (ser.is_loading() && version != TFRAG3_VERSION) {
     ASSERT_MSG(false, fmt::format("version mismatch when loading tfrag3 data. Got {}, expected {}",
                                   version, TFRAG3_VERSION));
   }

--- a/common/dma/dma.cpp
+++ b/common/dma/dma.cpp
@@ -115,10 +115,8 @@ std::string VifCode::print() {
     }
 
     default:
-      fmt::print("Unhandled vif code {}\n", (int)kind);
-
       result = "???";
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("Unhandled vif code {}", (int)kind));
       break;
   }
   // TODO: the rest of the VIF code.

--- a/common/dma/dma.h
+++ b/common/dma/dma.h
@@ -91,8 +91,7 @@ inline void emulate_dma(const void* source_base, void* dest_base, u32 tadr, u32 
         // does this transfer anything in TTE???
         return;
       default:
-        printf("bad tag: %d\n", (int)tag.kind);
-        ASSERT(false);
+        ASSERT_MSG(false, fmt::format("bad tag: {}", (int)tag.kind));
     }
   }
 }

--- a/common/dma/dma.h
+++ b/common/dma/dma.h
@@ -9,6 +9,7 @@
 #include <cstring>
 #include "common/common_types.h"
 #include "common/util/Assert.h"
+#include "third-party/fmt/core.h"
 
 struct DmaStats {
   double sync_time_ms = 0;

--- a/common/util/Assert.cpp
+++ b/common/util/Assert.cpp
@@ -2,13 +2,14 @@
 #include <cstdlib>
 
 #include "Assert.h"
+#include <string_view>
 
 void private_assert_failed(const char* expr,
                            const char* file,
                            int line,
                            const char* function,
                            const char* msg) {
-  if ((msg != NULL) && (msg[0] == '\0')) {
+  if (!msg || msg[0] == '\0') {
     fprintf(stderr, "Assertion failed: '%s'\n\tSource: %s:%d\n\tFunction: %s\n", expr, file, line,
             function);
   } else {
@@ -16,5 +17,18 @@ void private_assert_failed(const char* expr,
             expr, msg, file, line, function);
   }
   fflush(stdout);  // ensure any stdout logs are flushed before we terminate
+  fflush(stderr);
   abort();
+}
+
+void private_assert_failed(const char* expr,
+                           const char* file,
+                           int line,
+                           const char* function,
+                           const std::string_view& msg) {
+  if (msg.empty()) {
+    private_assert_failed(expr, file, line, function);
+  } else {
+    private_assert_failed(expr, file, line, function, msg.data());
+  }
 }

--- a/common/util/Assert.cpp
+++ b/common/util/Assert.cpp
@@ -3,7 +3,18 @@
 
 #include "Assert.h"
 
-void private_assert_failed(const char* expr, const char* file, int line, const char* function) {
-  fprintf(stderr, "%s:%d: Assertion failed: %s\nFunction: %s\n", file, line, expr, function);
+void private_assert_failed(const char* expr,
+                           const char* file,
+                           int line,
+                           const char* function,
+                           const char* msg) {
+  if ((msg != NULL) && (msg[0] == '\0')) {
+    fprintf(stderr, "Assertion failed: '%s'\n\tSource: %s:%d\n\tFunction: %s\n", expr, file, line,
+            function);
+  } else {
+    fprintf(stderr, "Assertion failed: '%s'\n\tMessage: %s\n\tSource: %s:%d\n\tFunction: %s\n",
+            expr, msg, file, line, function);
+  }
+  fflush(stdout);  // ensure any stdout logs are flushed before we terminate
   abort();
 }

--- a/common/util/Assert.h
+++ b/common/util/Assert.h
@@ -3,15 +3,21 @@
  * Custom ASSERT macro
  */
 
-#include "third-party/fmt/core.h"
-
 #pragma once
+
+#include <string_view>
 
 [[noreturn]] void private_assert_failed(const char* expr,
                                         const char* file,
                                         int line,
                                         const char* function,
                                         const char* msg = "");
+
+[[noreturn]] void private_assert_failed(const char* expr,
+                                        const char* file,
+                                        int line,
+                                        const char* function,
+                                        const std::string_view& msg);
 
 #ifdef _WIN32
 #define __PRETTY_FUNCTION__ __FUNCSIG__
@@ -21,5 +27,4 @@
   (void)((EX) || (private_assert_failed(#EX, __FILE__, __LINE__, __PRETTY_FUNCTION__), 0))
 
 #define ASSERT_MSG(EXPR, STR) \
-  (void)((EXPR) ||            \
-         (private_assert_failed(#EXPR, __FILE__, __LINE__, __PRETTY_FUNCTION__, STR.c_str()), 0))
+  (void)((EXPR) || (private_assert_failed(#EXPR, __FILE__, __LINE__, __PRETTY_FUNCTION__, STR), 0))

--- a/common/util/Assert.h
+++ b/common/util/Assert.h
@@ -3,12 +3,15 @@
  * Custom ASSERT macro
  */
 
+#include "third-party/fmt/core.h"
+
 #pragma once
 
 [[noreturn]] void private_assert_failed(const char* expr,
                                         const char* file,
                                         int line,
-                                        const char* function);
+                                        const char* function,
+                                        const char* msg = "");
 
 #ifdef _WIN32
 #define __PRETTY_FUNCTION__ __FUNCSIG__
@@ -16,3 +19,7 @@
 
 #define ASSERT(EX) \
   (void)((EX) || (private_assert_failed(#EX, __FILE__, __LINE__, __PRETTY_FUNCTION__), 0))
+
+#define ASSERT_MSG(EXPR, STR) \
+  (void)((EXPR) ||            \
+         (private_assert_failed(#EXPR, __FILE__, __LINE__, __PRETTY_FUNCTION__, STR.c_str()), 0))

--- a/common/util/FileUtil.cpp
+++ b/common/util/FileUtil.cpp
@@ -425,8 +425,7 @@ void MakeISOName(char* dst, const char* src) {
 
 void assert_file_exists(const char* path, const char* error_message) {
   if (!std::filesystem::exists(path)) {
-    fprintf(stderr, "File %s was not found: %s\n", path, error_message);
-    ASSERT(false);
+    ASSERT_MSG(false, fmt::format("File {} was not found: {}", path, error_message));
   }
 }
 

--- a/common/util/SmallVector.h
+++ b/common/util/SmallVector.h
@@ -61,8 +61,12 @@ class SmallVector {
   typename std::aligned_storage<sizeof(T), alignof(T)>::type m_inline[inline_elt_count];
 
   // get a T* at the beginning of our inline storage.
-  constexpr const T* inline_begin() const { return launder(reinterpret_cast<const T*>(m_inline)); }
-  constexpr T* inline_begin() { return launder(reinterpret_cast<T*>(m_inline)); }
+  constexpr const T* inline_begin() const {
+    return launder(reinterpret_cast<const T*>(m_inline));
+  }
+  constexpr T* inline_begin() {
+    return launder(reinterpret_cast<T*>(m_inline));
+  }
 
   // regardless of our storage mode, these hold the beginning and end of the storage.
   // by default, they are initialized to the inline storage.
@@ -86,7 +90,9 @@ class SmallVector {
   /*!
    * Free heap storage, without calling destructors of objects.
    */
-  void free_heap_storage(T* ptr) { delete[] launder(reinterpret_cast<uint8_t*>(ptr)); }
+  void free_heap_storage(T* ptr) {
+    delete[] launder(reinterpret_cast<uint8_t*>(ptr));
+  }
 
   /*!
    * Set the current storage to the inline memory.
@@ -98,7 +104,9 @@ class SmallVector {
     m_storage_end = inline_begin() + inline_elt_count;
   }
 
-  bool using_heap_storage() const { return m_storage_begin != inline_begin(); }
+  bool using_heap_storage() const {
+    return m_storage_begin != inline_begin();
+  }
 
   /*!
    * Allocate (if needed) storage to hold size objects.
@@ -200,7 +208,9 @@ class SmallVector {
   /*!
    * Constructor a SmallVector. By default the size is 0 and no elements are constructed.
    */
-  SmallVector() { initialize_storage_and_size(0); }
+  SmallVector() {
+    initialize_storage_and_size(0);
+  }
 
   /*!
    * Initialize vector with count elements that are default initialized
@@ -340,7 +350,9 @@ class SmallVector {
   /*!
    * See note on other assign.
    */
-  void assign(std::initializer_list<T> lst) { *this = SmallVector<T, inline_elt_count>(lst); }
+  void assign(std::initializer_list<T> lst) {
+    *this = SmallVector<T, inline_elt_count>(lst);
+  }
 
   /*!
    * Get the element at the index. Assert the index is valid.
@@ -361,59 +373,103 @@ class SmallVector {
   /*!
    * Get the element at the index. No range checking.
    */
-  T& operator[](std::size_t idx) { return m_storage_begin[idx]; }
+  T& operator[](std::size_t idx) {
+    return m_storage_begin[idx];
+  }
 
   /*!
    * Get the element at the index. No range checking.
    */
-  const T& operator[](std::size_t idx) const { return m_storage_begin[idx]; }
+  const T& operator[](std::size_t idx) const {
+    return m_storage_begin[idx];
+  }
 
   /*!
    * Get the first element. Not valid if size == 0
    */
-  T& front() { return m_storage_begin[0]; }
+  T& front() {
+    return m_storage_begin[0];
+  }
 
   /*!
    * Get the first element. Not valid if size == 0
    */
-  const T& front() const { return m_storage_begin[0]; }
+  const T& front() const {
+    return m_storage_begin[0];
+  }
 
   /*!
    * Get the last element. Not valid if size == 0
    */
-  T& back() { return m_storage_begin[m_size - 1]; }
+  T& back() {
+    return m_storage_begin[m_size - 1];
+  }
 
   /*!
    * Get the last element. Not valid if size == 0
    */
-  const T& back() const { return m_storage_begin[m_size - 1]; }
+  const T& back() const {
+    return m_storage_begin[m_size - 1];
+  }
 
   /*!
    * Get a pointer to data. This may become invalid after any resize, just like a std::vector.
    */
-  T* data() { return m_storage_begin; }
+  T* data() {
+    return m_storage_begin;
+  }
 
   /*!
    * Get a pointer to data. This may become invalid after any resize, just like a std::vector.
    */
-  const T* data() const { return m_storage_begin; }
+  const T* data() const {
+    return m_storage_begin;
+  }
 
-  iterator begin() { return m_storage_begin; }
-  const_iterator begin() const { return m_storage_begin; }
-  const_iterator cbegin() const { return m_storage_begin; }
-  iterator end() { return m_storage_begin + m_size; }
-  const_iterator end() const { return m_storage_begin + m_size; }
-  const_iterator cend() const { return m_storage_begin + m_size; }
+  iterator begin() {
+    return m_storage_begin;
+  }
+  const_iterator begin() const {
+    return m_storage_begin;
+  }
+  const_iterator cbegin() const {
+    return m_storage_begin;
+  }
+  iterator end() {
+    return m_storage_begin + m_size;
+  }
+  const_iterator end() const {
+    return m_storage_begin + m_size;
+  }
+  const_iterator cend() const {
+    return m_storage_begin + m_size;
+  }
 
-  reverse_iterator rbegin() { return m_storage_begin + m_size; }
-  const_reverse_iterator rbegin() const { return m_storage_begin + m_size; }
-  const_reverse_iterator crbegin() const { return m_storage_begin + m_size; }
-  reverse_iterator rend() { return m_storage_begin; }
-  const_reverse_iterator rend() const { return m_storage_begin; }
-  const_reverse_iterator crend() const { return m_storage_begin; }
+  reverse_iterator rbegin() {
+    return m_storage_begin + m_size;
+  }
+  const_reverse_iterator rbegin() const {
+    return m_storage_begin + m_size;
+  }
+  const_reverse_iterator crbegin() const {
+    return m_storage_begin + m_size;
+  }
+  reverse_iterator rend() {
+    return m_storage_begin;
+  }
+  const_reverse_iterator rend() const {
+    return m_storage_begin;
+  }
+  const_reverse_iterator crend() const {
+    return m_storage_begin;
+  }
 
-  bool empty() const { return m_size == 0; }
-  std::size_t size() const { return m_size; }
+  bool empty() const {
+    return m_size == 0;
+  }
+  std::size_t size() const {
+    return m_size;
+  }
 
   /*!
    * Make sure we have enough storage to hold desired_count without allocating.
@@ -439,7 +495,9 @@ class SmallVector {
   /*!
    * The number of elements we can hold without allocating more memory.
    */
-  std::size_t capacity() const { return m_storage_end - m_storage_begin; }
+  std::size_t capacity() const {
+    return m_storage_end - m_storage_begin;
+  }
 
   /*!
    * Shrink our heap allocation to the smallest possible size that can possibly hold the
@@ -544,7 +602,9 @@ class SmallVector {
     m_size++;
   }
 
-  void pop_back() { m_size--; }
+  void pop_back() {
+    m_size--;
+  }
 
   void relocate_some_and_destroy_rest(T* dst,
                                       T* src,

--- a/common/util/SmallVector.h
+++ b/common/util/SmallVector.h
@@ -61,12 +61,8 @@ class SmallVector {
   typename std::aligned_storage<sizeof(T), alignof(T)>::type m_inline[inline_elt_count];
 
   // get a T* at the beginning of our inline storage.
-  constexpr const T* inline_begin() const {
-    return launder(reinterpret_cast<const T*>(m_inline));
-  }
-  constexpr T* inline_begin() {
-    return launder(reinterpret_cast<T*>(m_inline));
-  }
+  constexpr const T* inline_begin() const { return launder(reinterpret_cast<const T*>(m_inline)); }
+  constexpr T* inline_begin() { return launder(reinterpret_cast<T*>(m_inline)); }
 
   // regardless of our storage mode, these hold the beginning and end of the storage.
   // by default, they are initialized to the inline storage.
@@ -90,9 +86,7 @@ class SmallVector {
   /*!
    * Free heap storage, without calling destructors of objects.
    */
-  void free_heap_storage(T* ptr) {
-    delete[] launder(reinterpret_cast<uint8_t*>(ptr));
-  }
+  void free_heap_storage(T* ptr) { delete[] launder(reinterpret_cast<uint8_t*>(ptr)); }
 
   /*!
    * Set the current storage to the inline memory.
@@ -104,9 +98,7 @@ class SmallVector {
     m_storage_end = inline_begin() + inline_elt_count;
   }
 
-  bool using_heap_storage() const {
-    return m_storage_begin != inline_begin();
-  }
+  bool using_heap_storage() const { return m_storage_begin != inline_begin(); }
 
   /*!
    * Allocate (if needed) storage to hold size objects.
@@ -208,9 +200,7 @@ class SmallVector {
   /*!
    * Constructor a SmallVector. By default the size is 0 and no elements are constructed.
    */
-  SmallVector() {
-    initialize_storage_and_size(0);
-  }
+  SmallVector() { initialize_storage_and_size(0); }
 
   /*!
    * Initialize vector with count elements that are default initialized
@@ -350,9 +340,7 @@ class SmallVector {
   /*!
    * See note on other assign.
    */
-  void assign(std::initializer_list<T> lst) {
-    *this = SmallVector<T, inline_elt_count>(lst);
-  }
+  void assign(std::initializer_list<T> lst) { *this = SmallVector<T, inline_elt_count>(lst); }
 
   /*!
    * Get the element at the index. Assert the index is valid.
@@ -373,103 +361,59 @@ class SmallVector {
   /*!
    * Get the element at the index. No range checking.
    */
-  T& operator[](std::size_t idx) {
-    return m_storage_begin[idx];
-  }
+  T& operator[](std::size_t idx) { return m_storage_begin[idx]; }
 
   /*!
    * Get the element at the index. No range checking.
    */
-  const T& operator[](std::size_t idx) const {
-    return m_storage_begin[idx];
-  }
+  const T& operator[](std::size_t idx) const { return m_storage_begin[idx]; }
 
   /*!
    * Get the first element. Not valid if size == 0
    */
-  T& front() {
-    return m_storage_begin[0];
-  }
+  T& front() { return m_storage_begin[0]; }
 
   /*!
    * Get the first element. Not valid if size == 0
    */
-  const T& front() const {
-    return m_storage_begin[0];
-  }
+  const T& front() const { return m_storage_begin[0]; }
 
   /*!
    * Get the last element. Not valid if size == 0
    */
-  T& back() {
-    return m_storage_begin[m_size - 1];
-  }
+  T& back() { return m_storage_begin[m_size - 1]; }
 
   /*!
    * Get the last element. Not valid if size == 0
    */
-  const T& back() const {
-    return m_storage_begin[m_size - 1];
-  }
+  const T& back() const { return m_storage_begin[m_size - 1]; }
 
   /*!
    * Get a pointer to data. This may become invalid after any resize, just like a std::vector.
    */
-  T* data() {
-    return m_storage_begin;
-  }
+  T* data() { return m_storage_begin; }
 
   /*!
    * Get a pointer to data. This may become invalid after any resize, just like a std::vector.
    */
-  const T* data() const {
-    return m_storage_begin;
-  }
+  const T* data() const { return m_storage_begin; }
 
-  iterator begin() {
-    return m_storage_begin;
-  }
-  const_iterator begin() const {
-    return m_storage_begin;
-  }
-  const_iterator cbegin() const {
-    return m_storage_begin;
-  }
-  iterator end() {
-    return m_storage_begin + m_size;
-  }
-  const_iterator end() const {
-    return m_storage_begin + m_size;
-  }
-  const_iterator cend() const {
-    return m_storage_begin + m_size;
-  }
+  iterator begin() { return m_storage_begin; }
+  const_iterator begin() const { return m_storage_begin; }
+  const_iterator cbegin() const { return m_storage_begin; }
+  iterator end() { return m_storage_begin + m_size; }
+  const_iterator end() const { return m_storage_begin + m_size; }
+  const_iterator cend() const { return m_storage_begin + m_size; }
 
-  reverse_iterator rbegin() {
-    return m_storage_begin + m_size;
-  }
-  const_reverse_iterator rbegin() const {
-    return m_storage_begin + m_size;
-  }
-  const_reverse_iterator crbegin() const {
-    return m_storage_begin + m_size;
-  }
-  reverse_iterator rend() {
-    return m_storage_begin;
-  }
-  const_reverse_iterator rend() const {
-    return m_storage_begin;
-  }
-  const_reverse_iterator crend() const {
-    return m_storage_begin;
-  }
+  reverse_iterator rbegin() { return m_storage_begin + m_size; }
+  const_reverse_iterator rbegin() const { return m_storage_begin + m_size; }
+  const_reverse_iterator crbegin() const { return m_storage_begin + m_size; }
+  reverse_iterator rend() { return m_storage_begin; }
+  const_reverse_iterator rend() const { return m_storage_begin; }
+  const_reverse_iterator crend() const { return m_storage_begin; }
 
-  bool empty() const {
-    return m_size == 0;
-  }
-  std::size_t size() const {
-    return m_size;
-  }
+  bool empty() const { return m_size == 0; }
+  std::size_t size() const { return m_size; }
 
   /*!
    * Make sure we have enough storage to hold desired_count without allocating.
@@ -495,9 +439,7 @@ class SmallVector {
   /*!
    * The number of elements we can hold without allocating more memory.
    */
-  std::size_t capacity() const {
-    return m_storage_end - m_storage_begin;
-  }
+  std::size_t capacity() const { return m_storage_end - m_storage_begin; }
 
   /*!
    * Shrink our heap allocation to the smallest possible size that can possibly hold the
@@ -602,9 +544,7 @@ class SmallVector {
     m_size++;
   }
 
-  void pop_back() {
-    m_size--;
-  }
+  void pop_back() { m_size--; }
 
   void relocate_some_and_destroy_rest(T* dst,
                                       T* src,

--- a/common/util/Timer.h
+++ b/common/util/Timer.h
@@ -26,13 +26,9 @@ class Timer {
   /*!
    * Get milliseconds elapsed
    */
-  double getMs() const {
-    return (double)getNs() / 1.e6;
-  }
+  double getMs() const { return (double)getNs() / 1.e6; }
 
-  double getUs() const {
-    return (double)getNs() / 1.e3;
-  }
+  double getUs() const { return (double)getNs() / 1.e3; }
 
   /*!
    * Get nanoseconds elapsed
@@ -42,9 +38,7 @@ class Timer {
   /*!
    * Get seconds elapsed
    */
-  double getSeconds() const {
-    return (double)getNs() / 1.e9;
-  }
+  double getSeconds() const { return (double)getNs() / 1.e9; }
 
   struct timespec _startTime = {};
 };

--- a/common/util/Timer.h
+++ b/common/util/Timer.h
@@ -26,9 +26,13 @@ class Timer {
   /*!
    * Get milliseconds elapsed
    */
-  double getMs() const { return (double)getNs() / 1.e6; }
+  double getMs() const {
+    return (double)getNs() / 1.e6;
+  }
 
-  double getUs() const { return (double)getNs() / 1.e3; }
+  double getUs() const {
+    return (double)getNs() / 1.e3;
+  }
 
   /*!
    * Get nanoseconds elapsed
@@ -38,7 +42,9 @@ class Timer {
   /*!
    * Get seconds elapsed
    */
-  double getSeconds() const { return (double)getNs() / 1.e9; }
+  double getSeconds() const {
+    return (double)getNs() / 1.e9;
+  }
 
   struct timespec _startTime = {};
 };

--- a/common/util/compress.cpp
+++ b/common/util/compress.cpp
@@ -4,6 +4,7 @@
 #include "compress.h"
 #include "third-party/zstd/lib/zstd.h"
 #include "common/util/Assert.h"
+#include "third-party/fmt/core.h"
 
 namespace compression {
 

--- a/common/util/compress.cpp
+++ b/common/util/compress.cpp
@@ -17,8 +17,7 @@ std::vector<u8> compress_zstd(const void* data, size_t size) {
   auto compressed_size =
       ZSTD_compress(result.data() + sizeof(size_t), max_compressed, data, size, 1);
   if (ZSTD_isError(compressed_size)) {
-    printf("ZSTD error: %s\n", ZSTD_getErrorName(compressed_size));
-    ASSERT(false);
+    ASSERT_MSG(false, fmt::format("ZSTD error: {}", ZSTD_getErrorName(compressed_size)));
   }
   result.resize(sizeof(size_t) + compressed_size);
   return result;
@@ -38,8 +37,7 @@ std::vector<u8> decompress_zstd(const void* data, size_t size) {
   auto decomp_size = ZSTD_decompress(result.data(), decompressed_size,
                                      (const u8*)data + sizeof(size_t), compressed_size);
   if (ZSTD_isError(decomp_size)) {
-    printf("ZSTD error: %s\n", ZSTD_getErrorName(compressed_size));
-    ASSERT(false);
+    ASSERT_MSG(false, fmt::format("ZSTD error: {}", ZSTD_getErrorName(compressed_size)));
   }
 
   ASSERT(decomp_size == decompressed_size);

--- a/decompiler/Disasm/InstructionParser.cpp
+++ b/decompiler/Disasm/InstructionParser.cpp
@@ -383,8 +383,7 @@ Instruction InstructionParser::parse_single_instruction(
         } else if (thing == "ni") {
           instr.il = 0;
         } else {
-          printf("Bad interlock specification. Got %s\n", thing.c_str());
-          ASSERT(false);
+          ASSERT_MSG(false, fmt::format("Bad interlock specification. Got {}", thing.c_str()));
         }
       } break;
 
@@ -399,14 +398,12 @@ Instruction InstructionParser::parse_single_instruction(
         } else if (thing == "w") {
           instr.cop2_bc = 3;
         } else {
-          printf("Bad broadcast. Got %s\n", thing.c_str());
-          ASSERT(false);
+          ASSERT_MSG(false, fmt::format("Bad broadcast. Got {}", thing.c_str()));
         }
       } break;
 
       default:
-        printf("missing DecodeType: %d\n", (int)step.decode);
-        ASSERT(false);
+        ASSERT_MSG(false, fmt::format("missing DecodeType: {}", (int)step.decode));
     }
   }
 

--- a/decompiler/Disasm/InstructionParser.cpp
+++ b/decompiler/Disasm/InstructionParser.cpp
@@ -4,6 +4,7 @@
 #include "common/common_types.h"
 #include "InstructionParser.h"
 #include "common/util/Assert.h"
+#include "third-party/fmt/core.h"
 
 namespace decompiler {
 InstructionParser::InstructionParser() {

--- a/decompiler/Disasm/Register.cpp
+++ b/decompiler/Disasm/Register.cpp
@@ -125,14 +125,12 @@ Register::Register(Reg::RegisterKind kind, uint32_t num) {
     case Reg::COP0:
     case Reg::VI:
       if (num > 32) {
-        fmt::print("RegisterKind: {}, greater than 32: {}\n", kind, num);
-        ASSERT(false);
+        ASSERT_MSG(false, fmt::format("RegisterKind: {}, greater than 32: {}", kind, num));
       }
       break;
     case Reg::SPECIAL:
       if (num > 4) {
-        fmt::print("Special RegisterKind: {}, greater than 4: {}\n", kind, num);
-        ASSERT(false);
+        ASSERT_MSG(false, fmt::format("Special RegisterKind: {}, greater than 4: {}", kind, num));
       }
       break;
     default:

--- a/decompiler/Function/CfgVtx.cpp
+++ b/decompiler/Function/CfgVtx.cpp
@@ -1307,8 +1307,7 @@ bool ControlFlowGraph::clean_up_asm_branches() {
         // build new sequence
         replaced = true;
         if (!b0->succ_branch) {
-          fmt::print("asm missing branch in block {}\n", b0->to_string());
-          ASSERT(false);
+          ASSERT_MSG(false, fmt::format("asm missing branch in block {}", b0->to_string()));
         }
         m_blocks.at(b0->succ_branch->get_first_block_id())->needs_label = true;
 

--- a/decompiler/IR2/Form.cpp
+++ b/decompiler/IR2/Form.cpp
@@ -626,8 +626,8 @@ goos::Object TranslatedAsmBranch::to_form_internal(const Env& env) const {
 
   if (m_branch_delay) {
     if (m_branch_delay->parent_element != this) {
-      fmt::print("bad ptr. Parent is {}\n", m_branch_delay->parent_element->to_string(env));
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("bad ptr. Parent is {}",
+                                    m_branch_delay->parent_element->to_string(env)));
     }
 
     ASSERT(m_branch_delay->parent_element->parent_form);
@@ -667,8 +667,8 @@ void TranslatedAsmBranch::collect_vars(RegAccessSet& vars, bool recursive) const
     m_branch_condition->collect_vars(vars, recursive);
     if (m_branch_delay) {
       if (m_branch_delay->parent_element != this) {
-        fmt::print("bad ptr. Parent is {}\n", (void*)m_branch_delay->parent_element);
-        ASSERT(false);
+        ASSERT_MSG(false,
+                   fmt::format("bad ptr. Parent is {}", (void*)m_branch_delay->parent_element));
       }
 
       for (auto& elt : m_branch_delay->elts()) {

--- a/decompiler/ObjectFile/LinkedObjectFile.cpp
+++ b/decompiler/ObjectFile/LinkedObjectFile.cpp
@@ -530,8 +530,8 @@ void LinkedObjectFile::process_fp_relative_links() {
               } break;
 
               default:
-                printf("unknown fp using op: %s\n", instr.to_string(labels).c_str());
-                ASSERT(false);
+                ASSERT_MSG(false,
+                           fmt::format("unknown fp using op: {}", instr.to_string(labels).c_str()));
             }
           }
         }
@@ -912,16 +912,14 @@ goos::Object LinkedObjectFile::to_form_script_object(int seg,
       } else {
         std::string debug;
         append_word_to_string(debug, word);
-        printf("don't know how to print %s\n", debug.c_str());
-        ASSERT(false);
+        ASSERT_MSG(false, fmt::format("don't know how to print {}", debug.c_str()));
       }
     } break;
 
     case 2:  // bad, a pair snuck through.
     default:
       // pointers should be aligned!
-      printf("align %d\n", byte_idx & 7);
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("align {}", byte_idx & 7));
   }
 
   return result;

--- a/decompiler/ObjectFile/LinkedObjectFileCreation.cpp
+++ b/decompiler/ObjectFile/LinkedObjectFileCreation.cpp
@@ -807,8 +807,7 @@ LinkedObjectFile to_linked_object_file(const std::vector<uint8_t>& data,
   } else if (header->version == 5) {
     link_v5(result, data, name, dts);
   } else {
-    printf("Unsupported version %d\n", header->version);
-    ASSERT(false);
+    ASSERT_MSG(false, fmt::format("Unsupported version {}", header->version));
   }
 
   return result;

--- a/decompiler/VuDisasm/VuDisassembler.cpp
+++ b/decompiler/VuDisasm/VuDisassembler.cpp
@@ -297,15 +297,13 @@ VuInstrK VuDisassembler::lower_kind(u32 in) {
       case 0b11110'1111'11:
         return VuInstrK::WAITP;
     }
-    fmt::print("Unknown lower special: 0b{:b}\n", in);
-    ASSERT(false);
+    ASSERT_MSG(false, fmt::format("Unknown lower special: 0b{:b}", in));
   } else {
     ASSERT((op & 0b1000000) == 0);
     ASSERT(op < 64);
     auto elt = m_lower_op6_table[(int)op];
     if (!elt.known) {
-      fmt::print("Invalid lower op6: 0b{:b} 0b{:b} 0x{:x}\n", op, in, in);
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("Invalid lower op6: 0b{:b} 0b{:b} 0x{:x}", op, in, in));
     }
     return elt.kind;
   }
@@ -370,13 +368,11 @@ VuInstrK VuDisassembler::upper_kind(u32 in) {
         break;
 
       default:
-        fmt::print("Invalid op11: 0b{:b}\n", upper_op11(in));
-        ASSERT(false);
+        ASSERT_MSG(false, fmt::format("Invalid op11: 0b{:b}", upper_op11(in)));
     }
   }
   if (!upper_info.known) {
-    fmt::print("Invalid upper op6: 0b{:b}\n", upper_op6(in));
-    ASSERT(false);
+    ASSERT_MSG(false, fmt::format("Invalid upper op6: 0b{:b}", upper_op6(in)));
   }
   return upper_info.kind;
 }
@@ -434,8 +430,7 @@ VuInstruction VuDisassembler::decode(VuInstrK kind, u32 data, int instr_idx) {
   instr.kind = kind;
   auto& inst = info(kind);
   if (!inst.known) {
-    fmt::print("instr idx {} is unknown\n", (int)kind);
-    ASSERT(false);
+    ASSERT_MSG(false, fmt::format("instr idx {} is unknown", (int)kind));
   }
   for (auto& step : inst.decode) {
     s64 value = -1;

--- a/decompiler/analysis/type_analysis.cpp
+++ b/decompiler/analysis/type_analysis.cpp
@@ -49,8 +49,7 @@ void modify_input_types_for_casts(
         state->get(cast.reg) = type_from_cast;
       }
     } catch (std::exception& e) {
-      printf("failed to parse hint: %s\n", e.what());
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("failed to parse hint: {}", e.what()));
     }
   }
 }

--- a/decompiler/config/jak1_ntsc_black_label/hacks.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/hacks.jsonc
@@ -423,7 +423,7 @@
     "draw-drawable-tree-ice-tfrag": [6, 8, 13, 15],
     "draw-drawable-tree-instance-tie": [10, 12, 18, 20, 26, 28, 37, 39],
     "draw-drawable-tree-instance-shrub": [5, 7, 9, 11],
-    
+
     "birth-pickup-at-point": [0],
     "draw-bones": [0, 1, 2, 8, 81],
     "draw-bones-hud": [7, 8],

--- a/decompiler/config/jak1_ntsc_black_label/label_types.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/label_types.jsonc
@@ -2106,9 +2106,7 @@
   ],
 
   "generic-vu0": [["L1", "vu-function"]],
-  "shrubbery": [
-    ["L133", "vu-function"]
-  ],
+  "shrubbery": [["L133", "vu-function"]],
 
   // please do not add things after this entry! git is dumb.
   "object-file-that-doesnt-actually-exist-and-i-just-put-this-here-to-prevent-merge-conflicts-with-this-file": []

--- a/decompiler/config/jak1_ntsc_black_label/type_casts.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label/type_casts.jsonc
@@ -7586,7 +7586,7 @@
     [[30, 38], "a2", "dma-packet"]
   ],
 
-  "draw-bones-shadow" : [
+  "draw-bones-shadow": [
     [10, "t0", "terrain-context"],
     [[36, 100], "t0", "shadow-dma-packet"],
     [[53, 58], "t6", "(inline-array vector)"],
@@ -7594,7 +7594,7 @@
     [[103, 106], "v1", "dma-packet"]
   ],
 
-  "shadow-execute-all" : [
+  "shadow-execute-all": [
     [108, "gp", "shadow-dcache"],
     [113, "gp", "shadow-dcache"],
     [118, "gp", "shadow-dcache"],
@@ -7605,7 +7605,7 @@
 
   "shadow-dma-init": [
     [[25, 29], "t6", "dma-packet"],
-    [[34,37], "t6", "gs-gif-tag"],
+    [[34, 37], "t6", "gs-gif-tag"],
     [41, "t4", "(pointer gs-reg)"],
     [43, "t4", "(pointer gs-reg)"],
     [45, "t4", "(pointer gs-test)"],
@@ -7690,9 +7690,7 @@
     [273, "t0", "(pointer uint64)"],
     [275, "t0", "(pointer gs-reg64)"]
   ],
-  "test-func": [
-    [7, "f1", "float"]
-  ],
+  "test-func": [[7, "f1", "float"]],
 
   "(method 14 drawable-tree-instance-shrub)": [
     [[12, 151], "gp", "prototype-bucket-shrub"],
@@ -7704,9 +7702,7 @@
     [151, "gp", "(inline-array prototype-bucket-shrub)"]
   ],
 
-  "(method 10 drawable-tree-instance-shrub)": [
-    [3, "a1", "terrain-context"]
-  ],
+  "(method 10 drawable-tree-instance-shrub)": [[3, "a1", "terrain-context"]],
 
   "draw-prototype-inline-array-shrub": [
     [[13, 55], "v1", "prototype-bucket-shrub"],
@@ -7740,13 +7736,9 @@
     [540, "v1", "terrain-context"]
   ],
 
-  "(method 8 drawable-tree-instance-shrub)": [
-    [54, "v1", "drawable-group"]
-  ],
+  "(method 8 drawable-tree-instance-shrub)": [[54, "v1", "drawable-group"]],
 
-  "draw-drawable-tree-instance-shrub": [
-    [85, "a0", "drawable-group"]
-  ],
+  "draw-drawable-tree-instance-shrub": [[85, "a0", "drawable-group"]],
 
   "shrub-init-frame": [
     [[6, 12], "a0", "dma-packet"],
@@ -7766,9 +7758,7 @@
     [54, "v1", "(pointer uint32)"]
   ],
 
-  "shrub-upload-view-data": [
-    [[3, 16], "a0", "dma-packet"]
-  ],
+  "shrub-upload-view-data": [[[3, 16], "a0", "dma-packet"]],
 
   "shrub-upload-model": [
     [[17, 26], "a3", "dma-packet"],
@@ -7776,8 +7766,6 @@
     [[47, 55], "a0", "dma-packet"]
   ],
 
-  "(method 12 effect-control)": [
-    ["_stack_", 112, "res-tag"]
-  ],
+  "(method 12 effect-control)": [["_stack_", 112, "res-tag"]],
   "placeholder-do-not-add-below": []
 }

--- a/decompiler/data/LinkedWordReader.h
+++ b/decompiler/data/LinkedWordReader.h
@@ -17,8 +17,7 @@ class LinkedWordReader {
       m_offset++;
       return result;
     } else {
-      ASSERT(false);
-      throw std::runtime_error("LinkedWordReader::get_type_tag failed");
+      ASSERT_MSG(false, fmt::format("LinkedWordReader::get_type_tag failed"));
     }
   }
 

--- a/decompiler/data/LinkedWordReader.h
+++ b/decompiler/data/LinkedWordReader.h
@@ -17,7 +17,7 @@ class LinkedWordReader {
       m_offset++;
       return result;
     } else {
-      ASSERT_MSG(false, fmt::format("LinkedWordReader::get_type_tag failed"));
+      ASSERT_MSG(false, "LinkedWordReader::get_type_tag failed");
     }
   }
 

--- a/decompiler/data/game_text.cpp
+++ b/decompiler/data/game_text.cpp
@@ -125,8 +125,7 @@ GameTextResult process_game_text(ObjectFileData& data, GameTextVersion version) 
     if (read_words[i] < 1) {
       std::string debug;
       data.linked_data.append_word_to_string(debug, words.at(i));
-      printf("[%d] %d 0x%s\n", i, int(read_words[i]), debug.c_str());
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("[{}] {} 0x{}", i, int(read_words[i]), debug.c_str()));
     }
   }
 

--- a/decompiler/data/tpage.cpp
+++ b/decompiler/data/tpage.cpp
@@ -276,7 +276,7 @@ Texture read_texture(ObjectFileData& data, const std::vector<LinkedWord>& words,
 
   auto kv = psms.find(tex.psm);
   if (kv == psms.end()) {
-    ASSERT_MSG(false, fmt::format("Got unsupported texture 0x{0:x}!", tex.psm));
+    ASSERT_MSG(false, fmt::format("Got unsupported texture 0x{:x}!", tex.psm));
   }
 
   return tex;

--- a/decompiler/data/tpage.cpp
+++ b/decompiler/data/tpage.cpp
@@ -276,8 +276,7 @@ Texture read_texture(ObjectFileData& data, const std::vector<LinkedWord>& words,
 
   auto kv = psms.find(tex.psm);
   if (kv == psms.end()) {
-    printf("Got unsupported texture 0x%x!\n", tex.psm);
-    ASSERT(false);
+    ASSERT_MSG(false, fmt::format("Got unsupported texture 0x{0:x}!", tex.psm));
   }
 
   return tex;

--- a/decompiler/level_extractor/BspHeader.cpp
+++ b/decompiler/level_extractor/BspHeader.cpp
@@ -298,8 +298,7 @@ void tfrag_debug_print_unpack(Ref start, int qwc_total) {
       case VifCode::Kind::NOP:
         break;
       default:
-        fmt::print("unknown: {}\n", next.print());
-        ASSERT(false);
+        ASSERT_MSG(false, fmt::format("unknown: {}", next.print()));
     }
   }
   fmt::print("-------------------------------------------\n");

--- a/decompiler/level_extractor/extract_level.cpp
+++ b/decompiler/level_extractor/extract_level.cpp
@@ -120,9 +120,8 @@ void confirm_textures_identical(TextureDB& tex_db) {
     } else {
       bool ok = it->second == tex.second.rgba_bytes;
       if (!ok) {
-        fmt::print("BAD duplicate: {} {} vs {}\n", name, tex.second.rgba_bytes.size(),
-                   it->second.size());
-        ASSERT(false);
+        ASSERT_MSG(false, fmt::format("BAD duplicate: {} {} vs {}", name,
+                                      tex.second.rgba_bytes.size(), it->second.size()));
       }
     }
   }

--- a/decompiler/level_extractor/extract_shrub.cpp
+++ b/decompiler/level_extractor/extract_shrub.cpp
@@ -129,7 +129,7 @@ u32 remap_texture(u32 original, const std::vector<level_tools::TextureRemap>& ma
   auto masked = original & 0xffffff00;
   for (auto& t : map) {
     if (t.original_texid == masked) {
-      ASSERT_MSG(false, fmt::format("OKAY! remapped!"));
+      ASSERT_MSG(false, "OKAY! remapped!");
       return t.new_texid | 20;
     }
   }

--- a/decompiler/level_extractor/extract_shrub.cpp
+++ b/decompiler/level_extractor/extract_shrub.cpp
@@ -129,8 +129,7 @@ u32 remap_texture(u32 original, const std::vector<level_tools::TextureRemap>& ma
   auto masked = original & 0xffffff00;
   for (auto& t : map) {
     if (t.original_texid == masked) {
-      fmt::print("OKAY! remapped!\n");
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("OKAY! remapped!"));
       return t.new_texid | 20;
     }
   }
@@ -502,14 +501,13 @@ void make_draws(tfrag3::Level& lev,
                 // we're missing a texture, just use the first one.
                 tex_it = tdb.textures.begin();
               } else {
-                fmt::print(
-                    "texture {} wasn't found. make sure it is loaded somehow. You may need to "
-                    "include "
-                    "ART.DGO or GAME.DGO in addition to the level DGOs for shared textures.\n",
-                    combo_tex);
-                fmt::print("tpage is {}\n", combo_tex >> 16);
-                fmt::print("id is {} (0x{:x})\n", combo_tex & 0xffff, combo_tex & 0xffff);
-                ASSERT(false);
+                ASSERT_MSG(
+                    false,
+                    fmt::format(
+                        "texture {} wasn't found. make sure it is loaded somehow. You may need to "
+                        "include ART.DGO or GAME.DGO in addition to the level DGOs for shared "
+                        "textures. tpage is {} id is {} (0x{:x})",
+                        combo_tex, combo_tex >> 16, combo_tex & 0xffff, combo_tex & 0xffff));
               }
             }
             // add a new texture to the level data

--- a/decompiler/level_extractor/extract_tfrag.cpp
+++ b/decompiler/level_extractor/extract_tfrag.cpp
@@ -2237,7 +2237,7 @@ void extract_tfrag(const level_tools::DrawableTreeTfrag* tree,
     } else if (tree->my_type() == "drawable-tree-trans-tfrag") {
       this_tree.kind = tfrag3::TFragmentTreeKind::TRANS;
     } else {
-      ASSERT(false, fmt::format("unknown tfrag tree kind: {}", tree->my_type()));
+      ASSERT_MSG(false, fmt::format("unknown tfrag tree kind: {}", tree->my_type()));
     }
 
     ASSERT(tree->length == (int)tree->arrays.size());

--- a/decompiler/level_extractor/extract_tfrag.cpp
+++ b/decompiler/level_extractor/extract_tfrag.cpp
@@ -1760,10 +1760,9 @@ void update_mode_from_alpha1(u64 val, DrawMode& mode) {
     mode.set_alpha_blend(DrawMode::AlphaBlend::SRC_0_FIX_DST);
     // src plus dest
   } else {
-    fmt::print("unsupported blend: a {} b {} c {} d {}\n", (int)reg.a_mode(), (int)reg.b_mode(),
-               (int)reg.c_mode(), (int)reg.d_mode());
     mode.set_alpha_blend(DrawMode::AlphaBlend::SRC_DST_SRC_DST);
-    ASSERT(false);
+    ASSERT_MSG(false, fmt::format("unsupported blend: a {} b {} c {} d {}", (int)reg.a_mode(),
+                                  (int)reg.b_mode(), (int)reg.c_mode(), (int)reg.d_mode()));
   }
 }
 
@@ -1786,9 +1785,8 @@ void update_mode_from_test1(u64 val, DrawMode& mode) {
       mode.set_alpha_test(DrawMode::AlphaTest::NEVER);
       break;
     default:
-      fmt::print("Alpha test: {} not supported\n", (int)test.alpha_test());
       mode.set_alpha_test(DrawMode::AlphaTest::ALWAYS);
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("Alpha test: {} not supported", (int)test.alpha_test()));
   }
 
   // AREF
@@ -1909,8 +1907,7 @@ void process_draw_mode(std::vector<TFragDraw>& all_draws,
           break;
         case GsRegisterAddress::CLAMP_1:
           if (!(val == 0b101 || val == 0 || val == 1 || val == 0b100)) {
-            fmt::print("clamp: 0x{:x}\n", val);
-            ASSERT(false);
+            ASSERT_MSG(false, fmt::format("clamp: 0x{:x}", val));
           }
 
           // this isn't quite right, but I'm hoping it's enough!
@@ -2014,13 +2011,14 @@ void make_tfrag3_data(std::map<u32, std::vector<GroupedDraw>>& draws,
           // we're missing a texture, just use the first one.
           tex_it = tdb.textures.begin();
         } else {
-          fmt::print(
-              "texture {} wasn't found. make sure it is loaded somehow. You may need to include "
-              "ART.DGO or GAME.DGO in addition to the level DGOs for shared textures.\n",
-              combo_tex_id);
-          fmt::print("tpage is {}\n", combo_tex_id >> 16);
-          fmt::print("id is {} (0x{:x})\n", combo_tex_id & 0xffff, combo_tex_id & 0xffff);
-          ASSERT(false);
+          ASSERT_MSG(
+              false,
+              fmt::format("texture {} wasn't found. make sure it is loaded somehow. You may need "
+                          "to include "
+                          "ART.DGO or GAME.DGO in addition to the level DGOs for shared textures."
+                          "tpage is {}. id is {} (0x{:x})",
+                          combo_tex_id, combo_tex_id >> 16, combo_tex_id & 0xffff,
+                          combo_tex_id & 0xffff));
         }
       }
       tfrag3_tex_id = texture_pool.size();
@@ -2239,8 +2237,7 @@ void extract_tfrag(const level_tools::DrawableTreeTfrag* tree,
     } else if (tree->my_type() == "drawable-tree-trans-tfrag") {
       this_tree.kind = tfrag3::TFragmentTreeKind::TRANS;
     } else {
-      fmt::print("unknown tfrag tree kind: {}\n", tree->my_type());
-      ASSERT(false);
+      ASSERT(false, fmt::format("unknown tfrag tree kind: {}", tree->my_type()));
     }
 
     ASSERT(tree->length == (int)tree->arrays.size());

--- a/decompiler/level_extractor/extract_tie.cpp
+++ b/decompiler/level_extractor/extract_tie.cpp
@@ -464,8 +464,7 @@ u32 remap_texture(u32 original, const std::vector<level_tools::TextureRemap>& ma
   auto masked = original & 0xffffff00;
   for (auto& t : map) {
     if (t.original_texid == masked) {
-      fmt::print("OKAY! remapped!\n");
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("OKAY! remapped!"));
       return t.new_texid | 20;
     }
   }
@@ -2012,8 +2011,7 @@ DrawMode process_draw_mode(const AdgifInfo& info, bool use_atest, bool use_decal
   // the clamp matters
   if (!(info.clamp_val == 0b101 || info.clamp_val == 0 || info.clamp_val == 1 ||
         info.clamp_val == 0b100)) {
-    fmt::print("clamp: 0x{:x}\n", info.clamp_val);
-    ASSERT(false);
+    ASSERT(false, fmt::format("clamp: 0x{:x}", info.clamp_val));
   }
 
   mode.set_clamp_s_enable(info.clamp_val & 0b1);
@@ -2104,14 +2102,13 @@ void add_vertices_and_static_draw(tfrag3::TieTree& tree,
                 // we're missing a texture, just use the first one.
                 tex_it = tdb.textures.begin();
               } else {
-                fmt::print(
-                    "texture {} wasn't found. make sure it is loaded somehow. You may need to "
-                    "include "
-                    "ART.DGO or GAME.DGO in addition to the level DGOs for shared textures.\n",
-                    combo_tex);
-                fmt::print("tpage is {}\n", combo_tex >> 16);
-                fmt::print("id is {} (0x{:x})\n", combo_tex & 0xffff, combo_tex & 0xffff);
-                ASSERT(false);
+                ASSERT_MSG(
+                    false,
+                    fmt::format(
+                        "texture {} wasn't found. make sure it is loaded somehow. You may need to "
+                        "include ART.DGO or GAME.DGO in addition to the level DGOs for shared "
+                        "textures. tpage is {}. id is {} (0x{:x})",
+                        combo_tex, combo_tex >> 16, combo_tex & 0xffff, combo_tex & 0xffff));
               }
             }
             // add a new texture to the level data

--- a/decompiler/level_extractor/extract_tie.cpp
+++ b/decompiler/level_extractor/extract_tie.cpp
@@ -2011,7 +2011,7 @@ DrawMode process_draw_mode(const AdgifInfo& info, bool use_atest, bool use_decal
   // the clamp matters
   if (!(info.clamp_val == 0b101 || info.clamp_val == 0 || info.clamp_val == 1 ||
         info.clamp_val == 0b100)) {
-    ASSERT(false, fmt::format("clamp: 0x{:x}", info.clamp_val));
+    ASSERT_MSG(false, fmt::format("clamp: 0x{:x}", info.clamp_val));
   }
 
   mode.set_clamp_s_enable(info.clamp_val & 0b1);

--- a/decompiler/level_extractor/extract_tie.cpp
+++ b/decompiler/level_extractor/extract_tie.cpp
@@ -464,7 +464,7 @@ u32 remap_texture(u32 original, const std::vector<level_tools::TextureRemap>& ma
   auto masked = original & 0xffffff00;
   for (auto& t : map) {
     if (t.original_texid == masked) {
-      ASSERT_MSG(false, fmt::format("OKAY! remapped!"));
+      ASSERT_MSG(false, "OKAY! remapped!");
       return t.new_texid | 20;
     }
   }

--- a/game/graphics/opengl_renderer/DirectRenderer.cpp
+++ b/game/graphics/opengl_renderer/DirectRenderer.cpp
@@ -253,8 +253,7 @@ void DirectRenderer::update_gl_prim(SharedRenderState* render_state) {
         case GsTest::AlphaTest::NEVER:
           break;
         default:
-          fmt::print("unknown alpha test: {}\n", (int)m_test_state.alpha_test);
-          ASSERT(false);
+          ASSERT_MSG(false, fmt::format("unknown alpha test: {}", (int)m_test_state.alpha_test));
       }
     }
 
@@ -618,9 +617,8 @@ void DirectRenderer::render_gif(const u8* data,
 
   if (size != UINT32_MAX) {
     if ((offset + 15) / 16 != size / 16) {
-      fmt::print("DirectRenderer size failed in {}\n", name_and_id());
-      fmt::print("expected: {}, got: {}\n", size, offset);
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("DirectRenderer size failed in {}. expected: {}, got: {}",
+                                    name_and_id(), size, offset));
     }
   }
 
@@ -693,8 +691,7 @@ void DirectRenderer::handle_ad(const u8* data,
       }
       break;
     default:
-      fmt::print("Address {} is not supported\n", register_address_name(addr));
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("Address {} is not supported", register_address_name(addr)));
   }
 }
 
@@ -1053,8 +1050,8 @@ void DirectRenderer::handle_xyzf2_common(u32 x,
       }
     } break;
     default:
-      fmt::print("prim type {} is unsupported in {}.\n", (int)m_prim_building.kind, name_and_id());
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("prim type {} is unsupported in {}.", (int)m_prim_building.kind,
+                                    name_and_id()));
   }
 }
 

--- a/game/graphics/opengl_renderer/DirectRenderer2.cpp
+++ b/game/graphics/opengl_renderer/DirectRenderer2.cpp
@@ -235,8 +235,7 @@ void DirectRenderer2::setup_opengl_for_draw_mode(const Draw& draw,
       case DrawMode::AlphaTest::NEVER:
         break;
       default:
-        fmt::print("unknown alpha test: {}\n", (int)draw.mode.get_alpha_test());
-        ASSERT(false);
+        ASSERT_MSG(false, fmt::format("unknown alpha test: {}", (int)draw.mode.get_alpha_test()));
     }
   }
 
@@ -540,8 +539,7 @@ void DirectRenderer2::handle_ad(const u8* data) {
     case GsRegisterAddress::TEXFLUSH:
       break;
     default:
-      fmt::print("Address {} is not supported\n", register_address_name(addr));
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("Address {} is not supported", register_address_name(addr)));
   }
 }
 

--- a/game/graphics/opengl_renderer/GenericProgram.cpp
+++ b/game/graphics/opengl_renderer/GenericProgram.cpp
@@ -358,8 +358,7 @@ void GenericRenderer::mscal_dispatch(int imm, SharedRenderState* render_state, S
       mscal_noclip_nopipe(render_state, prof);
       return;
     default:
-      fmt::print("Generic dispatch mscal: {}\n", imm);
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("Generic dispatch mscal: {}", imm));
   }
 
   L33: // R

--- a/game/graphics/opengl_renderer/GenericRenderer.cpp
+++ b/game/graphics/opengl_renderer/GenericRenderer.cpp
@@ -51,8 +51,7 @@ void GenericRenderer::render(DmaFollower& dma,
         case VifCode::Kind::NOP:
           break;
         default:
-          fmt::print("unknown vifcode0 empty tag: {}\n", v0.print());
-          ASSERT(false);
+          ASSERT_MSG(false, fmt::format("unknown vifcode0 empty tag: {}", v0.print()));
       }
       switch (v1.kind) {
         case VifCode::Kind::STCYCL:
@@ -64,8 +63,7 @@ void GenericRenderer::render(DmaFollower& dma,
           mscal(v1.immediate, render_state, prof);
           break;
         default:
-          fmt::print("unknown vifcode1 empty tag: {}\n", v1.print());
-          ASSERT(false);
+          ASSERT_MSG(false, fmt::format("unknown vifcode1 empty tag: {}", v1.print()));
       }
     } else if (v0.kind == VifCode::Kind::FLUSHA && v1.kind == VifCode::Kind::DIRECT) {
       if (render_state->use_direct2) {
@@ -129,11 +127,9 @@ void GenericRenderer::render(DmaFollower& dma,
         ASSERT(false);
       }
     } else {
-      fmt::print("Generic encountered unknown DMA.\n");
-      fmt::print("Size bytes: {}\n", data.size_bytes);
-      fmt::print("VIF0: {}\n", data.vifcode0().print());
-      fmt::print("VIF1: {}\n", data.vifcode1().print());
-      ASSERT(false);
+      ASSERT_MSG(false,
+                 fmt::format("Generic encountered unknown DMA. Size bytes: {}. VIF0: {}. VIF1: {}",
+                             data.size_bytes, data.vifcode0().print(), data.vifcode1().print()));
     }
     m_skipped_tags++;
   }
@@ -182,10 +178,9 @@ void GenericRenderer::handle_dma_stream(const u8* data,
         mscal(vc.immediate, render_state, prof);
         break;
       default:
-        fmt::print("Generic encountered unknown DMA in handle_dma_stream.\n");
-        fmt::print("Bytes remaining: {}\n", bytes);
-        fmt::print("VIF: {}\n", vc.print());
-        ASSERT(false);
+        ASSERT_MSG(false, fmt::format("Generic encountered unknown DMA in handle_dma_stream. Bytes "
+                                      "remaining: {}. VIF: {}",
+                                      bytes, vc.print()));
     }
   }
 }

--- a/game/graphics/opengl_renderer/MercProgram.cpp
+++ b/game/graphics/opengl_renderer/MercProgram.cpp
@@ -3141,8 +3141,7 @@ ASSERT(false);
   case 0x539:
     goto JUMP_539;
   default:
-    fmt::print("bad jump to {:x}\n", vu.vi08);
-  ASSERT(false);
+    ASSERT_MSG(false, fmt::format("bad jump to {:x}", vu.vi08));
   }
   L94:
   // 3072.0                     |  mulax.xyzw ACC, vf01, vf11 :i

--- a/game/graphics/opengl_renderer/MercRenderer.cpp
+++ b/game/graphics/opengl_renderer/MercRenderer.cpp
@@ -247,8 +247,7 @@ void MercRenderer::handle_merc_chain(DmaFollower& dma,
       }
       break;
     default:
-      fmt::print("unknown mscal: {}\n", mscal_addr);
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("unknown mscal: {}", mscal_addr));
   }
 
   //  while (true) {

--- a/game/graphics/opengl_renderer/ShadowRenderer.cpp
+++ b/game/graphics/opengl_renderer/ShadowRenderer.cpp
@@ -96,8 +96,8 @@ void ShadowRenderer::xgkick(u16 imm) {
                   // fmt::print("rgba: {} {} {} {}: {}\n", rgba[0], rgba[1], rgba[2], rgba[3], Q);
                 } break;
                 default:
-                  fmt::print("Address {} is not supported\n", register_address_name(addr));
-                  ASSERT(false);
+                  ASSERT_MSG(false, fmt::format("Address {} is not supported",
+                                                register_address_name(addr)));
               }
             } break;
             case GifTag::RegisterDescriptor::ST: {
@@ -308,8 +308,7 @@ void ShadowRenderer::render(DmaFollower& dma,
       dma.read_and_advance();
 
     } else {
-      fmt::print("{} {}\n", next.vifcode0().print(), next.vifcode1().print());
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("{} {}", next.vifcode0().print(), next.vifcode1().print()));
     }
   }
 

--- a/game/graphics/opengl_renderer/Shadow_PS2.cpp
+++ b/game/graphics/opengl_renderer/Shadow_PS2.cpp
@@ -131,8 +131,7 @@ void ShadowRenderer::handle_jalr_to_end_block(u16 val, u32& first_flag, u32& sec
       // nop                        |  nop                            739
       return;
     default:
-      fmt::print("unhandled end block: {}\n", val);
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("unhandled end block: {}", val));
   }
 }
 
@@ -1715,8 +1714,7 @@ void ShadowRenderer::run_mscal_vu2c(u16 imm) {
     case 699:
       goto INSTR_699;
     default:
-      fmt::print("unknown vu.vi15 @ L46: {}\n", vu.vi15);
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("unknown vu.vi15 @ L46: {}", vu.vi15));
   }
   // clang-format off
   // nop                        |  nop                            663
@@ -1890,7 +1888,6 @@ void ShadowRenderer::run_mscal_vu2c(u16 imm) {
     case 527:
       goto INSTR_527;
     default:
-      fmt::print("unknown vu.vi15 @ 722: {}\n", vu.vi15);
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("unknown vu.vi15 @ 722: {}", vu.vi15));
   }
 }

--- a/game/graphics/opengl_renderer/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/Sprite3.cpp
@@ -577,8 +577,7 @@ void Sprite3::handle_clamp(u64 val,
                            SharedRenderState* /*render_state*/,
                            ScopedProfilerNode& /*prof*/) {
   if (!(val == 0b101 || val == 0 || val == 1 || val == 0b100)) {
-    fmt::print("clamp: 0x{:x}\n", val);
-    ASSERT(false);
+    ASSERT_MSG(false, fmt::format("clamp: 0x{:x}", val));
   }
 
   m_current_mode.set_clamp_s_enable(val & 0b001);

--- a/game/graphics/opengl_renderer/SpriteRenderer.cpp
+++ b/game/graphics/opengl_renderer/SpriteRenderer.cpp
@@ -526,8 +526,7 @@ void SpriteRenderer::handle_clamp(u64 val,
                                   SharedRenderState* /*render_state*/,
                                   ScopedProfilerNode& /*prof*/) {
   if (!(val == 0b101 || val == 0 || val == 1 || val == 0b100)) {
-    fmt::print("clamp: 0x{:x}\n", val);
-    ASSERT(false);
+    ASSERT_MSG(false, fmt::format("clamp: 0x{:x}", val));
   }
 
   m_adgif_state.reg_clamp = val;

--- a/game/graphics/opengl_renderer/foreground/Generic2_DMA.cpp
+++ b/game/graphics/opengl_renderer/foreground/Generic2_DMA.cpp
@@ -180,8 +180,7 @@ u32 Generic2::handle_fragments_after_unpack_v4_32(const u8* data,
   // continue in this transfer
   off += first_unpack_bytes;
   if (off == end_of_vif) {
-    fmt::print("nothing after header upload\n");
-    ASSERT(false);
+    ASSERT(false, fmt::format("nothing after header upload"));
   }
 
   // the next thing is the vertex positions.

--- a/game/graphics/opengl_renderer/foreground/Generic2_DMA.cpp
+++ b/game/graphics/opengl_renderer/foreground/Generic2_DMA.cpp
@@ -180,7 +180,7 @@ u32 Generic2::handle_fragments_after_unpack_v4_32(const u8* data,
   // continue in this transfer
   off += first_unpack_bytes;
   if (off == end_of_vif) {
-    ASSERT_MSG(false, fmt::format("nothing after header upload"));
+    ASSERT_MSG(false, "nothing after header upload");
   }
 
   // the next thing is the vertex positions.

--- a/game/graphics/opengl_renderer/foreground/Generic2_DMA.cpp
+++ b/game/graphics/opengl_renderer/foreground/Generic2_DMA.cpp
@@ -180,7 +180,7 @@ u32 Generic2::handle_fragments_after_unpack_v4_32(const u8* data,
   // continue in this transfer
   off += first_unpack_bytes;
   if (off == end_of_vif) {
-    ASSERT(false, fmt::format("nothing after header upload"));
+    ASSERT_MSG(false, fmt::format("nothing after header upload"));
   }
 
   // the next thing is the vertex positions.

--- a/game/graphics/opengl_renderer/foreground/Generic2_OpenGL.cpp
+++ b/game/graphics/opengl_renderer/foreground/Generic2_OpenGL.cpp
@@ -106,8 +106,7 @@ void Generic2::setup_opengl_for_draw_mode(const DrawMode& draw_mode,
       case DrawMode::AlphaTest::NEVER:
         break;
       default:
-        fmt::print("unknown alpha test: {}\n", (int)draw_mode.get_alpha_test());
-        ASSERT(false);
+        ASSERT(false, fmt::format("unknown alpha test: {}", (int)draw_mode.get_alpha_test()));
     }
   }
 

--- a/game/graphics/opengl_renderer/foreground/Generic2_OpenGL.cpp
+++ b/game/graphics/opengl_renderer/foreground/Generic2_OpenGL.cpp
@@ -106,7 +106,7 @@ void Generic2::setup_opengl_for_draw_mode(const DrawMode& draw_mode,
       case DrawMode::AlphaTest::NEVER:
         break;
       default:
-        ASSERT(false, fmt::format("unknown alpha test: {}", (int)draw_mode.get_alpha_test()));
+        ASSERT_MSG(false, fmt::format("unknown alpha test: {}", (int)draw_mode.get_alpha_test()));
     }
   }
 

--- a/game/graphics/opengl_renderer/ocean/OceanMid.cpp
+++ b/game/graphics/opengl_renderer/ocean/OceanMid.cpp
@@ -122,12 +122,10 @@ void OceanMid::run(DmaFollower& dma, SharedRenderState* render_state, ScopedProf
           run_call43_vu2c();
           break;
         default:
-          fmt::print("unknown call2: {}\n", v0.immediate);
-          ASSERT(false);
+          ASSERT_MSG(false, fmt::format("unknown call2: {}", v0.immediate));
       }
     } else {
-      fmt::print("{} {}\n", data.vifcode0().print(), data.vifcode1().print());
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("{} {}", data.vifcode0().print(), data.vifcode1().print()));
     }
   }
   m_common_ocean_renderer.flush_mid(render_state, prof);

--- a/game/graphics/opengl_renderer/ocean/OceanNear.cpp
+++ b/game/graphics/opengl_renderer/ocean/OceanNear.cpp
@@ -102,8 +102,7 @@ void OceanNear::render(DmaFollower& dma,
           run_call39_vu2c();
           break;
         default:
-          fmt::print("unknown ocean near call: {}\n", v0.immediate);
-          ASSERT(false);
+          ASSERT_MSG(false, fmt::format("unknown ocean near call: {}", v0.immediate));
       }
     }
   }

--- a/game/kernel/klink.cpp
+++ b/game/kernel/klink.cpp
@@ -18,6 +18,7 @@
 #include "common/goal_constants.h"
 #include "game/mips2c/mips2c_table.h"
 #include "common/util/Assert.h"
+#include "third-party/fmt/core.h"
 
 namespace {
 // turn on printf's for debugging linking issues.
@@ -143,7 +144,7 @@ void link_control::begin(Ptr<uint8_t> object_file,
         }
       }
     } else {
-      ASSERT_MSG(false, fmt::format("UNHANDLED OBJECT FILE VERSION"));
+      ASSERT_MSG(false, "UNHANDLED OBJECT FILE VERSION");
     }
 
     if ((m_flags & LINK_FLAG_FORCE_DEBUG) && MasterDebug && !DiskBoot) {

--- a/game/kernel/klink.cpp
+++ b/game/kernel/klink.cpp
@@ -143,8 +143,7 @@ void link_control::begin(Ptr<uint8_t> object_file,
         }
       }
     } else {
-      printf("UNHANDLED OBJECT FILE VERSION\n");
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("UNHANDLED OBJECT FILE VERSION"));
     }
 
     if ((m_flags & LINK_FLAG_FORCE_DEBUG) && MasterDebug && !DiskBoot) {
@@ -254,8 +253,7 @@ uint32_t link_control::work() {
     ASSERT(!m_opengoal);
     rv = work_v2();
   } else {
-    printf("UNHANDLED OBJECT FILE VERSION %d IN WORK!\n", m_version);
-    ASSERT(false);
+    ASSERT_MSG(false, fmt::format("UNHANDLED OBJECT FILE VERSION {} IN WORK!", m_version));
     return 0;
   }
 
@@ -502,8 +500,7 @@ uint32_t link_control::work_v3() {
               lp = lp + ptr_link_v3(lp, ofh, m_segment_process);
               break;
             default:
-              printf("unknown link table thing %d\n", *lp);
-              ASSERT(false);
+              ASSERT_MSG(false, fmt::format("unknown link table thing {}", *lp));
               break;
           }
         }

--- a/game/kernel/kscheme.cpp
+++ b/game/kernel/kscheme.cpp
@@ -1213,8 +1213,7 @@ u64 call_method_of_type_arg2(u32 arg, Ptr<Type> type, u32 method_id, u32 a1, u32
               (*type_tag).offset);
     }
   }
-  printf("[ERROR] call_method_of_type_arg2 failed!\n");
-  ASSERT(false);
+  ASSERT_MSG(false, fmt::format("[ERROR] call_method_of_type_arg2 failed!"));
   return arg;
 }
 

--- a/game/kernel/kscheme.cpp
+++ b/game/kernel/kscheme.cpp
@@ -1213,7 +1213,7 @@ u64 call_method_of_type_arg2(u32 arg, Ptr<Type> type, u32 method_id, u32 a1, u32
               (*type_tag).offset);
     }
   }
-  ASSERT_MSG(false, fmt::format("[ERROR] call_method_of_type_arg2 failed!"));
+  ASSERT_MSG(false, "[ERROR] call_method_of_type_arg2 failed!");
   return arg;
 }
 

--- a/game/mips2c/functions/generic_merc.cpp
+++ b/game/mips2c/functions/generic_merc.cpp
@@ -1921,8 +1921,7 @@ void vcallms_311(ExecutionContext* c, u16* vis) {
       vcallms_311_case_427(c, vis);
       break;
     default:
-      fmt::print("BAD JUMP {}\n", vis[vi01]);
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("BAD JUMP {}", vis[vi01]));
   }
 }
 
@@ -1955,8 +1954,7 @@ void vcallms_311_reference(ExecutionContext* c, u16* vis) {
     case 427:
       goto JUMP_427;
     default:
-      fmt::print("BAD JUMP {}\n", vis[vi01]);
-      ASSERT(false);
+      ASSERT_MSG(false, fmt::format("BAD JUMP {}", vis[vi01]));
   }
 
   JUMP_314:

--- a/game/mips2c/mips2c_private.h
+++ b/game/mips2c/mips2c_private.h
@@ -886,9 +886,13 @@ struct ExecutionContext {
     Q = vf_src(src0).f[(int)bc0] / std::sqrt(std::abs(vf_src(src1).f[(int)bc1]));
   }
 
-  void vsqrt(int src, BC bc) { Q = std::sqrt(std::abs(vf_src(src).f[(int)bc])); }
+  void vsqrt(int src, BC bc) {
+    Q = std::sqrt(std::abs(vf_src(src).f[(int)bc]));
+  }
 
-  void sqrts(int src, int dst) { fprs[dst] = std::sqrt(std::abs(fprs[src])); }
+  void sqrts(int src, int dst) {
+    fprs[dst] = std::sqrt(std::abs(fprs[src]));
+  }
 
   void vmulq(DEST mask, int dst, int src) {
     auto s0 = vf_src(src);
@@ -908,7 +912,9 @@ struct ExecutionContext {
     }
   }
 
-  void vrxor(int src, BC bc) { gRng.rxor(vf_src(src).du32[(int)bc]); }
+  void vrxor(int src, BC bc) {
+    gRng.rxor(vf_src(src).du32[(int)bc]);
+  }
 
   void vaddq(DEST mask, int dst, int src) {
     auto s = vf_src(src);
@@ -938,7 +944,9 @@ struct ExecutionContext {
     }
   }
 
-  void mov64(int dest, int src) { gprs[dest].ds64[0] = gpr_src(src).du64[0]; }
+  void mov64(int dest, int src) {
+    gprs[dest].ds64[0] = gpr_src(src).du64[0];
+  }
 
   void vmove(DEST mask, int dest, int src) {
     auto s = vf_src(src);
@@ -973,22 +981,40 @@ struct ExecutionContext {
     gprs[dst].ds64[0] = value_signed;
   }
 
-  void dsra(int dst, int src, int sa) { gprs[dst].ds64[0] = gpr_src(src).ds64[0] >> sa; }
-  void dsrl(int dst, int src, int sa) { gprs[dst].du64[0] = gpr_src(src).du64[0] >> sa; }
+  void dsra(int dst, int src, int sa) {
+    gprs[dst].ds64[0] = gpr_src(src).ds64[0] >> sa;
+  }
+  void dsrl(int dst, int src, int sa) {
+    gprs[dst].du64[0] = gpr_src(src).du64[0] >> sa;
+  }
   void dsrav(int dst, int src, int sa) {
     gprs[dst].ds64[0] = gpr_src(src).ds64[0] >> gpr_src(sa).du32[0];
   }
   void dsllv(int dst, int src, int sa) {
     gprs[dst].ds64[0] = gpr_src(src).ds64[0] << (gpr_src(sa).du32[0] & 0b111111);
   }
-  void dsra32(int dst, int src, int sa) { gprs[dst].ds64[0] = gpr_src(src).ds64[0] >> (32 + sa); }
-  void dsrl32(int dst, int src, int sa) { gprs[dst].du64[0] = gpr_src(src).du64[0] >> (32 + sa); }
-  void sra(int dst, int src, int sa) { gprs[dst].ds64[0] = gpr_src(src).ds32[0] >> sa; }
-  void dsll(int dst, int src0, int sa) { gprs[dst].du64[0] = gpr_src(src0).du64[0] << sa; }
-  void dsll32(int dst, int src0, int sa) { gprs[dst].du64[0] = gpr_src(src0).du64[0] << (32 + sa); }
+  void dsra32(int dst, int src, int sa) {
+    gprs[dst].ds64[0] = gpr_src(src).ds64[0] >> (32 + sa);
+  }
+  void dsrl32(int dst, int src, int sa) {
+    gprs[dst].du64[0] = gpr_src(src).du64[0] >> (32 + sa);
+  }
+  void sra(int dst, int src, int sa) {
+    gprs[dst].ds64[0] = gpr_src(src).ds32[0] >> sa;
+  }
+  void dsll(int dst, int src0, int sa) {
+    gprs[dst].du64[0] = gpr_src(src0).du64[0] << sa;
+  }
+  void dsll32(int dst, int src0, int sa) {
+    gprs[dst].du64[0] = gpr_src(src0).du64[0] << (32 + sa);
+  }
 
-  void daddu(int dst, int src0, int src1) { gprs[dst].du64[0] = sgpr64(src0) + sgpr64(src1); }
-  void daddiu(int dst, int src0, s64 imm) { gprs[dst].du64[0] = sgpr64(src0) + imm; }
+  void daddu(int dst, int src0, int src1) {
+    gprs[dst].du64[0] = sgpr64(src0) + sgpr64(src1);
+  }
+  void daddiu(int dst, int src0, s64 imm) {
+    gprs[dst].du64[0] = sgpr64(src0) + imm;
+  }
   void addiu(int dst, int src0, s64 imm) {
     s32 temp = sgpr64(src0) + imm;
     gprs[dst].ds64[0] = temp;
@@ -1004,12 +1030,18 @@ struct ExecutionContext {
     gprs[dst].ds64[0] = temp;
   }
 
-  void dsubu(int dst, int src0, int src1) { gprs[dst].du64[0] = sgpr64(src0) - sgpr64(src1); }
+  void dsubu(int dst, int src0, int src1) {
+    gprs[dst].du64[0] = sgpr64(src0) - sgpr64(src1);
+  }
   void subu(int dst, int src0, int src1) {
     gprs[dst].ds64[0] = gpr_src(src0).ds32[0] - gpr_src(src1).ds32[0];
   }
-  void xor_(int dst, int src0, int src1) { gprs[dst].du64[0] = sgpr64(src0) ^ sgpr64(src1); }
-  void or_(int dst, int src0, int src1) { gprs[dst].du64[0] = sgpr64(src0) | sgpr64(src1); }
+  void xor_(int dst, int src0, int src1) {
+    gprs[dst].du64[0] = sgpr64(src0) ^ sgpr64(src1);
+  }
+  void or_(int dst, int src0, int src1) {
+    gprs[dst].du64[0] = sgpr64(src0) | sgpr64(src1);
+  }
 
   void movz(int dst, int src0, int src1) {
     if (sgpr64(src1) == 0) {
@@ -1035,9 +1067,15 @@ struct ExecutionContext {
     gprs[dst].ds64[0] = sresult;
   }
 
-  void xori(int dest, int src, u64 imm) { gprs[dest].du64[0] = gpr_src(src).du64[0] ^ imm; }
-  void andi(int dest, int src, u64 imm) { gprs[dest].du64[0] = gpr_src(src).du64[0] & imm; }
-  void ori(int dest, int src, u64 imm) { gprs[dest].du64[0] = gpr_src(src).du64[0] | imm; }
+  void xori(int dest, int src, u64 imm) {
+    gprs[dest].du64[0] = gpr_src(src).du64[0] ^ imm;
+  }
+  void andi(int dest, int src, u64 imm) {
+    gprs[dest].du64[0] = gpr_src(src).du64[0] & imm;
+  }
+  void ori(int dest, int src, u64 imm) {
+    gprs[dest].du64[0] = gpr_src(src).du64[0] | imm;
+  }
   void and_(int dest, int src0, int src1) {
     gprs[dest].du64[0] = gpr_src(src0).du64[0] & gpr_src(src1).du64[0];
   }
@@ -1141,9 +1179,15 @@ struct ExecutionContext {
     }
   }
 
-  void mov128_vf_gpr(int dst, int src) { memcpy(vfs[dst].f, gpr_src(src).f, 16); }
-  void mov128_gpr_vf(int dst, int src) { memcpy(gprs[dst].f, vf_src(src).f, 16); }
-  void mov128_gpr_gpr(int dst, int src) { gprs[dst] = gpr_src(src); }
+  void mov128_vf_gpr(int dst, int src) {
+    memcpy(vfs[dst].f, gpr_src(src).f, 16);
+  }
+  void mov128_gpr_vf(int dst, int src) {
+    memcpy(gprs[dst].f, vf_src(src).f, 16);
+  }
+  void mov128_gpr_gpr(int dst, int src) {
+    gprs[dst] = gpr_src(src);
+  }
 
   void vitof0(DEST mask, int dst, int src) {
     auto s = vf_src(src);
@@ -1210,9 +1254,15 @@ struct ExecutionContext {
     memcpy(&fprs[dst], &val, 4);
   }
 
-  void muls(int dst, int src0, int src1) { fprs[dst] = fprs[src0] * fprs[src1]; }
-  void adds(int dst, int src0, int src1) { fprs[dst] = fprs[src0] + fprs[src1]; }
-  void subs(int dst, int src0, int src1) { fprs[dst] = fprs[src0] - fprs[src1]; }
+  void muls(int dst, int src0, int src1) {
+    fprs[dst] = fprs[src0] * fprs[src1];
+  }
+  void adds(int dst, int src0, int src1) {
+    fprs[dst] = fprs[src0] + fprs[src1];
+  }
+  void subs(int dst, int src0, int src1) {
+    fprs[dst] = fprs[src0] - fprs[src1];
+  }
   void divs_accurate(int dst, int src0, int src1) {
     if (fprs[src1] == 0) {
       if (fprs[src0] < 0) {
@@ -1235,8 +1285,12 @@ struct ExecutionContext {
     memcpy(&fprs[dst], &v, 4);
   }
 
-  void movs(int dst, int src) { fprs[dst] = fprs[src]; }
-  void abss(int dst, int src) { fprs[dst] = std::abs(fprs[src]); }
+  void movs(int dst, int src) {
+    fprs[dst] = fprs[src];
+  }
+  void abss(int dst, int src) {
+    fprs[dst] = std::abs(fprs[src]);
+  }
 
   void cvtws(int dst, int src) {
     // float to int

--- a/game/mips2c/mips2c_private.h
+++ b/game/mips2c/mips2c_private.h
@@ -886,13 +886,9 @@ struct ExecutionContext {
     Q = vf_src(src0).f[(int)bc0] / std::sqrt(std::abs(vf_src(src1).f[(int)bc1]));
   }
 
-  void vsqrt(int src, BC bc) {
-    Q = std::sqrt(std::abs(vf_src(src).f[(int)bc]));
-  }
+  void vsqrt(int src, BC bc) { Q = std::sqrt(std::abs(vf_src(src).f[(int)bc])); }
 
-  void sqrts(int src, int dst) {
-    fprs[dst] = std::sqrt(std::abs(fprs[src]));
-  }
+  void sqrts(int src, int dst) { fprs[dst] = std::sqrt(std::abs(fprs[src])); }
 
   void vmulq(DEST mask, int dst, int src) {
     auto s0 = vf_src(src);
@@ -912,9 +908,7 @@ struct ExecutionContext {
     }
   }
 
-  void vrxor(int src, BC bc) {
-    gRng.rxor(vf_src(src).du32[(int)bc]);
-  }
+  void vrxor(int src, BC bc) { gRng.rxor(vf_src(src).du32[(int)bc]); }
 
   void vaddq(DEST mask, int dst, int src) {
     auto s = vf_src(src);
@@ -944,9 +938,7 @@ struct ExecutionContext {
     }
   }
 
-  void mov64(int dest, int src) {
-    gprs[dest].ds64[0] = gpr_src(src).du64[0];
-  }
+  void mov64(int dest, int src) { gprs[dest].ds64[0] = gpr_src(src).du64[0]; }
 
   void vmove(DEST mask, int dest, int src) {
     auto s = vf_src(src);
@@ -981,40 +973,22 @@ struct ExecutionContext {
     gprs[dst].ds64[0] = value_signed;
   }
 
-  void dsra(int dst, int src, int sa) {
-    gprs[dst].ds64[0] = gpr_src(src).ds64[0] >> sa;
-  }
-  void dsrl(int dst, int src, int sa) {
-    gprs[dst].du64[0] = gpr_src(src).du64[0] >> sa;
-  }
+  void dsra(int dst, int src, int sa) { gprs[dst].ds64[0] = gpr_src(src).ds64[0] >> sa; }
+  void dsrl(int dst, int src, int sa) { gprs[dst].du64[0] = gpr_src(src).du64[0] >> sa; }
   void dsrav(int dst, int src, int sa) {
     gprs[dst].ds64[0] = gpr_src(src).ds64[0] >> gpr_src(sa).du32[0];
   }
   void dsllv(int dst, int src, int sa) {
     gprs[dst].ds64[0] = gpr_src(src).ds64[0] << (gpr_src(sa).du32[0] & 0b111111);
   }
-  void dsra32(int dst, int src, int sa) {
-    gprs[dst].ds64[0] = gpr_src(src).ds64[0] >> (32 + sa);
-  }
-  void dsrl32(int dst, int src, int sa) {
-    gprs[dst].du64[0] = gpr_src(src).du64[0] >> (32 + sa);
-  }
-  void sra(int dst, int src, int sa) {
-    gprs[dst].ds64[0] = gpr_src(src).ds32[0] >> sa;
-  }
-  void dsll(int dst, int src0, int sa) {
-    gprs[dst].du64[0] = gpr_src(src0).du64[0] << sa;
-  }
-  void dsll32(int dst, int src0, int sa) {
-    gprs[dst].du64[0] = gpr_src(src0).du64[0] << (32 + sa);
-  }
+  void dsra32(int dst, int src, int sa) { gprs[dst].ds64[0] = gpr_src(src).ds64[0] >> (32 + sa); }
+  void dsrl32(int dst, int src, int sa) { gprs[dst].du64[0] = gpr_src(src).du64[0] >> (32 + sa); }
+  void sra(int dst, int src, int sa) { gprs[dst].ds64[0] = gpr_src(src).ds32[0] >> sa; }
+  void dsll(int dst, int src0, int sa) { gprs[dst].du64[0] = gpr_src(src0).du64[0] << sa; }
+  void dsll32(int dst, int src0, int sa) { gprs[dst].du64[0] = gpr_src(src0).du64[0] << (32 + sa); }
 
-  void daddu(int dst, int src0, int src1) {
-    gprs[dst].du64[0] = sgpr64(src0) + sgpr64(src1);
-  }
-  void daddiu(int dst, int src0, s64 imm) {
-    gprs[dst].du64[0] = sgpr64(src0) + imm;
-  }
+  void daddu(int dst, int src0, int src1) { gprs[dst].du64[0] = sgpr64(src0) + sgpr64(src1); }
+  void daddiu(int dst, int src0, s64 imm) { gprs[dst].du64[0] = sgpr64(src0) + imm; }
   void addiu(int dst, int src0, s64 imm) {
     s32 temp = sgpr64(src0) + imm;
     gprs[dst].ds64[0] = temp;
@@ -1030,18 +1004,12 @@ struct ExecutionContext {
     gprs[dst].ds64[0] = temp;
   }
 
-  void dsubu(int dst, int src0, int src1) {
-    gprs[dst].du64[0] = sgpr64(src0) - sgpr64(src1);
-  }
+  void dsubu(int dst, int src0, int src1) { gprs[dst].du64[0] = sgpr64(src0) - sgpr64(src1); }
   void subu(int dst, int src0, int src1) {
     gprs[dst].ds64[0] = gpr_src(src0).ds32[0] - gpr_src(src1).ds32[0];
   }
-  void xor_(int dst, int src0, int src1) {
-    gprs[dst].du64[0] = sgpr64(src0) ^ sgpr64(src1);
-  }
-  void or_(int dst, int src0, int src1) {
-    gprs[dst].du64[0] = sgpr64(src0) | sgpr64(src1);
-  }
+  void xor_(int dst, int src0, int src1) { gprs[dst].du64[0] = sgpr64(src0) ^ sgpr64(src1); }
+  void or_(int dst, int src0, int src1) { gprs[dst].du64[0] = sgpr64(src0) | sgpr64(src1); }
 
   void movz(int dst, int src0, int src1) {
     if (sgpr64(src1) == 0) {
@@ -1067,15 +1035,9 @@ struct ExecutionContext {
     gprs[dst].ds64[0] = sresult;
   }
 
-  void xori(int dest, int src, u64 imm) {
-    gprs[dest].du64[0] = gpr_src(src).du64[0] ^ imm;
-  }
-  void andi(int dest, int src, u64 imm) {
-    gprs[dest].du64[0] = gpr_src(src).du64[0] & imm;
-  }
-  void ori(int dest, int src, u64 imm) {
-    gprs[dest].du64[0] = gpr_src(src).du64[0] | imm;
-  }
+  void xori(int dest, int src, u64 imm) { gprs[dest].du64[0] = gpr_src(src).du64[0] ^ imm; }
+  void andi(int dest, int src, u64 imm) { gprs[dest].du64[0] = gpr_src(src).du64[0] & imm; }
+  void ori(int dest, int src, u64 imm) { gprs[dest].du64[0] = gpr_src(src).du64[0] | imm; }
   void and_(int dest, int src0, int src1) {
     gprs[dest].du64[0] = gpr_src(src0).du64[0] & gpr_src(src1).du64[0];
   }
@@ -1179,15 +1141,9 @@ struct ExecutionContext {
     }
   }
 
-  void mov128_vf_gpr(int dst, int src) {
-    memcpy(vfs[dst].f, gpr_src(src).f, 16);
-  }
-  void mov128_gpr_vf(int dst, int src) {
-    memcpy(gprs[dst].f, vf_src(src).f, 16);
-  }
-  void mov128_gpr_gpr(int dst, int src) {
-    gprs[dst] = gpr_src(src);
-  }
+  void mov128_vf_gpr(int dst, int src) { memcpy(vfs[dst].f, gpr_src(src).f, 16); }
+  void mov128_gpr_vf(int dst, int src) { memcpy(gprs[dst].f, vf_src(src).f, 16); }
+  void mov128_gpr_gpr(int dst, int src) { gprs[dst] = gpr_src(src); }
 
   void vitof0(DEST mask, int dst, int src) {
     auto s = vf_src(src);
@@ -1254,15 +1210,9 @@ struct ExecutionContext {
     memcpy(&fprs[dst], &val, 4);
   }
 
-  void muls(int dst, int src0, int src1) {
-    fprs[dst] = fprs[src0] * fprs[src1];
-  }
-  void adds(int dst, int src0, int src1) {
-    fprs[dst] = fprs[src0] + fprs[src1];
-  }
-  void subs(int dst, int src0, int src1) {
-    fprs[dst] = fprs[src0] - fprs[src1];
-  }
+  void muls(int dst, int src0, int src1) { fprs[dst] = fprs[src0] * fprs[src1]; }
+  void adds(int dst, int src0, int src1) { fprs[dst] = fprs[src0] + fprs[src1]; }
+  void subs(int dst, int src0, int src1) { fprs[dst] = fprs[src0] - fprs[src1]; }
   void divs_accurate(int dst, int src0, int src1) {
     if (fprs[src1] == 0) {
       if (fprs[src0] < 0) {
@@ -1285,12 +1235,8 @@ struct ExecutionContext {
     memcpy(&fprs[dst], &v, 4);
   }
 
-  void movs(int dst, int src) {
-    fprs[dst] = fprs[src];
-  }
-  void abss(int dst, int src) {
-    fprs[dst] = std::abs(fprs[src]);
-  }
+  void movs(int dst, int src) { fprs[dst] = fprs[src]; }
+  void abss(int dst, int src) { fprs[dst] = std::abs(fprs[src]); }
 
   void cvtws(int dst, int src) {
     // float to int

--- a/game/overlord/srpc.cpp
+++ b/game/overlord/srpc.cpp
@@ -10,6 +10,7 @@
 #include "sbank.h"
 #include "iso_api.h"
 #include "common/util/Assert.h"
+#include "third-party/fmt/core.h"
 
 using namespace iop;
 

--- a/game/overlord/srpc.cpp
+++ b/game/overlord/srpc.cpp
@@ -322,8 +322,7 @@ void* RPC_Player(unsigned int /*fno*/, void* data, int size) {
           // TODO ShutdownFilingSystem();
         } break;
         default: {
-          printf("Unhandled RPC Player command %d\n", (int)cmd->command);
-          ASSERT(false);
+          ASSERT_MSG(false, fmt::format("Unhandled RPC Player command {}", (int)cmd->command));
         } break;
       }
       n_messages--;
@@ -410,8 +409,7 @@ void* RPC_Loader(unsigned int /*fno*/, void* data, int size) {
           // SignalSema(gSema);
         } break;
         default:
-          printf("Unhandled RPC Loader command %d\n", (int)cmd->command);
-          ASSERT(false);
+          ASSERT_MSG(false, fmt::format("Unhandled RPC Loader command {}", (int)cmd->command));
       }
       n_messages--;
       cmd++;

--- a/goalc/debugger/Debugger.cpp
+++ b/goalc/debugger/Debugger.cpp
@@ -763,8 +763,8 @@ void Debugger::watcher() {
           break;
 #endif
         default:
-          printf("[Debugger] unhandled signal in watcher: %d\n", int(signal_info.kind));
-          ASSERT(false);
+          ASSERT_MSG(false, fmt::format("[Debugger] unhandled signal in watcher: {}",
+                                        int(signal_info.kind)));
       }
 
       {

--- a/goalc/emitter/CodeTester.cpp
+++ b/goalc/emitter/CodeTester.cpp
@@ -15,6 +15,7 @@
 #include <cstdio>
 #include "CodeTester.h"
 #include "IGen.h"
+#include "third-party/fmt/core.h"
 
 namespace emitter {
 
@@ -133,7 +134,7 @@ void CodeTester::init_code_buffer(int capacity) {
   code_buffer = (u8*)mmap(nullptr, capacity, PROT_EXEC | PROT_READ | PROT_WRITE,
                           MAP_ANONYMOUS | MAP_PRIVATE, 0, 0);
   if (code_buffer == (u8*)(-1)) {
-    ASSERT_MSG(false, fmt::format("[CodeTester] Failed to map memory!"));
+    ASSERT_MSG(false, "[CodeTester] Failed to map memory!");
   }
 
   code_buffer_capacity = capacity;

--- a/goalc/emitter/CodeTester.cpp
+++ b/goalc/emitter/CodeTester.cpp
@@ -133,8 +133,7 @@ void CodeTester::init_code_buffer(int capacity) {
   code_buffer = (u8*)mmap(nullptr, capacity, PROT_EXEC | PROT_READ | PROT_WRITE,
                           MAP_ANONYMOUS | MAP_PRIVATE, 0, 0);
   if (code_buffer == (u8*)(-1)) {
-    printf("[CodeTester] Failed to map memory!\n");
-    ASSERT(false);
+    ASSERT_MSG(false, fmt::format("[CodeTester] Failed to map memory!"));
   }
 
   code_buffer_capacity = capacity;

--- a/goalc/emitter/CodeTester.h
+++ b/goalc/emitter/CodeTester.h
@@ -91,13 +91,19 @@ class CodeTester {
   /*!
    * Get the name of the given register, for debugging.
    */
-  std::string reg_name(Register x) { return m_info.get_info(x).name; }
+  std::string reg_name(Register x) {
+    return m_info.get_info(x).name;
+  }
 
   /*!
    * Get number of bytes currently in use (offset of the next thing to be added)
    */
-  int size() const { return code_buffer_size; }
-  const u8* data() const { return code_buffer; }
+  int size() const {
+    return code_buffer_size;
+  }
+  const u8* data() const {
+    return code_buffer;
+  }
 
   /*!
    * Write over existing data at the given offset.

--- a/goalc/emitter/CodeTester.h
+++ b/goalc/emitter/CodeTester.h
@@ -91,19 +91,13 @@ class CodeTester {
   /*!
    * Get the name of the given register, for debugging.
    */
-  std::string reg_name(Register x) {
-    return m_info.get_info(x).name;
-  }
+  std::string reg_name(Register x) { return m_info.get_info(x).name; }
 
   /*!
    * Get number of bytes currently in use (offset of the next thing to be added)
    */
-  int size() const {
-    return code_buffer_size;
-  }
-  const u8* data() const {
-    return code_buffer;
-  }
+  int size() const { return code_buffer_size; }
+  const u8* data() const { return code_buffer; }
 
   /*!
    * Write over existing data at the given offset.

--- a/goalc/regalloc/Allocator.cpp
+++ b/goalc/regalloc/Allocator.cpp
@@ -570,7 +570,7 @@ bool try_spill_coloring(int var, RegAllocCache* cache, const AllocationInput& in
 
         if (spill_assignment.reg == -1) {
           ASSERT_MSG(false,
-                     fmt::format("SPILLING FAILED BECAUSE WE COULDN'T FIND A TEMP REGISTER!"));
+                     "SPILLING FAILED BECAUSE WE COULDN'T FIND A TEMP REGISTER!");
           return false;
         }
 

--- a/goalc/regalloc/Allocator.cpp
+++ b/goalc/regalloc/Allocator.cpp
@@ -569,8 +569,8 @@ bool try_spill_coloring(int var, RegAllocCache* cache, const AllocationInput& in
         }
 
         if (spill_assignment.reg == -1) {
-          printf("SPILLING FAILED BECAUSE WE COULDN'T FIND A TEMP REGISTER!\n");
-          ASSERT(false);
+          ASSERT_MSG(false,
+                     fmt::format("SPILLING FAILED BECAUSE WE COULDN'T FIND A TEMP REGISTER!"));
           return false;
         }
 

--- a/goalc/regalloc/Allocator.cpp
+++ b/goalc/regalloc/Allocator.cpp
@@ -569,8 +569,7 @@ bool try_spill_coloring(int var, RegAllocCache* cache, const AllocationInput& in
         }
 
         if (spill_assignment.reg == -1) {
-          ASSERT_MSG(false,
-                     "SPILLING FAILED BECAUSE WE COULDN'T FIND A TEMP REGISTER!");
+          ASSERT_MSG(false, "SPILLING FAILED BECAUSE WE COULDN'T FIND A TEMP REGISTER!");
           return false;
         }
 


### PR DESCRIPTION
For future reference, the regex i used to find the instances - `(.*print.*\n){1,5}.*ASSERT\(false\)`

Adds a `ASSERT_MSG` macro which you can pass a `std::string` into to be printed, or a string literal.  Will also flush stdout and stderr before `abort`ing now -- which should hopefully make logging more consistent.

Hopefully fixed the windows release and `task` commands on linux should now perform as expected.