### PR TITLE
[overlord] fix fakeiso close bug

### DIFF
--- a/game/overlord/fake_iso.cpp
+++ b/game/overlord/fake_iso.cpp
@@ -39,7 +39,7 @@ static LoadStackEntry sLoadStack[MAX_OPEN_FILES];  //! List of all files that ar
 FakeIsoEntry fake_iso_entries[MAX_ISO_FILES];      //! List of all known files
 static FileRecord sFiles[MAX_ISO_FILES];           //! List of "FileRecords" for IsoFs API consumers
 u32 fake_iso_entry_count;                          //! Total count of fake iso files
-static bool read_in_progress;                      //! Does the ISO Thread think we're reading?
+static LoadStackEntry* sReadInfo;                  // LoadStackEntry for currently reading file
 
 static int FS_Init(u8* buffer);
 static FileRecord* FS_Find(const char* name);
@@ -76,7 +76,7 @@ void fake_iso_init_globals() {
   fake_iso.load_music = FS_LoadMusic;
   fake_iso.poll_drive = FS_PollDrive;
 
-  read_in_progress = false;
+  sReadInfo = nullptr;
 }
 
 /*!
@@ -224,7 +224,9 @@ void FS_Close(LoadStackEntry* fd) {
 
   // close the FD
   fd->fr = nullptr;
-  read_in_progress = false;
+  if (fd == sReadInfo) {
+    sReadInfo = nullptr;
+  }
 }
 
 /*!
@@ -276,7 +278,7 @@ uint32_t FS_BeginRead(LoadStackEntry* fd, void* buffer, int32_t len) {
   }
 
   fd->location += (len / SECTOR_SIZE);
-  read_in_progress = true;
+  sReadInfo = fd;
 
   fclose(fp);
 
@@ -288,8 +290,8 @@ uint32_t FS_BeginRead(LoadStackEntry* fd, void* buffer, int32_t len) {
  */
 uint32_t FS_SyncRead() {
   // FS_BeginRead is blocking, so this is useless.
-  if (read_in_progress) {
-    read_in_progress = false;
+  if (sReadInfo) {
+    sReadInfo = nullptr;
     return CMD_STATUS_IN_PROGRESS;
   } else {
     return CMD_STATUS_READ_ERR;

--- a/game/overlord/iso_api.cpp
+++ b/game/overlord/iso_api.cpp
@@ -11,7 +11,7 @@ using namespace iop;
  * Load a File to IOP memory (blocking)
  */
 s32 LoadISOFileToIOP(FileRecord* file, void* addr, uint32_t length) {
-  lg::debug("[OVERLORD] LoadISOFileToIOP {}, {}/{} bytes", file->name, length, file->size);
+  lg::debug("[OVERLORD] LoadISOFileToIOP {}, {}/{} bytes", file->name, length, (s32)file->size);
   IsoCommandLoadSingle cmd;
   cmd.cmd_id = LOAD_TO_IOP_CMD_ID;
   cmd.messagebox_to_reply = 0;
@@ -33,7 +33,7 @@ s32 LoadISOFileToIOP(FileRecord* file, void* addr, uint32_t length) {
  * Load a File to IOP memory (blocking)
  */
 s32 LoadISOFileToEE(FileRecord* file, uint32_t addr, uint32_t length) {
-  lg::debug("[OVERLORD] LoadISOFileToEE {}, {}/{} bytes", file->name, length, file->size);
+  lg::debug("[OVERLORD] LoadISOFileToEE {}, {}/{} bytes", file->name, length, (s32)file->size);
   IsoCommandLoadSingle cmd;
   cmd.cmd_id = LOAD_TO_EE_CMD_ID;
   cmd.messagebox_to_reply = 0;

--- a/game/overlord/iso_cd.cpp
+++ b/game/overlord/iso_cd.cpp
@@ -54,7 +54,7 @@ mmode_func cdmmode = nullptr;               // function to call to set the expec
 static sceCdRMode sNominalMode;             // drive settings for "nominal" reading
 static sceCdRMode sStreamMode;              // drive settings for "streaming" reading
 static sceCdRMode* sMode;                   // pointer to currently selected read mode
-LoadStackEntry* sReadInfo;                  // LoadStackEntry for currently reading file
+static LoadStackEntry* sReadInfo;           // LoadStackEntry for currently reading file
 static u8* sSecBuffer[3];                   // Buffers for a single sector
 u32 add_files;                              // Should we add files we discover to the sFiles list?
 static FileRecord sFiles[MAX_ISO_FILES];    // Info for all files on the disc


### PR DESCRIPTION
This fixes a bug when file A is closed in the same iteration of the iso thread loop that a read from file B completes.

There is a feature that detects if file A is closed, and you have a buffer remaining for file A, then discard the buffer. But obviously this should not happen if file A is closed and you have a buffer for file B ready to go.

This fixes a reliable (for me) visibility corruption bug when riding the gondola up to snowy mountain while there is a heavy system load. The GORDOWN file is closed on the same iso thread loop as the first buffer for SNO.VIS is filled, and this buffer was incorrectly discarded.