### PR TITLE
ci: make linux release artifact structure match windows

### DIFF
--- a/.github/workflows/linux-workflow.yaml
+++ b/.github/workflows/linux-workflow.yaml
@@ -114,7 +114,7 @@ jobs:
         run: |
           mkdir -p ./ci-artifacts/out
           ./.github/scripts/releases/extract_build_linux.sh ./ci-artifacts/out ./
-          tar czf ./ci-artifacts/linux.tar.gz ./ci-artifacts/out
+          tar -czf ./ci-artifacts/linux.tar.gz -C ./ci-artifacts .
 
       - name: Upload Assets and Potential Publish Release
         if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler == 'clang'


### PR DESCRIPTION
Linux was including the `ci-artifacts/` folder in the tarball