### PR TITLE
game/deci2: Add a timeout on waiting for a client to connect to DECI2

### DIFF
--- a/common/cross_sockets/XSocket.h
+++ b/common/cross_sockets/XSocket.h
@@ -27,8 +27,10 @@ const int TCP_SOCKET_LEVEL = IPPROTO_TCP;
 int open_socket(int af, int type, int protocol);
 #ifdef __linux
 int accept_socket(int socket, sockaddr* addr, socklen_t* addrLen);
+int select_and_accept_socket(int socket, sockaddr* addr, socklen_t* addrLen, int microSeconds);
 #elif _WIN32
 int accept_socket(int socket, sockaddr* addr, int* addrLen);
+int select_and_accept_socket(int socket, sockaddr* addr, int* addrLen, int microSeconds);
 #endif
 void close_socket(int sock);
 int set_socket_option(int socket, int level, int optname, const void* optval, int optlen);


### PR DESCRIPTION
The DECI2 thread was not joining as the call to `accept` is blocking.  The proper way to do this is to instead call `select()` with a timeout, and if it returns successfully, accept it.

This still means there is a slight pause (max of 0.1s) when exiting the game, but this can be reduced (or removed entirely if we just terminate the thread, I don't see the harm in doing so if no client has connected to it)

Closes #1362
Closes #1366