### PR TITLE
make linux tests pass again

### DIFF
--- a/common/goos/Interpreter.cpp
+++ b/common/goos/Interpreter.cpp
@@ -1706,7 +1706,7 @@ Object Interpreter::eval_make_string_hash_table(const Object& form,
  */
 Object Interpreter::eval_hash_table_set(const Object& form,
                                         Arguments& args,
-                                        const std::shared_ptr<EnvironmentObject>& env) {
+                                        const std::shared_ptr<EnvironmentObject>& /*env*/) {
   vararg_check(form, args, {ObjectType::STRING_HASH_TABLE, ObjectType::STRING, {}}, {});
   args.unnamed.at(0).as_string_hash_table()->data[args.unnamed.at(1).as_string()->data] =
       args.unnamed.at(2);
@@ -1718,7 +1718,7 @@ Object Interpreter::eval_hash_table_set(const Object& form,
  */
 Object Interpreter::eval_hash_table_try_ref(const Object& form,
                                             Arguments& args,
-                                            const std::shared_ptr<EnvironmentObject>& env) {
+                                            const std::shared_ptr<EnvironmentObject>& /*env*/) {
   vararg_check(form, args, {ObjectType::STRING_HASH_TABLE, ObjectType::STRING}, {});
   const auto* table = args.unnamed.at(0).as_string_hash_table();
   const auto& it = table->data.find(args.unnamed.at(1).as_string()->data);

--- a/game/kernel/kboot.h
+++ b/game/kernel/kboot.h
@@ -19,8 +19,8 @@ struct MasterConfig {
   u16 timeout;           // todo           8
   u16 volume;            // todo           12
 
-  u16 territory;  // added. this is normally burnt onto the disc executable.
-  u16 disable_sound = 0; // added. disables all sound code.
+  u16 territory;          // added. this is normally burnt onto the disc executable.
+  u16 disable_sound = 0;  // added. disables all sound code.
 };
 
 enum class RuntimeExitStatus {

--- a/game/kernel/kboot.h
+++ b/game/kernel/kboot.h
@@ -20,6 +20,7 @@ struct MasterConfig {
   u16 volume;            // todo           12
 
   u16 territory;  // added. this is normally burnt onto the disc executable.
+  u16 disable_sound = 0; // added. disables all sound code.
 };
 
 enum class RuntimeExitStatus {

--- a/game/overlord/overlord.cpp
+++ b/game/overlord/overlord.cpp
@@ -17,9 +17,18 @@ int start_overlord(int argc, const char* const* argv) {
     sceSifInit();
   }
 
+  bool disable_sound = false;
+  for (int i = 1; i < argc; i++) {
+    if (std::string("-nosound") == argv[i]) {
+      disable_sound = true;
+    }
+  }
+
   sceSifInitRpc(0);
   InitBanks();
-  InitSound_Overlord();
+  if (!disable_sound) {
+    InitSound_Overlord();
+  }
   InitRamdisk();
   // RegisterVblankHandler(0, 0x20, VBlank_Handler, nullptr);
 

--- a/game/sound/sdshim.cpp
+++ b/game/sound/sdshim.cpp
@@ -16,6 +16,9 @@ u32 sceSdGetSwitch(u32 entry) {
 }
 
 u32 sceSdGetAddr(u32 entry) {
+  if (!voice) {
+    return 0;
+  }
   // u32 core = entry & 1;
   // u32 voice->id = (entry >> 1) & 0x1f;
   // u32 reg = entry & ~0x3f;
@@ -30,6 +33,9 @@ void sceSdSetSwitch(u32 entry, u32 value) {
 }
 
 void sceSdSetAddr(u32 entry, u32 value) {
+  if (!voice) {
+    return;
+  }
   [[maybe_unused]] u32 core = entry & 1;
   [[maybe_unused]] u32 voice_id = (entry >> 1) & 0x1f;
   u32 reg = entry & ~0x3f;
@@ -45,6 +51,9 @@ void sceSdSetAddr(u32 entry, u32 value) {
 }
 
 void sceSdSetParam(u32 entry, u32 value) {
+  if (!voice) {
+    return;
+  }
   [[maybe_unused]] u32 core = entry & 1;
   [[maybe_unused]] u32 voice_id = (entry >> 1) & 0x1f;
   u32 reg = entry & ~0x3f;

--- a/game/sound/sndshim.cpp
+++ b/game/sound/sndshim.cpp
@@ -14,7 +14,9 @@ void snd_StartSoundSystem() {
 }
 
 void snd_StopSoundSystem() {
-  player.reset();
+  if (player) {
+    player.reset();
+  }
 }
 
 // dma is always instant, allocation not required
@@ -25,7 +27,11 @@ s32 snd_GetFreeSPUDMA() {
 void snd_FreeSPUDMA([[maybe_unused]] s32 channel) {}
 
 s32 snd_GetTick() {
-  return player->get_tick();
+  if (player) {
+    return player->get_tick();
+  } else {
+    return 0;
+  }
 }
 
 void snd_RegisterIOPMemAllocator(AllocFun, FreeFun) {
@@ -59,35 +65,49 @@ void snd_SetReverbDepth(s32, s32, s32) {}
 void snd_SetReverbType(s32, s32) {}
 
 void snd_SetPanTable(s16* table) {
-  player->set_pan_table((snd::vol_pair*)table);
+  if (player) {
+    player->set_pan_table((snd::vol_pair*)table);
+  }
 }
 
 void snd_SetPlayBackMode(s32 mode) {
-  player->set_playback_mode(mode);
+  if (player) {
+    player->set_playback_mode(mode);
+  }
 }
 
 s32 snd_SoundIsStillPlaying(s32 sound_handle) {
-  if (player->sound_still_active(sound_handle)) {
-    return sound_handle;
+  if (player) {
+    if (player->sound_still_active(sound_handle)) {
+      return sound_handle;
+    }
   }
 
   return 0;
 }
 
 void snd_StopSound(s32 handle) {
-  player->stop_sound(handle);
+  if (player) {
+    player->stop_sound(handle);
+  }
 }
 
 void snd_SetSoundVolPan(s32 sound_handle, s32 vol, s32 pan) {
-  player->set_sound_vol_pan(sound_handle, vol, pan);
+  if (player) {
+    player->set_sound_vol_pan(sound_handle, vol, pan);
+  }
 }
 
 void snd_SetMasterVolume(s32 group, s32 volume) {
-  player->set_master_volume(group, volume);
+  if (player) {
+    player->set_master_volume(group, volume);
+  }
 }
 
 void snd_UnloadBank(s32 bank_handle) {
-  player->unload_bank(bank_handle);
+  if (player) {
+    player->unload_bank(bank_handle);
+  }
 }
 
 void snd_ResolveBankXREFS() {
@@ -95,23 +115,35 @@ void snd_ResolveBankXREFS() {
 }
 
 void snd_ContinueAllSoundsInGroup(u8 group) {
-  player->continue_all_sounds_in_group(group);
+  if (player) {
+    player->continue_all_sounds_in_group(group);
+  }
 }
 
 void snd_PauseAllSoundsInGroup(u8 group) {
-  player->pause_all_sounds_in_group(group);
+  if (player) {
+    player->pause_all_sounds_in_group(group);
+  }
 }
 
 void snd_SetMIDIRegister(s32 sound_handle, u8 reg, u8 value) {
-  player->set_midi_reg(sound_handle, reg, value);
+  if (player) {
+    player->set_midi_reg(sound_handle, reg, value);
+  }
 }
 
 s32 snd_PlaySoundVolPanPMPB(s32 bank, s32 sound, s32 vol, s32 pan, s32 pm, s32 pb) {
-  return player->play_sound(bank, sound, vol, pan, pm, pb);
+  if (player) {
+    return player->play_sound(bank, sound, vol, pan, pm, pb);
+  } else {
+    return 0;
+  }
 }
 
 void snd_SetSoundPitchModifier(s32 sound, s32 mod) {
-  player->set_sound_pmod(sound, mod);
+  if (player) {
+    player->set_sound_pmod(sound, mod);
+  }
 }
 
 void snd_SetSoundPitchBend(s32 sound, s32 bend) {
@@ -120,11 +152,15 @@ void snd_SetSoundPitchBend(s32 sound, s32 bend) {
 }
 
 void snd_PauseSound(s32 sound_handle) {
-  player->pause_sound(sound_handle);
+  if (player) {
+    player->pause_sound(sound_handle);
+  }
 }
 
 void snd_ContinueSound(s32 sound_handle) {
-  player->continue_sound(sound_handle);
+  if (player) {
+    player->continue_sound(sound_handle);
+  }
 }
 
 void snd_AutoPitch(s32, s32, s32, s32) {
@@ -138,8 +174,12 @@ void snd_AutoPitchBend(s32, s32, s32, s32) {
 
 s32 snd_BankLoadEx(const char* filename, s32 offset, s32, s32) {
   // printf("snd_BankLoadEx\n");
-  std::filesystem::path path = filename;
-  return player->load_bank(path, offset);
+  if (player) {
+    std::filesystem::path path = filename;
+    return player->load_bank(path, offset);
+  } else {
+    return 0;
+  }
 }
 
 s32 snd_GetVoiceStatus(s32 voice) {
@@ -152,9 +192,13 @@ s32 snd_GetVoiceStatus(s32 voice) {
 }
 
 void snd_keyOnVoiceRaw(u32 core, u32 voice_id) {
-  voice->key_on();
+  if (voice) {
+    voice->key_on();
+  }
 }
 
 void snd_keyOffVoiceRaw(u32 core, u32 voice_id) {
-  voice->key_off();
+  if (voice) {
+    voice->key_off();
+  }
 }

--- a/goal_src/game.gp
+++ b/goal_src/game.gp
@@ -1888,7 +1888,6 @@
  "debug/anim-tester.gc"
  "debug/viewer.gc"
  "debug/part-tester.gc"
- "debug/default-menu.gc"
  )
 
 (goal-src-sequence
@@ -1954,6 +1953,9 @@
 (goal-src "pc/subtitle.gc" "text" "pckernel" "hint-control" "loader-h" "gsound" "ambient")
 (goal-src "pc/progress-pc.gc" "progress" "pckernel")
 (goal-src "pc/anim-tester-x.gc" "pckernel" "gstring" "joint" "process-drawable" "art-h" "effect-control")
+
+;; the debug menu is modified to include PC specific options:
+(goal-src "engine/debug/default-menu.gc" "anim-tester-x" "part-tester")
 
 (group-list "all-code"
   `(,@(reverse *all-gc*))

--- a/test/goalc/framework/test_runner.cpp
+++ b/test/goalc/framework/test_runner.cpp
@@ -99,20 +99,20 @@ void CompilerTestRunner::run_always_pass(const std::string& test_category,
 }
 
 void runtime_no_kernel() {
-  constexpr int argc = 5;
-  const char* argv[argc] = {"", "-fakeiso", "-debug", "-nokernel", "-nodisplay"};
+  constexpr int argc = 6;
+  const char* argv[argc] = {"", "-fakeiso", "-debug", "-nokernel", "-nodisplay", "-nosound"};
   exec_runtime(argc, const_cast<char**>(argv));
 }
 
 void runtime_with_kernel() {
-  constexpr int argc = 4;
-  const char* argv[argc] = {"", "-fakeiso", "-debug", "-nodisplay"};
+  constexpr int argc = 5;
+  const char* argv[argc] = {"", "-fakeiso", "-debug", "-nodisplay", "-nosound"};
   exec_runtime(argc, const_cast<char**>(argv));
 }
 
 void runtime_with_kernel_no_debug_segment() {
-  constexpr int argc = 4;
-  const char* argv[argc] = {"", "-fakeiso", "-debug-mem", "-nodisplay"};
+  constexpr int argc = 5;
+  const char* argv[argc] = {"", "-fakeiso", "-debug-mem", "-nodisplay", "-nosound"};
   exec_runtime(argc, const_cast<char**>(argv));
 }
 

--- a/test/goalc/source_templates/with_game/test-build-all-code.gc
+++ b/test/goalc/source_templates/with_game/test-build-all-code.gc
@@ -1,0 +1,1 @@
+(make-group "all-code")

--- a/test/goalc/test_with_game.cpp
+++ b/test/goalc/test_with_game.cpp
@@ -944,7 +944,7 @@ TEST(TypeConsistency, MANUAL_TEST_TypeConsistencyWithBuildFirst) {
   Compiler compiler;
   compiler.enable_throw_on_redefines();
   add_expected_type_mismatches(compiler);
-  compiler.run_test_no_load("test/goalc/source_templates/with_game/test-build-game.gc");
+  compiler.run_test_no_load("test/goalc/source_templates/with_game/test-build-all-code.gc");
   compiler.run_test_no_load("decompiler/config/all-types.gc");
 }
 
@@ -953,7 +953,7 @@ TEST(TypeConsistency, TypeConsistency) {
   compiler.enable_throw_on_redefines();
   add_expected_type_mismatches(compiler);
   compiler.run_test_no_load("decompiler/config/all-types.gc");
-  compiler.run_test_no_load("test/goalc/source_templates/with_game/test-build-game.gc");
+  compiler.run_test_no_load("test/goalc/source_templates/with_game/test-build-all-code.gc");
 }
 
 struct VectorFloatRegister {


### PR DESCRIPTION
- adds a toggle to disable sound for unit tests.  Even though we tolerate `cubeb_init` failing, I hit an assert in pulseaudio when running tests on my laptop. 
- clean up logic for IOP argument string lengths
- actually build level code in type consistency (oops) and fix up deps for the `all-code` group.