### PR TITLE
assert toggle

### DIFF
--- a/common/util/Assert.cpp
+++ b/common/util/Assert.cpp
@@ -1,7 +1,9 @@
+#include "Assert.h"
+
+#ifndef NO_ASSERT
+
 #include <cstdio>
 #include <cstdlib>
-
-#include "Assert.h"
 #include <string_view>
 
 void private_assert_failed(const char* expr,
@@ -32,3 +34,5 @@ void private_assert_failed(const char* expr,
     private_assert_failed(expr, file, line, function, msg.data());
   }
 }
+
+#endif

--- a/common/util/Assert.h
+++ b/common/util/Assert.h
@@ -25,7 +25,6 @@
 #define __PRETTY_FUNCTION__ __FUNCSIG__
 #endif
 
-
 #define ASSERT(EX) \
   (void)((EX) || (private_assert_failed(#EX, __FILE__, __LINE__, __PRETTY_FUNCTION__), 0))
 

--- a/common/util/Assert.h
+++ b/common/util/Assert.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#ifndef NO_ASSERT
+
 #include <string_view>
 
 [[noreturn]] void private_assert_failed(const char* expr,
@@ -23,8 +25,16 @@
 #define __PRETTY_FUNCTION__ __FUNCSIG__
 #endif
 
+
 #define ASSERT(EX) \
   (void)((EX) || (private_assert_failed(#EX, __FILE__, __LINE__, __PRETTY_FUNCTION__), 0))
 
 #define ASSERT_MSG(EXPR, STR) \
   (void)((EXPR) || (private_assert_failed(#EXPR, __FILE__, __LINE__, __PRETTY_FUNCTION__, STR), 0))
+
+#else
+
+#define ASSERT(EX) ((void)0)
+#define ASSERT_MSG(EXPR, STR) ((void)0)
+
+#endif

--- a/decompiler/IR2/FormExpressionAnalysis.cpp
+++ b/decompiler/IR2/FormExpressionAnalysis.cpp
@@ -11,6 +11,7 @@
 #include "common/util/print_float.h"
 #include "decompiler/IR2/ExpressionHelpers.h"
 #include "decompiler/util/goal_constants.h"
+#include "common/util/Assert.h"
 
 /*
  * TODO

--- a/test/test_common_util.cpp
+++ b/test/test_common_util.cpp
@@ -16,6 +16,7 @@
 #include "common/util/CopyOnWrite.h"
 #include "common/util/SmallVector.h"
 #include "common/util/crc32.h"
+#include "common/util/Assert.h"
 
 TEST(CommonUtil, CpuInfo) {
   setup_cpu_info();
@@ -393,9 +394,11 @@ TEST(SmallVector, Construction) {
   EXPECT_FALSE(one.empty());
 }
 
+#ifndef NO_ASSERT
 TEST(Assert, Death) {
   EXPECT_DEATH(private_assert_failed("foo", "bar", 12, "aaa"), "");
 }
+#endif
 
 uint32_t crc_reference(const u8* data, size_t size) {
   u32 crc = 0xffffffff;


### PR DESCRIPTION
If we ever want to turn asserts off, we can now do it by just defining a single macro.