### PR TITLE
[graphics] merc2 fix, texture crash bug fix

### DIFF
--- a/game/graphics/opengl_renderer/EyeRenderer.cpp
+++ b/game/graphics/opengl_renderer/EyeRenderer.cpp
@@ -249,7 +249,7 @@ std::vector<EyeRenderer::SingleEyeDraws> EyeRenderer::get_draws(DmaFollower& dma
       pair_idx = y0 / SINGLE_EYE_SIZE;
       l_draw.pair = pair_idx;
       r_draw.pair = pair_idx;
-      if (tex0->get_data_ptr()) {
+      if (tex0 && tex0->get_data_ptr()) {
         u32 tex_val;
         memcpy(&tex_val, tex0->get_data_ptr(), 4);
         l_draw.clear_color = tex_val;
@@ -280,7 +280,7 @@ std::vector<EyeRenderer::SingleEyeDraws> EyeRenderer::get_draws(DmaFollower& dma
     AdgifHelper adgif1(adgif1_dma.data + 16);
     auto tex1 = render_state->texture_pool->lookup_gpu_texture(adgif1.tex0().tbp0());
 
-    {
+    if (tex1 && tex1->get_data_ptr()) {
       l_draw.pupil = read_eye_draw(dma);
       r_draw.pupil = read_eye_draw(dma);
       l_draw.pupil_tex = tex1;

--- a/game/graphics/opengl_renderer/SkyBlendCPU.cpp
+++ b/game/graphics/opengl_renderer/SkyBlendCPU.cpp
@@ -151,13 +151,16 @@ SkyBlendStats SkyBlendCPU::do_sky_blends(DmaFollower& dma,
     }
      */
     if (tex->get_data_ptr()) {
-      if (is_first_draw) {
-        blend_sky_initial_fast(intensity, m_texture_data[buffer_idx].data(), tex->get_data_ptr(),
-                               tex->data_size());
-      } else {
-        blend_sky_fast(intensity, m_texture_data[buffer_idx].data(), tex->get_data_ptr(),
-                       tex->data_size());
+      if (m_texture_data[buffer_idx].size() == tex->data_size()) {
+        if (is_first_draw) {
+          blend_sky_initial_fast(intensity, m_texture_data[buffer_idx].data(), tex->get_data_ptr(),
+                                 m_texture_data[buffer_idx].size());
+        } else {
+          blend_sky_fast(intensity, m_texture_data[buffer_idx].data(), tex->get_data_ptr(),
+                         m_texture_data[buffer_idx].size());
+        }
       }
+
       if (buffer_idx == 0) {
         if (is_first_draw) {
           stats.sky_draws++;

--- a/game/graphics/opengl_renderer/foreground/Merc2.h
+++ b/game/graphics/opengl_renderer/foreground/Merc2.h
@@ -65,14 +65,21 @@ class Merc2 : public BucketRenderer {
     math::Vector4f nmat[3];
   };
 
+  struct ShaderMercMat {
+    math::Vector4f tmat[4];
+    math::Vector4f nmat[3];
+    math::Vector4f pad;
+  };
+
   static constexpr int MAX_SKEL_BONES = 128;
-  static constexpr int MAX_SHADER_BONES = 8192;
+  static constexpr int BONE_VECTORS_PER_BONE = 7;
+  static constexpr int MAX_SHADER_BONE_VECTORS = 8192;  // ??
 
   static constexpr int MAX_LEVELS = 3;
   static constexpr int MAX_DRAWS_PER_LEVEL = 1024;
 
-  MercMat m_shader_matrix_buffer[MAX_SHADER_BONES];
-  MercMat m_skel_matrix_buffer[MAX_SKEL_BONES];
+  math::Vector4f m_shader_bone_vector_buffer[MAX_SHADER_BONE_VECTORS];
+  ShaderMercMat m_skel_matrix_buffer[MAX_SKEL_BONES];
 
   struct {
     GLuint light_direction[3];
@@ -137,7 +144,8 @@ class Merc2 : public BucketRenderer {
 
   std::vector<LevelDrawBucket> m_level_draw_buckets;
   u32 m_next_free_level_bucket = 0;
-  u32 m_next_free_bone = 0;
+  u32 m_next_free_bone_vector = 0;
+  size_t m_opengl_buffer_alignment = 0;
 
   void flush_draw_buckets(SharedRenderState* render_state, ScopedProfilerNode& prof);
 };

--- a/game/graphics/opengl_renderer/shaders/merc2.vert
+++ b/game/graphics/opengl_renderer/shaders/merc2.vert
@@ -36,6 +36,7 @@ out float fog;
 struct MercMatrixData {
     mat4 X;
     mat3 R;
+    vec4 pad;
 };
 
 layout (std140, binding = 1) uniform ub_bones {


### PR DESCRIPTION
This fixes a bug with merc2 where the alignment of the bones within the uniform buffer was a bit weird. I added some padding to the bones themselves and made sure to follow the exact alignment required by opengl.  In the end, we actually save memory compared to the original layout because we can insert not-multiple-of-bone gaps in the buffer to get alignment. There was an off by one that in rare cases could cause a bone to be skipped as well.

Also fixes crashes when turning off textures in the debug menu.