### PR TITLE
[graphics] improve blending when depth write is disabled

### DIFF
--- a/game/graphics/opengl_renderer/background/background_common.cpp
+++ b/game/graphics/opengl_renderer/background/background_common.cpp
@@ -103,9 +103,13 @@ DoubleDraw setup_opengl_from_draw_mode(DrawMode mode, u32 tex_unit, bool mipmap)
             // ok, no need for double draw
             break;
           case GsTest::AlphaFail::FB_ONLY:
-            // darn, we need to draw twice
-            double_draw.kind = DoubleDrawKind::AFAIL_NO_DEPTH_WRITE;
-            double_draw.aref_second = alpha_min;
+            if (mode.get_depth_write_enable()) {
+              // darn, we need to draw twice
+              double_draw.kind = DoubleDrawKind::AFAIL_NO_DEPTH_WRITE;
+              double_draw.aref_second = alpha_min;
+            } else {
+              alpha_min = 0.f;
+            }
             break;
           default:
             ASSERT(false);


### PR DESCRIPTION
closes #1297 

Avoids splitting into two draws (which causes blending issues) if the alpha test is configured in a "useless" way.
We previously caught one of these cases (setting alpha test to NEVER, FB_ONLY to disable depth writes), but now we catch the one used on the title screen (alpha test FB_ONLY, but depth writes always disabled). In this case, we don't need to do the draw splitting at all, so we can get more accurate blending by doing 1 draw with no alpha stuff.