### PR TITLE
[game] fix ambients stopping and swamp blimp tethers

### DIFF
--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -29692,7 +29692,7 @@
 ;; - Functions
 
 (define-extern swamp-rope-init-by-other (function vector entity-actor none :behavior swamp-rope))
-(define-extern swamp-blimp-setup (function none :behavior swamp-blimp))
+(define-extern swamp-blimp-setup (function int :behavior swamp-blimp))
 (define-extern tetherrock-get-info (function entity tetherrock-info))
 (define-extern swamp-rope-post (function none :behavior swamp-rope))
 (define-extern swamp-rope-break-code (function quaternion :behavior swamp-rope))

--- a/goal_src/kernel/gkernel.gc
+++ b/goal_src/kernel/gkernel.gc
@@ -2382,7 +2382,7 @@
 ;; The defstate macro isn't defined yet, so we do it manually.
 (define dead-state
         (the (state process) (new 'static 'state
-                                  :name #f
+                                  :name 'dead-state
                                   :next #f
                                   :exit #f
                                   :code #f

--- a/goal_src/levels/village2/swamp-blimp.gc
+++ b/goal_src/levels/village2/swamp-blimp.gc
@@ -1630,8 +1630,8 @@
           (vector-normalize! (the-as vector (-> self gondola-tilt-oscillator)) 1.0)
           )
         )
+      gp-0
       )
-    (none)
     )
   )
 

--- a/test/decompiler/reference/levels/village2/swamp-blimp_REF.gc
+++ b/test/decompiler/reference/levels/village2/swamp-blimp_REF.gc
@@ -1744,7 +1744,6 @@
   )
 
 ;; definition for function swamp-blimp-setup
-;; INFO: Return type mismatch int vs none.
 (defbehavior swamp-blimp-setup swamp-blimp ()
   (rlet ((vf0 :class vf))
     (init-vf0-vector)
@@ -1824,8 +1823,8 @@
           (vector-normalize! (the-as vector (-> self gondola-tilt-oscillator)) 1.0)
           )
         )
+      gp-0
       )
-    (none)
     )
   )
 


### PR DESCRIPTION
Will close #1365 and #1336.

When a process is `deactivate`d, the state is set to `dead-state`, and all stack frames are exited, including the `exit` for the current  `state`.  I had a typo in the decompilation of `gkernel.gc`, so the name of `dead-state` is `#f` instead of `'dead-state`. This caused the wrong branch in `process-taskable idle` to be taken, killing all in progress level hints.  This is likely what killed daxter hints.

Also fix a type bug in `swamp-blimp` that caused the cutscene at the end to not play. Wasn't caught by the decompiler because its the usual weird `event` handler stuff.