### PR TITLE
[game] fix ps crash and disappearing ram

### DIFF
--- a/goal_src/engine/nav/navigate.gc
+++ b/goal_src/engine/nav/navigate.gc
@@ -5,6 +5,13 @@
 ;; name in dgo: navigate
 ;; dgos: GAME, ENGINE
 
+;; note: added this to avoid a bug where enemies with NaN positions end up inside the nav mesh.
+;; it's not clear yet why the enemies have NaN positions, but nothing else seems to go wrong if we
+;; ignore them here. It's possible this happens as enemies are spawned/despawned by the visibility system.
+(defmacro is-nan? (flt)
+  `(and (< 0.0 ,flt) (< ,flt 0.0))
+  )
+
 ;; DECOMP BEGINS
 
 (define *nav-timer* (new 'global 'stopwatch))
@@ -2080,7 +2087,7 @@
                          (f0-9 (+ (-> sv-112 w) (-> sv-80 shape nav-radius)))
                          (f2-17 (+ 40960.0 f0-9))
                          )
-                    (when (< f1-3 (* f2-17 f2-17))
+                    (when (and (< f1-3 (* f2-17 f2-17)) (not (is-nan? (-> sv-112 x))))
                       (let ((v1-94 sv-96)
                             (a0-47 (-> sv-80 mesh origin))
                             )

--- a/goal_src/engine/nav/navigate.gc
+++ b/goal_src/engine/nav/navigate.gc
@@ -2087,6 +2087,8 @@
                          (f0-9 (+ (-> sv-112 w) (-> sv-80 shape nav-radius)))
                          (f2-17 (+ 40960.0 f0-9))
                          )
+                    ;; HACK: added a NaN check here. it seems like some enemies have bogus positions (maybe on their first frame?)
+                    ;; and in these cases we shouldn't bother including them in the mesh.
                     (when (and (< f1-3 (* f2-17 f2-17)) (not (is-nan? (-> sv-112 x))))
                       (let ((v1-94 sv-96)
                             (a0-47 (-> sv-80 mesh origin))

--- a/goal_src/engine/target/logic-target.gc
+++ b/goal_src/engine/target/logic-target.gc
@@ -5,6 +5,8 @@
 ;; name in dgo: logic-target
 ;; dgos: GAME, ENGINE
 
+;; target-start is modified due to changing the size of the stack in gkernel.gc
+
 ;; DECOMP BEGINS
 
 (defbehavior build-conversions target ((arg0 vector))
@@ -2082,7 +2084,8 @@
   (let* ((s5-0 (get-process *target-dead-pool* target #x4000))
          (v1-3 (when s5-0
                  (let ((t9-2 (method-of-type target activate)))
-                   (t9-2 (the-as target s5-0) *target-pool* 'target (&-> *dram-stack* 14336))
+                   ;; note: this constant must be DPROCESS_STACK_SIZE
+                   (t9-2 (the-as target s5-0) *target-pool* 'target (&-> *dram-stack* DPROCESS_STACK_SIZE))
                    )
                  (run-now-in-process s5-0 init-target arg1)
                  (-> s5-0 ppointer)


### PR DESCRIPTION
`ps` crash was because `target` was using the original game's stack size, but should use the updated one.

the ram would disappear because the `navigate` stuff looked at the position of other enemies which are NaNs. All the enemies in the area had a weird chain of setting each other to NaN and I'm not really sure how it all started. I suspect that the stupid snow bunny disappearing or being spawned in because of visibility is the cause, but can't prove it 100% yet.

On PS2 though, this would have behaved like the enemy is infinitely far away, and wouldn't be included in the nav mesh, so explicitly ignoring NaN things doesn't seem like the worst workaround.