### PR TITLE
remove unused str files from build system

### DIFF
--- a/goal_src/game.gp
+++ b/goal_src/game.gp
@@ -299,13 +299,6 @@
   "DE0197"
   "DE0199"
   "DE0202"
-  ;; jak other
-  "EIFISH"
-  "EIICE"
-  "EIFLUT"
-  "EIPOLE"
-  "EIRACER"
-  "EITUBE"
 
   ;; intro camera
   "NDINTRO"


### PR DESCRIPTION
These are unused in favor of just having them be in the level DGOs instead.