### PR TITLE
[graphics] fix edges of small eyes

### DIFF
--- a/game/graphics/opengl_renderer/EyeRenderer.cpp
+++ b/game/graphics/opengl_renderer/EyeRenderer.cpp
@@ -579,7 +579,7 @@ void EyeRenderer::run_gpu(const std::vector<SingleEyeDraws>& draws,
     // first, the clear
     float clear[4] = {0, 0, 0, 0};
     for (int i = 0; i < 4; i++) {
-      clear[i] = (draw.clear_color >> (8 * i)) / 255.f;
+      clear[i] = ((draw.clear_color >> (8 * i)) & 0xff) / 255.f;
     }
     glClearBufferfv(GL_COLOR, 0, clear);
 


### PR DESCRIPTION
Fixes the borders of eyes that are smaller than the 32x32 region when using the GPU eye renderer. The color of the corner should be used as the background in this case, but there was a bug in reading it.

![image](https://user-images.githubusercontent.com/48171810/171521518-7379befb-8567-4c3b-bba0-66dd82a77bcf.png)
