### PR TITLE
[game] fix daxter stuck face bug

### DIFF
--- a/goal_src/engine/target/sidekick.gc
+++ b/goal_src/engine/target/sidekick.gc
@@ -242,6 +242,14 @@
   (set! (-> self draw shadow-joint-index) (the-as uint 6))
   (set! (-> self draw shadow-ctrl) *target-shadow-control*)
   (logior! (-> self skel status) (janim-status eye))
+
+  (#when PC_PORT
+    ;; daxter can be killed mid-blerc, leaving blerc modifications in the merc data.
+    ;; once sidekick is restarted, the blerc-done flag will be lost, so the modifications will
+    ;; to work around this, just set blerc-done on spawn. it will run blerc with 0's on the
+    ;; first frame when daxter is drawn, clearing blerc data.
+    (logior! (-> self skel status) (janim-status blerc-done))
+    )
   (let ((v1-14 (-> self node-list data)))
     (set! (-> v1-14 0 param0) cspace<-cspace+quaternion!)
     (set! (-> v1-14 0 param1) (the-as basic (-> self parent-override 0 control unknown-cspace10 parent)))


### PR DESCRIPTION
fix daxter's face getting stuck when exiting a cutscene or similar.

This happened in the real game, but we handle the messed up state at the end improperly with merc2, which assumes that the blerc/blerc-done flags are used correctly.