### PR TITLE
[discord-rpc] fix status not being updated while indoors

### DIFF
--- a/game/kernel/kmachine.cpp
+++ b/game/kernel/kmachine.cpp
@@ -906,6 +906,9 @@ void update_discord_rpc(u32 discord_info) {
           strcpy(small_image_key, time_of_day_str(time));
           strcpy(small_image_text, "Time of day: ");
           strcat(small_image_text, get_time_of_day(time).c_str());
+        } else {
+          strcpy(small_image_key, "");
+          strcpy(small_image_text, "");
         }
       }
       rpc.smallImageKey = small_image_key;


### PR DESCRIPTION
When in an indoors area, the small time of day icon and text were not being cleared properly and would be filled with garbage data, which resulted in the game status not being updated until you left the area.