### PR TITLE
[decompiler] cleanup to get atomic ops working on jak2 inputs

### DIFF
--- a/common/symbols.h
+++ b/common/symbols.h
@@ -1,10 +1,13 @@
 #pragma once
 
+#include "common/versions.h"
+
 /*!
  * @file symbols.h
  * The location of fixed symbols in the GOAL symbol table.
  */
 
+namespace jak1_symbols {
 constexpr int FIX_SYM_EMPTY_CAR = -0xc;
 constexpr int FIX_SYM_EMPTY_PAIR = -0xa;
 constexpr int FIX_SYM_EMPTY_CDR = -0x8;
@@ -76,3 +79,34 @@ constexpr int FIX_SYM_SOUND = 0x1b8;                // ??
 constexpr int FIX_SYM_DGO = 0x1c0;                  // ??
 constexpr int FIX_SYM_TOP_LEVEL = 0x1c8;            // ??
 constexpr int FIX_FIXED_SYM_END_OFFSET = 0x1d0;
+}  // namespace jak1_symbols
+
+namespace jak2_symbols {
+constexpr int FIX_SYM_EMPTY_CAR = -0x8;
+constexpr int FIX_SYM_EMPTY_PAIR = -0x7;
+constexpr int FIX_SYM_EMPTY_CDR = -0x4;
+constexpr int FIX_SYM_FALSE = 0x0;  // GOAL boolean #f (note that this is equal to the $s7 register)
+constexpr int FIX_SYM_TRUE = 0x4;   // GOAL boolean #t
+}  // namespace jak2_symbols
+
+constexpr int false_symbol_offset() {
+  return jak1_symbols::FIX_SYM_FALSE;
+}
+
+constexpr int true_symbol_offset(GameVersion version) {
+  switch (version) {
+    case GameVersion::Jak1:
+      return jak1_symbols::FIX_SYM_TRUE;
+    case GameVersion::Jak2:
+      return jak2_symbols::FIX_SYM_TRUE;
+  }
+}
+
+constexpr int empty_pair_offset(GameVersion version) {
+  switch (version) {
+    case GameVersion::Jak1:
+      return jak1_symbols::FIX_SYM_EMPTY_PAIR;
+    case GameVersion::Jak2:
+      return jak2_symbols::FIX_SYM_EMPTY_PAIR;
+  }
+}

--- a/decompiler/Function/CfgVtx.cpp
+++ b/decompiler/Function/CfgVtx.cpp
@@ -2612,7 +2612,7 @@ std::shared_ptr<ControlFlowGraph> build_cfg(
     Function& func,
     const CondWithElseLengthHack& cond_with_else_hack,
     const std::unordered_set<int>& blocks_ending_in_asm_br) {
-  //  fmt::print("START {}\n", func.guessed_name.to_string());
+  // fmt::print("START {}\n", func.guessed_name.to_string());
   auto cfg = std::make_shared<ControlFlowGraph>();
 
   const auto& blocks = cfg->create_blocks(func.basic_blocks.size());

--- a/decompiler/ObjectFile/LinkedObjectFile.cpp
+++ b/decompiler/ObjectFile/LinkedObjectFile.cpp
@@ -508,27 +508,48 @@ void LinkedObjectFile::process_fp_relative_links() {
               case InstructionKind::DADDU:
               case InstructionKind::ADDU: {
                 ASSERT(prev_instr);
-                if (prev_instr->kind != InstructionKind::ORI) {
+                if (prev_instr->kind == InstructionKind::ORI) {
+                  ASSERT(prev_instr->kind == InstructionKind::ORI);
+                  int offset_reg_src_id = instr.kind == InstructionKind::DADDU ? 0 : 1;
+                  auto offset_reg = instr.get_src(offset_reg_src_id).get_reg();
+                  ASSERT(offset_reg == prev_instr->get_dst(0).get_reg());
+                  ASSERT(offset_reg == prev_instr->get_src(0).get_reg());
+                  auto& atom = prev_instr->get_imm_src();
+                  int additional_offset = 0;
+                  if (pprev_instr && pprev_instr->kind == InstructionKind::LUI) {
+                    ASSERT(pprev_instr->get_dst(0).get_reg() == offset_reg);
+                    additional_offset = (1 << 16) * pprev_instr->get_imm_src().get_imm();
+                    pprev_instr->get_imm_src().set_label(
+                        get_label_id_for(seg, current_fp + atom.get_imm() + additional_offset));
+                  }
+                  atom.set_label(
+                      get_label_id_for(seg, current_fp + atom.get_imm() + additional_offset));
+                  stats.n_fp_reg_use_resolved++;
+                } else if (prev_instr->kind == InstructionKind::DADDIU) {
+                  /*
+                   * Jak 2 has a new use of fp to access elements of a static array that looks like
+                   * this:
+                   *     (set! v1 (* idx stride))
+                   *     daddiu v1, v1, 8128
+                   *     daddu v1, v1, fp
+                   */
+                  auto val_plus_off_reg = prev_instr->get_dst(0).get_reg();
+
+                  // it's possible that this isn't always the case, but works for all of jak 2
+                  ASSERT(val_plus_off_reg == prev_instr->get_src(0).get_reg());
+                  ASSERT(val_plus_off_reg == instr.get_src(0).get_reg());
+                  ASSERT(val_plus_off_reg == instr.get_dst(0).get_reg());
+                  auto& atom = prev_instr->get_imm_src();
+                  atom.set_label(get_label_id_for(seg, current_fp + atom.get_imm()));
+
+                  stats.n_fp_reg_use_resolved++;
+                }
+                else {
                   lg::error("Failed to process fp relative links for (d)addu preceded by: {}",
                             prev_instr->to_string(labels));
                   return;
                 }
-                ASSERT(prev_instr->kind == InstructionKind::ORI);
-                int offset_reg_src_id = instr.kind == InstructionKind::DADDU ? 0 : 1;
-                auto offset_reg = instr.get_src(offset_reg_src_id).get_reg();
-                ASSERT(offset_reg == prev_instr->get_dst(0).get_reg());
-                ASSERT(offset_reg == prev_instr->get_src(0).get_reg());
-                auto& atom = prev_instr->get_imm_src();
-                int additional_offset = 0;
-                if (pprev_instr && pprev_instr->kind == InstructionKind::LUI) {
-                  ASSERT(pprev_instr->get_dst(0).get_reg() == offset_reg);
-                  additional_offset = (1 << 16) * pprev_instr->get_imm_src().get_imm();
-                  pprev_instr->get_imm_src().set_label(
-                      get_label_id_for(seg, current_fp + atom.get_imm() + additional_offset));
-                }
-                atom.set_label(
-                    get_label_id_for(seg, current_fp + atom.get_imm() + additional_offset));
-                stats.n_fp_reg_use_resolved++;
+
               } break;
 
               default:

--- a/decompiler/ObjectFile/LinkedObjectFile.cpp
+++ b/decompiler/ObjectFile/LinkedObjectFile.cpp
@@ -543,8 +543,7 @@ void LinkedObjectFile::process_fp_relative_links() {
                   atom.set_label(get_label_id_for(seg, current_fp + atom.get_imm()));
 
                   stats.n_fp_reg_use_resolved++;
-                }
-                else {
+                } else {
                   lg::error("Failed to process fp relative links for (d)addu preceded by: {}",
                             prev_instr->to_string(labels));
                   return;

--- a/decompiler/analysis/atomic_op_builder.h
+++ b/decompiler/analysis/atomic_op_builder.h
@@ -49,6 +49,7 @@ int convert_block_to_atomic_ops(int begin_idx,
                                 const std::vector<DecompilerLabel>& labels,
                                 FunctionAtomicOps* container,
                                 DecompWarnings& warnings,
+                                GameVersion version,
                                 bool inline_asm_hint = false,
                                 bool block_ends_in_asm_branch = false);
 
@@ -60,5 +61,6 @@ FunctionAtomicOps convert_function_to_atomic_ops(
     const std::vector<DecompilerLabel>& labels,
     DecompWarnings& warnings,
     bool hint_inline_asm,
-    const std::unordered_set<int>& blocks_ending_in_asm_branches);
+    const std::unordered_set<int>& blocks_ending_in_asm_branches,
+    GameVersion version);
 }  // namespace decompiler

--- a/decompiler/analysis/cfg_builder.cpp
+++ b/decompiler/analysis/cfg_builder.cpp
@@ -6,6 +6,7 @@
 #include "cfg_builder.h"
 #include "decompiler/Function/Function.h"
 #include "decompiler/IR2/Form.h"
+#include "decompiler/ObjectFile/LinkedObjectFile.h"
 #include "decompiler/util/MatchParam.h"
 
 namespace decompiler {
@@ -107,6 +108,13 @@ void clean_up_cond_with_else(FormPool& pool, FormElement* ir, const Env& env) {
 void clean_up_until_loop(FormPool& pool, UntilElement* ir, const Env& env) {
   auto condition_branch = get_condition_branch(ir->condition);
   ASSERT(condition_branch.first);
+  if (condition_branch.first->op()->branch_delay().kind() != IR2_BranchDelay::Kind::NOP) {
+    ASSERT_MSG(
+        false,
+        fmt::format(
+            "bad delay slot in until loop: {} in {}\n", env.func->name(),
+            condition_branch.first->op()->branch_delay().to_form(env.file->labels, env).print()));
+  }
   ASSERT(condition_branch.first->op()->branch_delay().kind() == IR2_BranchDelay::Kind::NOP);
   auto replacement = condition_branch.first->op()->get_condition_as_form(pool, env);
   replacement->invert();
@@ -708,6 +716,7 @@ void clean_up_cond_no_else_final(Function& func, CondNoElseElement* cne) {
       ASSERT(fr.has_value());
       cne->final_destination = *fr;
     } else {
+      fmt::print("failed to clean up cond_no_else_final: {}\n", func.name());
       ASSERT(false);
     }
   }
@@ -1634,6 +1643,10 @@ Form* cfg_to_ir_helper(FormPool& pool, Function& f, const CfgVtx* vtx) {
         ASSERT(delay_end - delay_start == 1);
         auto& op = f.ir2.atomic_ops->ops.at(delay_start);
         auto op_as_expr = dynamic_cast<SetVarOp*>(op.get());
+        if (!op_as_expr) {
+          fmt::print("bad in {}\n", f.name());
+          fmt::print("{}\n", op->to_string(f.ir2.env));
+        }
         ASSERT(op_as_expr);
         e.branch_delay = *op_as_expr;
       }

--- a/decompiler/analysis/mips2c.h
+++ b/decompiler/analysis/mips2c.h
@@ -2,9 +2,13 @@
 
 #include <vector>
 
+#include "common/versions.h"
+
 namespace decompiler {
 class Function;
 
-void run_mips2c(Function* f);
-void run_mips2c_jump_table(Function* f, const std::vector<int>& jump_table_locations);
+void run_mips2c(Function* f, GameVersion version);
+void run_mips2c_jump_table(Function* f,
+                           const std::vector<int>& jump_table_locations,
+                           GameVersion version);
 }  // namespace decompiler

--- a/decompiler/config.cpp
+++ b/decompiler/config.cpp
@@ -66,6 +66,7 @@ Config read_config_file(const std::string& path_to_config_file,
   config.process_art_groups = cfg.at("process_art_groups").get<bool>();
   config.hexdump_code = cfg.at("hexdump_code").get<bool>();
   config.hexdump_data = cfg.at("hexdump_data").get<bool>();
+  config.find_functions = cfg.at("find_functions").get<bool>();
   config.dump_objs = cfg.at("dump_objs").get<bool>();
   config.print_cfgs = cfg.at("print_cfgs").get<bool>();
   config.generate_symbol_definition_map = cfg.at("generate_symbol_definition_map").get<bool>();

--- a/decompiler/config.h
+++ b/decompiler/config.h
@@ -104,6 +104,7 @@ struct Config {
   bool process_art_groups = false;
   bool rip_levels = false;
   bool extract_collision = false;
+  bool find_functions = false;
 
   bool write_hex_near_instructions = false;
   bool hexdump_code = false;

--- a/decompiler/config/all-types2.gc
+++ b/decompiler/config/all-types2.gc
@@ -1,0 +1,16 @@
+;; type system setup
+(define-extern object type)
+(define-extern type type)
+(define-extern structure type)
+(define-extern uint128 type)
+(define-extern basic type)
+(define-extern pair type)
+(define-extern array type)
+
+
+
+;; some types we need.
+(declare-type sparticle-launch-group basic)
+(declare-type lightning-spec basic)
+(declare-type sparticle-launcher basic)
+(declare-type state basic)

--- a/decompiler/config/jak1_ntsc_black_label.jsonc
+++ b/decompiler/config/jak1_ntsc_black_label.jsonc
@@ -20,6 +20,9 @@
   // Run the decompiler
   "decompile_code": false,
 
+  // run the first pass of the decompiler
+  "find_functions": true,
+
   ////////////////////////////
   // DATA ANALYSIS OPTIONS
   ////////////////////////////

--- a/decompiler/config/jak2/hacks.jsonc
+++ b/decompiler/config/jak2/hacks.jsonc
@@ -27,7 +27,35 @@
   "hint_inline_assembly_functions": [],
 
   "asm_functions_by_name": [
+    // checking boxed type is different now - these make the cfg stuff sad
+    "type?", "print", "printl", "inspect", "valid?", "name=", "(method 8 res-lump)", "joint-control-remap!", "(method 21 game-info)", "(method 12 level)",
+    "bg", "(anon-function 2 cam-combiner)", "cspace-inspect-tree", "command-get-process", "command-get-trans", "(method 10 script-context)",
+    "(method 11 script-context)", "(method 9 script-context)", "(anon-function 64 script)", "(anon-function 61 script)", "(anon-function 60 script)",
+    "(anon-function 54 script)", "(anon-function 52 script)", "(anon-function 49 script)", "(anon-function 33 script)",  "debug-menu-func-decode",
+    "scene-player-init", "(method 77 spyder)", "(method 77 flamer)", "(method 77 grenadier)", "(method 224 bot)", "(method 77 rapid-gunner)",
+    // until loop without nop:
+    "rand-vu-int-count-excluding", "rand-vu-int-range-exclude", "(method 9 history)", "history-print", "history-draw",
+    "(method 9 sparticle-launcher)", "(method 18 tracking-spline)", "cam-string-find-position-rel!", "cam-layout-entity-volume-info-create",
+    "process-drawable-shock-skel-effect", "target-history-print", "display-list-control", "anim-test-anim-list-handler",
+    "anim-test-sequence-list-handler", "anim-tester-get-playing-item", "(method 9 mysql-nav-graph)", "(method 58 nav-graph-editor)",
+    "(method 120 enemy)", "start-pilot-recorder", "(anon-function 10 pilot-recorder)", "(method 0 hover-nav-control)",
+    "(method 24 nav-network)", "(method 11 predator-manager)", "(method 9 bot-speech-list)", "(method 9 bot-speech-list-shuffle)",
+    "(anon-function 10 sig-recorder)", "(method 14 trail-graph)", "(method 12 trail-graph)", "(method 11 trail-graph)",
+    // actual asm
+    "symlink2", "blerc-a-fragment", "blerc-execute", "foreground-check-longest-edge-asm", "generic-light-proc",
+    "shadow-add-single-edges","shadow-add-facing-single-tris", "shadow-add-double-tris", "shadow-add-double-edges",
+    "(method 12 collide-mesh)", "(method 17 collide-edge-work)", "(method 42 collide-shape)", "(method 12 collide-shape-prim-sphere)",
+    "(method 12 collide-shape-prim-mesh)", "(method 18 collide-shape-prim-mesh)", "(method 10 collide-cache-prim)",
+    "(method 17 collide-cache)", "(method 16 ocean)",
 
+    // unknown bug
+    "joint-mod-polar-look-at-guts", "(method 13 external-art-control)", "update-mood-copy-ctywide", "update-mood-copy-stadium",
+    "update-mood-drillb", "reset-target-tracking", "(anon-function 1 target)", "find-nearest-entity", "target-land-effect",
+    "(method 12 effect-control)", "(method 11 effect-control)", "(method 10 effect-control)",
+    "(anon-function 2 scene)", "progress-trans", "(method 10 bigmap)", "(method 9 editable-region)", "(method 57 enemy)",
+    "(anon-function 10 meet-brutter)", "(method 154 vehicle-racer)", "(method 188 predator)", "(anon-function 13 sig0-course)",
+    "(method 228 hal-sewer)", "(method 154 vehicle-city-racer)", "(method 53 squid)", "(anon-function 11 fort-floor-spike)",
+    "(method 29 gun-dummy)", "vehicle-explode-post", "(method 158 vehicle-guard)", "(method 207 metalhead-predator)"
   ],
 
   // these functions use pairs and the decompiler

--- a/decompiler/config/jak2_ntsc_v1.jsonc
+++ b/decompiler/config/jak2_ntsc_v1.jsonc
@@ -8,7 +8,7 @@
   // if you want to filter to only some object names.
   // it will make the decompiler much faster.
   "allowed_objects": [],
-  "banned_objects": [],
+  "banned_objects": ["effect-control"],
 
   ////////////////////////////
   // CODE ANALYSIS OPTIONS
@@ -19,7 +19,9 @@
   "disassemble_code": true,
 
   // Run the decompiler
-  "decompile_code": false,
+  "decompile_code": true,
+
+  "find_functions": true,
 
   ////////////////////////////
   // DATA ANALYSIS OPTIONS

--- a/decompiler/main.cpp
+++ b/decompiler/main.cpp
@@ -151,6 +151,11 @@ int main(int argc, char** argv) {
   db.process_labels();
   fmt::print("[Mem] After code: {} MB\n", get_peak_rss() / (1024 * 1024));
 
+  // top level decompile (do this before printing asm so we get function names)
+  if (config.find_functions) {
+    db.ir2_top_level_pass(config);
+  }
+
   // print disassembly
   if (config.disassemble_code || config.disassemble_data) {
     db.write_disassembly(out_folder, config.disassemble_data, config.disassemble_code,

--- a/game/graphics/gfx.cpp
+++ b/game/graphics/gfx.cpp
@@ -241,7 +241,7 @@ void set_fullscreen(DisplayMode mode, int screen) {
 }
 
 void input_mode_set(u32 enable) {
-  if (enable == s7.offset + FIX_SYM_TRUE) {  // #t
+  if (enable == s7.offset + jak1_symbols::FIX_SYM_TRUE) {  // #t
     Pad::g_input_mode_mapping = g_settings.pad_mapping_info;
     Pad::EnterInputMode();
   } else {

--- a/game/kernel/klink.cpp
+++ b/game/kernel/klink.cpp
@@ -21,6 +21,8 @@
 #include "common/util/Assert.h"
 #include "third-party/fmt/core.h"
 
+using namespace jak1_symbols;
+
 namespace {
 // turn on printf's for debugging linking issues.
 constexpr bool link_debug_printfs = false;

--- a/game/kernel/klisten.cpp
+++ b/game/kernel/klisten.cpp
@@ -17,6 +17,8 @@
 #include "kscheme.h"
 #include "common/symbols.h"
 
+using namespace jak1_symbols;
+
 Ptr<Symbol> ListenerLinkBlock;
 Ptr<Symbol> ListenerFunction;
 Ptr<Symbol> kernel_dispatcher;

--- a/game/kernel/kmachine.cpp
+++ b/game/kernel/kmachine.cpp
@@ -44,6 +44,7 @@
 
 #include "svnrev.h"
 
+using namespace jak1_symbols;
 using namespace ee;
 
 /*!

--- a/game/kernel/kprint.cpp
+++ b/game/kernel/kprint.cpp
@@ -24,6 +24,8 @@
 #include "common/symbols.h"
 #include "common/util/Assert.h"
 
+using namespace jak1_symbols;
+
 ///////////
 // SDATA
 ///////////

--- a/game/kernel/kscheme.cpp
+++ b/game/kernel/kscheme.cpp
@@ -25,6 +25,8 @@
 #include "game/mips2c/mips2c_table.h"
 #include "common/util/Assert.h"
 
+using namespace jak1_symbols;
+
 //! Controls link mode when EnableMethodSet = 0, MasterDebug = 1, DiskBoot = 0. Will enable a
 //! warning message if EnableMethodSet = 1
 u32 FastLink;

--- a/game/mips2c/mips2c_table.cpp
+++ b/game/mips2c/mips2c_table.cpp
@@ -5,6 +5,8 @@
 #include "game/kernel/kscheme.h"
 #include "common/symbols.h"
 
+using namespace jak1_symbols;
+
 extern "C" {
 void _mips2c_call_linux();
 void _mips2c_call_windows();

--- a/goalc/compiler/IR.cpp
+++ b/goalc/compiler/IR.cpp
@@ -5,7 +5,7 @@
 #include "common/symbols.h"
 
 using namespace emitter;
-
+using namespace jak1_symbols; // TODO jak 1 symbols
 namespace {
 Register get_reg(const RegVal* rv, const AllocationResult& allocs, emitter::IR_Record irec) {
   if (rv->rlet_constraint().has_value()) {

--- a/goalc/compiler/IR.cpp
+++ b/goalc/compiler/IR.cpp
@@ -5,7 +5,7 @@
 #include "common/symbols.h"
 
 using namespace emitter;
-using namespace jak1_symbols; // TODO jak 1 symbols
+using namespace jak1_symbols;  // TODO jak 1 symbols
 namespace {
 Register get_reg(const RegVal* rv, const AllocationResult& allocs, emitter::IR_Record irec) {
   if (rv->rlet_constraint().has_value()) {

--- a/goalc/debugger/Debugger.cpp
+++ b/goalc/debugger/Debugger.cpp
@@ -513,6 +513,8 @@ bool Debugger::write_memory(const u8* src_buffer, int size, u32 goal_addr) {
  * Read the GOAL Symbol table from an attached and halted target.
  */
 void Debugger::read_symbol_table() {
+  // todo: this assumes many things specific to jak 1.
+  using namespace jak1_symbols;
   ASSERT(is_valid() && is_attached() && is_halted());
   u32 bytes_read = 0;
   u32 reads = 0;

--- a/test/decompiler/FormRegressionTest.cpp
+++ b/test/decompiler/FormRegressionTest.cpp
@@ -173,7 +173,8 @@ std::unique_ptr<FormRegressionTest::TestData> FormRegressionTest::make_function(
 
   // convert instruction to atomic ops
   DecompWarnings warnings;
-  auto ops = convert_function_to_atomic_ops(test->func, program.labels, warnings, false, {});
+  auto ops = convert_function_to_atomic_ops(test->func, program.labels, warnings, false, {},
+                                            GameVersion::Jak1);
   test->func.ir2.atomic_ops = std::make_shared<FunctionAtomicOps>(std::move(ops));
   test->func.ir2.atomic_ops_succeeded = true;
   test->func.ir2.env.set_end_var(test->func.ir2.atomic_ops->end_op().return_var());

--- a/test/decompiler/test_AtomicOpBuilder.cpp
+++ b/test/decompiler/test_AtomicOpBuilder.cpp
@@ -24,6 +24,7 @@ std::string assembly_from_list(std::vector<std::string> assemblyLines) {
   return str;
 }
 
+// jak 1 specific
 void test_case(std::string assembly_lines,
                std::vector<std::string> output_lines,
                std::vector<std::vector<std::string>> write_regs,
@@ -45,7 +46,7 @@ void test_case(std::string assembly_lines,
   // treat the entire program as a single basic block, and convert!
   DecompWarnings warnings;
   convert_block_to_atomic_ops(0, prg.instructions.begin(), prg.instructions.end(), prg.labels,
-                              &container, warnings);
+                              &container, warnings, GameVersion::Jak1);
 
   // count operations
   EXPECT_EQ(container.ops.size(), output_lines.size());
@@ -130,7 +131,7 @@ TEST(DecompilerAtomicOpBuilder, RegUseDuplication) {
   FunctionAtomicOps container;
   DecompWarnings warnings;
   convert_block_to_atomic_ops(0, prg.instructions.begin(), prg.instructions.end(), prg.labels,
-                              &container, warnings);
+                              &container, warnings, GameVersion::Jak1);
   ASSERT_EQ(1, container.ops.size());
   auto& op = container.ops.at(0);
   for (const auto& reg_group : {op->read_regs(), op->write_regs(), op->clobber_regs()}) {

--- a/test/offline/offline_test_main.cpp
+++ b/test/offline/offline_test_main.cpp
@@ -307,6 +307,7 @@ void disassemble(Decompiler& dc) {
 
 void decompile(Decompiler& dc, const OfflineTestConfig& config) {
   dc.db->extract_art_info();
+  dc.db->ir2_top_level_pass(*dc.config);
   dc.db->analyze_functions_ir2({}, *dc.config, config.skip_compile_functions,
                                config.skip_compile_states);
 }

--- a/test/test_kernel.cpp
+++ b/test/test_kernel.cpp
@@ -11,6 +11,8 @@
 #include "game/kernel/kscheme.h"
 #include "all_jak1_symbols.h"
 
+using namespace jak1_symbols;
+
 TEST(Kernel, strend) {
   char test[] = "test";
   char* end = strend(test);

--- a/tools/MemoryDumpTool/main.cpp
+++ b/tools/MemoryDumpTool/main.cpp
@@ -114,6 +114,7 @@ struct SymbolMap {
 };
 
 SymbolMap build_symbol_map(const Ram& ram, u32 s7) {
+  // TODO jak 1 specific
   fmt::print("finding symbols...\n");
   SymbolMap map;
   /*
@@ -150,9 +151,10 @@ SymbolMap build_symbol_map(const Ram& ram, u32 s7) {
 std::unordered_map<u32, std::string> build_type_map(const Ram& ram,
                                                     const SymbolMap& symbols,
                                                     u32 s7) {
+  // TODO jak 1 specific
   std::unordered_map<u32, std::string> result;
   fmt::print("finding types...\n");
-  u32 type_of_type = ram.word(s7 + FIX_SYM_TYPE_TYPE);
+  u32 type_of_type = ram.word(s7 + jak1_symbols::FIX_SYM_TYPE_TYPE);
   ASSERT(type_of_type == ram.word(symbols.name_to_addr.at("type")));
 
   for (const auto& [name, addr] : symbols.name_to_addr) {


### PR DESCRIPTION
small tweaks required to get all of jak 2 going through atomic ops pass.  There's still some missing stuff, but it's  enough for all the inspect methods and top-levels to get through ao.

This is as much as we need to develop the type inspector stuff, so at this point I'm going to transition to working on decompiler improvements and stop working on jak 2 specific missing things.