### PR TITLE
game: automatically apply framelimiter on high refresh rate monitors

### DIFF
--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -112,9 +112,9 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
       ImGui::Checkbox("Enable V-Sync", &m_vsync);
       ImGui::Separator();
       ImGui::Checkbox("Framelimiter", &framelimiter);
-      ImGui::InputFloat("Target FPS", &m_target_fps_text);
+      ImGui::InputFloat("Target FPS", &target_fps_input);
       if (ImGui::MenuItem("Apply")) {
-        target_fps = m_target_fps_text;
+        target_fps = target_fps_input;
       }
       ImGui::Separator();
       ImGui::Checkbox("Accurate Lag Mode", &experimental_accurate_lag);

--- a/game/graphics/opengl_renderer/debug_gui.h
+++ b/game/graphics/opengl_renderer/debug_gui.h
@@ -50,6 +50,8 @@ class OpenGlDebugGui {
   bool should_advance_frame() { return m_frame_timer.should_advance_frame(); }
   bool should_gl_finish() { return m_frame_timer.do_gl_finish; }
 
+  void init_framerate_settings();
+
   bool get_screenshot_flag() {
     if (m_want_screenshot) {
       m_want_screenshot = false;
@@ -68,6 +70,7 @@ class OpenGlDebugGui {
   bool record_events = false;
   bool dump_events = false;
   bool want_reboot_in_debug = false;
+  bool m_vsync = true;
 
  private:
   FrameTimeRecorder m_frame_timer;
@@ -77,6 +80,5 @@ class OpenGlDebugGui {
   bool m_subtitle_editor = false;
   bool m_want_screenshot = false;
   char m_screenshot_save_name[256] = "screenshot.png";
-  bool m_vsync = true;
-  float m_target_fps_text = 60.0;
+  float target_fps_input = 60.f;
 };

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -166,11 +166,36 @@ static std::shared_ptr<GfxDisplay> gl_make_main_display(int width,
   glfwSetWindowIcon(window, 1, images);
   stbi_image_free(images[0].pixels);
   g_gfx_data = std::make_unique<GraphicsData>();
+
   gl_inited = true;
 
-  // enable vsync by default
-  // glfwSwapInterval(1);
-  glfwSwapInterval(settings.vsync);
+  // init framerate settings
+  GLFWmonitor* primary_monitor = glfwGetPrimaryMonitor();
+  if (primary_monitor) {
+    auto primary_monitor_video_mode = glfwGetVideoMode(primary_monitor);
+
+    if (primary_monitor_video_mode && primary_monitor_video_mode->refreshRate > 60) {
+      // Use the framelimiter by default and disable vsync
+      g_gfx_data->debug_gui.framelimiter = true;
+      g_gfx_data->debug_gui.m_vsync = false;
+      g_gfx_data->vsync_enabled = false;
+      glfwSwapInterval(false);
+    } else {
+      // enable vsync
+      g_gfx_data->debug_gui.framelimiter = false;
+      g_gfx_data->debug_gui.m_vsync = true;
+      g_gfx_data->vsync_enabled = true;
+      // glfwSwapInterval(1);
+      glfwSwapInterval(settings.vsync);
+    }
+  } else {
+    // enable vsync
+    g_gfx_data->debug_gui.framelimiter = false;
+    g_gfx_data->debug_gui.m_vsync = true;
+    g_gfx_data->vsync_enabled = true;
+    // glfwSwapInterval(1);
+    glfwSwapInterval(settings.vsync);
+  }
 
   SetDisplayCallbacks(window);
   Pad::initialize();


### PR DESCRIPTION
This is not totally perfect because it uses the primary monitor.  Though this is a gap in our code in general (other places just use the primary monitor as well).

Ideally we'd remember which monitor the game was opened on / is within and handle things accordingly.

Needs to be tested on a slow monitor, for my 144hz -- the game finally runs at the proper speed by default (60fps feels so slow compared to 400fps...)

Likely supersedes #1288 