### PR TITLE
release: include error metadata file for launcher purposes

### DIFF
--- a/.github/scripts/releases/error-code-metadata.json
+++ b/.github/scripts/releases/error-code-metadata.json
@@ -1,0 +1,20 @@
+{
+  "4000": {
+    "msg": "Validation Failed: Cannot locate ELF"
+  },
+  "4001": {
+    "msg": "Validation Failed: Game serial missing from valid game database"
+  },
+  "4002": {
+    "msg": "Validation Failed: ELF missing from valid game database"
+  },
+  "4010": {
+    "msg": "Validation Failed: Bad or unexpected ISO contents"
+  },
+  "4011": {
+    "msg": "Validation Failed: Extracted an unexpected amount of files from ISO"
+  },
+  "4020": {
+    "msg": "Validation Failed: ISO Extraction failed, output directory did not contain expected files"
+  }
+}

--- a/.github/scripts/releases/extract_build_linux.sh
+++ b/.github/scripts/releases/extract_build_linux.sh
@@ -16,12 +16,14 @@ strip $DEST/goalc
 strip $DEST/extractor
 
 mkdir -p $DEST/data
+mkdir -p $DEST/data/launcher/
 mkdir -p $DEST/data/decompiler/
 mkdir -p $DEST/data/assets
 mkdir -p $DEST/data/game
 mkdir -p $DEST/data/log
 mkdir -p $DEST/data/game/graphics/opengl_renderer/
 
+cp -r $SOURCE/.github/scripts/releases/error-code-metadata.json $DEST/data/launcher/error-code-metadata.json
 cp -r $SOURCE/decompiler/config $DEST/data/decompiler/
 cp -r $SOURCE/goal_src $DEST/data
 cp -r $SOURCE/game/assets $DEST/data/game/

--- a/.github/scripts/releases/extract_build_windows.sh
+++ b/.github/scripts/releases/extract_build_windows.sh
@@ -12,12 +12,14 @@ cp $SOURCE/build/bin/goalc.exe $DEST
 cp $SOURCE/build/bin/extractor.exe $DEST
 
 mkdir -p $DEST/data
+mkdir -p $DEST/data/launcher/
 mkdir -p $DEST/data/decompiler/
 mkdir -p $DEST/data/assets
 mkdir -p $DEST/data/game
 mkdir -p $DEST/data/log
 mkdir -p $DEST/data/game/graphics/opengl_renderer/
 
+cp -r $SOURCE/.github/scripts/releases/error-code-metadata.json $DEST/data/launcher/error-code-metadata.json
 cp -r $SOURCE/decompiler/config $DEST/data/decompiler/
 cp -r $SOURCE/goal_src $DEST/data
 cp -r $SOURCE/game/assets $DEST/data/game/

--- a/.github/workflows/linux-workflow.yaml
+++ b/.github/workflows/linux-workflow.yaml
@@ -114,9 +114,8 @@ jobs:
         run: |
           mkdir -p ./ci-artifacts/out
           ./.github/scripts/releases/extract_build_linux.sh ./ci-artifacts/out ./
-          pushd ci-artifacts
-          tar czf linux.tar.gz -C ./out .
-          popd
+          cd ci-artifacts/out
+          tar czf ../linux.tar.gz .
 
       - name: Upload Assets and Potential Publish Release
         if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler == 'clang'

--- a/.github/workflows/linux-workflow.yaml
+++ b/.github/workflows/linux-workflow.yaml
@@ -115,7 +115,7 @@ jobs:
           mkdir -p ./ci-artifacts/out
           ./.github/scripts/releases/extract_build_linux.sh ./ci-artifacts/out ./
           pushd ci-artifacts
-          tar czf linux.tar.gz ./out
+          tar czf linux.tar.gz -C ./out .
           popd
 
       - name: Upload Assets and Potential Publish Release

--- a/.github/workflows/windows-workflow.yaml
+++ b/.github/workflows/windows-workflow.yaml
@@ -85,7 +85,7 @@ jobs:
         run: |
           mkdir -p ./ci-artifacts/out
           ./.github/scripts/releases/extract_build_windows.sh ./ci-artifacts/out ./
-          7z a -tzip ./ci-artifacts/windows.zip ./ci-artifacts/out
+          7z a -tzip ./ci-artifacts/windows.zip ./ci-artifacts/out/*
 
       - name: Upload Assets and Potential Publish Release
         if: github.repository == 'open-goal/jak-project' && startsWith(github.ref, 'refs/tags/') && matrix.compiler == 'clang'

--- a/common/log/log.cpp
+++ b/common/log/log.cpp
@@ -9,6 +9,7 @@
 #include <Windows.h>
 #endif
 #include "common/util/Assert.h"
+#include "common/util/FileUtil.h"
 
 namespace lg {
 struct Logger {
@@ -79,6 +80,7 @@ void log_message(level log_level, LogTime& now, const char* message) {
 
 void set_file(const std::string& filename) {
   ASSERT(!gLogger.fp);
+  file_util::create_dir_if_needed_for_file(filename);
   gLogger.fp = fopen(filename.c_str(), "w");
   ASSERT(gLogger.fp);
 }

--- a/common/util/FileUtil.cpp
+++ b/common/util/FileUtil.cpp
@@ -32,6 +32,7 @@
 #include <cstring>
 #endif
 #include "common/util/Assert.h"
+#include <common/log/log.h>
 
 namespace file_util {
 std::filesystem::path get_user_home_dir() {
@@ -201,7 +202,7 @@ void write_rgba_png(const std::string& name, void* data, int w, int h) {
 void write_text_file(const std::string& file_name, const std::string& text) {
   FILE* fp = fopen(file_name.c_str(), "w");
   if (!fp) {
-    printf("Failed to fopen %s\n", file_name.c_str());
+    lg::error("Failed to fopen {}\n", file_name);
     throw std::runtime_error("Failed to open file");
   }
   fprintf(fp, "%s\n", text.c_str());

--- a/common/util/FileUtil.cpp
+++ b/common/util/FileUtil.cpp
@@ -71,7 +71,11 @@ std::string get_current_executable_path() {
 #ifdef _WIN32
   char buffer[FILENAME_MAX];
   GetModuleFileNameA(NULL, buffer, FILENAME_MAX);
-  return std::string(buffer);
+  std::string file_path(buffer);
+  if (file_path.rfind("\\\\?\\", 0) == 0) {
+    return file_path.substr(4);
+  }
+  return file_path;
 #else
   // do Linux stuff
   char buffer[FILENAME_MAX + 1];

--- a/decompiler/extractor/main.cpp
+++ b/decompiler/extractor/main.cpp
@@ -261,6 +261,9 @@ void decompile(std::filesystem::path jak1_input_files) {
   db.find_code(config);
   db.process_labels();
 
+  // ensure asset dir exists
+  file_util::create_dir_if_needed(file_util::get_file_path({"assets"}));
+
   // text files
   {
     auto result = db.process_game_text_files(config);


### PR DESCRIPTION
This adds a simple metadata file to the release process that lets the launcher know what error codes mean.  This keeps this repo as the source of truth instead of having to make assumptions in the launcher (and hoping nothing changes).

Also got rid of the `out/` subfolder inside the release assets