### PR TITLE
actions: add `libpulse-dev` dependency to fix audio on pipewire systems

### DIFF
--- a/.github/workflows/linux-workflow.yaml
+++ b/.github/workflows/linux-workflow.yaml
@@ -41,7 +41,7 @@ jobs:
         run: git submodule update --init --recursive -j 2
 
       - name: Get Common Package Dependencies
-        run: sudo apt install build-essential cmake clang gcc g++ lcov make nasm libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev zip
+        run: sudo apt install build-essential cmake clang gcc g++ lcov make nasm libxrandr-dev libxinerama-dev libxcursor-dev libpulse-dev libxi-dev zip
 
       - name: Get Clang
         if: matrix.compiler == 'clang'


### PR DESCRIPTION
On the Linux release version, `cubeb` would fail to init on systems that use Pipewire as the audio backend due to a missing build dependency.