### PR TITLE
game: remove mystery windows chime sound when starting up

### DIFF
--- a/game/overlord/soundcommon.cpp
+++ b/game/overlord/soundcommon.cpp
@@ -1,6 +1,7 @@
 #include "soundcommon.h"
 #include <cstdio>
 #include "common/util/Assert.h"
+#include <string>
 
 // TODO strcpy_toupper
 // TODO atoi
@@ -16,7 +17,9 @@ void ReadBankSoundInfo(SoundBank* bank, SoundBank* unk, s32 unk2) {
 void PrintBankInfo(SoundBank* bank) {
   printf("Bank %s\n\n", bank->name);
   for (u32 i = 0; i < bank->sound_count; i++) {
-    printf("%d : %16s : min %d max %d curve %d\n", i, bank->sound[i].name,
+    // Some characters use the full 16 characters (bonelurker-grunt) and dont have a null terminator
+    std::string name = std::string(bank->sound[i].name, 16);
+    printf("%d : %16s : min %d max %d curve %d\n", i, name.c_str(),
            bank->sound[i].fallof_params & 0x3fff, (bank->sound[i].fallof_params >> 14) & 0x3fff,
            bank->sound[i].fallof_params >> 28);
   }


### PR DESCRIPTION
`bonelurker-grunt` uses the full 16 characters, so there is no null-terminator.  The print would overflow and read until the next name's null terminator.

The resulting print of the random garbage between was the cause of the mystery chime.