### PR TITLE
windows graphics fixes

### DIFF
--- a/game/graphics/display.h
+++ b/game/graphics/display.h
@@ -10,10 +10,6 @@
 #include "common/util/Assert.h"
 #include "gfx.h"
 
-// lol hax
-#define __NYI_DEF \
-  { ASSERT_MSG(false, "nyi"); }
-
 // a GfxDisplay class is equivalent to a window that displays stuff. This holds an actual internal
 // window pointer used by whichever renderer. It also contains functions for setting and
 // retrieving certain window parameters.
@@ -49,6 +45,7 @@ class GfxDisplay {
   virtual void get_size(int* w, int* h) = 0;
   virtual GfxDisplayMode get_fullscreen() = 0;
   virtual void render() = 0;
+  virtual void set_lock(bool lock) = 0;
   bool is_active() const { return get_window() != nullptr; }
   void set_title(const char* title);
   const char* title() const { return m_title; }

--- a/game/graphics/gfx.cpp
+++ b/game/graphics/gfx.cpp
@@ -242,6 +242,12 @@ void set_fullscreen(GfxDisplayMode mode, int screen) {
   }
 }
 
+void set_window_lock(bool lock) {
+  if (Display::GetMainDisplay()) {
+    Display::GetMainDisplay()->set_lock(lock);
+  }
+}
+
 void input_mode_set(u32 enable) {
   if (enable == s7.offset + jak1_symbols::FIX_SYM_TRUE) {  // #t
     Pad::g_input_mode_mapping = g_settings.pad_mapping_info;

--- a/game/graphics/gfx.h
+++ b/game/graphics/gfx.h
@@ -115,6 +115,7 @@ GfxDisplayMode get_fullscreen();
 void get_screen_size(s64 vmode_idx, s32* w, s32* h, s32* c);
 void set_letterbox(int w, int h);
 void set_fullscreen(GfxDisplayMode mode, int screen);
+void set_window_lock(bool lock);
 void input_mode_set(u32 enable);
 void input_mode_save();
 s64 get_mapped_button(s64 pad, s64 button);

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -135,6 +135,7 @@ static int gl_init(GfxSettings& settings) {
   }
   glfwWindowHint(GLFW_DOUBLEBUFFER, GLFW_TRUE);
   glfwWindowHint(GLFW_SAMPLES, 1);
+  glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
 
   return 0;
 }
@@ -430,6 +431,10 @@ void GLDisplay::get_screen_size(int vmode_idx, s32* w_out, s32* h_out, s32* coun
   if (h_out) {
     *h_out = vmode->height;
   }
+}
+
+void GLDisplay::set_lock(bool lock) {
+  glfwSetWindowAttrib(m_window, GLFW_RESIZABLE, lock ? GLFW_TRUE : GLFW_FALSE);
 }
 
 void update_global_profiler() {

--- a/game/graphics/pipelines/opengl.h
+++ b/game/graphics/pipelines/opengl.h
@@ -34,6 +34,7 @@ class GLDisplay : public GfxDisplay {
   void set_size(int w, int h);
   void update_fullscreen(GfxDisplayMode mode, int screen);
   void render();
+  void set_lock(bool lock);
 };
 
 extern const GfxRendererModule gRendererOpenGL;

--- a/game/kernel/kmachine.cpp
+++ b/game/kernel/kmachine.cpp
@@ -964,6 +964,10 @@ void set_fullscreen(u32 symptr, s64 screen) {
   }
 }
 
+void set_window_lock(u32 symptr) {
+  Gfx::set_window_lock(symptr == s7.offset);
+}
+
 void set_collision(u32 symptr) {
   Gfx::g_global_settings.collision_enable = symptr != s7.offset;
 }
@@ -1012,6 +1016,7 @@ void InitMachine_PCPort() {
   make_function_symbol_from_c("pc-get-screen-size", (void*)get_screen_size);
   make_function_symbol_from_c("pc-set-window-size", (void*)Gfx::set_window_size);
   make_function_symbol_from_c("pc-set-fullscreen", (void*)set_fullscreen);
+  make_function_symbol_from_c("pc-set-window-lock", (void*)set_window_lock);
 
   // graphics things
   make_function_symbol_from_c("pc-set-letterbox", (void*)Gfx::set_letterbox);

--- a/goal_src/engine/gfx/texture.gc
+++ b/goal_src/engine/gfx/texture.gc
@@ -1960,7 +1960,7 @@
            )
           )
         (let ((font-tx-2 (lookup-texture-by-id (new 'static 'texture-id :index #x2 :page #x4fe)))
-             (font-tx-2-dest #xe0000)
+             (font-tx-2-dest #xe6000)
              (font-tx-2-fmt (gs-psm mt4hh))
              )
           (texture-relocate dma-buff font-tx-2 font-tx-2-dest (the-as gs-psm font-tx-2-fmt) font-clut)

--- a/goal_src/engine/sparticle/sparticle-launcher.gc
+++ b/goal_src/engine/sparticle/sparticle-launcher.gc
@@ -938,7 +938,8 @@
           (if (-> *pc-settings* ps2-parts?)
               ;; pc port : launchers have larger bsphere if you have ps2 parts off
               (sphere-in-view-frustum? (the-as sphere gp-1))
-              (sphere-in-view-frustum? (the-as sphere (let ((bsph (new-stack-vector0))) (vector-copy! bsph gp-1) (*! (-> bsph w) 4.0) bsph))))
+              (sphere-in-view-frustum? (the-as sphere (begin (*! (-> gp-1 w) 8.0) gp-1)))
+              )
           )
       )
      )
@@ -990,10 +991,10 @@
           (set! f30-0 0.0)
           )
       
-      ;; pc hack for more particles.
+      ;; if we have ps2 particles off, say we're at the camera
       (with-pc
         (if (not (-> *pc-settings* ps2-parts?))
-            (/! f30-0 256.0)))
+            (set! f30-0 0.0)))
       
       ;; loop over particles in the group.
       (let ((s2-1 (-> obj length)))

--- a/goal_src/kernel-defs.gc
+++ b/goal_src/kernel-defs.gc
@@ -353,6 +353,7 @@
 (define-extern pc-mkdir-file-path (function string none))
 (define-extern pc-sound-set-flava-hack (function int none))
 (define-extern pc-sound-set-fade-hack (function int none))
+(define-extern pc-set-window-lock (function symbol none))
 
 (defenum pc-prof-event
   (begin 0)

--- a/goal_src/pc/pckernel-h.gc
+++ b/goal_src/pc/pckernel-h.gc
@@ -31,7 +31,7 @@
 (defglobalconstant PC_KERNEL_VERSION_BUILD #x0001)
 (defglobalconstant PC_KERNEL_VERSION_REVISION #x0005)
 
-(defglobalconstant PC_KERNEL_VERSION_MINOR #x0004)
+(defglobalconstant PC_KERNEL_VERSION_MINOR #x0005)
 (defglobalconstant PC_KERNEL_VERSION_MAJOR #x0001)
 (defglobalconstant PC_KERNEL_VERSION (logior
                                         (ash PC_KERNEL_VERSION_MAJOR 48)
@@ -213,6 +213,7 @@
    (letterbox? symbol) ;; letterbox. #f = stretched
    (vsync? symbol) ;; vsync.
    (font-scale float) ;; font scaling.
+   (window-lock? symbol) ;; whether the window can be resized by the user or not.
 
    ;; debug settings
    (os symbol) ;; windows, linux, macos
@@ -320,6 +321,7 @@
     (set-size! (_type_ int int) none)
     (set-aspect! (_type_ int int) none)
     (set-aspect-ratio! (_type_ float) none)
+    (set-window-lock! (_type_ symbol) symbol)
     (read-from-file (_type_ string) symbol)
     (write-to-file (_type_ string) symbol)
     (update-cheats (_type_) int)
@@ -389,9 +391,10 @@
   (set! (-> obj mood-override?) #f)
   (set! (-> obj movie?) #f)
   (set! (-> obj font-scale) 1.0)
-  (set! (-> obj aspect-custom-x) 1)
-  (set! (-> obj aspect-custom-y) 1)
+  (set! (-> obj aspect-custom-x) 4)
+  (set! (-> obj aspect-custom-y) 3)
   (set! (-> obj discord-rpc?) #t)
+  (set! (-> obj window-lock?) #t)
 
   (reset-gfx obj)
   (reset-audio obj)

--- a/goal_src/pc/pckernel.gc
+++ b/goal_src/pc/pckernel.gc
@@ -156,7 +156,9 @@
     )
 
   (pc-set-fullscreen (-> obj display-mode) 0)
-  (if (= 'windowed (-> obj display-mode))
+  (if (and (= 'windowed (-> obj display-mode))
+           (or (!= (-> obj win-width) (-> obj real-width))
+               (!= (-> obj win-height) (-> obj real-height))))
       (pc-set-window-size (max 320 (-> obj win-width)) (max 240 (-> obj win-height))))
 
   (pc-discord-rpc-set (if (-> obj discord-rpc?) 1 0))

--- a/goal_src/pc/pckernel.gc
+++ b/goal_src/pc/pckernel.gc
@@ -91,6 +91,11 @@
   (set! (-> obj aspect-ratio-reciprocal) (/ ASPECT_4X3 aspect))
   (none))
 
+(defmethod set-window-lock! pc-settings ((obj pc-settings) (lock symbol))
+  "set the aspect ratio used for rendering."
+  (pc-set-window-lock lock)
+  (set! (-> obj window-lock?) lock))
+
 (defmethod commit-to-file pc-settings ((obj pc-settings))
   "commits the current settings to the file"
   ;; auto load settings if available
@@ -157,6 +162,7 @@
 
   (pc-set-fullscreen (-> obj display-mode) 0)
   (if (and (= 'windowed (-> obj display-mode))
+           (-> obj window-lock?)
            (or (!= (-> obj win-width) (-> obj real-width))
                (!= (-> obj win-height) (-> obj real-height))))
       (pc-set-window-size (max 320 (-> obj win-width)) (max 240 (-> obj win-height))))


### PR DESCRIPTION
Fixes lag due to setting window size every frame and adds a window lock so that users can't resize/maximize the window (it won't work). The lock can be changed using `set-window-lock!` if you want to have free control.