### PR TITLE
github: improve bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,52 +1,71 @@
-name: Bug Report
+name: "\U0001F41B Bug Report"
 description: Create a bug report.
 labels: ["bug"]
 body:
-- type: textarea
-  attributes:
-    label: Describe the Bug
-    description: A clear and concise description of what the bug is. You may post screenshots or videos of the bug here.
-  validations:
-    required: true
+  - type: checkboxes
+    attributes:
+      label: Acknowledgements
+      description: Take a couple minutes to help our maintainers work faster.
+      options:
+        - label: I have [searched](https://github.com/open-goal/jak-project/issues?q=is%3Aissue+is%3Aopen+label%3Abug+sort%3Aupdated-desc) for duplicate or closed bug reports
+          required: true
+        - label: I understand that I am supposed to provide my own legitimately obtained copy of the game
+          required: true
 
-- type: textarea
-  attributes:
-    label: How To Reproduce
-    description: Steps to reproduce the behavior. You can also post a video of it here.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is. You may post screenshots or videos of the bug here.
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: Expected Behavior
-    description: A clear and concise description of the expected behavior.
-    placeholder: When I do X, Y should happen.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: How To Reproduce
+      description: Steps to reproduce the behavior. You can also post a video of it here.
+    validations:
+      required: true
 
-- type: input
-  attributes:
-    label: Operating System
-    description: Windows version, Linux distribution, etc.
-  validations:
-    required: true
+  - type: dropdown
+    attributes:
+      label: Does this problem occur on original hardware or PCSX2?
+      description: Some things that may seem like bugs are actually exactly how the original game behaved.
+      options:
+        - Yes, it's unique to OpenGOAL
+        - Didn't check
+        - Not needed, bug is obvious
+    validations:
+      required: true
 
-- type: dropdown
-  attributes:
-    label: OpenGOAL Version
-    options:
-      - Release
-      - Compiled from source
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of the expected behavior.
+      placeholder: When I do X, Y should happen.
+    validations:
+      required: true
 
-- type: dropdown
-  attributes:
-    label: Game Version
-    options:
-      - NTSC 1.0 (black label)
-      - NTSC Greatest Hits version (red label)
-      - PAL
-      - JP
-  validations:
-    required: true
+  - type: input
+    attributes:
+      label: Operating System
+      description: Windows version, Linux distribution, etc.
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: OpenGOAL Version
+      description: Either the release version (vX.X.X) or the commit sha if you've built from source
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Game Version
+      options:
+        - NTSC 1.0 (black label)
+        - NTSC Greatest Hits version (red label)
+        - PAL
+        - JP
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -69,3 +69,13 @@ body:
         - JP
     validations:
       required: true
+
+  - type: dropdown
+    attributes:
+      label: Are you using a high refresh-rate monitor (>60Hz)
+      options:
+        - No
+        - Yes
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/enhancement-request.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.yml
@@ -1,24 +1,24 @@
-name: Enhancement Request
+name: "\U0001F680 Enhancement Request"
 description: Suggest an improvement for an existing feature.
 labels: ["enhancement"]
 body:
-- type: textarea
-  attributes:
-    label: What feature is your idea related to?
-    description: A clear and concise description of what the problem is.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: What feature is your idea related to?
+      description: A clear and concise description of what the problem is.
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: Describe the solution you'd like.
-    description: A clear and concise description of what you want to happen.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Describe the solution you'd like.
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: Additional context
-    description: Any other context or screenshots about the enhancement request here.
-  validations:
-    required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Any other context or screenshots about the enhancement request here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,24 +1,24 @@
-name: Feature Request
+name: "\U0001F3AE Game Feature Request"
 description: Suggest an idea for the game
 labels: ["game"]
 body:
-- type: textarea
-  attributes:
-    label: Is your feature request related to a problem?
-    description: A clear and concise description of what the problem is.
-  validations:
-    required: true
-    
-- type: textarea
-  attributes:
-    label: Describe the solution you'd like.
-    description: A clear and concise description of what you want to happen.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of what the problem is.
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: Additional context
-    description: Add any other context or screenshots about the feature request here.
-  validations:
-    required: false
+  - type: textarea
+    attributes:
+      label: Describe the solution you'd like.
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false

--- a/goalc/build_level/gltf_mesh_extract.cpp
+++ b/goalc/build_level/gltf_mesh_extract.cpp
@@ -2,8 +2,9 @@
  * Mesh extraction for GLTF meshes.
  */
 
-#include <optional>
 #include "gltf_mesh_extract.h"
+
+#include <optional>
 
 #include "common/log/log.h"
 #include "common/math/geometry.h"


### PR DESCRIPTION
This:
- adds some acknowledgements to the bug report (check for duplicates, have your own legit copy)
- asks if they've reproduced the bug on original hardware or not as this is often a first step we take
- improves the version gathering input, as just "release" is too ambiguous
- formats the issue template's yaml a bit