### PR TITLE
discord-rpc: check for custom levels and add placeholder icon

### DIFF
--- a/game/discord.cpp
+++ b/game/discord.cpp
@@ -61,7 +61,7 @@ const char* jak1_get_full_level_name(const char* level_name) {
   if (nice_name != jak1_level_names.end()) {
     return nice_name->second.c_str();
   }
-  return "Unknown";
+  return "unknown";
 };
 
 // time of day string to append to level name for icons

--- a/game/kernel/kmachine.cpp
+++ b/game/kernel/kmachine.cpp
@@ -859,8 +859,12 @@ void update_discord_rpc(u32 discord_info) {
       } else {
         strcpy(large_image_key, level);
       }
-      rpc.largeImageKey = large_image_key;
       strcpy(large_image_text, full_level_name);
+      if (!strcmp(full_level_name, "unknown")) {
+        strcpy(large_image_key, full_level_name);
+        strcpy(large_image_text, level);
+      }
+      rpc.largeImageKey = large_image_key;
       if (!strcmp(level, "finalboss")) {
         strcpy(state, "Fighting Final Boss");
       } else if (plantboss != offset_of_s7()) {


### PR DESCRIPTION
Instead of not having a level icon when in an unknown level, it now uses the OpenGOAL logo as a placeholder icon and displays the custom level's name in the tooltip.
![image](https://user-images.githubusercontent.com/6624576/175371157-aea6a3f8-30aa-4cc0-8c8f-269db89fc0e3.png)