### PR TITLE
Replace assert with user-friendly error if ISO is invalid or not found

### DIFF
--- a/.github/scripts/releases/error-code-metadata.json
+++ b/.github/scripts/releases/error-code-metadata.json
@@ -20,4 +20,10 @@
   "4030": {
     "msg": "Decompilation Failed: An error occurred"
   }
+  "4040": {
+    "msg": "Extraction Failed: Provided game data file was not an ISO file"
+  }
+  "4041": {
+    "msg": "Extraction Failed: Provided game data file was corrupt or has unexpected size"
+  }
 }

--- a/decompiler/extractor/main.cpp
+++ b/decompiler/extractor/main.cpp
@@ -73,7 +73,7 @@ IsoFile extract_files(std::filesystem::path data_dir_path,
 
   // assuming ISO size and extension checks are only needed if input is not a folder
   if (data_dir_path.extension() != ".iso") {
-    fmt::print(stderr, "ERROR: an ISO file could not be located in data path";
+    fmt::print(stderr, "ERROR: an ISO file could not be located in data path");
     // return {ExtractorErrorCode::VALIDATION_MISSING_ISO, std::nullopt};
   }
   auto fp = fopen(data_dir_path.string().c_str(), "rb");

--- a/decompiler/extractor/main.cpp
+++ b/decompiler/extractor/main.cpp
@@ -69,7 +69,8 @@ IsoFile extract_files(std::filesystem::path data_dir_path,
                       std::filesystem::path extracted_iso_path) {
   fmt::print(
       "Note: Provided game data path '{}' points to a file, not a directory. Assuming it's an ISO "
-      "file and attempting to extract!\n", data_dir_path.string());
+      "file and attempting to extract!\n",
+      data_dir_path.string());
 
   std::filesystem::create_directories(extracted_iso_path);
 
@@ -418,13 +419,18 @@ int main(int argc, char** argv) {
 
     int flags = 0;
     if (std::filesystem::is_regular_file(data_dir_path)) {
-      // it's a file, make sure it's an .iso file
-      //to-do: verify game header data as well
-      if (data_dir_path.extension() != ".iso") {
+      // it's a file, normalize extension case and verify it's an ISO file
+      std::string ext = data_dir_path.extension().string();
+      std::transform(ext.begin(), ext.end(), ext.begin(),
+                     [](unsigned char c) { return std::tolower(c); });
+
+      if (ext != ".iso") {
         fmt::print(stderr, "ERROR: Provided game data path contains a file that isn't a .ISO!");
         return static_cast<int>(ExtractorErrorCode::EXTRACTION_INVALID_ISO_PATH);
       }
+
       // make sure the .iso is greater than 1GB in size
+      // to-do: verify game header data as well
       if (std::filesystem::file_size(data_dir_path) < 1000000000) {
         fmt::print(
             stderr,

--- a/decompiler/extractor/main.cpp
+++ b/decompiler/extractor/main.cpp
@@ -73,7 +73,7 @@ IsoFile extract_files(std::filesystem::path data_dir_path,
 
   // assuming ISO size and extension checks are only needed if input is not a folder
   if (data_dir_path.extension() != ".iso") {
-    fmt::print(stderr, "ERROR: an ISO file could not be located in path {}\n", data_dir_path);
+    fmt::print(stderr, "ERROR: an ISO file could not be located in data path";
     // return {ExtractorErrorCode::VALIDATION_MISSING_ISO, std::nullopt};
   }
   auto fp = fopen(data_dir_path.string().c_str(), "rb");

--- a/decompiler/extractor/main.cpp
+++ b/decompiler/extractor/main.cpp
@@ -72,9 +72,9 @@ IsoFile extract_files(std::filesystem::path data_dir_path,
   std::filesystem::create_directories(extracted_iso_path);
 
   // assuming ISO size and extension checks are only needed if input is not a folder
-  if (!data_dir_path.extension() != ".iso"))
+  if (data_dir_path.extension() != ".iso"))
   {
-      fmt::print(stderr, "ERROR: file type is not ISO");
+      fmt::print(stderr, "ERROR: file type is not ISO\n");
       // fmt::print(stderr, "ERROR: an ISO file could not be located in path {}\n", data_dir_path);
       // return {ExtractorErrorCode::VALIDATION_MISSING_ISO, std::nullopt};
     }

--- a/decompiler/extractor/main.cpp
+++ b/decompiler/extractor/main.cpp
@@ -69,7 +69,7 @@ IsoFile extract_files(std::filesystem::path data_dir_path,
                       std::filesystem::path extracted_iso_path) {
   fmt::print(
       "Note: Provided game data path '{}' points to a file, not a directory. Assuming it's an ISO "
-      "file and attempting to extract!\n");
+      "file and attempting to extract!\n", data_dir_path.string());
 
   std::filesystem::create_directories(extracted_iso_path);
 

--- a/decompiler/extractor/main.cpp
+++ b/decompiler/extractor/main.cpp
@@ -23,6 +23,7 @@ enum class ExtractorErrorCode {
   VALIDATION_BAD_ISO_CONTENTS = 4010,
   VALIDATION_INCORRECT_EXTRACTION_COUNT = 4011,
   VALIDATION_BAD_EXTRACTION = 4020,
+  VALIDATION_MISSING_ISO = 4025,
   DECOMPILATION_GENERIC_ERROR = 4030
 };
 
@@ -66,10 +67,16 @@ void setup_global_decompiler_stuff(std::optional<std::filesystem::path> project_
 
 IsoFile extract_files(std::filesystem::path data_dir_path,
                       std::filesystem::path extracted_iso_path) {
-  fmt::print("Note: input isn't a folder, assuming it's an ISO file...\n");
+  fmt::print("Note: could not find game data folder, attempting to locate ISO file.\n");
 
   std::filesystem::create_directories(extracted_iso_path);
 
+//assuming ISO size and extension checks are only needed if input is not a folder
+  if (!data_dir_path::extension != ".iso")
+  {
+    fmt::print(stderr, "ERROR: an ISO file could not be located in path {}\n", data_dir_path);
+    return {ExtractorErrorCode::VALIDATION_MISSING_ISO, std::nullopt};
+  }
   auto fp = fopen(data_dir_path.string().c_str(), "rb");
   ASSERT_MSG(fp, "failed to open input ISO file\n");
   IsoFile iso = unpack_iso_files(fp, extracted_iso_path, true, true);

--- a/decompiler/extractor/main.cpp
+++ b/decompiler/extractor/main.cpp
@@ -72,12 +72,10 @@ IsoFile extract_files(std::filesystem::path data_dir_path,
   std::filesystem::create_directories(extracted_iso_path);
 
   // assuming ISO size and extension checks are only needed if input is not a folder
-  if (data_dir_path.extension() != ".iso"))
-  {
-      fmt::print(stderr, "ERROR: file type is not ISO\n");
-      // fmt::print(stderr, "ERROR: an ISO file could not be located in path {}\n", data_dir_path);
-      // return {ExtractorErrorCode::VALIDATION_MISSING_ISO, std::nullopt};
-    }
+  if (data_dir_path.extension() != ".iso") {
+    fmt::print(stderr, "ERROR: an ISO file could not be located in path {}\n", data_dir_path);
+    // return {ExtractorErrorCode::VALIDATION_MISSING_ISO, std::nullopt};
+  }
   auto fp = fopen(data_dir_path.string().c_str(), "rb");
   ASSERT_MSG(fp, "failed to open input ISO file\n");
   IsoFile iso = unpack_iso_files(fp, extracted_iso_path, true, true);

--- a/decompiler/extractor/main.cpp
+++ b/decompiler/extractor/main.cpp
@@ -71,12 +71,13 @@ IsoFile extract_files(std::filesystem::path data_dir_path,
 
   std::filesystem::create_directories(extracted_iso_path);
 
-//assuming ISO size and extension checks are only needed if input is not a folder
-  if (!data_dir_path::extension != ".iso")
+  // assuming ISO size and extension checks are only needed if input is not a folder
+  if (!data_dir_path.extension() != ".iso"))
   {
-    fmt::print(stderr, "ERROR: an ISO file could not be located in path {}\n", data_dir_path);
-    return {ExtractorErrorCode::VALIDATION_MISSING_ISO, std::nullopt};
-  }
+      fmt::print(stderr, "ERROR: file type is not ISO");
+      // fmt::print(stderr, "ERROR: an ISO file could not be located in path {}\n", data_dir_path);
+      // return {ExtractorErrorCode::VALIDATION_MISSING_ISO, std::nullopt};
+    }
   auto fp = fopen(data_dir_path.string().c_str(), "rb");
   ASSERT_MSG(fp, "failed to open input ISO file\n");
   IsoFile iso = unpack_iso_files(fp, extracted_iso_path, true, true);

--- a/decompiler/extractor/main.cpp
+++ b/decompiler/extractor/main.cpp
@@ -58,7 +58,8 @@ static const std::map<std::string, std::map<xxh::hash64_t, ISOMetadata>> isoData
        {"Jak & Daxter™: The Precursor Legacy", "PAL", 338, 16850370297611763875U, "jak1_pal"}}}},
     {"SCPS-15021",
      {{16909372048085114219U,
-       {"ジャックＸダクスター　～　旧世界の遺産", "NTSC-J", 338, 1262350561338887717, "jak1_jp"}}}}};
+       {"ジャックＸダクスター　～　旧世界の遺産", "NTSC-J", 338, 1262350561338887717,
+        "jak1_jp"}}}}};
 
 void setup_global_decompiler_stuff(std::optional<std::filesystem::path> project_path_override) {
   decompiler::init_opcode_info();


### PR DESCRIPTION
This adds some additional context to the extractor, checking the extension type of the game data path if it is not a folder, and returning a more user-friendly error if the game data file is not valid. When I get home I will finish this by adding a size and header check and making sure the error code is properly returned to the launcher. 

Addresses #1539, hoping I'm on the right track here.