### PR TITLE
compiler speed improvement

### DIFF
--- a/common/goos/ParseHelpers.h
+++ b/common/goos/ParseHelpers.h
@@ -19,7 +19,7 @@ template <typename T>
 void for_each_in_list(const goos::Object& list, T f) {
   const goos::Object* iter = &list;
   while (iter->is_pair()) {
-    auto lap = iter->as_pair();
+    const auto& lap = iter->as_pair();
     f(lap->car);
     iter = &lap->cdr;
   }

--- a/common/versions.h
+++ b/common/versions.h
@@ -9,10 +9,8 @@
 
 namespace versions {
 // language version (OpenGOAL)
-constexpr s32 GOAL_VERSION_MAJOR = 0;
-constexpr s32 GOAL_VERSION_MINOR = 9;
-
-constexpr int DECOMPILER_VERSION = 4;
+constexpr s32 GOAL_VERSION_MAJOR = 1;
+constexpr s32 GOAL_VERSION_MINOR = 0;
 
 namespace jak1 {
 // these versions are from the game

--- a/decompiler/main.cpp
+++ b/decompiler/main.cpp
@@ -29,7 +29,6 @@ int main(int argc, char** argv) {
   lg::set_stdout_level(lg::level::info);
   lg::set_flush_level(lg::level::info);
   lg::initialize();
-  lg::info("GOAL Decompiler version {}\n", versions::DECOMPILER_VERSION);
 
   init_opcode_info();
 

--- a/docs/progress-notes/changelog.md
+++ b/docs/progress-notes/changelog.md
@@ -221,3 +221,6 @@ The compiler is now much more aggressive in where and how it expands macros and 
 - Several places where macros could be incorrectly executed more than once (possibly causing unwanted side effects) have been fixed.
 - Fixed bug in size calculation of non-inline stack arrays. Previous behavior was a compiler assert.
 - Correctly handle `mod` for unsigned numbers. Previous behavior was to treat all inputs as 32-bit signed integers.
+
+## V1.0 Revised constant propagation, speed improvements
+Improved error messages around macros

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -26,10 +26,23 @@ enum MathMode { MATH_INT, MATH_BINT, MATH_FLOAT, MATH_INVALID };
 
 enum class ReplStatus { OK, WANT_EXIT, WANT_RELOAD };
 
+struct CompilationOptions {
+  std::string filename;                 // input file
+  std::string disassembly_output_file;  // file to write, containing x86 assembly output
+  bool load = false;                    // send to target
+  bool color = false;                   // do register allocation/code generation passes
+  bool write = false;                   // write object file to out/obj
+  bool no_code = false;                 // file shouldn't generate code, throw error if it does
+  bool disassemble = false;             // either print disassembly to stdout or output_file
+  bool print_time = false;              // print timing statistics
+};
+
 class Compiler {
  public:
   Compiler(const std::string& user_profile = "#f", std::unique_ptr<ReplWrapper> repl = nullptr);
   ~Compiler();
+  void asm_file(const CompilationOptions& options);
+
   void save_repl_history();
   void print_to_repl(const std::string_view& str);
   std::string get_prompt();

--- a/goalc/compiler/compilation/Atoms.cpp
+++ b/goalc/compiler/compilation/Atoms.cpp
@@ -286,8 +286,8 @@ Val* Compiler::compile_no_const_prop(const goos::Object& code, Env* env) {
  * Highest level compile function
  */
 Val* Compiler::compile(const goos::Object& code, Env* env) {
-  auto propagated = try_constant_propagation(code, env);
-  return compile_no_const_prop(propagated.value, env);
+  // auto propagated = try_constant_propagation(code, env);
+  return compile_no_const_prop(code, env);
 }
 
 /*!

--- a/goalc/compiler/compilation/Macro.cpp
+++ b/goalc/compiler/compilation/Macro.cpp
@@ -267,7 +267,7 @@ bool Compiler::expand_macro_once(const goos::Object& src, goos::Object* out, Env
 
   auto goos_result = m_goos.eval_list_return_last(macro->body, macro->body, mac_env);
   // make the macro expanded form point to the source where the macro was used for error messages.
-  m_goos.reader.db.inherit_info(src, goos_result);
+  // m_goos.reader.db.inherit_info(src, goos_result);
 
   *out = goos_result;
   return true;

--- a/goalc/make/Tools.cpp
+++ b/goalc/make/Tools.cpp
@@ -30,8 +30,11 @@ bool CompilerTool::needs_run(const ToolInput& task) {
 bool CompilerTool::run(const ToolInput& task) {
   // todo check inputs
   try {
-    m_compiler->run_front_end_on_string(
-        fmt::format("(asm-file \"{}\" :no-time-prints :color :write)", task.input.at(0)));
+    CompilationOptions options;
+    options.filename = task.input.at(0);
+    options.color = true;
+    options.write = true;
+    m_compiler->asm_file(options);
   } catch (std::exception& e) {
     fmt::print("Compilation failed: {}\n", e.what());
     return false;

--- a/goalc/regalloc/Allocator_v2.cpp
+++ b/goalc/regalloc/Allocator_v2.cpp
@@ -222,7 +222,7 @@ class VarAssignment {
     }
   }
 
-  const std::vector<bool> live_vector() const { return m_live; }
+  const std::vector<bool>& live_vector() const { return m_live; }
 
  private:
   // common info

--- a/goalc/regalloc/IRegSet.h
+++ b/goalc/regalloc/IRegSet.h
@@ -20,7 +20,7 @@
 
 class IRegSet {
  public:
-  IRegSet() { m_data.reserve(4); }
+  IRegSet() { resize(64 * 4); }
 
   /*!
    * Add the given ireg to the set.


### PR DESCRIPTION
The idea described in https://github.com/open-goal/jak-project/issues/1538, plus a few small tweaks to make things a little faster. This also cleans up `asm_file` and how the make system runs the compiler to make the end of the error messages less silly