### PR TITLE
Fix volume calculation when falloff curve is zero

### DIFF
--- a/game/overlord/ssound.cpp
+++ b/game/overlord/ssound.cpp
@@ -216,7 +216,7 @@ Sound* AllocateSound() {
 
 s32 CalculateFallofVolume(Vec3w* pos, s32 volume, s32 fo_curve, s32 fo_min, s32 fo_max) {
   if (fo_curve == 0) {
-    return 0;
+    return volume;
   }
 
   s32 xdiff = gEarTrans.x - pos->x;


### PR DESCRIPTION
Super simple fix to match the original overlord behavior for `CalculateFalloffVolume`.

Fixes #1380.