### PR TITLE
config: change linux and windows config directories

### DIFF
--- a/common/goos/ReplUtils.cpp
+++ b/common/goos/ReplUtils.cpp
@@ -54,18 +54,20 @@ void ReplWrapper::add_to_history(const std::string& line) {
 }
 
 void ReplWrapper::save_history() {
-  // NOTE - library doesn't seem unicode safe on windows
-  std::filesystem::path path = file_util::get_user_home_dir();
-  if (std::filesystem::exists(path)) {
+  std::filesystem::path path = file_util::get_user_config_dir();
+  if (file_util::create_dir_if_needed(path)) {
     repl.history_save((path / ".opengoal.repl.history").string());
+  } else {
+    fmt::print("Couldn't save REPL history file to '{}'", path.string());
   }
 }
 
 void ReplWrapper::load_history() {
-  // NOTE - library doesn't seem unicode safe on windows
-  std::filesystem::path path = file_util::get_user_home_dir();
+  std::filesystem::path path = file_util::get_user_config_dir() / ".opengoal.repl.history";
   if (std::filesystem::exists(path)) {
-    repl.history_load((path / ".opengoal.repl.history").string());
+    repl.history_load(path.string());
+  } else {
+    fmt::print("Couldn't locate REPL history file at '{}'", path.string());
   }
 }
 

--- a/common/util/FileUtil.cpp
+++ b/common/util/FileUtil.cpp
@@ -48,17 +48,32 @@ std::filesystem::path get_user_home_dir() {
 #endif
 }
 
-std::filesystem::path get_user_game_dir() {
-  // TODO - i anticipate UTF-8 problems on windows with our current FS api
-  return get_user_home_dir() / "OpenGOAL";
+std::filesystem::path get_user_config_dir() {
+  std::filesystem::path config_base_path;
+#ifdef _WIN32
+  auto config_base_dir = std::getenv("APPDATA");
+  config_base_path = std::filesystem::path(std::string(config_base_dir));
+#elif __linux
+  // Docs - https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+  // Prefer XDG_CONFIG_HOME if available
+  auto config_base_dir = std::getenv("XDG_CONFIG_HOME");
+  if (!config_base_dir) {
+    config_base_path = get_user_home_dir() / ".config";
+  } else {
+    config_base_path = std::string(config_base_dir);
+  }
+#endif
+  return config_base_path / "OpenGOAL";
 }
 
 std::filesystem::path get_user_settings_dir() {
-  return get_user_game_dir() / "jak1" / "settings";
+  // TODO - jak2
+  return get_user_config_dir() / "jak1" / "settings";
 }
 
 std::filesystem::path get_user_memcard_dir() {
-  return get_user_game_dir() / "jak1" / "saves";
+  // TODO - jak2
+  return get_user_config_dir() / "jak1" / "saves";
 }
 
 struct {
@@ -171,8 +186,7 @@ std::string get_file_path(const std::vector<std::string>& input) {
 
 bool create_dir_if_needed(const std::filesystem::path& path) {
   if (!std::filesystem::is_directory(path)) {
-    std::filesystem::create_directories(path);
-    return true;
+    return std::filesystem::create_directories(path);
   }
   return false;
 }

--- a/common/util/FileUtil.h
+++ b/common/util/FileUtil.h
@@ -16,7 +16,7 @@ namespace fs = std::filesystem;
 
 namespace file_util {
 std::filesystem::path get_user_home_dir();
-std::filesystem::path get_user_game_dir();
+std::filesystem::path get_user_config_dir();
 std::filesystem::path get_user_settings_dir();
 std::filesystem::path get_user_memcard_dir();
 std::filesystem::path get_jak_project_dir();

--- a/game/kernel/jak1/kmachine.cpp
+++ b/game/kernel/jak1/kmachine.cpp
@@ -637,7 +637,7 @@ void InitMachine_PCPort() {
   }
 
   // setup string constants
-  auto user_dir_path = file_util::get_user_game_dir();
+  auto user_dir_path = file_util::get_user_config_dir();
   intern_from_c("*pc-user-dir-base-path*")->value =
       make_string_from_c(user_dir_path.string().c_str());
   // TODO - we will eventually need a better way to know what game we are playing

--- a/game/kernel/jak2/kmachine.cpp
+++ b/game/kernel/jak2/kmachine.cpp
@@ -519,7 +519,7 @@ void InitMachine_PCPort() {
   }
 
   // setup string constants
-  auto user_dir_path = file_util::get_user_game_dir();
+  auto user_dir_path = file_util::get_user_config_dir();
   intern_from_c("*pc-user-dir-base-path*")->value() =
       make_string_from_c(user_dir_path.string().c_str());
   // TODO - we will eventually need a better way to know what game we are playing


### PR DESCRIPTION
Closes #1578 

For Linux:
- Prefers `$XDG_CONFIG_HOME/OpenGOAL` or `$HOME/.config/OpenGOAL`

For Windows:
- `$APPDATA/OpenGOAL`
  - `$APPDATA` is equivalent to `$CSIDL_APPDATA` which can be equal to `C:\Documents and Settings\username\Application Data` or `C:\Users\username\AppData\Roaming`
  - There is probably a more consistent way using `FOLDERID_RoamingAppData` but:
    - You have to either use a Win32 API `SHGetFolderPathW` or a vista+ `SHGetKnownFolderPath` function.  The former uses annoying utf-16 and the latter introduces a new minimum requirement.