### PR TITLE
game: read current date correctly for save data

### DIFF
--- a/game/sce/libscf.cpp
+++ b/game/sce/libscf.cpp
@@ -1,5 +1,7 @@
 #include "libscf.h"
 
+#include <ctime>
+
 namespace ee {
 int sceScfGetAspect() {
   return SCE_ASPECT_43;
@@ -10,13 +12,20 @@ int sceScfGetLanguage() {
 }
 
 void sceCdReadClock(sceCdCLOCK* result) {
+  time_t t = time(0);
+  std::tm* date = localtime(&t);
+
+  // convert decimal value into hex value with identical digit representation
+  // e.g. 60 -> 0x60
+  auto convert = [](u8 val) -> u8 { return ((val % 10) * 0x01) + ((val / 10) * 0x10); };
+
   result->stat = 0;  // ??
-  result->second = 1;
-  result->minute = 0x92;
-  result->hour = 0x76;
-  result->week = 13;
-  result->day = 0x99;
-  result->month = 0x16;
-  result->year = 0x19;
+  result->second = convert(date->tm_sec);
+  result->minute = convert(date->tm_min);
+  result->hour = convert(date->tm_hour);
+  result->week = convert((date->tm_yday - date->tm_wday + 7) / 7);
+  result->day = convert(date->tm_mday);
+  result->month = convert(date->tm_mon + 1);
+  result->year = convert(date->tm_year - 100);
 }
 }  // namespace ee


### PR DESCRIPTION
Makes `sceCdReadClock` pass the correct date values as required by `scf-get-time` in GOAL by converting every decimal value to a hex `u8` with the same digit representation.