### PR TITLE
[decompiler] missing features in inspect method detection

### DIFF
--- a/common/type_system/Type.h
+++ b/common/type_system/Type.h
@@ -209,6 +209,7 @@ class Field {
   void mark_as_user_placed() { m_placed_by_user = true; }
   std::string print() const;
   const TypeSpec& type() const { return m_type; }
+  TypeSpec& type() { return m_type; }
   bool is_inline() const { return m_inline; }
   bool is_array() const { return m_array; }
   bool is_dynamic() const { return m_dynamic; }

--- a/decompiler/ObjectFile/ObjectFileDB_IR2.cpp
+++ b/decompiler/ObjectFile/ObjectFileDB_IR2.cpp
@@ -114,7 +114,7 @@ void ObjectFileDB::analyze_functions_ir2(
       for_each_function_def_order_in_obj(data, [&](Function& f, int) { f.ir2 = {}; });
     } else {
       for_each_function_def_order_in_obj(data, [&](Function& f, int seg) {
-        if (seg == 0) {
+        if (seg == TOP_LEVEL_SEGMENT) {
           return;  // keep top-levels
         }
         if (f.guessed_name.kind == FunctionName::FunctionKind::METHOD &&
@@ -317,6 +317,8 @@ void ObjectFileDB::ir2_analyze_all_types(const std::filesystem::path& output_fil
   }
 
   std::unordered_set<std::string> already_seen;
+  TypeInspectorCache ti_cache;
+
   for_each_obj([&](ObjectFileData& data) {
     if (data.obj_version != 3) {
       return;
@@ -331,7 +333,7 @@ void ObjectFileDB::ir2_analyze_all_types(const std::filesystem::path& output_fil
       } else {
         if (f.is_inspect_method && bad_types.find(f.guessed_name.type_name) == bad_types.end()) {
           object_result.type_defs.push_back(inspect_inspect_method(
-              f, f.guessed_name.type_name, dts, data.linked_data, previous_game_ts.ts));
+              f, f.guessed_name.type_name, dts, data.linked_data, previous_game_ts.ts, ti_cache));
         }
       }
     });

--- a/decompiler/analysis/analyze_inspect_method.h
+++ b/decompiler/analysis/analyze_inspect_method.h
@@ -8,11 +8,37 @@
 
 namespace decompiler {
 
+struct TypeInspectorResult {
+  bool success = false;
+  int type_size = -1;
+  int type_method_count = -1;
+  int parent_method_count = 9;
+  int type_heap_base = -1;
+
+  std::string warnings;
+  std::vector<Field> fields_of_type;
+  bool is_basic = false;
+  bool found_flags = false;
+
+  std::string type_name;
+  std::string parent_type_name;
+  u64 flags = 0;
+
+  std::string print_as_deftype(
+      StructureType* old_game_type,
+      std::unordered_map<std::string, TypeInspectorResult>& previous_results);
+};
+
+struct TypeInspectorCache {
+  std::unordered_map<std::string, TypeInspectorResult> previous_results;
+};
+
 std::string inspect_inspect_method(Function& inspect_method,
                                    const std::string& type_name,
                                    DecompilerTypeSystem& dts,
                                    LinkedObjectFile& file,
-                                   TypeSystem& previous_game_ts);
+                                   TypeSystem& previous_game_ts,
+                                   TypeInspectorCache& ti_cache);
 
 std::string inspect_top_level_symbol_defines(std::unordered_set<std::string>& already_seen,
                                              Function& top_level,

--- a/decompiler/config/jak2/hacks.jsonc
+++ b/decompiler/config/jak2/hacks.jsonc
@@ -6,7 +6,8 @@
   "types_with_bad_inspect_methods": [
     "game-task-event",
     "game-task-control",
-    "predator-edge"
+    "predator-edge",
+    "manipy"
   ],
 
   "no_type_analysis_functions_by_name": [],


### PR DESCRIPTION
Support `inspect` methods of processes, use decompiler "guesses" a little more aggressively.