### PR TITLE
[jak2] goalc supports multiple projects

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(common
+        versions.cpp
         audio/audio_formats.cpp
         cross_os_debug/xdbg.cpp
         cross_sockets/XSocket.cpp

--- a/common/versions.cpp
+++ b/common/versions.cpp
@@ -1,0 +1,15 @@
+#include "versions.h"
+
+#include "common/util/Assert.h"
+
+#include "third-party/fmt/core.h"
+
+GameVersion game_name_to_version(const std::string& name) {
+  if (name == "jak1") {
+    return GameVersion::Jak1;
+  } else if (name == "jak2") {
+    return GameVersion::Jak2;
+  } else {
+    ASSERT_MSG(false, fmt::format("invalid game name: {}", name));
+  }
+}

--- a/common/versions.h
+++ b/common/versions.h
@@ -5,6 +5,8 @@
  * Version numbers for GOAL Language, Kernel, etc...
  */
 
+#include <string>
+
 #include "common/common_types.h"
 
 namespace versions {
@@ -49,3 +51,5 @@ struct PerGameVersion {
 };
 
 constexpr PerGameVersion<const char*> game_version_names = {"jak1", "jak2"};
+
+GameVersion game_name_to_version(const std::string& name);

--- a/decompiler/extractor/main.cpp
+++ b/decompiler/extractor/main.cpp
@@ -193,7 +193,7 @@ ExtractorErrorCode compile(const fs::path& iso_data_path, const std::string& dat
   // Determine which config to use from the database
   const auto version_info = get_version_info_or_default(iso_data_path);
 
-  Compiler compiler;
+  Compiler compiler(game_name_to_version(version_info.game_name));
   compiler.make_system().set_constant("*iso-data*", absolute(iso_data_path).string());
   compiler.make_system().set_constant("*use-iso-data-path*", true);
 

--- a/game/kernel/jak1/kmachine.cpp
+++ b/game/kernel/jak1/kmachine.cpp
@@ -37,6 +37,7 @@
 #include "game/kernel/jak1/ksound.h"
 #include "game/kernel/svnrev.h"
 #include "game/mips2c/mips2c_table.h"
+#include "game/sce/deci2.h"
 #include "game/sce/libcdvd_ee.h"
 #include "game/sce/libdma.h"
 #include "game/sce/libgraph.h"
@@ -336,6 +337,9 @@ int InitMachine() {
 
   if (MasterDebug) {  // connect to GOAL compiler
     InitGoalProto();
+  } else {
+    // shut down the deci2 stuff, we don't need it.
+    ee::sceDeci2Disable();
   }
 
   lg::info("InitSound");

--- a/game/runtime.cpp
+++ b/game/runtime.cpp
@@ -92,7 +92,10 @@ void deci2_runner(SystemThreadInterface& iface) {
 
   // in our own thread, wait for the EE to register the first protocol driver
   lg::debug("[DECI2] Waiting for EE to register protos");
-  server.wait_for_protos_ready();
+  if (!server.wait_for_protos_ready()) {
+    // requested shutdown before protos became ready.
+    return;
+  }
   // then allow the server to accept connections
   bool server_ok = server.init_server();
   if (!server_ok) {

--- a/game/sce/deci2.cpp
+++ b/game/sce/deci2.cpp
@@ -137,4 +137,8 @@ s32 sceDeci2ExSend(s32 s, void* buf, u16 len) {
   server->send_data(buf, len);
   return len;
 }
+
+void sceDeci2Disable() {
+  server->send_shutdown();
+}
 }  // namespace ee

--- a/game/sce/deci2.h
+++ b/game/sce/deci2.h
@@ -20,5 +20,6 @@ s32 sceDeci2Close(s32 s);
 s32 sceDeci2ReqSend(s32 s, char dest);
 s32 sceDeci2ExRecv(s32 s, void* buf, u16 len);
 s32 sceDeci2ExSend(s32 s, void* buf, u16 len);
+void sceDeci2Disable();
 
 }  // namespace ee

--- a/game/system/Deci2Server.h
+++ b/game/system/Deci2Server.h
@@ -19,8 +19,9 @@ class Deci2Server : public XSocketServer {
   void send_data(void* buf, u16 len);
 
   bool is_client_connected();
-  void wait_for_protos_ready();
+  bool wait_for_protos_ready();  // return true if ready, false if we should shut down.
   void send_proto_ready(Deci2Driver* drivers, int* driver_count);
+  void send_shutdown();
 
   void lock();
   void unlock();
@@ -29,6 +30,7 @@ class Deci2Server : public XSocketServer {
   void accept_thread_func();
 
  private:
+  bool want_shutdown = false;
   bool protocols_ready = false;
   std::condition_variable cv;
   Deci2Driver* d2_drivers = nullptr;

--- a/goal_src/goal-lib.gc
+++ b/goal_src/goal-lib.gc
@@ -1,13 +1,5 @@
 ;;-*-Lisp-*-
 
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; OTHER STUFF
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; tell compiler about stuff defined/implemented in the runtime.
-(asm-file "goal_src/jak1/kernel-defs.gc")
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; BUILD SYSTEM
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -37,10 +29,6 @@
 (desfun run-frontend-command (file)
   `(asm-file ,file :no-code)
   )
-
-
-(defmacro load-art-import (name)
-  `(asm-file ,(string-append "goal_src/jak1/import/" (symbol->string name) "-ag.gc") :no-code :no-throw))
 
 (defmacro load-imports ()
   `(begin
@@ -1044,14 +1032,17 @@
   `(defconstant ,name (-> self draw art-group data ,idx))
   )
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Load Project
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;; build system stuff
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; hack to get a goos variable in goal
-(defmacro __get_jak1_full_game () *jak1-full-game*)
-(defconstant *jak1-full-game* (__get_jak1_full_game))
-
-;; todo: loading jak1 by default
-(load-project "goal_src/jak1/game.gp")
+(#cond
+  ((eq? GAME_VERSION 'jak1)
+   (asm-file "goal_src/jak1/compiler-setup.gc")
+   (seval (fmt #t "Jak 1 Mode\n"))
+   )
+  ((eq? GAME_VERSION 'jak2)
+   (asm-file "goal_src/jak2/compiler-setup.gc")
+   (seval (fmt #t "Jak 2 Mode\n"))
+   )
+  )

--- a/goal_src/jak1/compiler-setup.gc
+++ b/goal_src/jak1/compiler-setup.gc
@@ -1,0 +1,18 @@
+;;
+;; Compiler Setup for Jak 1
+;;
+
+;; load kernel type definitions.
+;; these types/functions are provided by Jak 1's runtime.
+(asm-file "goal_src/jak1/kernel-defs.gc")
+
+;; load jak 1 project
+(load-project "goal_src/jak1/game.gp")
+
+;; jak 1 - specific library stuff.
+
+(defmacro __get_jak1_full_game () *jak1-full-game*)
+(defconstant *jak1-full-game* (__get_jak1_full_game))
+
+(defmacro load-art-import (name)
+  `(asm-file ,(string-append "goal_src/jak1/import/" (symbol->string name) "-ag.gc") :no-code :no-throw))

--- a/goal_src/jak1/kernel-defs.gc
+++ b/goal_src/jak1/kernel-defs.gc
@@ -75,15 +75,15 @@
   )
 
 (defenum link-flag
-    :bitfield #t
-    :type int32
-    (output-load-msg 0)
-    (output-load-true-msg 1)
-    (execute-login 2)
-    (print-login 3)
-    (force-debug 4)
-    (fast-link 5)
-    )
+  :bitfield #t
+  :type int32
+  (output-load-msg 0)
+  (output-load-true-msg 1)
+  (execute-login 2)
+  (print-login 3)
+  (force-debug 4)
+  (fast-link 5)
+  )
 
 
 (define-extern string->symbol (function string symbol))

--- a/goal_src/jak2/compiler-setup.gc
+++ b/goal_src/jak2/compiler-setup.gc
@@ -1,0 +1,10 @@
+;;
+;; Compiler Setup for Jak 2
+;;
+
+;; load kernel type definitions.
+;; these types/functions are provided by Jak 2's runtime.
+(asm-file "goal_src/jak2/kernel-defs.gc")
+
+;; load jak 1 project
+(load-project "goal_src/jak2/game.gp")

--- a/goal_src/jak2/kernel-defs.gc
+++ b/goal_src/jak2/kernel-defs.gc
@@ -1,0 +1,77 @@
+;; kernel-defs.gc
+;; everything defined in the C Kernel / runtime
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; kscheme - InitHeapAndSymbol
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; fixed symbols
+(define-extern #f symbol)
+(define-extern #t symbol)
+(define-extern function type)
+(define-extern basic type)
+(define-extern string type)
+(define-extern symbol type)
+(define-extern type type)
+(define-extern object type)
+(define-extern link-block type)
+(define-extern integer type)
+(define-extern sinteger type)
+(define-extern uinteger type)
+(define-extern binteger type)
+(define-extern int8 type)
+(define-extern int16 type)
+(define-extern int32 type)
+(define-extern int64 type)
+(define-extern int128 type)
+(define-extern uint8 type)
+(define-extern uint16 type)
+(define-extern uint32 type)
+(define-extern uint64 type)
+(define-extern uint128 type)
+(define-extern float type)
+(define-extern process-tree type)
+(define-extern process type)
+(define-extern thread type)
+(define-extern structure type)
+(define-extern pair type)
+(define-extern pointer type)
+(define-extern number type)
+(define-extern array type)
+(define-extern vu-function type)
+(define-extern connectable type)
+(define-extern stack-frame type)
+(define-extern file-stream type)
+(define-extern kheap type)
+(define-extern nothing (function none))
+(define-extern delete-basic (function basic none))
+(define-extern static symbol)
+(define-extern global kheap)
+(define-extern debug kheap)
+(define-extern loading-level kheap)   ;; not a kheap at boot
+(define-extern loading-package kheap) ;; not a kheap at boot
+(define-extern process-level-heap kheap) ;; not a kheap at boot
+(define-extern stack symbol)
+(define-extern scratch symbol)
+(define-extern *stratch-top* pointer)
+(define-extern zero-func (function int))
+
+(defenum kmalloc-flags
+  :bitfield #t
+  (align-16    4)
+  (align-64    6)
+  (align-256   8)
+  (memset     12)
+  (top        13)
+  )
+
+(defenum link-flag
+  :bitfield #t
+  :type int32
+  (output-load-msg 0)
+  (output-load-true-msg 1)
+  (execute-login 2)
+  (print-login 3)
+  (force-debug 4)
+  (fast-link 5)
+  )

--- a/goalc/compiler/Compiler.cpp
+++ b/goalc/compiler/Compiler.cpp
@@ -18,8 +18,11 @@
 
 using namespace goos;
 
-Compiler::Compiler(const std::string& user_profile, std::unique_ptr<ReplWrapper> repl)
-    : m_goos(user_profile),
+Compiler::Compiler(GameVersion version,
+                   const std::string& user_profile,
+                   std::unique_ptr<ReplWrapper> repl)
+    : m_version(version),
+      m_goos(user_profile),
       m_debugger(&m_listener, &m_goos.reader),
       m_repl(std::move(repl)),
       m_make(user_profile) {
@@ -31,8 +34,10 @@ Compiler::Compiler(const std::string& user_profile, std::unique_ptr<ReplWrapper>
   // let the build system run us
   m_make.add_tool(std::make_shared<CompilerTool>(this));
 
+  // define game version before loading goal-lib.gc
+  m_goos.set_global_variable_by_name("GAME_VERSION", m_goos.intern(game_version_names[m_version]));
+
   // load GOAL library
-  // TODO - Jak2 - BAD!
   Object library_code = m_goos.reader.read_from_file({"goal_src", "goal-lib.gc"});
   compile_object_file("goal-lib", library_code, false);
 

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -39,7 +39,9 @@ struct CompilationOptions {
 
 class Compiler {
  public:
-  Compiler(const std::string& user_profile = "#f", std::unique_ptr<ReplWrapper> repl = nullptr);
+  Compiler(GameVersion version,
+           const std::string& user_profile = "#f",
+           std::unique_ptr<ReplWrapper> repl = nullptr);
   ~Compiler();
   void asm_file(const CompilationOptions& options);
 
@@ -90,6 +92,7 @@ class Compiler {
   MakeSystem& make_system() { return m_make; }
 
  private:
+  GameVersion m_version;
   TypeSystem m_ts;
   std::unique_ptr<GlobalEnv> m_global_env = nullptr;
   std::unique_ptr<None> m_none = nullptr;

--- a/test/goalc/test_arithmetic.cpp
+++ b/test/goalc/test_arithmetic.cpp
@@ -120,7 +120,7 @@ class ArithmeticTests : public testing::TestWithParam<IntegerParam> {
   // Called before the first test in this test suite.
   static void SetUpTestSuite() {
     runtime_thread = std::make_unique<std::thread>(std::thread((GoalTest::runtime_no_kernel)));
-    compiler = std::make_unique<Compiler>();
+    compiler = std::make_unique<Compiler>(GameVersion::Jak1);
     runner = std::make_unique<GoalTest::CompilerTestRunner>();
     runner->c = compiler.get();
   }

--- a/test/goalc/test_collections.cpp
+++ b/test/goalc/test_collections.cpp
@@ -24,7 +24,7 @@ class CollectionTests : public testing::TestWithParam<CollectionParam> {
  public:
   static void SetUpTestSuite() {
     runtime_thread = std::make_unique<std::thread>(std::thread((GoalTest::runtime_no_kernel)));
-    compiler = std::make_unique<Compiler>();
+    compiler = std::make_unique<Compiler>(GameVersion::Jak1);
     runner = std::make_unique<GoalTest::CompilerTestRunner>();
     runner->c = compiler.get();
   }

--- a/test/goalc/test_compiler.cpp
+++ b/test/goalc/test_compiler.cpp
@@ -7,5 +7,6 @@
 #include "gtest/gtest.h"
 
 TEST(CompilerAndRuntime, ConstructCompiler) {
-  Compiler compiler;
+  Compiler compiler1(GameVersion::Jak1);
+  Compiler compiler2(GameVersion::Jak2);
 }

--- a/test/goalc/test_control_statements.cpp
+++ b/test/goalc/test_control_statements.cpp
@@ -24,7 +24,7 @@ class ControlStatementTests : public testing::TestWithParam<ControlStatementPara
  public:
   static void SetUpTestSuite() {
     runtime_thread = std::make_unique<std::thread>(std::thread((GoalTest::runtime_no_kernel)));
-    compiler = std::make_unique<Compiler>();
+    compiler = std::make_unique<Compiler>(GameVersion::Jak1);
     runner = std::make_unique<GoalTest::CompilerTestRunner>();
     runner->c = compiler.get();
   }

--- a/test/goalc/test_debugger.cpp
+++ b/test/goalc/test_debugger.cpp
@@ -33,8 +33,8 @@ void connect_compiler_and_debugger(Compiler& compiler, bool do_break) {
   }
 }
 }  // namespace
-TEST(Debugger, DebuggerBasicConnect) {
-  Compiler compiler;
+TEST(Jak1Debugger, DebuggerBasicConnect) {
+  Compiler compiler(GameVersion::Jak1);
   // evidently you can't ptrace threads in your own process, so we need to run the runtime in a
   // separate process.
   if (!fork()) {
@@ -50,8 +50,8 @@ TEST(Debugger, DebuggerBasicConnect) {
   }
 }
 
-TEST(Debugger, DebuggerBreakAndContinue) {
-  Compiler compiler;
+TEST(Jak1Debugger, DebuggerBreakAndContinue) {
+  Compiler compiler(GameVersion::Jak1);
   // evidently you can't ptrace threads in your own process, so we need to run the runtime in a
   // separate process.
   if (!fork()) {
@@ -72,8 +72,8 @@ TEST(Debugger, DebuggerBreakAndContinue) {
   }
 }
 
-TEST(Debugger, DebuggerReadMemory) {
-  Compiler compiler;
+TEST(Jak1Debugger, DebuggerReadMemory) {
+  Compiler compiler(GameVersion::Jak1);
   // evidently you can't ptrace threads in your own process, so we need to run the runtime in a
   // separate process.
   if (!fork()) {
@@ -96,8 +96,8 @@ TEST(Debugger, DebuggerReadMemory) {
   }
 }
 
-TEST(Debugger, DebuggerWriteMemory) {
-  Compiler compiler;
+TEST(Jak1Debugger, DebuggerWriteMemory) {
+  Compiler compiler(GameVersion::Jak1);
   // evidently you can't ptrace threads in your own process, so we need to run the runtime in a
   // separate process.
   if (!fork()) {
@@ -127,8 +127,8 @@ TEST(Debugger, DebuggerWriteMemory) {
   }
 }
 
-TEST(Debugger, Symbol) {
-  Compiler compiler;
+TEST(Jak1Debugger, Symbol) {
+  Compiler compiler(GameVersion::Jak1);
   // evidently you can't ptrace threads in your own process, so we need to run the runtime in a
   // separate process.
   if (!fork()) {
@@ -158,8 +158,8 @@ TEST(Debugger, Symbol) {
   }
 }
 
-TEST(Debugger, SimpleBreakpoint) {
-  Compiler compiler;
+TEST(Jak1Debugger, SimpleBreakpoint) {
+  Compiler compiler(GameVersion::Jak1);
 
   if (!fork()) {
     GoalTest::runtime_no_kernel();

--- a/test/goalc/test_game_no_debug.cpp
+++ b/test/goalc/test_game_no_debug.cpp
@@ -1,11 +1,11 @@
-// Test the game running without loading debug segments.
+// Test jak1 running without loading debug segments.
 
 #include "goalc/compiler/Compiler.h"
 #include "gtest/gtest.h"
 #include "test/goalc/framework/test_runner.h"
 
-TEST(GameNoDebugSegment, Init) {
-  Compiler compiler;
+TEST(Jak1NoDebugSegment, Init) {
+  Compiler compiler(GameVersion::Jak1);
   compiler.run_front_end_on_string("(build-kernel)");
   std::thread runtime_thread = std::thread(GoalTest::runtime_with_kernel_no_debug_segment);
 

--- a/test/goalc/test_goal_kernel.cpp
+++ b/test/goalc/test_goal_kernel.cpp
@@ -5,10 +5,10 @@
 #include "gtest/gtest.h"
 #include "test/goalc/framework/test_runner.h"
 
-class KernelTest : public testing::Test {
+class Jak1KernelTest : public testing::Test {
  public:
   static void SetUpTestSuite() {
-    shared_compiler = std::make_unique<SharedCompiler>();
+    shared_compiler = std::make_unique<SharedCompiler>(GameVersion::Jak1);
     printf("Building kernel...\n");
     try {
       // a macro in goal-lib.gc
@@ -37,6 +37,7 @@ class KernelTest : public testing::Test {
   void TearDown() {}
 
   struct SharedCompiler {
+    SharedCompiler(GameVersion v) : compiler(v) {}
     std::thread runtime_thread;
     Compiler compiler;
     GoalTest::CompilerTestRunner runner;
@@ -45,7 +46,7 @@ class KernelTest : public testing::Test {
   static std::unique_ptr<SharedCompiler> shared_compiler;
 };
 
-std::unique_ptr<KernelTest::SharedCompiler> KernelTest::shared_compiler;
+std::unique_ptr<Jak1KernelTest::SharedCompiler> Jak1KernelTest::shared_compiler;
 
 namespace {
 std::string send_code_and_get_multiple_responses(const std::string& code,
@@ -70,7 +71,7 @@ std::string send_code_and_get_multiple_responses(const std::string& code,
 }
 }  // namespace
 
-TEST_F(KernelTest, Basic) {
+TEST_F(Jak1KernelTest, Basic) {
   shared_compiler->runner.c->run_test_from_string(
       "(ml \"test/goalc/source_templates/kernel/kernel-test.gc\")");
   std::string result =
@@ -102,7 +103,7 @@ TEST_F(KernelTest, Basic) {
   EXPECT_EQ(expected, result);
 }
 
-TEST_F(KernelTest, RunFunctionInProcess) {
+TEST_F(Jak1KernelTest, RunFunctionInProcess) {
   shared_compiler->runner.c->run_test_from_string(
       "(ml \"test/goalc/source_templates/kernel/kernel-test.gc\")");
   std::string result =
@@ -121,7 +122,7 @@ TEST_F(KernelTest, RunFunctionInProcess) {
   EXPECT_EQ(expected, result);
 }
 
-TEST_F(KernelTest, StateAndXmm) {
+TEST_F(Jak1KernelTest, StateAndXmm) {
   shared_compiler->runner.c->run_test_from_string(
       "(ml \"test/goalc/source_templates/kernel/kernel-test.gc\")");
   std::string result =
@@ -135,7 +136,7 @@ TEST_F(KernelTest, StateAndXmm) {
   EXPECT_EQ(expected, result);
 }
 
-TEST_F(KernelTest, ThrowXmm) {
+TEST_F(Jak1KernelTest, ThrowXmm) {
   shared_compiler->runner.c->run_test_from_string(
       "(ml \"test/goalc/source_templates/kernel/kernel-test.gc\")");
   std::string result =

--- a/test/goalc/test_variables.cpp
+++ b/test/goalc/test_variables.cpp
@@ -23,7 +23,7 @@ struct VariableParam {
 class VariableTests : public testing::TestWithParam<VariableParam> {
  public:
   static void SetUpTestSuite() {
-    shared_compiler = std::make_unique<SharedCompiler>();
+    shared_compiler = std::make_unique<SharedCompiler>(GameVersion::Jak1);
     shared_compiler->runtime_thread = std::thread((GoalTest::runtime_no_kernel));
     shared_compiler->runner.c = &shared_compiler->compiler;
   }
@@ -42,6 +42,7 @@ class VariableTests : public testing::TestWithParam<VariableParam> {
   void TearDown() {}
 
   struct SharedCompiler {
+    SharedCompiler(GameVersion version) : compiler(version) {}
     std::thread runtime_thread;
     Compiler compiler;
     GoalTest::CompilerTestRunner runner;

--- a/test/goalc/test_with_game.cpp
+++ b/test/goalc/test_with_game.cpp
@@ -24,7 +24,7 @@
 class WithGameTests : public ::testing::Test {
  public:
   static void SetUpTestSuite() {
-    shared_compiler = std::make_unique<SharedCompiler>();
+    shared_compiler = std::make_unique<SharedCompiler>(GameVersion::Jak1);
     try {
       shared_compiler->compiler.run_test_no_load(
           "test/goalc/source_templates/with_game/test-build-game.gc");
@@ -56,6 +56,7 @@ class WithGameTests : public ::testing::Test {
   void TearDown() {}
 
   struct SharedCompiler {
+    SharedCompiler(GameVersion v) : compiler(v) {}
     std::thread runtime_thread;
     Compiler compiler;
     GoalTest::CompilerTestRunner runner;
@@ -73,7 +74,7 @@ std::unique_ptr<WithGameTests::SharedCompiler> WithGameTests::shared_compiler;
 class WithMinimalGameTests : public ::testing::Test {
  public:
   static void SetUpTestSuite() {
-    shared_compiler = std::make_unique<SharedCompiler>();
+    shared_compiler = std::make_unique<SharedCompiler>(GameVersion::Jak1);
     try {
       shared_compiler->compiler.run_front_end_on_string("(build-kernel)");
     } catch (std::exception& e) {
@@ -109,6 +110,7 @@ class WithMinimalGameTests : public ::testing::Test {
   void TearDown() {}
 
   struct SharedCompiler {
+    SharedCompiler(GameVersion v) : compiler(v) {}
     std::thread runtime_thread;
     Compiler compiler;
     GoalTest::CompilerTestRunner runner;
@@ -943,16 +945,16 @@ void add_expected_type_mismatches(Compiler& c) {
   c.add_ignored_define_extern_symbol("tfrag-init-buffer");
 }
 
-TEST(TypeConsistency, MANUAL_TEST_TypeConsistencyWithBuildFirst) {
-  Compiler compiler;
+TEST(Jak1TypeConsistency, MANUAL_TEST_TypeConsistencyWithBuildFirst) {
+  Compiler compiler(GameVersion::Jak1);
   compiler.enable_throw_on_redefines();
   add_expected_type_mismatches(compiler);
   compiler.run_test_no_load("test/goalc/source_templates/with_game/test-build-all-code.gc");
   compiler.run_test_no_load("decompiler/config/all-types.gc");
 }
 
-TEST(TypeConsistency, TypeConsistency) {
-  Compiler compiler;
+TEST(Jak1TypeConsistency, TypeConsistency) {
+  Compiler compiler(GameVersion::Jak1);
   compiler.enable_throw_on_redefines();
   add_expected_type_mismatches(compiler);
   compiler.run_test_no_load("decompiler/config/all-types.gc");

--- a/test/offline/offline_test_main.cpp
+++ b/test/offline/offline_test_main.cpp
@@ -49,8 +49,9 @@ std::unordered_map<std::string, std::string> game_name_to_config = {
 
 // TODO - i think these should be partitioned by game name instead of it being in the filename
 // (and the names not being consistent)
-std::unordered_map<std::string, std::string> game_name_to_all_types = {{"jak1", "all-types.gc"},
-                                                                       {"jak2", "all-types2.gc"}};
+std::unordered_map<std::string, std::string> game_name_to_all_types = {
+    {"jak1", "all-types.gc"},
+    {"jak2", "jak2/all-types.gc"}};
 
 Decompiler setup_decompiler(const std::vector<DecompilerFile>& files,
                             const std::vector<DecompilerArtFile>& art_files,
@@ -197,7 +198,7 @@ bool compile(Decompiler& dc,
              const OfflineTestConfig& config,
              const std::string& game_name) {
   fmt::print("Setting up compiler...\n");
-  Compiler compiler;
+  Compiler compiler(game_name_to_version(game_name));
 
   compiler.run_front_end_on_file({"decompiler", "config", game_name_to_all_types[game_name]});
   compiler.run_front_end_on_file(


### PR DESCRIPTION
This doesn't make any changes to the compiler for jak2 differences, but just sets up the framework for having multiple versions:
- `goal_src/<version>/compiler-setup.gc` is a place to load game-specific stuff like `kernel-defs.gc`, `game.gp` and others (like the jak1 art group stuff)
- `Compiler` takes a version in the constructor. This can be accessed by all C++ `Compiler` code and in GOAL with `GAME_VERSION`.
- `goalc` program defaults to jak1, but takes a `--game jak2` argument like the offline tests.
- other misc small fixes. For now, the majority of tests are jak1 only.