### PR TITLE
Sprite Distort

### DIFF
--- a/common/dma/gs.h
+++ b/common/dma/gs.h
@@ -125,6 +125,7 @@ std::string register_address_name(u32 reg);
 
 struct GsZbuf {
   GsZbuf(u64 val) : data(val) {}
+  GsZbuf() = default;
 
   u32 zbp() const { return data & 0b1'1111'1111; }
 

--- a/common/math/Vector.h
+++ b/common/math/Vector.h
@@ -248,7 +248,7 @@ class Vector {
   }
 
   Vector<T, 3> xyz() const { return head<3>(); }
-  Vector<T, 3> xy() const { return head<2>(); }
+  Vector<T, 2> xy() const { return head<2>(); }
 
   void fill(const T& val) {
     for (auto& x : m_data) {

--- a/docs/scratch/sprite_distort_vu1.txt
+++ b/docs/scratch/sprite_distort_vu1.txt
@@ -1,0 +1,94 @@
+;; VU memory:
+;; 0:   GS vertex data (buffer 1)
+;; 176: GS vertex data (buffer 2)
+;; 352: sinetables.entry[128]
+;; 480: sinetables.ientry[9]
+;; 489: sinetables.giftag
+;; 490: sinetables.color
+;; 511: num sprites
+;; 512: sprite data
+
+;; Init
+  lq.xyzw vf01, 489(vi00)    |  nop                         ;; Load giftag
+  lq.xyzw vf05, 490(vi00)    |  nop                         ;; Load color
+  ilw.x vi01, 511(vi00)      |  nop                         ;; Load number of sprites
+  iaddiu vi04, vi00, 0x200   |  nop                         ;; Address of sprite data (512)
+  iaddi vi02, vi00, 0x0      |  nop                      
+
+;; Loop for each sprite
+L1:
+  ilw.w vi07, 1(vi04)        |  nop                         ;; Get sprite.flag
+                                                            ;; The flag represents the 'resolution' of the sprite,
+                                                            ;; which is a circle. The vertices are constructed below
+                                                            ;; by creating "pie-slices" of a circle where the number
+                                                            ;; of slices is the value of flag. In practice, flag
+                                                            ;; can range from 3-11.
+  ior vi05, vi02, vi00       |  nop                      
+  ilw.x vi06, 477(vi07)      |  nop                         ;; Get ptr to sinetables.entry
+                                                            ;; addr = sinetables.ientry[flag - 3]
+                                                            ;; The smallest value of flag is 3 and 3 + 477 = 480, 
+                                                            ;; which is sinetables.ientry.
+                                                            ;; The values in ientry are an index of entry + 352, 
+                                                            ;; which gives the address of an entry element.
+  sqi.xyzw vf01, vi05        |  nop                         ;; Write giftag to GS data
+  iaddiu vi08, vi07, 0x4000  |  nop                      
+  iaddiu vi08, vi08, 0x4000  |  nop                         
+  isw.x vi08, -1(vi05)       |  nop                         ;; Set giftag.nloop to flag (number of slices)
+  lqi.xyzw vf02, vi04        |  nop                         ;; Get sprite.xyz
+  lqi.xyzw vf03, vi04        |  nop                         ;; Get sprite.st
+  lqi.xyzw vf04, vi04        |  nop                         ;; Get sprite.rgba
+  nop                        |  ftoi4.xyzw vf14, vf02    
+
+;; Loop the number of times denoted by sprite.flag
+;; Here, we build the GS data for a single distort sprite
+L2:
+  lqi.xyzw vf06, vi06        |  nop                         ;; Load 4 sine table vectors
+  lqi.xyzw vf07, vi06        |  nop                      
+  lq.xyzw vf08, 0(vi06)      |  nop                      
+  lq.xyzw vf09, 1(vi06)      |  nop                      
+  iaddi vi07, vi07, -0x1     |  muly.xyzw vf10, vf06, vf04  ;; Decrement loop count
+  nop                        |  mulz.xyzw vf11, vf07, vf04  ;; Calculate vertex positions, texture coords, and color
+  nop                        |  muly.xyzw vf12, vf08, vf04
+  nop                        |  mulz.xyzw vf13, vf09, vf04
+  nop                        |  mulx.xyzw vf06, vf06, vf04
+  nop                        |  mulx.xyzw vf07, vf07, vf04
+  nop                        |  mulx.xyzw vf08, vf08, vf04
+  nop                        |  mulx.xyzw vf09, vf09, vf04
+  nop                        |  add.xyzw vf10, vf10, vf02
+  nop                        |  add.xyzw vf11, vf11, vf03
+  nop                        |  add.xyzw vf12, vf12, vf02
+  nop                        |  add.xyzw vf13, vf13, vf03
+  nop                        |  add.xyzw vf06, vf06, vf02
+  nop                        |  add.xyzw vf07, vf07, vf03
+  nop                        |  add.xyzw vf08, vf08, vf02
+  nop                        |  add.xyzw vf09, vf09, vf03
+  nop                        |  ftoi4.xyzw vf10, vf10    
+  nop                        |  ftoi4.xyzw vf12, vf12    
+  nop                        |  ftoi4.xyzw vf06, vf06    
+  nop                        |  ftoi4.xyzw vf08, vf08    
+  sqi.xyzw vf07, vi05        |  nop                         ;; Write the 5 vertexes for this "pie-slice" to GS data
+  sqi.xyzw vf05, vi05        |  nop                      
+  sqi.xyzw vf06, vi05        |  nop                      
+  sqi.xyzw vf09, vi05        |  nop                      
+  sqi.xyzw vf05, vi05        |  nop                      
+  sqi.xyzw vf08, vi05        |  nop                      
+  sqi.xyzw vf11, vi05        |  nop                      
+  sqi.xyzw vf05, vi05        |  nop                      
+  sqi.xyzw vf10, vi05        |  nop                      
+  sqi.xyzw vf13, vi05        |  nop                      
+  sqi.xyzw vf05, vi05        |  nop                      
+  sqi.xyzw vf12, vi05        |  nop                      
+  sqi.xyzw vf03, vi05        |  nop                      
+  sqi.xyzw vf05, vi05        |  nop                      
+  ibne vi00, vi07, L2        |  nop                         ;; Repeat for remaining slices
+  sqi.xyzw vf14, vi05        |  nop                      
+
+;; Finally, tell the GS to draw the current sprite and switch
+;; to the other buffer for the next sprite
+  xgkick vi02                |  nop                         ;; Draw sprite
+  iaddi vi01, vi01, -0x1     |  nop                      
+  iaddiu vi03, vi00, 0xb0    |  nop                         ;; Switch buffer
+  ibne vi00, vi01, L1        |  nop                         ;; Loop for remaining sprites
+  isub vi02, vi03, vi02      |  nop                      
+  nop                        |  nop :e                   
+  nop                        |  nop                      

--- a/game/graphics/opengl_renderer/BucketRenderer.h
+++ b/game/graphics/opengl_renderer/BucketRenderer.h
@@ -59,6 +59,8 @@ struct SharedRenderState {
 
   int window_width_px;
   int window_height_px;
+  int window_offset_x_px;
+  int window_offset_y_px;
 };
 
 /*!

--- a/game/graphics/opengl_renderer/BucketRenderer.h
+++ b/game/graphics/opengl_renderer/BucketRenderer.h
@@ -56,6 +56,9 @@ struct SharedRenderState {
   EyeRenderer* eye_renderer = nullptr;
 
   std::string load_status_debug;
+
+  int window_width_px;
+  int window_height_px;
 };
 
 /*!

--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -417,6 +417,8 @@ void OpenGLRenderer::setup_frame(int window_width_px,
 
   m_render_state.window_width_px = window_width_px;
   m_render_state.window_height_px = window_height_px;
+  m_render_state.window_offset_x_px = offset_x;
+  m_render_state.window_offset_y_px = offset_y;
 }
 
 /*!

--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -414,6 +414,9 @@ void OpenGLRenderer::setup_frame(int window_width_px,
   glDepthMask(GL_TRUE);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
   glDisable(GL_BLEND);
+
+  m_render_state.window_width_px = window_width_px;
+  m_render_state.window_height_px = window_height_px;
 }
 
 /*!

--- a/game/graphics/opengl_renderer/Shader.cpp
+++ b/game/graphics/opengl_renderer/Shader.cpp
@@ -87,6 +87,7 @@ ShaderLibrary::ShaderLibrary() {
   at(ShaderId::SHADOW) = {"shadow"};
   at(ShaderId::COLLISION) = {"collision"};
   at(ShaderId::MERC2) = {"merc2"};
+  at(ShaderId::SPRITE_DISTORT) = {"sprite_distort"};
 
   for (auto& shader : m_shaders) {
     ASSERT_MSG(shader.okay(), "Shader compiled");

--- a/game/graphics/opengl_renderer/Shader.h
+++ b/game/graphics/opengl_renderer/Shader.h
@@ -42,6 +42,7 @@ enum class ShaderId {
   SHRUB = 17,
   COLLISION = 18,
   MERC2 = 19,
+  SPRITE_DISTORT = 20,
   MAX_SHADERS
 };
 

--- a/game/graphics/opengl_renderer/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/Sprite3.cpp
@@ -215,6 +215,11 @@ void Sprite3::render_distorter(DmaFollower& dma,
     distort_dma(dma);
   }
 
+  if (!m_enabled || !m_distort_enable) {
+    // Distort disabled, we can stop here since all the DMA has been read
+    return;
+  }
+
   // Setup vertex data
   {
     auto prof_node = prof.make_scoped_child("setup");
@@ -754,6 +759,7 @@ void Sprite3::render(DmaFollower& dma, SharedRenderState* render_state, ScopedPr
 
 void Sprite3::draw_debug_window() {
   ImGui::Separator();
+  ImGui::Text("Distort sprites: %d", m_distort_stats.total_sprites);
   ImGui::Text("2D Group 0 (World) blocks: %d sprites: %d", m_debug_stats.blocks_2d_grp0,
               m_debug_stats.count_2d_grp0);
   ImGui::Text("2D Group 1 (HUD) blocks: %d sprites: %d", m_debug_stats.blocks_2d_grp1,
@@ -762,6 +768,7 @@ void Sprite3::draw_debug_window() {
   ImGui::Checkbox("2d", &m_2d_enable);
   ImGui::SameLine();
   ImGui::Checkbox("3d", &m_3d_enable);
+  ImGui::Checkbox("Distort", &m_distort_enable);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/game/graphics/opengl_renderer/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/Sprite3.cpp
@@ -323,12 +323,11 @@ void Sprite3::render_distorter(DmaFollower& dma,
 
     // Build vertex data and draw
     int in_v_idx = 0;
-    int out_v_idx = 0;
     int sprites_left = num_sprites_vec.x();
 
     // This part is mostly ripped from the VU program
     do {
-      out_v_idx = 0;
+      int out_v_idx = 0;
 
       // flag seems to represent the 'resolution' of the circle sprite used to create the distortion
       // effect For example, a flag value of 3 will create a circle using 3 "pie-slice" shapes
@@ -367,11 +366,13 @@ void Sprite3::render_distorter(DmaFollower& dma,
         math::Vector3f vf06_3 = vf06_2;
         math::Vector3f vf08_3 = vf08_2;
 
-        m_sprite_distorter_vertices.at(out_v_idx++) = {.xyz = vf06_3, .st = vf07_2};
-        m_sprite_distorter_vertices.at(out_v_idx++) = {.xyz = vf08_3, .st = vf09_2};
-        m_sprite_distorter_vertices.at(out_v_idx++) = {.xyz = vf10, .st = vf11};
-        m_sprite_distorter_vertices.at(out_v_idx++) = {.xyz = vf12, .st = vf13};
-        m_sprite_distorter_vertices.at(out_v_idx++) = {.xyz = vf14, .st = vf03};
+        m_sprite_distorter_vertices.at(out_v_idx++) =
+            SpriteDistortVertex{.xyz = vf06_3, .st = vf07_2};
+        m_sprite_distorter_vertices.at(out_v_idx++) =
+            SpriteDistortVertex{.xyz = vf08_3, .st = vf09_2};
+        m_sprite_distorter_vertices.at(out_v_idx++) = SpriteDistortVertex{.xyz = vf10, .st = vf11};
+        m_sprite_distorter_vertices.at(out_v_idx++) = SpriteDistortVertex{.xyz = vf12, .st = vf13};
+        m_sprite_distorter_vertices.at(out_v_idx++) = SpriteDistortVertex{.xyz = vf14, .st = vf03};
       } while (flag != 0);
 
       // Upload sprite to vertex buffer

--- a/game/graphics/opengl_renderer/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/Sprite3.cpp
@@ -170,7 +170,7 @@ Sprite3::Sprite3(const std::string& name, BucketId my_id)
   );
   glEnableVertexAttribArray(1);
   glVertexAttribPointer(1,                                        // location 1 in the shader
-                        3,                                        // 2 floats per vert
+                        2,                                        // 2 floats per vert
                         GL_FLOAT,                                 // floats
                         GL_TRUE,                                  // normalized, ignored,
                         sizeof(SpriteDistortVertex),              //

--- a/game/graphics/opengl_renderer/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/Sprite3.cpp
@@ -45,7 +45,8 @@ bool looks_like_distort_frame_data(const DmaFollower& dma) {
 }  // namespace
 
 constexpr int SPRITE_RENDERER_MAX_SPRITES = 8000;
-constexpr int SPRITE_RENDERER_MAX_DISTORT_SPRITES = 256;  // size of sprite-aux-list in GOAL code
+constexpr int SPRITE_RENDERER_MAX_DISTORT_SPRITES =
+    256 * 8;  // size of sprite-aux-list in GOAL code * SPRITE_MAX_AMOUNT_MULT
 
 Sprite3::Sprite3(const std::string& name, BucketId my_id)
     : BucketRenderer(name, my_id), m_direct(name, my_id, 1024) {

--- a/game/graphics/opengl_renderer/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/Sprite3.cpp
@@ -156,7 +156,8 @@ Sprite3::Sprite3(const std::string& name, BucketId my_id)
   glBindBuffer(GL_ARRAY_BUFFER, m_distort_ogl.vertex_buffer);
   // note: each sprite shares a single vertex per slice, account for that here
   int distort_vert_buffer_len =
-       SPRITE_RENDERER_MAX_DISTORT_SPRITES * ((5 - 1) * 11 + 1); // max * ((verts_per_slice - 1) * max_slices + 1)
+      SPRITE_RENDERER_MAX_DISTORT_SPRITES *
+      ((5 - 1) * 11 + 1);  // max * ((verts_per_slice - 1) * max_slices + 1)
   glBufferData(GL_ARRAY_BUFFER, distort_vert_buffer_len * sizeof(SpriteDistortVertex), nullptr,
                GL_DYNAMIC_DRAW);
   glEnableVertexAttribArray(0);
@@ -176,10 +177,9 @@ Sprite3::Sprite3(const std::string& name, BucketId my_id)
                         (void*)offsetof(SpriteDistortVertex, st)  // offset in array
   );
 
-
   // note: add one extra element per sprite that marks the end of a triangle strip
-  int distort_idx_buffer_len =
-      SPRITE_RENDERER_MAX_DISTORT_SPRITES * ((5 * 11) + 1);  // max * ((verts_per_slice * max_slices) + 1)
+  int distort_idx_buffer_len = SPRITE_RENDERER_MAX_DISTORT_SPRITES *
+                               ((5 * 11) + 1);  // max * ((verts_per_slice * max_slices) + 1)
   glGenBuffers(1, &m_distort_ogl.index_buffer);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_distort_ogl.index_buffer);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, distort_idx_buffer_len * sizeof(u32), nullptr,
@@ -315,8 +315,7 @@ void Sprite3::render_distorter(DmaFollower& dma,
 
   // Upload element data
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_distort_ogl.index_buffer);
-  glBufferData(GL_ELEMENT_ARRAY_BUFFER,
-               m_sprite_distorter_indices.size() * sizeof(u32),
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_sprite_distorter_indices.size() * sizeof(u32),
                m_sprite_distorter_indices.data(), GL_DYNAMIC_DRAW);
 
   // Draw

--- a/game/graphics/opengl_renderer/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/Sprite3.cpp
@@ -221,7 +221,7 @@ void Sprite3::render_distorter(DmaFollower& dma,
 
   auto tex1 = m_sprite_distorter_setup.tex1;
   ASSERT(tex1.mmag() == true);
-  ASSERT(tex1.mmin() == true);
+  ASSERT(tex1.mmin() == 1);
   handle_tex1(tex1.data, render_state, prof);
 
   auto alpha = m_sprite_distorter_setup.alpha;
@@ -366,13 +366,11 @@ void Sprite3::render_distorter(DmaFollower& dma,
         math::Vector3f vf06_3 = vf06_2;
         math::Vector3f vf08_3 = vf08_2;
 
-        m_sprite_distorter_vertices.at(out_v_idx++) =
-            SpriteDistortVertex{.xyz = vf06_3, .st = vf07_2};
-        m_sprite_distorter_vertices.at(out_v_idx++) =
-            SpriteDistortVertex{.xyz = vf08_3, .st = vf09_2};
-        m_sprite_distorter_vertices.at(out_v_idx++) = SpriteDistortVertex{.xyz = vf10, .st = vf11};
-        m_sprite_distorter_vertices.at(out_v_idx++) = SpriteDistortVertex{.xyz = vf12, .st = vf13};
-        m_sprite_distorter_vertices.at(out_v_idx++) = SpriteDistortVertex{.xyz = vf14, .st = vf03};
+        m_sprite_distorter_vertices.at(out_v_idx++) = {vf06_3, vf07_2};
+        m_sprite_distorter_vertices.at(out_v_idx++) = {vf08_3, vf09_2};
+        m_sprite_distorter_vertices.at(out_v_idx++) = {vf10, vf11};
+        m_sprite_distorter_vertices.at(out_v_idx++) = {vf12, vf13};
+        m_sprite_distorter_vertices.at(out_v_idx++) = {vf14, vf03};
       } while (flag != 0);
 
       // Upload sprite to vertex buffer

--- a/game/graphics/opengl_renderer/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/Sprite3.cpp
@@ -429,9 +429,17 @@ void Sprite3::distort_draw(SharedRenderState* render_state, ScopedProfilerNode& 
   glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
   glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_distort_ogl.fbo);
 
-  glBlitFramebuffer(0, 0, m_distort_ogl.fbo_width, m_distort_ogl.fbo_height, 0, 0,
-                    m_distort_ogl.fbo_width, m_distort_ogl.fbo_height, GL_COLOR_BUFFER_BIT,
-                    GL_NEAREST);
+  glBlitFramebuffer(render_state->window_offset_x_px,                                   // srcX0
+                    render_state->window_offset_y_px,                                   // srcY0
+                    render_state->window_width_px + render_state->window_offset_x_px,   // srcX1
+                    render_state->window_height_px + render_state->window_offset_y_px,  // srcY1
+                    0,                                                                  // dstX0
+                    0,                                                                  // dstY0
+                    m_distort_ogl.fbo_width,                                            // dstX1
+                    m_distort_ogl.fbo_height,                                           // dstY1
+                    GL_COLOR_BUFFER_BIT,                                                // mask
+                    GL_NEAREST                                                          // filter
+  ); 
 
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
 

--- a/game/graphics/opengl_renderer/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/Sprite3.cpp
@@ -444,7 +444,7 @@ void Sprite3::distort_draw(SharedRenderState* render_state, ScopedProfilerNode& 
                     m_distort_ogl.fbo_height,                                           // dstY1
                     GL_COLOR_BUFFER_BIT,                                                // mask
                     GL_NEAREST                                                          // filter
-  ); 
+  );
 
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
 

--- a/game/graphics/opengl_renderer/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/Sprite3.cpp
@@ -35,7 +35,7 @@ u32 process_sprite_chunk_header(DmaFollower& dma) {
 }
 
 /*!
- * Does the next DMA transfer look like the frame data for sprite distort? 
+ * Does the next DMA transfer look like the frame data for sprite distort?
  */
 bool looks_like_distort_frame_data(const DmaFollower& dma) {
   return dma.current_tag().kind == DmaTag::Kind::CNT &&
@@ -135,8 +135,7 @@ Sprite3::Sprite3(const std::string& name, BucketId my_id)
   glBindTexture(GL_TEXTURE_2D, m_distort_ogl.fbo_texture);
 
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, m_distort_ogl.fbo_width, m_distort_ogl.fbo_height, 0,
-               GL_RGB,
-               GL_UNSIGNED_BYTE, NULL);
+               GL_RGB, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -144,8 +143,7 @@ Sprite3::Sprite3(const std::string& name, BucketId my_id)
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
   glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                         m_distort_ogl.fbo_texture,
-                         0);  
+                         m_distort_ogl.fbo_texture, 0);
 
   ASSERT(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
 
@@ -156,26 +154,25 @@ Sprite3::Sprite3(const std::string& name, BucketId my_id)
   glGenVertexArrays(1, &m_distort_ogl.vao);
   glBindVertexArray(m_distort_ogl.vao);
   glBindBuffer(GL_ARRAY_BUFFER, m_distort_ogl.vertex_buffer);
-  auto distort_verts = SPRITE_RENDERER_MAX_DISTORT_SPRITES * 5 * 11; // max * verts_per_slice * max_slices
+  auto distort_verts =
+      SPRITE_RENDERER_MAX_DISTORT_SPRITES * 5 * 11;  // max * verts_per_slice * max_slices
   auto distort_bytes = distort_verts * sizeof(SpriteDistortVertex);
   glBufferData(GL_ARRAY_BUFFER, distort_bytes, nullptr, GL_DYNAMIC_DRAW);
   glEnableVertexAttribArray(0);
-  glVertexAttribPointer(
-      0,                                         // location 0 in the shader
-      3,                                         // 3 floats per vert
-      GL_FLOAT,                                  // floats
-      GL_TRUE,                                   // normalized, ignored,
-      sizeof(SpriteDistortVertex),               //
-      (void*)offsetof(SpriteDistortVertex, xyz)  // offset in array
+  glVertexAttribPointer(0,                                         // location 0 in the shader
+                        3,                                         // 3 floats per vert
+                        GL_FLOAT,                                  // floats
+                        GL_TRUE,                                   // normalized, ignored,
+                        sizeof(SpriteDistortVertex),               //
+                        (void*)offsetof(SpriteDistortVertex, xyz)  // offset in array
   );
   glEnableVertexAttribArray(1);
-  glVertexAttribPointer(
-      1,                                         // location 1 in the shader
-      3,                                         // 2 floats per vert
-      GL_FLOAT,                                  // floats
-      GL_TRUE,                                   // normalized, ignored,
-      sizeof(SpriteDistortVertex),               //
-      (void*)offsetof(SpriteDistortVertex, st)   // offset in array
+  glVertexAttribPointer(1,                                        // location 1 in the shader
+                        3,                                        // 2 floats per vert
+                        GL_FLOAT,                                 // floats
+                        GL_TRUE,                                  // normalized, ignored,
+                        sizeof(SpriteDistortVertex),              //
+                        (void*)offsetof(SpriteDistortVertex, st)  // offset in array
   );
 
   glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -239,10 +236,10 @@ void Sprite3::render_distorter(DmaFollower& dma,
   // Next thing should be the sprite-distorter tables
   auto sprite_distorter_tables = dma.read_and_advance();
   unpack_to_stcycl(&m_sprite_distorter_sine_tables, sprite_distorter_tables,
-                   VifCode::Kind::UNPACK_V4_32,
-                   4,4,0x8b * 16,0x160,false,false);
+                   VifCode::Kind::UNPACK_V4_32, 4, 4, 0x8b * 16, 0x160, false, false);
 
-  ASSERT(GsPrim(m_sprite_distorter_sine_tables.gs_gif_tag.prim()).kind() == GsPrim::Kind::TRI_STRIP);
+  ASSERT(GsPrim(m_sprite_distorter_sine_tables.gs_gif_tag.prim()).kind() ==
+         GsPrim::Kind::TRI_STRIP);
 
   // Next would be the program, but we don't have it.
 
@@ -290,19 +287,19 @@ void Sprite3::render_distorter(DmaFollower& dma,
 
   // Read DMA packets and draw
   while (looks_like_distort_frame_data(dma)) {
-    //printf("Distort data start\n");
+    // printf("Distort data start\n");
 
     int sprite_idx = 0;
     math::Vector<u32, 4> num_sprites_vec;
 
     // Read packets
-    do  {
+    do {
       int qwc = dma.current_tag().qwc;
       int dest = dma.current_tag_vifcode1().immediate;
       auto distort_data = dma.read_and_advance();
 
-      //printf("Distort data packet qwc: %d dest: %d\n", qwc, dest);
-      
+      // printf("Distort data packet qwc: %d dest: %d\n", qwc, dest);
+
       if (dest == 511) {
         // VU address 511 specifies the number of sprites
         unpack_to_no_stcycl(&num_sprites_vec, distort_data, VifCode::Kind::UNPACK_V4_32, 16, dest,
@@ -333,13 +330,13 @@ void Sprite3::render_distorter(DmaFollower& dma,
     do {
       out_v_idx = 0;
 
-      // flag seems to represent the 'resolution' of the circle sprite used to create the distortion effect
-      // For example, a flag value of 3 will create a circle using 3 "pie-slice" shapes
+      // flag seems to represent the 'resolution' of the circle sprite used to create the distortion
+      // effect For example, a flag value of 3 will create a circle using 3 "pie-slice" shapes
       u32 flag = m_sprite_distorter_frame_data.at(in_v_idx).flag;
 
       // flag has a minimum value of 3 which represents the first ientry
-      // Additionally, the ientry index has 352 added to it (which is the start of the entry array in VU memory),
-      // so we need to subtract that as well
+      // Additionally, the ientry index has 352 added to it (which is the start of the entry array
+      // in VU memory), so we need to subtract that as well
       int entry_index = m_sprite_distorter_sine_tables.ientry[flag - 3].x() - 352;
 
       // Here would be adding the giftag, but we don't need that
@@ -380,8 +377,7 @@ void Sprite3::render_distorter(DmaFollower& dma,
       // Upload sprite to vertex buffer
       glBindBuffer(GL_ARRAY_BUFFER, m_distort_ogl.vertex_buffer);
       glBufferData(GL_ARRAY_BUFFER, out_v_idx * sizeof(SpriteDistortVertex),
-                   m_sprite_distorter_vertices.data(),
-                   GL_DYNAMIC_DRAW);
+                   m_sprite_distorter_vertices.data(), GL_DYNAMIC_DRAW);
 
       // Draw (xgkick)
       prof.add_draw_call();
@@ -917,7 +913,7 @@ void Sprite3::do_block_common(SpriteMode mode,
     bucket->ids.push_back(start_vtx_id + 2);
     bucket->ids.push_back(start_vtx_id + 3);
     bucket->ids.push_back(UINT32_MAX);
-    
+
     auto& vert1 = m_vertices_3d.at(start_vtx_id + 0);
 
     vert1.xyz_sx = m_vec_data_2d[sprite_idx].xyz_sx;

--- a/game/graphics/opengl_renderer/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/Sprite3.cpp
@@ -213,7 +213,7 @@ void Sprite3::render_distorter(DmaFollower& dma,
   // Read DMA
   {
     auto prof_node = prof.make_scoped_child("dma");
-    distort_dma(dma);
+    distort_dma(dma, prof_node);
   }
 
   if (!m_enabled || !m_distort_enable) {
@@ -224,7 +224,7 @@ void Sprite3::render_distorter(DmaFollower& dma,
   // Setup vertex data
   {
     auto prof_node = prof.make_scoped_child("setup");
-    distort_setup();
+    distort_setup(prof_node);
   }
 
   // Draw
@@ -237,7 +237,7 @@ void Sprite3::render_distorter(DmaFollower& dma,
 /*!
  * Reads all sprite distort related DMA packets.
  */
-void Sprite3::distort_dma(DmaFollower& dma) {
+void Sprite3::distort_dma(DmaFollower& dma, ScopedProfilerNode& /*prof*/) {
   // First should be the GS setup
   auto sprite_distorter_direct_setup = dma.read_and_advance();
   ASSERT(sprite_distorter_direct_setup.vifcode0().kind == VifCode::Kind::NOP);
@@ -327,7 +327,7 @@ void Sprite3::distort_dma(DmaFollower& dma) {
 /*!
  * Sets up OpenGL data for each distort sprite.
  */
-void Sprite3::distort_setup() {
+void Sprite3::distort_setup(ScopedProfilerNode& /*prof*/) {
   m_distort_stats.total_tris = 0;
 
   m_sprite_distorter_vertices.clear();

--- a/game/graphics/opengl_renderer/Sprite3.h
+++ b/game/graphics/opengl_renderer/Sprite3.h
@@ -22,6 +22,7 @@ class Sprite3 : public BucketRenderer {
   void render_distorter(DmaFollower& dma,
                         SharedRenderState* render_state,
                         ScopedProfilerNode& prof);
+  int read_and_create_distort_sprites(DmaFollower& dma);
   void handle_sprite_frame_setup(DmaFollower& dma);
   void render_3d(DmaFollower& dma);
   void render_2d_group0(DmaFollower& dma,
@@ -89,6 +90,7 @@ class Sprite3 : public BucketRenderer {
   struct {
     GLuint vao;
     GLuint vertex_buffer;
+    GLuint index_buffer;
     GLuint fbo;
     GLuint fbo_texture;
     int fbo_width = 640;
@@ -96,6 +98,7 @@ class Sprite3 : public BucketRenderer {
   } m_distort_ogl;
 
   std::vector<SpriteDistortVertex> m_sprite_distorter_vertices;
+  std::vector<u32> m_sprite_distorter_indices;
   std::vector<SpriteDistortFrameData> m_sprite_distorter_frame_data;
   SpriteDistorterSetup m_sprite_distorter_setup;  // direct data
   SpriteDistorterSineTables m_sprite_distorter_sine_tables;

--- a/game/graphics/opengl_renderer/Sprite3.h
+++ b/game/graphics/opengl_renderer/Sprite3.h
@@ -22,8 +22,8 @@ class Sprite3 : public BucketRenderer {
   void render_distorter(DmaFollower& dma,
                         SharedRenderState* render_state,
                         ScopedProfilerNode& prof);
-  void distort_dma(DmaFollower& dma);
-  void distort_setup();
+  void distort_dma(DmaFollower& dma, ScopedProfilerNode& prof);
+  void distort_setup(ScopedProfilerNode& prof);
   void distort_draw(SharedRenderState* render_state, ScopedProfilerNode& prof);
   void handle_sprite_frame_setup(DmaFollower& dma);
   void render_3d(DmaFollower& dma);

--- a/game/graphics/opengl_renderer/Sprite3.h
+++ b/game/graphics/opengl_renderer/Sprite3.h
@@ -22,7 +22,9 @@ class Sprite3 : public BucketRenderer {
   void render_distorter(DmaFollower& dma,
                         SharedRenderState* render_state,
                         ScopedProfilerNode& prof);
-  int read_and_create_distort_sprites(DmaFollower& dma);
+  void distort_dma(DmaFollower& dma);
+  void distort_setup();
+  void distort_draw(SharedRenderState* render_state, ScopedProfilerNode& prof);
   void handle_sprite_frame_setup(DmaFollower& dma);
   void render_3d(DmaFollower& dma);
   void render_2d_group0(DmaFollower& dma,
@@ -38,6 +40,7 @@ class Sprite3 : public BucketRenderer {
                        SharedRenderState* render_state,
                        ScopedProfilerNode& prof);
 
+  void update_mode_from_alpha1(u64 val, DrawMode& mode);
   void handle_tex0(u64 val, SharedRenderState* render_state, ScopedProfilerNode& prof);
   void handle_tex1(u64 val, SharedRenderState* render_state, ScopedProfilerNode& prof);
   // void handle_mip(u64 val, SharedRenderState* render_state, ScopedProfilerNode& prof);
@@ -97,11 +100,16 @@ class Sprite3 : public BucketRenderer {
     int fbo_height = 480;
   } m_distort_ogl;
 
+  struct {
+    int total_sprites;
+    int total_tris;
+  } m_distort_stats;
+
   std::vector<SpriteDistortVertex> m_sprite_distorter_vertices;
   std::vector<u32> m_sprite_distorter_indices;
-  std::vector<SpriteDistortFrameData> m_sprite_distorter_frame_data;
   SpriteDistorterSetup m_sprite_distorter_setup;  // direct data
   SpriteDistorterSineTables m_sprite_distorter_sine_tables;
+  std::vector<SpriteDistortFrameData> m_sprite_distorter_frame_data;
 
   u8 m_sprite_direct_setup[3 * 16];
   SpriteFrameData m_frame_data;  // qwa: 980

--- a/game/graphics/opengl_renderer/Sprite3.h
+++ b/game/graphics/opengl_renderer/Sprite3.h
@@ -46,7 +46,57 @@ class Sprite3 : public BucketRenderer {
 
   void flush_sprites(SharedRenderState* render_state, ScopedProfilerNode& prof, bool double_draw);
 
-  u8 m_sprite_distorter_setup[7 * 16];  // direct data
+  struct SpriteDistorterSetup {
+    GifTag gif_tag;
+    GsZbuf zbuf;
+    u64 zbuf_addr;
+    GsTex0 tex0;
+    u64 tex0_addr;
+    GsTex1 tex1;
+    u64 tex1_addr;
+    u64 miptbp;
+    u64 miptbp_addr;
+    u64 clamp;
+    u64 clamp_addr;
+    GsAlpha alpha;
+    u64 alpha_addr;
+  };
+  static_assert(sizeof(SpriteDistorterSetup) == (7 * 16));
+
+  struct SpriteDistorterSineTables {
+    Vector4f entry[128];
+    math::Vector<u32, 4> ientry[9];
+    GifTag gs_gif_tag;
+    math::Vector<u32, 4> color;
+  };
+  static_assert(sizeof(SpriteDistorterSineTables) == (0x8b * 16));
+
+  struct SpriteDistortFrameData {
+    math::Vector3f xyz;
+    float num_255; // always 255.0
+    math::Vector2f st;
+    float one; // always 1.0
+    u32 flag;
+    Vector4f rgba;
+  };
+  static_assert(sizeof(SpriteDistortFrameData) == 16 * 3);
+
+  struct SpriteDistortVertex {
+    math::Vector3f xyz;
+    math::Vector2f st;
+  };
+
+  GLuint m_distort_vao;
+  GLuint m_distort_vertex_buffer;
+  GLuint m_distort_fbo;
+  GLuint m_distort_fbo_texture;
+  int m_distort_fbo_width = 800;
+  int m_distort_fbo_height = 600;
+
+  SpriteDistortVertex m_sprite_distorter_vertex[14080];
+  SpriteDistortFrameData m_sprite_distorter_frame_data[256];
+  SpriteDistorterSetup m_sprite_distorter_setup;  // direct data
+  SpriteDistorterSineTables m_sprite_distorter_sine_tables;
   u8 m_sprite_direct_setup[3 * 16];
   SpriteFrameData m_frame_data;  // qwa: 980
   Sprite3DMatrixData m_3d_matrix_data;

--- a/game/graphics/opengl_renderer/Sprite3.h
+++ b/game/graphics/opengl_renderer/Sprite3.h
@@ -72,12 +72,12 @@ class Sprite3 : public BucketRenderer {
   static_assert(sizeof(SpriteDistorterSineTables) == (0x8b * 16));
 
   struct SpriteDistortFrameData {
-    math::Vector3f xyz; // position
-    float num_255;      // always 255.0
-    math::Vector2f st;  // texture coords
-    float num_1;        // always 1.0
-    u32 flag;           // 'resolution' of the sprite
-    Vector4f rgba;      // ? (doesn't seem to be color)
+    math::Vector3f xyz;  // position
+    float num_255;       // always 255.0
+    math::Vector2f st;   // texture coords
+    float num_1;         // always 1.0
+    u32 flag;            // 'resolution' of the sprite
+    Vector4f rgba;       // ? (doesn't seem to be color)
   };
   static_assert(sizeof(SpriteDistortFrameData) == 16 * 3);
 

--- a/game/graphics/opengl_renderer/Sprite3.h
+++ b/game/graphics/opengl_renderer/Sprite3.h
@@ -72,12 +72,12 @@ class Sprite3 : public BucketRenderer {
   static_assert(sizeof(SpriteDistorterSineTables) == (0x8b * 16));
 
   struct SpriteDistortFrameData {
-    math::Vector3f xyz;
-    float num_255; // always 255.0
-    math::Vector2f st;
-    float one; // always 1.0
-    u32 flag;
-    Vector4f rgba;
+    math::Vector3f xyz; // position
+    float num_255;      // always 255.0
+    math::Vector2f st;  // texture coords
+    float num_1;        // always 1.0
+    u32 flag;           // 'resolution' of the sprite
+    Vector4f rgba;      // ? (doesn't seem to be color)
   };
   static_assert(sizeof(SpriteDistortFrameData) == 16 * 3);
 
@@ -86,17 +86,20 @@ class Sprite3 : public BucketRenderer {
     math::Vector2f st;
   };
 
-  GLuint m_distort_vao;
-  GLuint m_distort_vertex_buffer;
-  GLuint m_distort_fbo;
-  GLuint m_distort_fbo_texture;
-  int m_distort_fbo_width = 800;
-  int m_distort_fbo_height = 600;
+  struct {
+    GLuint vao;
+    GLuint vertex_buffer;
+    GLuint fbo;
+    GLuint fbo_texture;
+    int fbo_width = 640;
+    int fbo_height = 480;
+  } m_distort_ogl;
 
-  SpriteDistortVertex m_sprite_distorter_vertex[14080];
-  SpriteDistortFrameData m_sprite_distorter_frame_data[256];
+  std::vector<SpriteDistortVertex> m_sprite_distorter_vertices;
+  std::vector<SpriteDistortFrameData> m_sprite_distorter_frame_data;
   SpriteDistorterSetup m_sprite_distorter_setup;  // direct data
   SpriteDistorterSineTables m_sprite_distorter_sine_tables;
+
   u8 m_sprite_direct_setup[3 * 16];
   SpriteFrameData m_frame_data;  // qwa: 980
   Sprite3DMatrixData m_3d_matrix_data;

--- a/game/graphics/opengl_renderer/Sprite3.h
+++ b/game/graphics/opengl_renderer/Sprite3.h
@@ -131,6 +131,7 @@ class Sprite3 : public BucketRenderer {
 
   bool m_2d_enable = true;
   bool m_3d_enable = true;
+  bool m_distort_enable = true;
 
   struct SpriteVertex3D {
     math::Vector4f xyz_sx;              // position + x scale

--- a/game/graphics/opengl_renderer/shaders/sprite_distort.frag
+++ b/game/graphics/opengl_renderer/shaders/sprite_distort.frag
@@ -1,0 +1,23 @@
+#version 430 core
+
+out vec4 out_color;
+
+uniform sampler2D framebuffer_tex;
+
+in flat vec4 fragment_color;
+in vec2 tex_coord;
+
+void main() {
+  vec4 color = fragment_color;
+
+  // game specifies the color as (0.5, 0.5, 0.5, 0.5), but it doesn't look right unless rgb is 1.0
+  color.r = 1.0f;
+  color.g = 1.0f;
+  color.b = 1.0f;
+
+  // HACK: adjust the texture coords, 0.06 here is arbitrary
+  vec2 texture_coords = vec2(tex_coord.x, (1.0f - tex_coord.y) - 0.06f);
+
+  // sample framebuffer texture
+  out_color = color * texture(framebuffer_tex, texture_coords);
+}

--- a/game/graphics/opengl_renderer/shaders/sprite_distort.frag
+++ b/game/graphics/opengl_renderer/shaders/sprite_distort.frag
@@ -10,13 +10,11 @@ in vec2 tex_coord;
 void main() {
   vec4 color = fragment_color;
 
-  // game specifies the color as (0.5, 0.5, 0.5, 0.5), but it doesn't look right unless rgb is 1.0
-  color.r = 1.0f;
-  color.g = 1.0f;
-  color.b = 1.0f;
+  // correct color
+  color *= 2;
 
-  // HACK: adjust the texture coords, 0.06 here is arbitrary
-  vec2 texture_coords = vec2(tex_coord.x, (1.0f - tex_coord.y) - 0.06f);
+  // correct texture coordinates
+  vec2 texture_coords = vec2(tex_coord.x, (1.0f - tex_coord.y) - (1 - (448.0/512.0)) / 2);
 
   // sample framebuffer texture
   out_color = color * texture(framebuffer_tex, texture_coords);

--- a/game/graphics/opengl_renderer/shaders/sprite_distort.vert
+++ b/game/graphics/opengl_renderer/shaders/sprite_distort.vert
@@ -1,0 +1,26 @@
+#version 430 core
+
+layout (location = 0) in vec3 xyz;
+layout (location = 1) in vec2 st;
+
+uniform vec4 u_color;
+
+out flat vec4 fragment_color;
+out vec2 tex_coord;
+
+void main() {
+    fragment_color = u_color;
+    tex_coord = st;
+    vec4 transformed = vec4(xyz, 1.0);
+
+    // correct xy offset
+    transformed.xy -= (2048.);
+    // correct z scale
+    transformed.z /= (8388608);
+    transformed.z -= 1;
+    // correct xy scale
+    transformed.x /= (256);
+    transformed.y /= -(128);
+
+    gl_Position = transformed;
+}

--- a/goal_src/jak1/engine/gfx/sprite/sprite-distort.gc
+++ b/goal_src/jak1/engine/gfx/sprite/sprite-distort.gc
@@ -75,11 +75,11 @@
     ;; set up giftag
     (set! (-> tables giftag tag)
           (new 'static 'gif-tag64
-               :nloop #x1 ;; 1 byte?
-               :eop #x1 ;; end of packet
-               :pre #x1 ;; enable prim
-               :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :tme #x1) ;; tri-strip primitives, texture mapping 1 (on)
-               :nreg #xf ;; 15 registers
+               :nloop 1
+               :eop 1
+               :pre 1
+               :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :tme 1)
+               :nreg 15
                )
           )
     ;; set up registers
@@ -103,7 +103,6 @@
                )
           )
     ;; set color
-    ;; TODO: make set-vector! ?
     (set! (-> tables color vector4w x) 128)
     (set! (-> tables color vector4w y) 128)
     (set! (-> tables color vector4w z) 128)
@@ -126,13 +125,13 @@
   (dma-buffer-add-gs-set dma-buff
     ;; dont update zbuffer
     (zbuf-1 (new 'static 'gs-zbuf :zbp #x1c0 :psm (gs-psm ct24) :zmsk 1))
-    ;; 9x8 view into the display framebuffer?
+    ;; use framebuffer as texture
     (tex0-1 (new 'static 'gs-tex0 :tbw #x8 :tw #x9 :th #x8 :tbp0 (* frame-base-pointer 32)))
-    ;; texture with bilinear filtering
+    ;; bilinear filtering
     (tex1-1 (new 'static 'gs-tex1 :mmag 1 :mmin 1))
     ;; mipmapping
     (miptbp1-1 (new 'static 'gs-miptbp))
-    ;; set wrap mode to clamp
+    ;; set texture wrap mode to clamp
     (clamp-1
       (new 'static 'gs-clamp
           :wms (gs-tex-wrap-mode region-clamp)

--- a/goal_src/jak1/engine/gfx/sprite/sprite-distort.gc
+++ b/goal_src/jak1/engine/gfx/sprite/sprite-distort.gc
@@ -26,59 +26,64 @@
 
 (defun sprite-distorter-generate-tables ()
   "Regenerate sprite-distorter tables.  This should be done whenever the aspect ratio changes"
-  (let ((gp-0 *sprite-distorter-sine-tables*))
-    (let ((s3-0 0)
-          (s5-0 0)
-          (s4-0 3)
-          (f28-0 (- (-> *math-camera* perspective vector 0 x)))
-          (f30-0 (- (-> *math-camera* perspective vector 1 y)))
+  (let ((tables *sprite-distorter-sine-tables*))
+    (let ((entry-index 0)
+          (ientry-index 0)
+          (iterations 3)
+          ;; get camera aspect
+          (cam-aspx (- (-> *math-camera* perspective vector 0 x)))
+          (cam-aspy (- (-> *math-camera* perspective vector 1 y)))
           )
-      (when (or (!= f28-0 (-> gp-0 aspx)) (!= f30-0 (-> gp-0 aspy)))
-        (set! (-> gp-0 aspx) f28-0)
-        (set! (-> gp-0 aspy) f30-0)
-        (while (< s4-0 12)
-          (set! (-> gp-0 ientry s5-0 vector4w x) (+ s3-0 352))
-          (+! s5-0 1)
-          (dotimes (s2-0 s4-0)
-            (let ((f26-0 (* 65536.0 (/ (the float s2-0) (the float s4-0)))))
+      ;; regenerate if aspect ratio changed
+      (when (or (!= cam-aspx (-> tables aspx)) (!= cam-aspy (-> tables aspy)))
+        (set! (-> tables aspx) cam-aspx)
+        (set! (-> tables aspy) cam-aspy)
+        (while (< iterations 12)
+          ;; set ientry
+          (set! (-> tables ientry ientry-index vector4w x) (+ entry-index 352)) ;; 352 = tables.entry in VU
+          (+! ientry-index 1)
+          ;; set entries
+          (dotimes (i iterations)
+            (let ((f26-0 (* 65536.0 (/ (the float i) (the float iterations)))))
               (set-vector!
-               (-> gp-0 entry s3-0)
-               (* (sin f26-0) f28-0)
-               (* (cos f26-0) f30-0)
+               (-> tables entry entry-index)
+               (* (sin f26-0) cam-aspx)
+               (* (cos f26-0) cam-aspy)
                0.0
                0.0
                )
-              (let ((s3-1 (+ s3-0 1)))
-                (set-vector!
-                 (-> gp-0 entry s3-1)
-                 (* (* 0.001953125 f28-0) (sin f26-0))
-                 (* (* 0.00390625 f30-0) (cos f26-0))
-                 0.0
-                 0.0
-                 )
-                (set! s3-0 (+ s3-1 1))
+              (set-vector!
+                (-> tables entry (+ entry-index 1))
+                (* (* 0.001953125 cam-aspx) (sin f26-0))
+                (* (* 0.00390625 cam-aspy) (cos f26-0))
+                0.0
+                0.0
                 )
+              (+! entry-index 2)
               )
             )
-          (+! s4-0 1)
+          (+! iterations 1)
           )
-        (set-vector! (-> gp-0 entry s3-0) 0.0 f30-0 0.0 0.0)
-        (let ((v1-17 (+ s3-0 1)))
-          (set-vector! (-> gp-0 entry v1-17) 0.0 (* 0.00390625 f30-0) 0.0 0.0)
-          (+ v1-17 1)
+        ;; final entry pair
+        (set-vector! (-> tables entry entry-index) 0.0 cam-aspy 0.0 0.0)
+        (let ((v1-17 (+ entry-index 1)))
+          (set-vector! (-> tables entry v1-17) 0.0 (* 0.00390625 cam-aspy) 0.0 0.0)
+          (+ v1-17 1) ;; ?
           )
         )
       )
-    (set! (-> gp-0 giftag tag)
+    ;; set up giftag
+    (set! (-> tables giftag tag)
           (new 'static 'gif-tag64
-               :nloop #x1
-               :eop #x1
-               :pre #x1
-               :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :tme #x1)
-               :nreg #xf
+               :nloop #x1 ;; 1 byte?
+               :eop #x1 ;; end of packet
+               :pre #x1 ;; enable prim
+               :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :tme #x1) ;; tri-strip primitives, texture mapping 1 (on)
+               :nreg #xf ;; 15 registers
                )
           )
-    (set! (-> gp-0 giftag regs)
+    ;; set up registers
+    (set! (-> tables giftag regs)
           (new 'static 'gif-tag-regs
                :regs0 (gif-reg-id st)
                :regs1 (gif-reg-id rgbaq)
@@ -97,10 +102,12 @@
                :regs14 (gif-reg-id xyzf2)
                )
           )
-    (set! (-> gp-0 color vector4w x) 128)
-    (set! (-> gp-0 color vector4w y) 128)
-    (set! (-> gp-0 color vector4w z) 128)
-    (set! (-> gp-0 color vector4w w) 128)
+    ;; set color
+    ;; TODO: make set-vector! ?
+    (set! (-> tables color vector4w x) 128)
+    (set! (-> tables color vector4w y) 128)
+    (set! (-> tables color vector4w z) 128)
+    (set! (-> tables color vector4w w) 128)
     )
   0
   (none)
@@ -111,92 +118,40 @@
 (define sprite-distort-vu1-block (new 'static 'vu-function))
 
 
-(defun sprite-init-distorter ((arg0 dma-buffer) (arg1 uint))
+(defun sprite-init-distorter ((dma-buff dma-buffer) (frame-base-pointer uint))
   "Set up DMA for setting up the sprite-distorter renderer"
   ;;(format #t "distorter: ~d~%" (-> *sprite-aux-list* entry))
-  (let* ((v1-0 arg0)
-         (a2-0 (the-as object (-> v1-0 base)))
-         )
-    (set! (-> (the-as dma-packet a2-0) dma) (new 'static 'dma-tag :qwc #x7 :id (dma-tag-id cnt)))
-    (set! (-> (the-as dma-packet a2-0) vif0) (new 'static 'vif-tag))
-    (set! (-> (the-as dma-packet a2-0) vif1) (new 'static 'vif-tag :imm #x7 :cmd (vif-cmd direct) :msk #x1))
-    (set! (-> v1-0 base) (&+ (the-as pointer a2-0) 16))
+  
+  ;; set up GS registers
+  (dma-buffer-add-gs-set dma-buff
+    ;; dont update zbuffer
+    (zbuf-1 (new 'static 'gs-zbuf :zbp #x1c0 :psm (gs-psm ct24) :zmsk 1))
+    ;; 9x8 view into the display framebuffer?
+    (tex0-1 (new 'static 'gs-tex0 :tbw #x8 :tw #x9 :th #x8 :tbp0 (* frame-base-pointer 32)))
+    ;; texture with bilinear filtering
+    (tex1-1 (new 'static 'gs-tex1 :mmag 1 :mmin 1))
+    ;; mipmapping
+    (miptbp1-1 (new 'static 'gs-miptbp))
+    ;; set wrap mode to clamp
+    (clamp-1
+      (new 'static 'gs-clamp
+          :wms (gs-tex-wrap-mode region-clamp)
+          :wmt (gs-tex-wrap-mode region-clamp)
+          :maxu #x1ff
+          :maxv (-> *video-parms* screen-masky)
+          )
+      )
+    ;; blend source and framebuffer RGB
+    (alpha-1 (new 'static 'gs-alpha :b 1 :d 1))
     )
-  (let* ((v1-1 arg0)
-         (a2-2 (the-as object (-> v1-1 base)))
-         )
-    (set! (-> (the-as gs-gif-tag a2-2) tag)
-          (new 'static 'gif-tag64 :nloop #x1 :eop #x1 :nreg #x6)
-          )
-    (set! (-> (the-as gs-gif-tag a2-2) regs)
-          (new 'static 'gif-tag-regs
-               :regs0 (gif-reg-id a+d)
-               :regs1 (gif-reg-id a+d)
-               :regs2 (gif-reg-id a+d)
-               :regs3 (gif-reg-id a+d)
-               :regs4 (gif-reg-id a+d)
-               :regs5 (gif-reg-id a+d)
-               :regs6 (gif-reg-id a+d)
-               :regs7 (gif-reg-id a+d)
-               :regs8 (gif-reg-id a+d)
-               :regs9 (gif-reg-id a+d)
-               :regs10 (gif-reg-id a+d)
-               :regs11 (gif-reg-id a+d)
-               :regs12 (gif-reg-id a+d)
-               :regs13 (gif-reg-id a+d)
-               :regs14 (gif-reg-id a+d)
-               :regs15 (gif-reg-id a+d)
-               )
-          )
-    (set! (-> v1-1 base) (&+ (the-as pointer a2-2) 16))
+  ;; send distorter sine tables
+  (dma-buffer-add-ref-vif2 dma-buff #x8b
+    (-> *sprite-distorter-sine-tables* entry)
+    (new 'static 'vif-tag :imm #x404 :cmd (vif-cmd stcycl))
+    (new 'static 'vif-tag :imm #x160 :num #x8b :cmd (vif-cmd unpack-v4-32))
     )
-  (let* ((v1-2 arg0)
-         (a2-4 (-> v1-2 base))
-         )
-    (set! (-> (the-as (pointer gs-zbuf) a2-4) 0)
-          (new 'static 'gs-zbuf :zbp #x1c0 :psm (gs-psm ct24) :zmsk #x1)
-          )
-    (set! (-> (the-as (pointer gs-reg64) a2-4) 1) (gs-reg64 zbuf-1))
-    (set! (-> (the-as (pointer gs-tex0) a2-4) 2)
-          (new 'static 'gs-tex0 :tbw #x8 :tw #x9 :th #x8 :tbp0 (* arg1 32))
-          )
-    (set! (-> (the-as (pointer gs-reg64) a2-4) 3) (gs-reg64 tex0-1))
-    (set! (-> (the-as (pointer gs-tex1) a2-4) 4)
-          (new 'static 'gs-tex1 :mmag #x1 :mmin #x1)
-          )
-    (set! (-> (the-as (pointer gs-reg64) a2-4) 5) (gs-reg64 tex1-1))
-    (set! (-> (the-as (pointer gs-miptbp) a2-4) 6) (new 'static 'gs-miptbp))
-    (set! (-> (the-as (pointer gs-reg64) a2-4) 7) (gs-reg64 miptbp1-1))
-    (set! (-> (the-as (pointer gs-clamp) a2-4) 8)
-          (new 'static 'gs-clamp
-               :wms (gs-tex-wrap-mode region-clamp)
-               :wmt (gs-tex-wrap-mode region-clamp)
-               :maxu #x1ff
-               :maxv (-> *video-parms* screen-masky)
-               )
-          )
-    (set! (-> (the-as (pointer gs-reg64) a2-4) 9) (gs-reg64 clamp-1))
-    (set! (-> (the-as (pointer gs-alpha) a2-4) 10)
-          (new 'static 'gs-alpha :b #x1 :d #x1)
-          )
-    (set! (-> (the-as (pointer gs-reg64) a2-4) 11) (gs-reg64 alpha-1))
-    (set! (-> v1-2 base) (&+ a2-4 96))
-    )
-  (let* ((v1-3 arg0)
-         (a1-15 (the-as object (-> v1-3 base)))
-         )
-    (set! (-> (the-as dma-packet a1-15) dma)
-          (new 'static 'dma-tag
-               :qwc #x8b
-               :id (dma-tag-id ref)
-               :addr (the-as uint (-> *sprite-distorter-sine-tables* entry))
-               )
-          )
-    (set! (-> (the-as dma-packet a1-15) vif0) (new 'static 'vif-tag :imm #x404 :cmd (vif-cmd stcycl)))
-    (set! (-> (the-as dma-packet a1-15) vif1) (new 'static 'vif-tag :imm #x160 :num #x8b :cmd (vif-cmd unpack-v4-32)))
-    (set! (-> v1-3 base) (&+ (the-as pointer a1-15) 16))
-    )
-  (dma-buffer-add-vu-function arg0 sprite-distort-vu1-block 1)
+  ;; load VU1 code
+  (dma-buffer-add-vu-function dma-buff sprite-distort-vu1-block 1)
   0
   (none)
   )

--- a/goal_src/jak1/engine/gfx/sprite/sprite.gc
+++ b/goal_src/jak1/engine/gfx/sprite/sprite.gc
@@ -117,7 +117,6 @@
   )
 
 (defun add-to-sprite-aux-list ((arg0 sparticle-system) (arg1 sparticle-cpuinfo) (arg2 sprite-vec-data-3d))
-  (return 0) ;; hack
   (let ((v1-0 *sprite-aux-list*))
     (when (< (-> v1-0 entry) (-> v1-0 num-entries))
       (set! (-> v1-0 data (-> v1-0 entry)) (-> arg1 sprite))

--- a/goal_src/jak1/engine/gfx/sprite/sprite.gc
+++ b/goal_src/jak1/engine/gfx/sprite/sprite.gc
@@ -87,6 +87,9 @@
 
 (defmethod new sprite-aux-list ((allocation symbol) (type-to-make type) (size int))
   "Allocate a sprite-aux-list with room for size 4-byte entries"
+  (#when PC_BIG_MEMORY
+    (*! size SPRITE_MAX_AMOUNT_MULT)
+    )
   (let ((v0-0 (object-new allocation type-to-make
                           (the-as int (+ (-> type-to-make size) (the-as uint (* (+ size -1) 4))))
                           )


### PR DESCRIPTION
This PR implements the sprite distortion effect as part of the sprite3 renderer.

I'm still fairly new to a lot of stuff in this project, so if there's anything I need to refactor or clean up please let me know!

The sprite distort effect needs to read the active framebuffer to do its thing. I implemented this by creating a separate framebuffer managed by the sprite renderer. When it comes time to render sprite distortion, the default framebuffer's color buffer is blitted (using `glBlitFramebuffer`) to this framebuffer. Then the color buffer of this framebuffer is bound to the shader as a texture. I'm not sure what the performance implications of this are. I have a feeling there's a faster way to implement this effect, but this was a super simple approach.

Since the sprite renderer managed framebuffer needs to have the same dimensions as the default framebuffer, I added the pixel width/height of the window to `SharedRenderState`. I'm not sure if this is the most appropriate way to pass this information to the renderer. Currently, the renderer will resize the framebuffer on demand and checks to see if the width/height changed each frame.

**Issues:**
~At the moment the effect is not perfectly accurate to the original game. Specifically, the texture coordinates used for sampling the framebuffer texture don't look right unless the Y-axis is flipped and then offset by \~0.06. I know this isn't right but I don't really understand why this is necessary.~

~Additionally, the current implementation issues a lot of draw calls (one for each sprite).~