### PR TITLE
Some high FPS fixes

### DIFF
--- a/goal_src/jak1/engine/common-obs/generic-obs.gc
+++ b/goal_src/jak1/engine/common-obs/generic-obs.gc
@@ -1763,7 +1763,7 @@
              (f1-1 (* -546.13336 f0-0))
              (f0-2 (fmin 546.13336 (fmax -546.13336 f1-1)))
              )
-        (matrix-axis-angle! gp-0 (-> *camera* local-down) f0-2)
+        (matrix-axis-angle! gp-0 (-> *camera* local-down) (* DISPLAY_FPS_RATIO f0-2)) ;; high fps fix
         )
       (vector-matrix*! (-> self view-flat) (-> self view-flat) gp-0)
       )

--- a/goal_src/jak1/engine/common-obs/generic-obs.gc
+++ b/goal_src/jak1/engine/common-obs/generic-obs.gc
@@ -4,6 +4,7 @@
 ;; name: generic-obs.gc
 ;; name in dgo: generic-obs
 ;; dgos: GAME, ENGINE
+;; note: changed for high fps
 
 (define-extern convert-to-hud-object (function process-drawable hud none :behavior process-drawable))
 
@@ -1763,7 +1764,7 @@
              (f1-1 (* -546.13336 f0-0))
              (f0-2 (fmin 546.13336 (fmax -546.13336 f1-1)))
              )
-        (matrix-axis-angle! gp-0 (-> *camera* local-down) (* DISPLAY_FPS_RATIO f0-2)) ;; high fps fix
+        (matrix-axis-angle! gp-0 (-> *camera* local-down) (* DISPLAY_FPS_RATIO f0-2)) ;; changed for high fps
         )
       (vector-matrix*! (-> self view-flat) (-> self view-flat) gp-0)
       )

--- a/goal_src/jak1/engine/common-obs/rigid-body.gc
+++ b/goal_src/jak1/engine/common-obs/rigid-body.gc
@@ -450,7 +450,7 @@
   (+! (-> obj sim-time-remaining)
       (* 0.0033333334 (the float (- (-> *display* base-frame-counter) (-> *display* old-base-frame-counter))))
       )
-  (let ((f30-0 (* DISPLAY_FPS_RATIO 0.016666668))
+  (let ((f30-0 (* DISPLAY_FPS_RATIO 0.016666668)) ;; high fps fix
         (f28-0 (* 0.0033333334 (the float (logand #xffffff (-> *display* base-frame-counter)))))
         )
     (while (>= (-> obj sim-time-remaining) (* 0.5 f30-0))

--- a/goal_src/jak1/engine/common-obs/rigid-body.gc
+++ b/goal_src/jak1/engine/common-obs/rigid-body.gc
@@ -4,6 +4,7 @@
 ;; name: rigid-body.gc
 ;; name in dgo: rigid-body
 ;; dgos: GAME, COMMON, L1
+;; note: changed for high fps
 
 ;; DECOMP BEGINS
 
@@ -450,7 +451,7 @@
   (+! (-> obj sim-time-remaining)
       (* 0.0033333334 (the float (- (-> *display* base-frame-counter) (-> *display* old-base-frame-counter))))
       )
-  (let ((f30-0 (* DISPLAY_FPS_RATIO 0.016666668)) ;; high fps fix
+  (let ((f30-0 (* DISPLAY_FPS_RATIO 0.016666668)) ;; changed for high fps
         (f28-0 (* 0.0033333334 (the float (logand #xffffff (-> *display* base-frame-counter)))))
         )
     (while (>= (-> obj sim-time-remaining) (* 0.5 f30-0))

--- a/goal_src/jak1/engine/common-obs/rigid-body.gc
+++ b/goal_src/jak1/engine/common-obs/rigid-body.gc
@@ -450,7 +450,7 @@
   (+! (-> obj sim-time-remaining)
       (* 0.0033333334 (the float (- (-> *display* base-frame-counter) (-> *display* old-base-frame-counter))))
       )
-  (let ((f30-0 0.016666668)
+  (let ((f30-0 (* DISPLAY_FPS_RATIO 0.016666668))
         (f28-0 (* 0.0033333334 (the float (logand #xffffff (-> *display* base-frame-counter)))))
         )
     (while (>= (-> obj sim-time-remaining) (* 0.5 f30-0))

--- a/goal_src/jak1/engine/ui/hud-classes.gc
+++ b/goal_src/jak1/engine/ui/hud-classes.gc
@@ -1637,7 +1637,9 @@
         )
       )
     )
-  (if (and (< 0.0 arg1) (and (< arg1 0.2) (zero? (logand (-> *display* integral-frame-counter) 4))))
+  ;; low eco flashing
+  ;; modified to support high fps
+  (if (and (< 0.0 arg1) (and (< arg1 0.2) (zero? (logand (the int (* DISPLAY_FPS_RATIO (-> *display* integral-frame-counter))) 4))))
       (set! arg3 (* arg3 2))
       )
   (set! (-> arg5 pos y) (the float arg2))

--- a/goal_src/jak1/engine/ui/hud-classes.gc
+++ b/goal_src/jak1/engine/ui/hud-classes.gc
@@ -296,9 +296,12 @@
      )
     (else
       (let ((f0-3 128.0))
+        ;; low health flashing
+        ;; modified to support high fps
         (when (and *target* (= (-> *target* fact-info-target health) 1.0))
-          (let ((v1-16 (logand (-> *display* integral-frame-counter) 7)))
-            (set! f0-3 (if (zero? (logand (-> *display* integral-frame-counter) 8))
+          (let* ((scaled-frame-counter (the int (* DISPLAY_FPS_RATIO (-> *display* integral-frame-counter))))
+                 (v1-16 (logand scaled-frame-counter 7)))
+            (set! f0-3 (if (zero? (logand scaled-frame-counter 8))
                            (+ 128.0 (* 18.142857 (the float v1-16)))
                            (- 255.0 (* 18.142857 (the float v1-16)))
                            )

--- a/goal_src/jak1/engine/ui/hud-classes.gc
+++ b/goal_src/jak1/engine/ui/hud-classes.gc
@@ -4,6 +4,7 @@
 ;; name: hud-classes.gc
 ;; name in dgo: hud-classes
 ;; dgos: GAME, ENGINE
+;; note: changed for high fps
 
 ;; DECOMP BEGINS
 

--- a/goal_src/jak1/levels/racer_common/racer-part.gc
+++ b/goal_src/jak1/levels/racer_common/racer-part.gc
@@ -121,7 +121,7 @@
   (let ((f0-1 (/ (-> *target* racer heat) (-> *RACER-bank* heat-max))))
     (set! (-> arg2 vector 1 z) (* 182.04445 (+ -45.0 (* 215.0 f0-1))))
     (cond
-      ((and (< 0.8 f0-1) (zero? (logand (-> *display* integral-frame-counter) 8)))
+      ((and (< 0.8 f0-1) (zero? (logand (the int (* DISPLAY_FPS_RATIO (-> *display* integral-frame-counter))) 8))) ;; changed for high fps
        (set! (-> arg2 vector 2 x) 128.0)
        (set! (-> arg2 vector 2 y) 0.0)
        (set! (-> arg2 vector 2 z) 0.0)
@@ -148,7 +148,7 @@
      (set! (-> arg0 vector 2 y) (- 128.0 (* 640.0 (+ -0.6 arg1))))
      (set! (-> arg0 vector 2 z) 0.0)
      )
-    ((zero? (logand (-> *display* integral-frame-counter) 8))
+    ((zero? (logand (the int (* DISPLAY_FPS_RATIO (-> *display* integral-frame-counter))) 8)) ;; changed for high fps
      (set! (-> arg0 vector 2 x) 128.0)
      (set! (-> arg0 vector 2 y) 0.0)
      (set! (-> arg0 vector 2 z) 0.0)

--- a/goal_src/jak1/levels/racer_common/racer-part.gc
+++ b/goal_src/jak1/levels/racer_common/racer-part.gc
@@ -4,6 +4,7 @@
 ;; name: racer-part.gc
 ;; name in dgo: racer-part
 ;; dgos: L1, FIC, LAV, MIS, OGR, RACERP, ROL
+;; note: changed for high fps
 
 ;; DECOMP BEGINS
 

--- a/goal_src/jak1/levels/rolling/rolling-lightning-mole.gc
+++ b/goal_src/jak1/levels/rolling/rolling-lightning-mole.gc
@@ -4,6 +4,7 @@
 ;; name: rolling-lightning-mole.gc
 ;; name in dgo: rolling-lightning-mole
 ;; dgos: L1, ROL
+;; note: changed for high fps
 
 ;; DECOMP BEGINS
 

--- a/goal_src/jak1/levels/rolling/rolling-lightning-mole.gc
+++ b/goal_src/jak1/levels/rolling/rolling-lightning-mole.gc
@@ -174,6 +174,11 @@
 
 (defbehavior fleeing-nav-enemy-adjust-nav-info fleeing-nav-enemy ()
   (let ((f30-0 (vector-vector-distance (-> *camera* tpos-curr-adj) (-> *camera* tpos-old-adj))))
+    ;; High FPS fix: stop-chase and notice distances are calculated between a min/max range where 
+    ;; the further the camera moved since last frame decides how close the chosen value is to the 
+    ;; max distance. Since this is called more often above 60 FPS, the distance is skewed to the
+    ;; lower end. This scales the distance back up based on the FPS ratio.
+    (set! f30-0 (/ f30-0 DISPLAY_FPS_RATIO))
     (set! (-> self nav-info notice-distance) (lerp-clamp
                                                (-> self flee-info min-notice-dist)
                                                (-> self flee-info max-notice-dist)

--- a/goal_src/jak1/levels/swamp/kermit.gc
+++ b/goal_src/jak1/levels/swamp/kermit.gc
@@ -878,6 +878,9 @@ nav-enemy-default-event-handler
        (-> self collide-info transv)
        (compute-acc-due-to-gravity (-> self collide-info) (new-stack-vector0) 0.0)
        )
+     ;; high fps fix
+     (*! (-> self collide-info transv x) DISPLAY_FPS_RATIO)
+     (*! (-> self collide-info transv z) DISPLAY_FPS_RATIO)
      (integrate-for-enemy-with-move-to-ground!
        (-> self collide-info)
        (-> self collide-info transv)

--- a/goal_src/jak1/levels/swamp/kermit.gc
+++ b/goal_src/jak1/levels/swamp/kermit.gc
@@ -4,6 +4,7 @@
 ;; name: kermit.gc
 ;; name in dgo: kermit
 ;; dgos: L1, SWA
+;; note: changed for high fps
 
 (declare-type kermit nav-enemy)
 

--- a/goal_src/jak1/levels/swamp/swamp-rat.gc
+++ b/goal_src/jak1/levels/swamp/swamp-rat.gc
@@ -4,6 +4,7 @@
 ;; name: swamp-rat.gc
 ;; name in dgo: swamp-rat
 ;; dgos: L1, SWA
+;; note: changed for high fps
 
 (declare-type swamp-rat-nest process-drawable)
 (declare-type billy process-taskable)
@@ -175,7 +176,7 @@ swamp-rat-default-event-handler
   )
 
 (defbehavior swamp-rat-update-wiggle-target swamp-rat ((arg0 vector))
-  (+! (-> self wiggle-angle) (* DISPLAY_FPS_RATIO (-> self delta-wiggle-angle))) ;; high fps fix
+  (+! (-> self wiggle-angle) (* DISPLAY_FPS_RATIO (-> self delta-wiggle-angle))) ;; changed for high fps
   (if (< 65536.0 (-> self wiggle-angle))
       (set! (-> self wiggle-angle) (+ -65536.0 (-> self wiggle-angle)))
       )

--- a/goal_src/jak1/levels/swamp/swamp-rat.gc
+++ b/goal_src/jak1/levels/swamp/swamp-rat.gc
@@ -175,7 +175,7 @@ swamp-rat-default-event-handler
   )
 
 (defbehavior swamp-rat-update-wiggle-target swamp-rat ((arg0 vector))
-  (+! (-> self wiggle-angle) (-> self delta-wiggle-angle))
+  (+! (-> self wiggle-angle) (* DISPLAY_FPS_RATIO (-> self delta-wiggle-angle))) ;; high fps fix
   (if (< 65536.0 (-> self wiggle-angle))
       (set! (-> self wiggle-angle) (+ -65536.0 (-> self wiggle-angle)))
       )


### PR DESCRIPTION
Fixes high FPS issues with:
- Rigidbody simulation (fixes #1511 and issue with floating platforms snapping back to their neutral position when Jak jumps off them too quickly)
- Lightning moles leaving the 'chase' state too easily (fixes the remaining issue in #1524)
- Swamp rats wiggling too fast
- 'Kermit' zipping to Jak while airborne
- Low health HUD flashing
- Low eco HUD flashing
- High zoomer heat HUD flashing
- Camera rotation when falling from a blue eco launcher

Some of these issues were listed in the mega thread #1499 