### PR TITLE
[decompiler] fix memory leak on empty pairs

### DIFF
--- a/decompiler/ObjectFile/LinkedObjectFile.cpp
+++ b/decompiler/ObjectFile/LinkedObjectFile.cpp
@@ -178,7 +178,11 @@ void LinkedObjectFile::symbol_link_word(int source_segment,
   if (word.kind() != LinkedWord::PLAIN_DATA) {
     printf("bad symbol link word\n");
   }
-  word.set_to_symbol(kind, name);
+  if (kind == LinkedWord::EMPTY_PTR) {
+    word.set_to_empty_ptr();
+  } else {
+    word.set_to_symbol(kind, name);
+  }
 }
 
 /*!


### PR DESCRIPTION
Fixes #1631.

The decompiler has a separate link type for the empty pair - it shouldn't have a string.  This won't make much difference in actual memory usage, but makes valgrind happy.