### PR TITLE
[gfx] fixes for when the window is forced to weird size

### DIFF
--- a/game/graphics/gfx.h
+++ b/game/graphics/gfx.h
@@ -73,8 +73,8 @@ static constexpr int PAT_MAT_COUNT = 23;
 struct GfxGlobalSettings {
   // note: this is actually the size of the display that ISN'T letterboxed
   // the excess space is what will be letterboxed away.
-  int lbox_w;
-  int lbox_h;
+  int lbox_w = 640;
+  int lbox_h = 480;
 
   // actual game resolution
   int game_res_w = 640;

--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -483,6 +483,7 @@ void OpenGLRenderer::setup_frame(const RenderOptions& settings) {
     } else {
       lg::error("bad framebuffer setup. fbo: {}, tex: {}, zbuf: {}, fbo2: {}, tex2: {}",
                 fbo_state.fbo, fbo_state.tex, fbo_state.zbuf, fbo_state.fbo2, fbo_state.tex2);
+      lg::error("size was: {} x {}\n", fbo_state.width, fbo_state.height);
       fbo_state.delete_objects();
     }
   } else {

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -517,8 +517,9 @@ void GLDisplay::render() {
   // render game!
   if (g_gfx_data->debug_gui.should_advance_frame()) {
     auto p = scoped_prof("game-render");
-    render_game_frame(Gfx::g_global_settings.game_res_w, Gfx::g_global_settings.game_res_h, win_w,
-                      win_h, lbox_w, lbox_h, Gfx::g_global_settings.msaa_samples);
+    render_game_frame(windowed() ? win_w : Gfx::g_global_settings.game_res_w,
+                      windowed() ? win_h : Gfx::g_global_settings.game_res_h, win_w, win_h, lbox_w,
+                      lbox_h, Gfx::g_global_settings.msaa_samples);
   }
 
   if (g_gfx_data->debug_gui.should_gl_finish()) {

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -517,9 +517,8 @@ void GLDisplay::render() {
   // render game!
   if (g_gfx_data->debug_gui.should_advance_frame()) {
     auto p = scoped_prof("game-render");
-    render_game_frame(windowed() ? win_w : Gfx::g_global_settings.game_res_w,
-                      windowed() ? win_h : Gfx::g_global_settings.game_res_h, win_w, win_h, lbox_w,
-                      lbox_h, Gfx::g_global_settings.msaa_samples);
+    render_game_frame(Gfx::g_global_settings.game_res_w, Gfx::g_global_settings.game_res_h, win_w,
+                      win_h, lbox_w, lbox_h, Gfx::g_global_settings.msaa_samples);
   }
 
   if (g_gfx_data->debug_gui.should_gl_finish()) {

--- a/goal_src/jak1/pc/pckernel.gc
+++ b/goal_src/jak1/pc/pckernel.gc
@@ -205,7 +205,7 @@
     )
   ;; do game resolution
   (if (= (-> obj display-mode) 'windowed)
-      (pc-set-game-resolution (-> obj win-width) (-> obj win-height))
+      (pc-set-game-resolution (-> obj real-width) (-> obj real-height))
       (pc-set-game-resolution (-> obj width) (-> obj height)))
 
   ;; set msaa sample rate. if invalid, just reset to 4.


### PR DESCRIPTION
Sets the rendering resolution to the window resolution when in windowed mode. This prevents blurriness if:
- you disable window-lock and resize
- you force the window a size that it doesn't want to be at

Let me know if this will cause other problems.  I'd really like to eventually have a mode where you can just resize the window and normal, and the game renders at the right resolution. All the forced sizes/resolution/fullscreen stuff don't really work well for me, though this is mostly a linux/glfw problem and there's not much we can do.

maybe initializing `lbox` solves https://github.com/open-goal/jak-project/issues/1651 - it went away after these changes and rebooting my computer :man_shrugging: 