### PR TITLE
[graphics] Another possible way to handle windowed

### DIFF
--- a/game/graphics/gfx.h
+++ b/game/graphics/gfx.h
@@ -73,8 +73,8 @@ static constexpr int PAT_MAT_COUNT = 23;
 struct GfxGlobalSettings {
   // note: this is actually the size of the display that ISN'T letterboxed
   // the excess space is what will be letterboxed away.
-  int lbox_w;
-  int lbox_h;
+  int lbox_w = 640;
+  int lbox_h = 480;
 
   // actual game resolution
   int game_res_w = 640;

--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -483,6 +483,7 @@ void OpenGLRenderer::setup_frame(const RenderOptions& settings) {
     } else {
       lg::error("bad framebuffer setup. fbo: {}, tex: {}, zbuf: {}, fbo2: {}, tex2: {}",
                 fbo_state.fbo, fbo_state.tex, fbo_state.zbuf, fbo_state.fbo2, fbo_state.tex2);
+      lg::error("size was: {} x {}\n", fbo_state.width, fbo_state.height);
       fbo_state.delete_objects();
     }
   } else {

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -140,7 +140,6 @@ static int gl_init(GfxSettings& settings) {
     glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_FALSE);
   }
   glfwWindowHint(GLFW_DOUBLEBUFFER, GLFW_TRUE);
-  glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
 
   return 0;
 }

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -517,8 +517,9 @@ void GLDisplay::render() {
   // render game!
   if (g_gfx_data->debug_gui.should_advance_frame()) {
     auto p = scoped_prof("game-render");
-    render_game_frame(Gfx::g_global_settings.game_res_w, Gfx::g_global_settings.game_res_h, win_w,
-                      win_h, lbox_w, lbox_h, Gfx::g_global_settings.msaa_samples);
+    render_game_frame(windowed() ? win_w : Gfx::g_global_settings.game_res_w,
+                      windowed() ? win_h : Gfx::g_global_settings.game_res_h, win_w, win_h, lbox_w,
+                      lbox_h, Gfx::g_global_settings.msaa_samples);
   }
 
   if (g_gfx_data->debug_gui.should_gl_finish()) {

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -517,9 +517,8 @@ void GLDisplay::render() {
   // render game!
   if (g_gfx_data->debug_gui.should_advance_frame()) {
     auto p = scoped_prof("game-render");
-    render_game_frame(windowed() ? win_w : Gfx::g_global_settings.game_res_w,
-                      windowed() ? win_h : Gfx::g_global_settings.game_res_h, win_w, win_h, lbox_w,
-                      lbox_h, Gfx::g_global_settings.msaa_samples);
+    render_game_frame(Gfx::g_global_settings.game_res_w, Gfx::g_global_settings.game_res_h, win_w,
+                      win_h, lbox_w, lbox_h, Gfx::g_global_settings.msaa_samples);
   }
 
   if (g_gfx_data->debug_gui.should_gl_finish()) {

--- a/goal_src/jak1/pc/pckernel.gc
+++ b/goal_src/jak1/pc/pckernel.gc
@@ -205,7 +205,7 @@
     )
   ;; do game resolution
   (if (= (-> obj display-mode) 'windowed)
-      (pc-set-game-resolution (-> obj win-width) (-> obj win-height))
+      (pc-set-game-resolution (-> obj real-width) (-> obj real-height))
       (pc-set-game-resolution (-> obj width) (-> obj height)))
 
   ;; set msaa sample rate. if invalid, just reset to 4.

--- a/goal_src/jak1/pc/pckernel.gc
+++ b/goal_src/jak1/pc/pckernel.gc
@@ -64,6 +64,7 @@
     ((= 'windowed (-> obj display-mode))
       (set! (-> obj win-width) width)
       (set! (-> obj win-height) height)
+      (pc-set-window-size (max PC_MIN_WIDTH (-> obj win-width)) (max PC_MIN_HEIGHT (-> obj win-height)))
       )
     (else
       (set! (-> obj width) width)
@@ -197,11 +198,6 @@
         (if (< (pc-get-screen-rate -1) (-> obj target-fps))
             (pc-set-vsync #f))
         (pc-set-frame-rate (-> obj target-fps)))
-
-    (if (and (= 'windowed (-> obj display-mode))
-             (or (!= (-> obj win-width) (-> obj real-width))
-                 (!= (-> obj win-height) (-> obj real-height))))
-        (pc-set-window-size (max PC_MIN_WIDTH (-> obj win-width)) (max PC_MIN_HEIGHT (-> obj win-height))))
     )
   ;; do game resolution
   (if (= (-> obj display-mode) 'windowed)
@@ -1017,7 +1013,6 @@
 
 
 (define *pc-settings* (new 'global 'pc-settings))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; entity debugging


### PR DESCRIPTION
In this mode, you can resize the window and pick the resolution from the menu.  When the resolution is selected, it will adjust the window to that resolution, but still allows you to resize it as needed.

All the old letterboxing/aspect ratio stuff works like normal.

I tested this for a bit on linux and it seemed to work pretty well, but not sure if there's windows-specific things to watch out for.