### PR TITLE
[sparticle] workaround for 150fps crashes

### DIFF
--- a/game/mips2c/functions/sparticle_launcher.cpp
+++ b/game/mips2c/functions/sparticle_launcher.cpp
@@ -367,7 +367,13 @@ u64 execute(void* ctxt) {
   c->lw(t4, 8, t1);                                 // lw t4, 8(t1)
   bc = c->sgpr64(v1) == c->sgpr64(a3);              // beq v1, a3, L151
   c->daddiu(t3, t1, 12);                            // daddiu t3, t1, 12
-  if (bc) {goto block_6;}                           // branch non-likely
+  if (bc) {
+    if (c->sgpr64(t4) != 0) {
+      goto block_6;
+    } else {
+      printf("HACK: ignoring cached adgif to avoid crash on particle with unset texture.\n");
+     }
+  }                           // branch non-likely
 
   bc = c->sgpr64(t2) == 0;                          // beq t2, r0, L150
   c->daddiu(t4, t1, 172);                           // daddiu t4, t1, 172


### PR DESCRIPTION
The particle adgif cache will crash if the first particle ever launched has a texture-id of 0. It's not clear if this is something that should be supported, but booting up 150fps with ps2-parts enabled causes it. If we just make the cache not crash, the game seems to work fine.