### PR TITLE
[gfx] fix merc/generic eye detection

### DIFF
--- a/goal_src/jak1/engine/gfx/foreground/bones.gc
+++ b/goal_src/jak1/engine/gfx/foreground/bones.gc
@@ -1279,6 +1279,7 @@
                      (when (and
                              (< (-> geom effect effect-idx tri-count) 100)
                              (-> geom header eye-ctrl)
+                             (nonzero? (-> geom header eye-ctrl))
                              )
                        (set! pc-force-mercneric #t)
                        )


### PR DESCRIPTION
Will fix https://github.com/open-goal/jak-project/issues/1433
The detection for eyes was wrong and made small models accidentally render with generic.