### PR TITLE
change out folder for Windows release w/ debug info

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,7 +31,7 @@
       "name": "base-windows-relwithdeb",
       "hidden": true,
       "inherits": "base",
-      "binaryDir": "${sourceDir}/out/build/RelWithDeb",
+      "binaryDir": "${sourceDir}/out/build/Release",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}"


### PR DESCRIPTION
changes it back to what it was before. Saves the hassle of having duplicate scripts for Windows.