### PR TITLE
[graphics] switch to depth-pass shadows

### DIFF
--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -573,6 +573,7 @@ void OpenGLRenderer::setup_frame(const RenderOptions& settings) {
   glViewport(0, 0, settings.game_res_w, settings.game_res_h);
   glClearColor(0.0, 0.0, 0.0, 0.0);
   glClearDepth(0.0);
+  glClearStencil(0);
   glDepthMask(GL_TRUE);
   // Note: could rely on sky renderer to clear depth and color, but this causes problems with
   // letterboxing

--- a/game/graphics/opengl_renderer/ShadowRenderer.cpp
+++ b/game/graphics/opengl_renderer/ShadowRenderer.cpp
@@ -348,16 +348,6 @@ void ShadowRenderer::draw(SharedRenderState* render_state, ScopedProfilerNode& p
 
   render_state->shaders.at(ShaderId::SHADOW).activate();
 
-  glUniform4f(glGetUniformLocation(render_state->shaders[ShaderId::SHADOW].id(), "color_uniform"),
-              0., 0.4, 0., 0.5);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ogl.index_buffer[1]);
-  glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_next_back_index * sizeof(u32), m_back_indices,
-               GL_STREAM_DRAW);
-
-  // First pass.
-  // here, we don't write depth or color.
-  // but we increment stencil on depth fail.
-
   glDepthMask(GL_FALSE);  // no depth writes.
   if (m_debug_draw_volume) {
     glEnable(GL_BLEND);
@@ -366,45 +356,63 @@ void ShadowRenderer::draw(SharedRenderState* render_state, ScopedProfilerNode& p
   } else {
     glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);  // no color writes.
   }
-  glStencilFunc(GL_ALWAYS, 0, 0);          // always pass stencil
-  glStencilOp(GL_KEEP, GL_INCR, GL_KEEP);  // increment on depth fail.
-  glDrawElements(GL_TRIANGLES, m_next_back_index, GL_UNSIGNED_INT, nullptr);
 
-  if (m_debug_draw_volume) {
-    glDisable(GL_BLEND);
-    glUniform4f(glGetUniformLocation(render_state->shaders[ShaderId::SHADOW].id(), "color_uniform"),
-                0., 0.0, 0., 0.5);
-    glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
-    glDrawElements(GL_TRIANGLES, m_next_back_index, GL_UNSIGNED_INT, nullptr);
-    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-    glEnable(GL_BLEND);
-  }
-  prof.add_draw_call();
-  prof.add_tri(m_next_back_index / 3);
+  // First pass.
+  // here, we don't write depth or color.
+  // but we increment stencil on depth fail.
 
-  glUniform4f(glGetUniformLocation(render_state->shaders[ShaderId::SHADOW].id(), "color_uniform"),
-              0.4, 0.0, 0., 0.5);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ogl.index_buffer[0]);
-  glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_next_front_index * sizeof(u32), m_front_indices,
-               GL_STREAM_DRAW);
-  // Second pass.
-  // same settings, but decrement.
-  glStencilOp(GL_KEEP, GL_DECR, GL_KEEP);  // decrement on depth fail.
-  glDrawElements(GL_TRIANGLES, (m_next_front_index - 6), GL_UNSIGNED_INT, nullptr);
-  if (m_debug_draw_volume) {
-    glDisable(GL_BLEND);
+  {
     glUniform4f(glGetUniformLocation(render_state->shaders[ShaderId::SHADOW].id(), "color_uniform"),
-                0., 0.0, 0., 0.5);
-    glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+                0., 0.4, 0., 0.5);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ogl.index_buffer[0]);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_next_front_index * sizeof(u32), m_front_indices,
+                 GL_STREAM_DRAW);
+    glStencilFunc(GL_ALWAYS, 0, 0);          // always pass stencil
+    glStencilOp(GL_KEEP, GL_KEEP, GL_INCR);  // increment on depth pass.
     glDrawElements(GL_TRIANGLES, (m_next_front_index - 6), GL_UNSIGNED_INT, nullptr);
-    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-    glEnable(GL_BLEND);
+
+    if (m_debug_draw_volume) {
+      glDisable(GL_BLEND);
+      glUniform4f(
+          glGetUniformLocation(render_state->shaders[ShaderId::SHADOW].id(), "color_uniform"), 0.,
+          0.0, 0., 0.5);
+      glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+      glDrawElements(GL_TRIANGLES, (m_next_front_index - 6), GL_UNSIGNED_INT, nullptr);
+      glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+      glEnable(GL_BLEND);
+    }
+    prof.add_draw_call();
+    prof.add_tri(m_next_back_index / 3);
   }
 
-  prof.add_draw_call();
-  prof.add_tri(m_next_front_index / 3);
+  {
+    glUniform4f(glGetUniformLocation(render_state->shaders[ShaderId::SHADOW].id(), "color_uniform"),
+                0.4, 0.0, 0., 0.5);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ogl.index_buffer[1]);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_next_back_index * sizeof(u32), m_back_indices,
+                 GL_STREAM_DRAW);
+    // Second pass.
+    // same settings, but decrement.
+    glStencilFunc(GL_ALWAYS, 0, 0);
+    glStencilOp(GL_KEEP, GL_KEEP, GL_DECR);  // decrement on depth pass.
+    glDrawElements(GL_TRIANGLES, m_next_back_index, GL_UNSIGNED_INT, nullptr);
+    if (m_debug_draw_volume) {
+      glDisable(GL_BLEND);
+      glUniform4f(
+          glGetUniformLocation(render_state->shaders[ShaderId::SHADOW].id(), "color_uniform"), 0.,
+          0.0, 0., 0.5);
+      glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+      glDrawElements(GL_TRIANGLES, (m_next_back_index - 0), GL_UNSIGNED_INT, nullptr);
+      glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+      glEnable(GL_BLEND);
+    }
+
+    prof.add_draw_call();
+    prof.add_tri(m_next_front_index / 3);
+  }
 
   // finally, draw shadow.
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ogl.index_buffer[0]);
   glUniform4f(glGetUniformLocation(render_state->shaders[ShaderId::SHADOW].id(), "color_uniform"),
               0.13, 0.13, 0.13, 0.5);
   glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);


### PR DESCRIPTION
Previously we used depth-fail (see https://en.wikipedia.org/wiki/Shadow_volume). I did not look closely enough at the original code and I got it wrong.  Depth-fail works if the camera is in the shadow volume, but has slightly different behavior on leaky meshes as depth-pass.  It turns out there are some cases (farmer, daxter on the rock in the intro cutscene) where the mesh has a hole, but it's oriented in a way where it only causes problems with depth-fail.  So this switches things to depth pass.

I did try to get the camera inside of the volume and it seems like the game properly disables the shadow when this happens.  It's easy to see this on the pelican when it's flying around.