### PR TITLE
Implement scheduling of IOP threads.

### DIFF
--- a/game/runtime.cpp
+++ b/game/runtime.cpp
@@ -254,8 +254,8 @@ void iop_runner(SystemThreadInterface& iface) {
   while (!iface.get_want_exit() && !iop.want_exit) {
     // the IOP kernel just runs at full blast, so we only run the IOP when the EE is waiting on the
     // IOP. Each time the EE is waiting on the IOP, it will run an iteration of the IOP kernel.
-    //iop.wait_run_iop();
-    iop.kernel.dispatch();
+    auto delay = iop.kernel.dispatch();
+    iop.wait_run_iop(delay);
   }
 }
 }  // namespace

--- a/game/runtime.cpp
+++ b/game/runtime.cpp
@@ -254,7 +254,7 @@ void iop_runner(SystemThreadInterface& iface) {
   while (!iface.get_want_exit() && !iop.want_exit) {
     // the IOP kernel just runs at full blast, so we only run the IOP when the EE is waiting on the
     // IOP. Each time the EE is waiting on the IOP, it will run an iteration of the IOP kernel.
-    iop.wait_run_iop();
+    //iop.wait_run_iop();
     iop.kernel.dispatch();
   }
 }

--- a/game/runtime.cpp
+++ b/game/runtime.cpp
@@ -244,7 +244,7 @@ void iop_runner(SystemThreadInterface& iface) {
   bool complete = false;
   start_overlord_wrapper(iop.overlord_argc, iop.overlord_argv, &complete);  // todo!
   while (complete == false) {
-    iop.kernel.dispatch();
+    iop.wait_run_iop(iop.kernel.dispatch());
   }
 
   // unblock the EE, the overlord is set up!
@@ -252,10 +252,9 @@ void iop_runner(SystemThreadInterface& iface) {
 
   // IOP Kernel loop
   while (!iface.get_want_exit() && !iop.want_exit) {
-    // the IOP kernel just runs at full blast, so we only run the IOP when the EE is waiting on the
-    // IOP. Each time the EE is waiting on the IOP, it will run an iteration of the IOP kernel.
-    auto delay = iop.kernel.dispatch();
-    iop.wait_run_iop(delay);
+    // The IOP scheduler informs us of how many microseconds are left until it has something to do.
+    // So we can wait for that long or until something else needs it to wake up.
+    iop.wait_run_iop(iop.kernel.dispatch());
   }
 }
 }  // namespace

--- a/game/runtime.cpp
+++ b/game/runtime.cpp
@@ -244,7 +244,7 @@ void iop_runner(SystemThreadInterface& iface) {
   bool complete = false;
   start_overlord_wrapper(iop.overlord_argc, iop.overlord_argv, &complete);  // todo!
   while (complete == false) {
-    iop.kernel.dispatchAll();
+    iop.kernel.dispatch();
   }
 
   // unblock the EE, the overlord is set up!
@@ -255,7 +255,7 @@ void iop_runner(SystemThreadInterface& iface) {
     // the IOP kernel just runs at full blast, so we only run the IOP when the EE is waiting on the
     // IOP. Each time the EE is waiting on the IOP, it will run an iteration of the IOP kernel.
     iop.wait_run_iop();
-    iop.kernel.dispatchAll();
+    iop.kernel.dispatch();
   }
 }
 }  // namespace

--- a/game/sce/iop.cpp
+++ b/game/sce/iop.cpp
@@ -86,7 +86,7 @@ void* AllocSysMemory(int type, unsigned long size, void* addr) {
  * Create a new thread
  */
 s32 CreateThread(ThreadParam* param) {
-  return iop->kernel.CreateThread(param->name, (void (*)())param->entry);
+  return iop->kernel.CreateThread(param->name, (void (*)())param->entry, param->initPriority);
 }
 
 /*!
@@ -158,8 +158,7 @@ int sceCdMmode(int media) {
 }
 
 void DelayThread(u32 usec) {
-  iop->kernel.SuspendThread();
-  (void)usec;
+  iop->kernel.DelayThread(usec);
 }
 
 int sceCdBreak() {

--- a/game/sce/iop.cpp
+++ b/game/sce/iop.cpp
@@ -90,6 +90,13 @@ s32 CreateThread(ThreadParam* param) {
 }
 
 /*!
+ * Exit current thread
+ */
+s32 ExitThread() {
+  return iop->kernel.ExitThread();
+}
+
+/*!
  * Create a new message box.
  */
 s32 CreateMbx(MbxParam* param) {

--- a/game/sce/iop.h
+++ b/game/sce/iop.h
@@ -96,6 +96,7 @@ void CpuEnableIntr();
 void SleepThread();
 void DelayThread(u32 usec);
 s32 CreateThread(ThreadParam* param);
+s32 ExitThread();
 s32 StartThread(s32 thid, u32 arg);
 s32 WakeupThread(s32 thid);
 

--- a/game/sce/sif_ee.cpp
+++ b/game/sce/sif_ee.cpp
@@ -84,12 +84,12 @@ s32 sceSifCallRpc(sceSifClientData* bd,
   ASSERT(!end_para);
   ASSERT(mode == 1);  // async
   iop->kernel.sif_rpc(bd->rpcd.id, fno, mode, send, ssize, recv, rsize);
-  iop->signal_run_iop(false);
+  iop->signal_run_iop();
   return 0;
 }
 
 s32 sceSifCheckStatRpc(sceSifRpcData* bd) {
-  iop->signal_run_iop(false);
+  iop->signal_run_iop();
   return iop->kernel.sif_busy(bd->id);
 }
 

--- a/game/system/IOP_Kernel.cpp
+++ b/game/system/IOP_Kernel.cpp
@@ -165,6 +165,7 @@ micros IOP_Kernel::dispatch() {
 }
 
 void IOP_Kernel::set_rpc_queue(iop::sceSifQueueData* qd, u32 thread) {
+  sif_mtx.lock();
   for (const auto& r : sif_records) {
     ASSERT(!(r.qd == qd || r.thread_to_wake == thread));
   }
@@ -172,6 +173,7 @@ void IOP_Kernel::set_rpc_queue(iop::sceSifQueueData* qd, u32 thread) {
   rec.thread_to_wake = thread;
   rec.qd = qd;
   sif_records.push_back(rec);
+  sif_mtx.unlock();
 }
 
 typedef void* (*sif_rpc_handler)(unsigned int, void*, int);

--- a/game/system/IOP_Kernel.cpp
+++ b/game/system/IOP_Kernel.cpp
@@ -153,15 +153,16 @@ micros IOP_Kernel::dispatch() {
   updateDelay();
 
   IopThread* next = schedNext();
-  if (next == nullptr) {
-    // printf("[IOP Kernel] No runnable threads %d\n");
-    return lowestWait();
+  while (next != nullptr) {
+    // printf("[IOP Kernel] Dispatch %s (%d)\n", next->name.c_str(), next->thID);
+    runThread(next);
+    updateDelay();
+    next = schedNext();
+    // printf("[IOP Kernel] back to kernel!\n");
   }
 
-  // printf("[IOP Kernel] Dispatch %s (%d)\n", next->name.c_str(), next->thID);
-  runThread(next);
-  // printf("[IOP Kernel] back to kernel!\n");
-  return std::chrono::microseconds(0);
+  // printf("[IOP Kernel] No runnable threads\n");
+  return lowestWait();
 }
 
 void IOP_Kernel::set_rpc_queue(iop::sceSifQueueData* qd, u32 thread) {

--- a/game/system/IOP_Kernel.cpp
+++ b/game/system/IOP_Kernel.cpp
@@ -31,18 +31,18 @@ void IOP_Kernel::StartThread(s32 id) {
  * Run a thread (call from kernel)
  */
 void IOP_Kernel::runThread(s32 id) {
-  ASSERT(_currentThread == -1);  // should run in the kernel thread
-  _currentThread = id;
+  ASSERT(_currentThread == nullptr);  // should run in the kernel thread
+  _currentThread = &threads.at(id);
   threads.at(id).state = IopThread::State::Run;
   co_switch(threads.at(id).thread);
-  _currentThread = -1;
+  _currentThread = nullptr;
 }
 
 /*!
  * Return to kernel from a thread, not to be called from the kernel thread.
  */
 void IOP_Kernel::exitThread() {
-  s32 oldThread = getCurrentThread();
+  IopThread* oldThread = _currentThread;
   co_switch(kernel_thread);
 
   // check kernel resumed us correctly
@@ -55,9 +55,9 @@ void IOP_Kernel::exitThread() {
  * This does not match the behaviour of any real IOP function.
  */
 void IOP_Kernel::SuspendThread() {
-  ASSERT(getCurrentThread() >= 0);
+  ASSERT(_currentThread);
 
-  threads.at(getCurrentThread()).state = IopThread::State::Ready;
+  _currentThread->state = IopThread::State::Ready;
   exitThread();
 }
 
@@ -65,9 +65,9 @@ void IOP_Kernel::SuspendThread() {
  * Sleep a thread.  Must be explicitly woken up.
  */
 void IOP_Kernel::SleepThread() {
-  ASSERT(getCurrentThread() >= 0);
+  ASSERT(_currentThread);
 
-  threads.at(getCurrentThread()).state = IopThread::State::Suspend;
+  _currentThread->state = IopThread::State::Suspend;
   exitThread();
 }
 

--- a/game/system/IOP_Kernel.cpp
+++ b/game/system/IOP_Kernel.cpp
@@ -138,13 +138,14 @@ void IOP_Kernel::dispatch() {
 
   IopThread* next = schedNext();
   if (next == nullptr) {
-    printf("[IOP Kernel] No runnable threads\n");
+    //printf("[IOP Kernel] No runnable threads\n");
+    usleep(0);
     return;
   }
 
-  printf("[IOP Kernel] Dispatch %s (%d)\n", next->name.c_str(), next->thID);
+  //printf("[IOP Kernel] Dispatch %s (%d)\n", next->name.c_str(), next->thID);
   runThread(next);
-  printf("[IOP Kernel] back to kernel!\n");
+  //printf("[IOP Kernel] back to kernel!\n");
 }
 
 void IOP_Kernel::set_rpc_queue(iop::sceSifQueueData* qd, u32 thread) {

--- a/game/system/IOP_Kernel.cpp
+++ b/game/system/IOP_Kernel.cpp
@@ -158,6 +158,8 @@ void IOP_Kernel::sif_rpc(s32 rpcChannel,
   rec->cmd.started = false;
   rec->cmd.finished = false;
 
+  WakeupThread(rec->thread_to_wake);  // TODO threadsafe?
+
   sif_mtx.unlock();
 }
 
@@ -199,7 +201,7 @@ void IOP_Kernel::rpc_loop(iop::sceSifQueueData* qd) {
         sif_mtx.unlock();
       }
     }
-    SuspendThread();
+    SleepThread();
   }
 }
 

--- a/game/system/IOP_Kernel.h
+++ b/game/system/IOP_Kernel.h
@@ -172,6 +172,7 @@ class IOP_Kernel {
   void runThread(IopThread* thread);
   void exitThread();
   void updateDelay();
+  void processWakeups();
 
   IopThread* schedNext();
   time_stamp nextWakeup();
@@ -183,9 +184,10 @@ class IOP_Kernel {
   std::vector<std::queue<void*>> mbxs;
   std::vector<SifRecord> sif_records;
   std::vector<Semaphore> semas;
+  std::queue<int> wakeup_queue;
   bool mainThreadSleep = false;
   FILE* iso_disc_file = nullptr;
-  std::mutex sif_mtx;
+  std::mutex sif_mtx, wakeup_mtx;
 };
 
 #endif  // JAK_IOP_KERNEL_H

--- a/game/system/IOP_Kernel.h
+++ b/game/system/IOP_Kernel.h
@@ -104,7 +104,10 @@ class IOP_Kernel {
   /*!
    * Get current thread ID.
    */
-  s32 getCurrentThread() { return _currentThread; }
+  s32 getCurrentThread() {
+    ASSERT(_currentThread);
+    return _currentThread->thID;
+  }
 
   /*!
    * Create a message box
@@ -162,7 +165,7 @@ class IOP_Kernel {
   void exitThread();
   cothread_t kernel_thread;
   s32 _nextThID = 0;
-  s32 _currentThread = {-1};
+  IopThread* _currentThread = nullptr;
   std::vector<IopThread> threads;
   std::vector<std::queue<void*>> mbxs;
   std::vector<SifRecord> sif_records;

--- a/game/system/IOP_Kernel.h
+++ b/game/system/IOP_Kernel.h
@@ -62,11 +62,12 @@ struct IopThread {
 
   IopThread(std::string n, void (*f)(), s32 ID, u32 priority)
       : name(std::move(n)), function(f), priority(priority), thID(ID) {
-    thread = co_create(0x300000, f);
+    thread = co_create(0x300000, functionWrapper);
   }
 
   ~IopThread() { co_delete(thread); }
 
+  static void functionWrapper();
   std::string name;
   void (*function)();
   cothread_t thread;
@@ -98,6 +99,7 @@ class IOP_Kernel {
   ~IOP_Kernel();
 
   s32 CreateThread(std::string n, void (*f)(), u32 priority);
+  s32 ExitThread();
   void StartThread(s32 id);
   void DelayThread(u32 usec);
   void SleepThread();

--- a/game/system/IOP_Kernel.h
+++ b/game/system/IOP_Kernel.h
@@ -25,7 +25,6 @@ struct sceSifQueueData;
 }
 
 using time_stamp = std::chrono::time_point<std::chrono::steady_clock, std::chrono::microseconds>;
-using micros = std::chrono::duration<int, std::micro>;
 
 struct SifRpcCommand {
   bool started = true;
@@ -103,7 +102,7 @@ class IOP_Kernel {
   void DelayThread(u32 usec);
   void SleepThread();
   void WakeupThread(s32 id);
-  micros dispatch();
+  time_stamp dispatch();
   void set_rpc_queue(iop::sceSifQueueData* qd, u32 thread);
   void rpc_loop(iop::sceSifQueueData* qd);
   void shutdown();
@@ -173,7 +172,7 @@ class IOP_Kernel {
   void updateDelay();
 
   IopThread* schedNext();
-  micros lowestWait();
+  time_stamp nextWakeup();
 
   cothread_t kernel_thread;
   s32 _nextThID = 0;

--- a/game/system/IOP_Kernel.h
+++ b/game/system/IOP_Kernel.h
@@ -9,6 +9,7 @@
 #include <queue>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "common/common_types.h"
@@ -24,6 +25,7 @@ struct sceSifQueueData;
 }
 
 using time_stamp = std::chrono::time_point<std::chrono::steady_clock, std::chrono::microseconds>;
+using micros = std::chrono::duration<int, std::micro>;
 
 struct SifRpcCommand {
   bool started = true;
@@ -60,7 +62,7 @@ struct IopThread {
   };
 
   IopThread(std::string n, void (*f)(), s32 ID, u32 priority)
-      : name(n), function(f), thID(ID), priority(priority) {
+      : name(std::move(n)), function(f), priority(priority), thID(ID) {
     thread = co_create(0x300000, f);
   }
 
@@ -101,7 +103,7 @@ class IOP_Kernel {
   void DelayThread(u32 usec);
   void SleepThread();
   void WakeupThread(s32 id);
-  void dispatch();
+  micros dispatch();
   void set_rpc_queue(iop::sceSifQueueData* qd, u32 thread);
   void rpc_loop(iop::sceSifQueueData* qd);
   void shutdown();
@@ -171,6 +173,8 @@ class IOP_Kernel {
   void updateDelay();
 
   IopThread* schedNext();
+  micros lowestWait();
+
   cothread_t kernel_thread;
   s32 _nextThID = 0;
   IopThread* _currentThread = nullptr;

--- a/game/system/iop_thread.cpp
+++ b/game/system/iop_thread.cpp
@@ -55,31 +55,19 @@ void* IOP::iop_alloc(int size) {
   return mem;
 }
 
-void IOP::wait_run_iop() {
-  std::unique_lock<std::mutex> lk(iters_mutex);
-  if (iop_iters_des > iop_iters_act) {
-    iop_iters_act++;
-    return;
-  }
-
-  iop_run_cv.wait(lk, [&] { return iop_iters_des > iop_iters_act; });
-  iop_iters_act++;
+void IOP::wait_run_iop(std::chrono::duration<int, std::micro> duration) {
+  std::unique_lock<std::mutex> lk(run_cv_mutex);
+  iop_run_cv.wait_until(lk, std::chrono::steady_clock::now() + duration);
 }
 
 void IOP::kill_from_ee() {
   want_exit = true;
-  signal_run_iop(true);
+  signal_run_iop();
 }
 
-void IOP::signal_run_iop(bool force) {
-  std::unique_lock<std::mutex> lk(iters_mutex);
-  if (iop_iters_act == iop_iters_des || force) {
-    iop_iters_des++;  // todo, tune this
-    if (iop_iters_des - iop_iters_act > 500) {
-      iop_iters_des = iop_iters_act + 500;
-    }
-    iop_run_cv.notify_all();
-  }
+void IOP::signal_run_iop() {
+  std::unique_lock<std::mutex> lk(run_cv_mutex);
+  iop_run_cv.notify_all();
 }
 
 IOP::~IOP() {

--- a/game/system/iop_thread.cpp
+++ b/game/system/iop_thread.cpp
@@ -55,9 +55,10 @@ void* IOP::iop_alloc(int size) {
   return mem;
 }
 
-void IOP::wait_run_iop(std::chrono::duration<int, std::micro> duration) {
+void IOP::wait_run_iop(
+    std::chrono::time_point<std::chrono::steady_clock, std::chrono::microseconds> wakeup) {
   std::unique_lock<std::mutex> lk(run_cv_mutex);
-  iop_run_cv.wait_until(lk, std::chrono::steady_clock::now() + duration);
+  iop_run_cv.wait_until(lk, wakeup);
 }
 
 void IOP::kill_from_ee() {

--- a/game/system/iop_thread.h
+++ b/game/system/iop_thread.h
@@ -20,7 +20,9 @@ class IOP {
   void wait_for_overlord_init_finish();
   void signal_overlord_init_finish();
   void signal_run_iop();
-  void wait_run_iop(std::chrono::duration<int, std::micro> duration);
+
+  void wait_run_iop(
+      std::chrono::time_point<std::chrono::steady_clock, std::chrono::microseconds> duration);
   void kill_from_ee();
 
   void set_ee_main_mem(u8* mem) { ee_main_mem = mem; }

--- a/game/system/iop_thread.h
+++ b/game/system/iop_thread.h
@@ -19,8 +19,8 @@ class IOP {
   void wait_for_overlord_start_cmd();
   void wait_for_overlord_init_finish();
   void signal_overlord_init_finish();
-  void signal_run_iop(bool force);
-  void wait_run_iop();
+  void signal_run_iop();
+  void wait_run_iop(std::chrono::duration<int, std::micro> duration);
   void kill_from_ee();
 
   void set_ee_main_mem(u8* mem) { ee_main_mem = mem; }
@@ -33,14 +33,12 @@ class IOP {
 
   IOP_Kernel kernel;
   u8* ee_main_mem = nullptr;
-  u64 iop_iters_des = 0;
-  u64 iop_iters_act = 0;
   bool want_exit = false;
 
  private:
   std::vector<void*> allocations;
   std::condition_variable cv;
-  std::mutex iop_mutex, iters_mutex;
+  std::mutex iop_mutex, run_cv_mutex;
   bool overlord_init_done = false;
   std::condition_variable iop_run_cv;
 };


### PR DESCRIPTION
This is an experiment on top of #1684 that implements more realistic scheduling of threads and a new strategy for throttling the IOP.

Given that the current solution is working well I'm not very certain if this is a good idea.

Threads are now scheduled like the kernel on the real IOP does them, the highest priority thread in ready state is always ran. For this to work we now also respect the argument to DelayThread and leave them in wait state until the specified time runs out.

This also requires changing the method by which we throttle the IOP kernel, wait_run_iop now uses information from the scheduler to wait until the kernel has a new thread ready to run.