### PR TITLE
Add in-game option to switch fullscreen monitor

### DIFF
--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -1597,6 +1597,8 @@
   (scene-255                    #x12ff)
   (hint-0                       #x1300)
   (hint-511                     #x14ff)
+  (display                      #x1600)
+  (display-fmt                  #x1601)
 ;; GAME-TEXT-ID ENUM ENDS
   )
 
@@ -15737,6 +15739,7 @@
   (flava-player)
   (memcard-disable-auto-save)
   (memcard-auto-save-disabled)
+  (monitor)
 
   ;; the last one!
   (max)
@@ -15770,6 +15773,7 @@
   (button-music)
   (button-flava)
   (cheat-toggle)
+  (monitor)
   )
 
 (defenum game-option-menu

--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -1481,6 +1481,8 @@
   (subtitle-enabled             #x1040)
   (subtitle-disabled            #x1041)
   (text-language                #x1042)
+  (display                      #x1043)
+  (display-fmt                  #x1044)
   (msaa                         #x1050)
   (x-times-fmt                  #x1051)
   (2-times                      #x1052)
@@ -1597,8 +1599,6 @@
   (scene-255                    #x12ff)
   (hint-0                       #x1300)
   (hint-511                     #x14ff)
-  (display                      #x1600)
-  (display-fmt                  #x1601)
 ;; GAME-TEXT-ID ENUM ENDS
   )
 

--- a/game/assets/jak1/text/game_text_en.gs
+++ b/game/assets/jak1/text/game_text_en.gs
@@ -104,6 +104,10 @@
         "SUBTITLES DISABLED")
 (#x1042 "TEXT LANGUAGE"
         "TEXT LANGUAGE")
+(#x1043 "DISPLAY"
+        "DISPLAY")
+(#x1044 "DISPLAY ~D"
+        "DISPLAY ~D")
 
 (#x1050 "MSAA"
         "MSAA")
@@ -333,11 +337,6 @@
         "DANSK")
 (#x1116 "NORSK"
         "NORSK")
-
-(#x1600 "DISPLAY"
-        "DISPLAY")
-(#x1601 "DISPLAY ~D"
-        "DISPLAY ~D")
 
 ;; -----------------
 ;; test

--- a/game/assets/jak1/text/game_text_en.gs
+++ b/game/assets/jak1/text/game_text_en.gs
@@ -334,6 +334,10 @@
 (#x1116 "NORSK"
         "NORSK")
 
+(#x1600 "DISPLAY"
+        "DISPLAY")
+(#x1601 "DISPLAY ~D"
+        "DISPLAY ~D")
 
 ;; -----------------
 ;; test

--- a/game/graphics/display.cpp
+++ b/game/graphics/display.cpp
@@ -61,12 +61,6 @@ int GfxDisplay::height() {
   return h;
 }
 
-void GfxDisplay::backup_params() {
-  get_size(&m_width, &m_height);
-  get_position(&m_xpos, &m_ypos);
-  fmt::print("backed up window: {},{} {}x{}\n", m_xpos, m_ypos, m_width, m_height);
-}
-
 /*
 ********************************
 * DISPLAY

--- a/game/graphics/display.h
+++ b/game/graphics/display.h
@@ -26,7 +26,7 @@ class GfxDisplay {
  protected:
   bool m_main;
   GfxDisplayMode m_fullscreen_target_mode = GfxDisplayMode::Windowed;
-  GfxDisplayMode m_last_fullscreen_mode;
+  GfxDisplayMode m_last_fullscreen_mode = GfxDisplayMode::Windowed;
 
   int m_last_windowed_xpos = 0;
   int m_last_windowed_ypos = 0;

--- a/game/graphics/display.h
+++ b/game/graphics/display.h
@@ -19,8 +19,8 @@
 class GfxDisplay {
   const char* m_title;
 
-  int m_fullscreen_screen;
-  int m_fullscreen_target_screen;
+  int m_fullscreen_screen = -1;
+  int m_fullscreen_target_screen = -1;
   bool m_imgui_visible;
 
  protected:

--- a/game/graphics/display.h
+++ b/game/graphics/display.h
@@ -25,7 +25,11 @@ class GfxDisplay {
 
  protected:
   bool m_main;
+  // next mode
   GfxDisplayMode m_fullscreen_target_mode = GfxDisplayMode::Windowed;
+  // current mode (start as -1 to force an initial fullscreen update)
+  GfxDisplayMode m_fullscreen_mode = (GfxDisplayMode)-1;
+  // previous mode (last frame)
   GfxDisplayMode m_last_fullscreen_mode = GfxDisplayMode::Windowed;
 
   int m_last_windowed_xpos = 0;
@@ -46,32 +50,34 @@ class GfxDisplay {
   virtual int get_monitor_count() = 0;
   virtual void get_position(int* x, int* y) = 0;
   virtual void get_size(int* w, int* h) = 0;
-  virtual GfxDisplayMode get_fullscreen() = 0;
   virtual void render() = 0;
   virtual void set_lock(bool lock) = 0;
   virtual bool minimized() = 0;
+  virtual bool fullscreen_pending() {
+    return fullscreen_mode() != m_fullscreen_target_mode ||
+           m_fullscreen_screen != m_fullscreen_target_screen;
+  }
+  virtual void fullscreen_flush() {
+    update_fullscreen(m_fullscreen_target_mode, m_fullscreen_target_screen);
+
+    m_fullscreen_mode = m_fullscreen_target_mode;
+    m_fullscreen_screen = m_fullscreen_target_screen;
+  }
+
   bool is_active() const { return get_window() != nullptr; }
   void set_title(const char* title);
   const char* title() const { return m_title; }
-
-  bool fullscreen_pending() {
-    return get_fullscreen() != m_fullscreen_target_mode ||
-           m_fullscreen_screen != m_fullscreen_target_screen;
-  }
-  void fullscreen_flush() {
-    update_fullscreen(m_fullscreen_target_mode, m_fullscreen_target_screen);
-    m_fullscreen_screen = m_fullscreen_target_screen;
-  }
   void set_fullscreen(GfxDisplayMode mode, int screen) {
     m_fullscreen_target_mode = mode;
     m_fullscreen_target_screen = screen;
   }
-  void update_last_fullscreen_mode() { m_last_fullscreen_mode = get_fullscreen(); }
+  void update_last_fullscreen_mode() { m_last_fullscreen_mode = fullscreen_mode(); }
   GfxDisplayMode last_fullscreen_mode() const { return m_last_fullscreen_mode; }
+  GfxDisplayMode fullscreen_mode() { return m_fullscreen_mode; }
   int fullscreen_screen() const { return m_fullscreen_screen; }
   void set_imgui_visible(bool visible) { m_imgui_visible = visible; }
   bool is_imgui_visible() const { return m_imgui_visible; }
-  bool windowed() { return get_fullscreen() == GfxDisplayMode::Windowed; }
+  bool windowed() { return fullscreen_mode() == GfxDisplayMode::Windowed; }
 
   int width();
   int height();

--- a/game/graphics/display.h
+++ b/game/graphics/display.h
@@ -19,13 +19,6 @@
 class GfxDisplay {
   const char* m_title;
 
-  // NOT actual size! just backups
-  int m_width;
-  int m_height;
-  // same here
-  int m_xpos;
-  int m_ypos;
-
   int m_fullscreen_screen;
   int m_fullscreen_target_screen;
   bool m_imgui_visible;
@@ -34,6 +27,11 @@ class GfxDisplay {
   bool m_main;
   GfxDisplayMode m_fullscreen_target_mode = GfxDisplayMode::Windowed;
   GfxDisplayMode m_last_fullscreen_mode;
+
+  int m_last_windowed_xpos = 0;
+  int m_last_windowed_ypos = 0;
+  int m_last_windowed_width = 640;
+  int m_last_windowed_height = 480;
 
  public:
   virtual ~GfxDisplay() {}
@@ -45,6 +43,7 @@ class GfxDisplay {
   virtual int get_screen_vmode_count() = 0;
   virtual void get_screen_size(int vmode_idx, s32* w, s32* h) = 0;
   virtual int get_screen_rate(int vmode_idx) = 0;
+  virtual int get_monitor_count() = 0;
   virtual void get_position(int* x, int* y) = 0;
   virtual void get_size(int* w, int* h) = 0;
   virtual GfxDisplayMode get_fullscreen() = 0;
@@ -55,10 +54,12 @@ class GfxDisplay {
   void set_title(const char* title);
   const char* title() const { return m_title; }
 
-  bool fullscreen_pending() { return get_fullscreen() != m_fullscreen_target_mode; }
+  bool fullscreen_pending() {
+    return get_fullscreen() != m_fullscreen_target_mode ||
+           m_fullscreen_screen != m_fullscreen_target_screen;
+  }
   void fullscreen_flush() {
     update_fullscreen(m_fullscreen_target_mode, m_fullscreen_target_screen);
-    // TODO no
     m_fullscreen_screen = m_fullscreen_target_screen;
   }
   void set_fullscreen(GfxDisplayMode mode, int screen) {
@@ -71,11 +72,6 @@ class GfxDisplay {
   void set_imgui_visible(bool visible) { m_imgui_visible = visible; }
   bool is_imgui_visible() const { return m_imgui_visible; }
   bool windowed() { return get_fullscreen() == GfxDisplayMode::Windowed; }
-  void backup_params();
-  int width_backup() const { return m_width; }
-  int height_backup() const { return m_height; }
-  int xpos_backup() const { return m_xpos; }
-  int ypos_backup() const { return m_ypos; }
 
   int width();
   int height();

--- a/game/graphics/gfx.cpp
+++ b/game/graphics/gfx.cpp
@@ -243,6 +243,13 @@ int get_screen_rate(s64 vmode_idx) {
   return 0;
 }
 
+int get_monitor_count() {
+  if (Display::GetMainDisplay()) {
+    return Display::GetMainDisplay()->get_monitor_count();
+  }
+  return 0;
+}
+
 void get_screen_size(s64 vmode_idx, s32* w, s32* h) {
   if (Display::GetMainDisplay()) {
     Display::GetMainDisplay()->get_screen_size(vmode_idx, w, h);

--- a/game/graphics/gfx.cpp
+++ b/game/graphics/gfx.cpp
@@ -223,7 +223,7 @@ void get_window_scale(float* x, float* y) {
 
 GfxDisplayMode get_fullscreen() {
   if (Display::GetMainDisplay()) {
-    return Display::GetMainDisplay()->get_fullscreen();
+    return Display::GetMainDisplay()->fullscreen_mode();
   } else {
     return GfxDisplayMode::Windowed;
   }

--- a/game/graphics/gfx.h
+++ b/game/graphics/gfx.h
@@ -138,6 +138,7 @@ void get_window_scale(float* x, float* y);
 GfxDisplayMode get_fullscreen();
 int get_screen_vmode_count();
 int get_screen_rate(s64 vmode_idx);
+int get_monitor_count();
 void get_screen_size(s64 vmode_idx, s32* w, s32* h);
 void set_frame_rate(int rate);
 void set_vsync(bool vsync);

--- a/game/graphics/pipelines/opengl.h
+++ b/game/graphics/pipelines/opengl.h
@@ -32,12 +32,19 @@ class GLDisplay : public GfxDisplay {
   void get_screen_size(int vmode_idx, s32* w, s32* h);
   int get_screen_rate(int vmode_idx);
   int get_screen_vmode_count();
+  int get_monitor_count();
   GfxDisplayMode get_fullscreen();
   void set_size(int w, int h);
   void update_fullscreen(GfxDisplayMode mode, int screen);
   void render();
   bool minimized();
   void set_lock(bool lock);
+  void on_key(GLFWwindow* window, int key, int scancode, int action, int mods);
+  void on_window_pos(GLFWwindow* window, int xpos, int ypos);
+  void on_window_size(GLFWwindow* window, int width, int height);
+
+ private:
+  GLFWmonitor* get_monitor(int index);
 };
 
 extern const GfxRendererModule gRendererOpenGL;

--- a/game/graphics/pipelines/opengl.h
+++ b/game/graphics/pipelines/opengl.h
@@ -19,8 +19,6 @@ enum GlfwKeyAction {
 };
 
 class GLDisplay : public GfxDisplay {
-  GLFWwindow* m_window;
-
  public:
   GLDisplay(GLFWwindow* window, bool is_main);
   virtual ~GLDisplay();
@@ -44,6 +42,8 @@ class GLDisplay : public GfxDisplay {
   void on_window_size(GLFWwindow* window, int width, int height);
 
  private:
+  GLFWwindow* m_window;
+
   GLFWmonitor* get_monitor(int index);
 };
 

--- a/game/graphics/pipelines/opengl.h
+++ b/game/graphics/pipelines/opengl.h
@@ -31,18 +31,22 @@ class GLDisplay : public GfxDisplay {
   int get_screen_rate(int vmode_idx);
   int get_screen_vmode_count();
   int get_monitor_count();
-  GfxDisplayMode get_fullscreen();
   void set_size(int w, int h);
   void update_fullscreen(GfxDisplayMode mode, int screen);
   void render();
   bool minimized();
+  bool fullscreen_pending() override;
+  void fullscreen_flush() override;
   void set_lock(bool lock);
   void on_key(GLFWwindow* window, int key, int scancode, int action, int mods);
   void on_window_pos(GLFWwindow* window, int xpos, int ypos);
   void on_window_size(GLFWwindow* window, int width, int height);
+  void on_iconify(GLFWwindow* window, int iconified);
 
  private:
   GLFWwindow* m_window;
+  bool m_minimized = false;
+  GLFWvidmode m_last_video_mode = {0, 0, 0, 0, 0, 0};
 
   GLFWmonitor* get_monitor(int index);
 };

--- a/game/kernel/common/kmachine.cpp
+++ b/game/kernel/common/kmachine.cpp
@@ -404,6 +404,13 @@ s64 get_screen_vmode_count() {
   return Gfx::get_screen_vmode_count();
 }
 
+/*!
+ * Returns the number of available monitors.
+ */
+int get_monitor_count() {
+  return Gfx::get_monitor_count();
+}
+
 void mkdir_path(u32 filepath) {
   auto filepath_str = std::string(Ptr<String>(filepath).c()->data());
   file_util::create_dir_if_needed_for_file(filepath_str);

--- a/game/kernel/common/kmachine.h
+++ b/game/kernel/common/kmachine.h
@@ -63,6 +63,7 @@ void get_window_scale(u32 x_ptr, u32 y_ptr);
 void get_screen_size(s64 vmode_idx, u32 w_ptr, u32 h_ptr);
 s64 get_screen_rate(s64 vmode_idx);
 s64 get_screen_vmode_count();
+int get_monitor_count();
 void mkdir_path(u32 filepath);
 u64 filepath_exists(u32 filepath);
 void prof_event(u32 name, u32 kind);

--- a/game/kernel/jak1/kmachine.cpp
+++ b/game/kernel/jak1/kmachine.cpp
@@ -622,6 +622,7 @@ void InitMachine_PCPort() {
   make_function_symbol_from_c("pc-get-screen-size", (void*)get_screen_size);
   make_function_symbol_from_c("pc-get-screen-rate", (void*)get_screen_rate);
   make_function_symbol_from_c("pc-get-screen-vmode-count", (void*)get_screen_vmode_count);
+  make_function_symbol_from_c("pc-get-monitor-count", (void*)get_monitor_count);
   make_function_symbol_from_c("pc-set-window-size", (void*)Gfx::set_window_size);
   make_function_symbol_from_c("pc-set-fullscreen", (void*)set_fullscreen);
   make_function_symbol_from_c("pc-set-frame-rate", (void*)set_frame_rate);

--- a/goal_src/jak1/engine/ui/progress/progress-h.gc
+++ b/goal_src/jak1/engine/ui/progress/progress-h.gc
@@ -122,6 +122,7 @@
   (flava-player)
   (memcard-disable-auto-save)
   (memcard-auto-save-disabled)
+  (monitor)
 
   ;; the last one!
   (max)
@@ -155,6 +156,7 @@
   (button-music)
   (button-flava)
   (cheat-toggle)
+  (monitor)
   )
     )
   )

--- a/goal_src/jak1/engine/ui/progress/progress-static.gc
+++ b/goal_src/jak1/engine/ui/progress/progress-static.gc
@@ -151,7 +151,7 @@
   )
 
 ;; maps options to a progress screen
-(define *options-remap* (new 'static 'boxed-array :type (array game-option) :length 0 :allocated-length (#if (not PC_PORT) 35 61)))
+(define *options-remap* (new 'static 'boxed-array :type (array game-option) :length 0 :allocated-length (#if (not PC_PORT) 35 60)))
 
 ;; TODO probably an enum.
 ;; maps level-info indices to the appropriate offset in *level-task-data*

--- a/goal_src/jak1/engine/ui/progress/progress-static.gc
+++ b/goal_src/jak1/engine/ui/progress/progress-static.gc
@@ -151,7 +151,7 @@
   )
 
 ;; maps options to a progress screen
-(define *options-remap* (new 'static 'boxed-array :type (array game-option) :length 0 :allocated-length (#if (not PC_PORT) 35 60)))
+(define *options-remap* (new 'static 'boxed-array :type (array game-option) :length 0 :allocated-length (#if (not PC_PORT) 35 61)))
 
 ;; TODO probably an enum.
 ;; maps level-info indices to the appropriate offset in *level-task-data*

--- a/goal_src/jak1/engine/ui/progress/progress.gc
+++ b/goal_src/jak1/engine/ui/progress/progress.gc
@@ -842,6 +842,7 @@
                         (= v1-2 (progress-screen cheats))
                         (= v1-2 (progress-screen music-player))
                         (= v1-2 (progress-screen flava-player))
+                        (= v1-2 (progress-screen monitor))
                         )
                     )
                   )

--- a/goal_src/jak1/engine/ui/text-h.gc
+++ b/goal_src/jak1/engine/ui/text-h.gc
@@ -747,6 +747,8 @@
   (scene-255                    #x12ff)
   (hint-0                       #x1300)
   (hint-511                     #x14ff)
+  (display                      #x1600)
+  (display-fmt                  #x1601)
 ;; GAME-TEXT-ID ENUM ENDS
   )
 

--- a/goal_src/jak1/engine/ui/text-h.gc
+++ b/goal_src/jak1/engine/ui/text-h.gc
@@ -631,6 +631,8 @@
   (subtitle-enabled             #x1040)
   (subtitle-disabled            #x1041)
   (text-language                #x1042)
+  (display                      #x1043)
+  (display-fmt                  #x1044)
   (msaa                         #x1050)
   (x-times-fmt                  #x1051)
   (2-times                      #x1052)
@@ -747,8 +749,6 @@
   (scene-255                    #x12ff)
   (hint-0                       #x1300)
   (hint-511                     #x14ff)
-  (display                      #x1600)
-  (display-fmt                  #x1601)
 ;; GAME-TEXT-ID ENUM ENDS
   )
 

--- a/goal_src/jak1/kernel-defs.gc
+++ b/goal_src/jak1/kernel-defs.gc
@@ -337,6 +337,7 @@
 (define-extern pc-get-screen-size (function int (pointer int32) (pointer int32) none))
 (define-extern pc-get-screen-rate (function int int))
 (define-extern pc-get-screen-vmode-count (function int))
+(define-extern pc-get-monitor-count (function int))
 (define-extern pc-get-os (function symbol))
 (define-extern pc-get-window-size (function (pointer int32) (pointer int32) none))
 (define-extern pc-get-window-scale (function (pointer float) (pointer float) none))

--- a/goal_src/jak1/pc/pckernel-h.gc
+++ b/goal_src/jak1/pc/pckernel-h.gc
@@ -219,6 +219,7 @@
    (vsync? symbol) ;; vsync.
    (font-scale float) ;; font scaling.
    (window-lock? symbol) ;; whether the window can be resized by the user or not.
+   (monitor int32) ;; index of which monitor to use when fullscreen or borderless
 
    ;; debug settings
    (os symbol) ;; windows, linux, macos
@@ -330,6 +331,7 @@
     (set-aspect-ratio! (_type_ float) none)
     (set-window-lock! (_type_ symbol) symbol)
     (set-frame-rate! (_type_ int) int)
+    (set-monitor! (_type_ int) none)
     (read-from-file (_type_ string) symbol)
     (write-to-file (_type_ string) symbol)
     (update-cheats (_type_) int)

--- a/goal_src/jak1/pc/pckernel.gc
+++ b/goal_src/jak1/pc/pckernel.gc
@@ -122,6 +122,11 @@
 
   rate)
 
+(defmethod set-monitor! pc-settings ((obj pc-settings) (monitor int))
+  "set the monitor to use when in fullscreen/borderless"
+  (set! (-> obj monitor) monitor)
+  (none))
+
 (defmethod commit-to-file pc-settings ((obj pc-settings))
   "commits the current settings to the file"
   ;; auto load settings if available
@@ -188,7 +193,8 @@
     )
 
   ;; set fullscreen to what we want
-  (pc-set-fullscreen (-> obj display-mode) 0)
+  (pc-set-fullscreen (-> obj display-mode) (-> obj monitor))
+
   ;; set window size and fps automatically if the window lock is enabled.
   (when (-> obj window-lock?)
     (pc-set-vsync (-> obj vsync?))
@@ -786,6 +792,7 @@
                       )
                   )
                 (("display-mode") (set-display-mode! obj (file-stream-read-symbol file)))
+                (("monitor") (set-monitor! obj (file-stream-read-int file)))
                 (("letterbox") (set! (-> obj letterbox?) (file-stream-read-symbol file)))
                 (("vsync") (set! (-> obj vsync?) (file-stream-read-symbol file)))
                 (("font-scale") (set! (-> obj font-scale) (file-stream-read-float file)))
@@ -903,6 +910,7 @@
                                                   (-> obj aspect-custom-x) (-> obj aspect-custom-y)
                                                   (-> obj aspect-ratio-auto?))
     (format file "  (display-mode ~A)~%" (-> obj display-mode))
+    (format file "  (monitor ~D)~%" (-> obj monitor))
     (format file "  (letterbox ~A)~%" (-> obj letterbox?))
     (format file "  (vsync ~A)~%" (-> obj vsync?))
     (format file "  (font-scale ~f)~%" (-> obj font-scale))

--- a/goal_src/jak1/pc/pckernel.gc
+++ b/goal_src/jak1/pc/pckernel.gc
@@ -192,6 +192,13 @@
      )
     )
 
+  ;; if monitor selection is out of bounds (e.g. if a monitor got disconnected),
+  ;; then default to the primary monitor
+  (when (>= (-> obj monitor) (pc-get-monitor-count))
+    (format 0 "Monitor selection out of bounds, defaulting to primary monitor.~%")
+    (set! (-> obj monitor) 0)
+    )
+
   ;; set fullscreen to what we want
   (pc-set-fullscreen (-> obj display-mode) (-> obj monitor))
 

--- a/goal_src/jak1/pc/progress-pc.gc
+++ b/goal_src/jak1/pc/progress-pc.gc
@@ -138,6 +138,7 @@
 (define *graphic-options-pc* (new 'static 'boxed-array :type game-option
     (new 'static 'game-option :option-type (game-option-type menu) :name (game-text-id game-resolution) :scale #t :param3 (game-option-menu resolution))
     (new 'static 'game-option :option-type (game-option-type display-mode) :name (game-text-id display-mode) :scale #t)
+    (new 'static 'game-option :option-type (game-option-type menu) :name (game-text-id display) :scale #t :param3 (game-option-menu monitor))
     (new 'static 'game-option :option-type (game-option-type on-off) :name (game-text-id vsync) :scale #t)
     (new 'static 'game-option :option-type (game-option-type menu) :name (game-text-id aspect-ratio) :scale #t :param3 (game-option-menu aspect-ratio))
     (new 'static 'game-option :option-type (game-option-type msaa) :name (game-text-id msaa) :scale #t)
@@ -502,6 +503,22 @@
   *temp-options*
   )
 
+(defun build-monitor-options ()
+  (set! (-> *temp-options* length) 0)
+
+  (dotimes (i (pc-get-monitor-count))
+    (let ((option (-> *temp-options* (length *temp-options*))))
+      (set! (-> option option-type) (game-option-type monitor))
+      (set! (-> option name) (game-text-id display-fmt))
+      (set! (-> option param1) (the float i))
+      (set! (-> option scale) #t)
+
+      (1+! (-> *temp-options* length))
+      )
+    )
+  
+  (add-back-option)
+  )
 
 
 
@@ -681,6 +698,7 @@
   (set! (-> *options-remap* (progress-screen flava-player))               *temp-options*)
   (set! (-> *options-remap* (progress-screen memcard-disable-auto-save))  *yes-no-options*)
   (set! (-> *options-remap* (progress-screen memcard-auto-save-disabled)) *ok-options*)
+  (set! (-> *options-remap* (progress-screen monitor))                    *temp-options*)
 
   ;; set default params
   (set! (-> *progress-state* aspect-ratio-choice) (get-aspect-ratio))
@@ -710,9 +728,10 @@
   (set! (-> *game-options-pc* 6 value-to-modify) (&-> *progress-carousell* int-backup))
   (set! (-> *game-options-pc* 7 value-to-modify) (&-> *progress-carousell* int-backup))
   (set! (-> *graphic-options-pc* 1 value-to-modify) (&-> *progress-carousell* int-backup))
-  (set! (-> *graphic-options-pc* 2 value-to-modify) (&-> *pc-settings* vsync?))
-  (set! (-> *graphic-options-pc* 4 value-to-modify) (&-> *progress-carousell* int-backup))
+  (set! (-> *graphic-options-pc* 2 value-to-modify) (&-> *pc-settings* monitor))
+  (set! (-> *graphic-options-pc* 3 value-to-modify) (&-> *pc-settings* vsync?))
   (set! (-> *graphic-options-pc* 5 value-to-modify) (&-> *progress-carousell* int-backup))
+  (set! (-> *graphic-options-pc* 6 value-to-modify) (&-> *progress-carousell* int-backup))
   (set! (-> *graphic-options-no-frame-rate-pc* 1 value-to-modify) (&-> *progress-carousell* int-backup))
   (set! (-> *graphic-options-no-frame-rate-pc* 2 value-to-modify) (&-> *pc-settings* vsync?))
   (set! (-> *graphic-options-no-frame-rate-pc* 4 value-to-modify) (&-> *progress-carousell* int-backup))
@@ -771,6 +790,9 @@
       (if (= (-> obj display-state-stack 0) (progress-screen title))
           (set! (-> *options-remap* (-> obj display-state)) *secrets-title*)
           (set! (-> *options-remap* (-> obj display-state)) *secrets*))
+      )
+    (((progress-screen monitor))
+      (build-monitor-options)
       )
     )
   ;; run nav code
@@ -1166,6 +1188,19 @@
                (let ((newx (the int (-> options (-> obj option-index) param1)))
                      (newy (the int (-> options (-> obj option-index) param2))))
                    (set-size! *pc-settings* newx newy))
+               (cpad-clear! 0 x)
+               (cpad-clear! 0 circle)
+               (cpad-clear! 0 square)
+               (cpad-clear! 0 triangle)
+               (sound-play "cursor-options")
+               (set! (-> obj next-display-state) (progress-screen invalid))
+               (commit-to-file *pc-settings*)
+               )
+              ((= (-> options (-> obj option-index) option-type) (game-option-type monitor))
+               ;; monitor button
+               (let ((monitor (the int (-> options (-> obj option-index) param1))))
+                 (set-monitor! *pc-settings* monitor)
+                 )
                (cpad-clear! 0 x)
                (cpad-clear! 0 circle)
                (cpad-clear! 0 square)
@@ -1725,6 +1760,14 @@
              (set! option-str (string-format (lookup-text! *common-text* (-> options index name) #f)
                                       (the int (-> options index param1)) (the int (-> options index param2))))
              )
+            (((game-option-type monitor))
+              ;; monitor list
+             (set! option-str 
+                   (string-format (lookup-text! *common-text* (-> options index name) #f)
+                                  (+ 1 (the int (-> options index param1)))
+                                  )
+                   )
+             )
             (else
              (cond
               ((and (-> obj selected-option) (= (-> obj option-index) index))
@@ -2143,6 +2186,7 @@
           (progress-screen aspect-ratio)
           (progress-screen secrets)
           (progress-screen cheats)
+          (progress-screen monitor)
           )
          (hide-progress-icons)
          (draw-options self 115 25 0.82)

--- a/goal_src/jak1/pc/progress-pc.gc
+++ b/goal_src/jak1/pc/progress-pc.gc
@@ -1203,8 +1203,6 @@
                  )
                (cpad-clear! 0 x)
                (cpad-clear! 0 circle)
-               (cpad-clear! 0 square)
-               (cpad-clear! 0 triangle)
                (sound-play "cursor-options")
                (set! (-> obj next-display-state) (progress-screen invalid))
                (commit-to-file *pc-settings*)

--- a/third-party/imgui/imgui_impl_glfw.cpp
+++ b/third-party/imgui/imgui_impl_glfw.cpp
@@ -197,8 +197,12 @@ void ImGui_ImplGlfw_CharCallback(GLFWwindow* window, unsigned int c)
     io.AddInputCharacter(c);
 }
 
-void ImGui_ImplGlfw_MonitorCallback(GLFWmonitor*, int)
+void ImGui_ImplGlfw_MonitorCallback(GLFWmonitor* monitor, int event)
 {
+  ImGui_ImplGlfw_Data* bd = ImGui_ImplGlfw_GetBackendData();
+  if (bd->PrevUserCallbackMonitor != NULL)
+    bd->PrevUserCallbackMonitor(monitor, event);
+
 	// Unused in 'master' branch but 'docking' branch will use this, so we declare it ahead of it so if you have to install callbacks you can install this one too.
 }
 


### PR DESCRIPTION
Worth mentioning that the selected location is referred to as 'monitor' in code but 'display' on the UI. Monitor is consistent with GLFW's terms, but display makes more sense to users. The options are also listed as just 'DISPLAY 1', 'DISPLAY 2', etc. I would have preferred to show the monitor's name but I wasn't sure how to get those strings into GOAL.

Let me know if I went a little overboard on the refactoring, I ran into some issues tracking the previous windowed pos/size when going from fullscreen to windowed, so I changed it quite a bit.  

Also, I had to modify the ImGui source, their GLFW implementation hijacks the monitor changed callback but never calls our registered callback (unlike the other events they steal). I have no idea why that code is even in ImGui's current release since their callback is empty and marked as such...

Closes #1454