### PR TITLE
Fix bg-custom making level-load-info :music-bank not work.

### DIFF
--- a/goal_src/jak1/engine/game/main.gc
+++ b/goal_src/jak1/engine/game/main.gc
@@ -635,7 +635,7 @@
           (dotimes (a0-8 (-> *level* length))
             (let ((a1-6 (-> *level* level a0-8)))
               (when (= (-> a1-6 status) 'active)
-                (if (and (= (-> a1-6 name) v1-13) (-> *level* play?))
+                (if (= (-> a1-6 name) v1-13)
                     (set! (-> *setting-control* default music) (-> a1-6 info music-bank))
                     )
                 )


### PR DESCRIPTION
With these changes, I played around in the game, checking ND intro, some cutscenes, some gameplay, and haven't noticed any difference.
BUT now if you set :music-bank in level-info for your custom level, and use bg-custom, the music will work. Before this change it kept playing the music that was loaded at the time when bg-custom was used, even after respawning and things like that.

The `(set! (-> *level* play?) #f)` line in the bg-custom function is probably important, I tried commenting it out and then game became unstable in custom levels. So instead I investigated why/how 'play?' is related to music, and found that one line that I modified.

I use bg-custom very often, and this music issue always bothered me.

This may not be the safest change, but I have no way to see everything that am I affecting with this change (that may be impossible even). So if this is rejected, or a different solution is suggested, I will understand.

If my explanation of the issue is unclear/messy, please let me know, and I will try to give a clearer answer.