### PR TITLE
Automatically switch to dedicated GPU in OpenGOAL runtime

### DIFF
--- a/game/main.cpp
+++ b/game/main.cpp
@@ -45,8 +45,6 @@ void setup_logging(bool verbose) {
   lg::initialize();
 }
 
-
-
 /*!
  * Entry point for the game.
  */

--- a/game/main.cpp
+++ b/game/main.cpp
@@ -17,6 +17,13 @@
 
 #include "game/discord.h"
 
+#ifdef _WIN32
+extern "C" {
+__declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
+__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+#endif
+
 // Discord RPC
 extern int64_t gStartTime;
 
@@ -37,6 +44,8 @@ void setup_logging(bool verbose) {
   }
   lg::initialize();
 }
+
+
 
 /*!
  * Entry point for the game.


### PR DESCRIPTION
Some machines with dual-GPUs cannot properly detect OpenGOAL as a high-performance application and properly utilize the dedicated GPU. This sets a flag for both Radeon and NVIDIA GPUs to always use the high performance GPU when available. I do not have a dual-GPU machine to test this on, but this should just work out of the box, and doesn't seem to cause any issues for machines that aren't utilizing dual-GPUs. 