### PR TITLE
game/imgui: remove V-Sync checkbox as it can't be interacted with

### DIFF
--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -117,8 +117,6 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
     }
 
     if (ImGui::BeginMenu("Frame Rate")) {
-      ImGui::Checkbox("Enable V-Sync", &Gfx::g_global_settings.vsync);
-      ImGui::Separator();
       ImGui::Checkbox("Framelimiter", &Gfx::g_global_settings.framelimiter);
       ImGui::InputFloat("Target FPS", &target_fps_input);
       if (ImGui::MenuItem("Apply")) {


### PR DESCRIPTION
The imgui checkbox for v-sync hasn't been functional since the in-game vsync option was added.  The imgui checkbox gets overridden by the game so this is just a source of potential confusion now.  You have to change vsync via the game.