### PR TITLE
[decompiler] handle types without inspects better in all-types

### DIFF
--- a/decompiler/ObjectFile/ObjectFileDB.h
+++ b/decompiler/ObjectFile/ObjectFileDB.h
@@ -201,7 +201,18 @@ class ObjectFileDB {
     // symbol-name : type-name
     std::unordered_map<std::string, std::string> symbol_types;
 
-    std::vector<std::string> type_defs;
+    struct TypeInfo {
+      bool from_inspect_method = false;  // does this come from an inspect method?
+      // if from inspect method:
+      std::string type_definition;  // the deftype generated from the inspect method.
+      // if not from inspect method:
+      u32 flags = 0;
+      std::string parent;
+    };
+
+    std::vector<std::string> type_names_in_order;
+    std::unordered_map<std::string, TypeInfo> type_info;
+
     std::string symbol_defs;
   };
   void ir2_analyze_all_types(const fs::path& output_file,

--- a/decompiler/analysis/analyze_inspect_method.h
+++ b/decompiler/analysis/analyze_inspect_method.h
@@ -44,11 +44,11 @@ std::string inspect_inspect_method(Function& inspect_method,
                                    TypeInspectorCache& ti_cache,
                                    ObjectFileDB::PerObjectAllTypeInfo& object_file_meta);
 
-std::string inspect_top_level_for_metadata(Function& top_level,
-                                           LinkedObjectFile& file,
-                                           DecompilerTypeSystem& dts,
-                                           DecompilerTypeSystem& previous_game_ts,
-                                           ObjectFileDB::PerObjectAllTypeInfo& object_file_meta);
+void inspect_top_level_for_metadata(Function& top_level,
+                                    LinkedObjectFile& file,
+                                    DecompilerTypeSystem& dts,
+                                    DecompilerTypeSystem& previous_game_ts,
+                                    ObjectFileDB::PerObjectAllTypeInfo& object_file_meta);
 
 std::string inspect_top_level_symbol_defines(Function& top_level,
                                              LinkedObjectFile& file,

--- a/decompiler/config/jak2/all-types.gc
+++ b/decompiler/config/jak2/all-types.gc
@@ -7471,6 +7471,11 @@
   )
 |#
 
+;; (deftype drawable-inline-array-node (drawable-inline-array)
+;;   ()
+;;   :flag-assert #x1100000044
+;;   )
+
 #|
 (deftype draw-node-dma (structure)
   ((banka draw-node 32 :offset-assert 4) ;; guessed by decompiler
@@ -7486,6 +7491,16 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; drawable-tree-h                ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; (deftype drawable-tree (drawable-group)
+;;   ()
+;;   :flag-assert #x1100000020
+;;   )
+
+;; (deftype drawable-tree-array (drawable-group)
+;;   ()
+;;   :flag-assert #x1100000020
+;;   )
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -7503,6 +7518,16 @@
     )
   )
 |#
+
+;; (deftype drawable-tree-actor (drawable-tree)
+;;   ()
+;;   :flag-assert #x1100000020
+;;   )
+
+;; (deftype drawable-inline-array-actor (drawable-inline-array)
+;;   ()
+;;   :flag-assert #x1100000044
+;;   )
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -7566,6 +7591,11 @@
     )
   )
 |#
+
+;; (deftype drawable-inline-array-region-prim (drawable-inline-array)
+;;   ()
+;;   :flag-assert #x1100000044
+;;   )
 
 #|
 (deftype drawable-region-sphere (drawable-region-prim)
@@ -7809,16 +7839,6 @@
 |#
 
 #|
-(deftype gsf-vertex-array (UNKNOWN)
-  ((vtx gsf-vertex :dynamic :offset-assert 0) ;; guessed by decompiler
-   )
-  :method-count-assert 0
-  :size-assert         #x0
-  :flag-assert         #x0
-  )
-|#
-
-#|
 (deftype gsf-fx-vertex (structure)
   ((clr vector4ub :inline :offset-assert 0)
    (tex vector2uh :inline :offset-assert 4)
@@ -7826,16 +7846,6 @@
   :method-count-assert 9
   :size-assert         #x8
   :flag-assert         #x900000008
-  )
-|#
-
-#|
-(deftype gsf-fx-vertex-array (UNKNOWN)
-  ((data gsf-fx-vertex :dynamic :offset-assert 0) ;; guessed by decompiler
-   )
-  :method-count-assert 0
-  :size-assert         #x0
-  :flag-assert         #x0
   )
 |#
 
@@ -8043,6 +8053,26 @@
   :method-count-assert 9
   :size-assert         #x100
   :flag-assert         #x900000100
+  )
+|#
+
+#|
+(deftype gsf-vertex-array (UNKNOWN)
+  ((vtx gsf-vertex :dynamic :offset-assert 0) ;; guessed by decompiler
+   )
+  :method-count-assert 0
+  :size-assert         #x0
+  :flag-assert         #x0
+  )
+|#
+
+#|
+(deftype gsf-fx-vertex-array (UNKNOWN)
+  ((data gsf-fx-vertex :dynamic :offset-assert 0) ;; guessed by decompiler
+   )
+  :method-count-assert 0
+  :size-assert         #x0
+  :flag-assert         #x0
   )
 |#
 
@@ -9137,6 +9167,11 @@
   )
 |#
 
+;; (deftype joint-anim-matrix (joint-anim)
+;;   ()
+;;   :flag-assert #x900000010
+;;   )
+
 #|
 (deftype joint-anim-transformq (joint-anim)
   ()
@@ -9253,6 +9288,11 @@
   )
 |#
 
+;; (deftype art-mesh-anim (art-element)
+;;   ()
+;;   :flag-assert #xd00000020
+;;   )
+
 #|
 (deftype art-joint-anim (art-element)
   ((speed                  float                          :offset-assert 20)
@@ -9272,6 +9312,21 @@
     )
   )
 |#
+
+;; (deftype art-group (art)
+;;   ()
+;;   :flag-assert #xf00000020
+;;   )
+
+;; (deftype art-mesh-geo (art-element)
+;;   ()
+;;   :flag-assert #xd00000020
+;;   )
+
+;; (deftype art-joint-geo (art-element)
+;;   ()
+;;   :flag-assert #xd00000020
+;;   )
 
 #|
 (deftype art-joint-anim-manager-slot (structure)
@@ -9905,6 +9960,16 @@
   :method-count-assert 9
   :size-assert         #x28
   :flag-assert         #x900000028
+  )
+|#
+
+#|
+(deftype merc-blend-data (UNKNOWN)
+  ((int8-data int8 :dynamic :offset-assert 0) ;; guessed by decompiler
+   )
+  :method-count-assert 0
+  :size-assert         #x0
+  :flag-assert         #x0
   )
 |#
 
@@ -10666,6 +10731,11 @@
 ;; memcard-h                      ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; (deftype mc-handle (int32)
+;;   ()
+;;   :flag-assert #x900000004
+;;   )
+
 #|
 (deftype mc-file-info (structure)
   ((present               int32     :offset-assert 0)
@@ -10939,6 +11009,11 @@
     )
   )
 |#
+
+;; (deftype gui-control (basic)
+;;   ()
+;;   :flag-assert #x1900000cd0
+;;   )
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -13439,6 +13514,11 @@
 ;; generic-obs-h                  ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; (deftype manipy (process-drawable)
+;;   ()
+;;   :flag-assert #x1501000174
+;;   )
+
 #|
 (deftype part-spawner (process)
   ((root         trsqv                                    :offset-assert 124) ;; guessed by decompiler
@@ -13797,6 +13877,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; collide-target-h               ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; (deftype control-info (collide-shape-moving)
+;;   ()
+;;   :flag-assert #x4400001910
+;;   )
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -14275,6 +14360,11 @@
     )
   )
 |#
+
+;; (deftype drawable-tree-collide-fragment (drawable-tree)
+;;   ()
+;;   :flag-assert #x1100000020
+;;   )
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -15100,6 +15190,16 @@
   )
 |#
 
+;; (deftype drawable-inline-array-instance-shrub (drawable-inline-array)
+;;   ()
+;;   :flag-assert #x1100000074
+;;   )
+
+;; (deftype drawable-tree-instance-shrub (drawable-tree)
+;;   ()
+;;   :flag-assert #x1100000020
+;;   )
+
 #|
 (deftype generic-shrub-fragment (drawable)
   ((textures (inline-array adgif-shader)  :offset-assert 4) ;; guessed by decompiler
@@ -15120,6 +15220,21 @@
     )
   )
 |#
+
+;; (deftype prototype-shrubbery (drawable-inline-array)
+;;   ()
+;;   :flag-assert #x1100000044
+;;   )
+
+;; (deftype prototype-trans-shrubbery (prototype-shrubbery)
+;;   ()
+;;   :flag-assert #x1100000044
+;;   )
+
+;; (deftype prototype-generic-shrub (drawable-group)
+;;   ()
+;;   :flag-assert #x1100000020
+;;   )
 
 #|
 (deftype shrubbery-matrix (structure)
@@ -15298,6 +15413,11 @@
   )
 |#
 
+;; (deftype drawable-inline-array-instance-tie (drawable-inline-array)
+;;   ()
+;;   :flag-assert #x1100000064
+;;   )
+
 #|
 (deftype drawable-tree-instance-tie (drawable-tree)
   ()
@@ -15309,6 +15429,11 @@
     )
   )
 |#
+
+;; (deftype prototype-tie (drawable-inline-array)
+;;   ()
+;;   :flag-assert #x1100000064
+;;   )
 
 #|
 (deftype tie-matrix (structure)
@@ -15636,6 +15761,36 @@
     )
   )
 |#
+
+;; (deftype drawable-inline-array-tfrag (drawable-inline-array)
+;;   ()
+;;   :flag-assert #x1100000064
+;;   )
+
+;; (deftype drawable-inline-array-tfrag-trans (drawable-inline-array-tfrag)
+;;   ()
+;;   :flag-assert #x11000000b4
+;;   )
+
+;; (deftype drawable-inline-array-tfrag-water (drawable-inline-array-tfrag)
+;;   ()
+;;   :flag-assert #x11000000b4
+;;   )
+
+;; (deftype drawable-tree-tfrag (drawable-tree)
+;;   ()
+;;   :flag-assert #x1100000020
+;;   )
+
+;; (deftype drawable-tree-tfrag-trans (drawable-tree-tfrag)
+;;   ()
+;;   :flag-assert #x1100000020
+;;   )
+
+;; (deftype drawable-tree-tfrag-water (drawable-tree-tfrag-trans)
+;;   ()
+;;   :flag-assert #x1100000020
+;;   )
 
 #|
 (deftype tfrag-dists (structure)
@@ -16075,6 +16230,31 @@
   :flag-assert         #x900000010
   )
 |#
+
+;; (deftype entity (res-lump)
+;;   ()
+;;   :flag-assert #x1b00000034
+;;   )
+
+;; (deftype entity-camera (entity)
+;;   ()
+;;   :flag-assert #x1b00000050
+;;   )
+
+;; (deftype entity-nav-mesh (entity)
+;;   ()
+;;   :flag-assert #x1d00000038
+;;   )
+
+;; (deftype entity-race-mesh (entity)
+;;   ()
+;;   :flag-assert #x1d00000038
+;;   )
+
+;; (deftype entity-actor (entity)
+;;   ()
+;;   :flag-assert #x2100000050
+;;   )
 
 #|
 (deftype actor-reference (structure)
@@ -18863,6 +19043,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; spatial-hash-h                 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; (deftype grid-hash-word (uint8)
+;;   ()
+;;   :flag-assert #x900000001
+;;   )
 
 #|
 (deftype grid-hash-box (structure)
@@ -32229,6 +32414,11 @@
   ;; Failed to read fields.
   )
 |#
+
+;; (deftype predator-edge (structure)
+;;   ()
+;;   :flag-assert #x900000004
+;;   )
 
 #|
 (deftype predator-graph (structure)

--- a/decompiler/config/jak2/all-types.gc
+++ b/decompiler/config/jak2/all-types.gc
@@ -7471,10 +7471,17 @@
   )
 |#
 
-;; (deftype drawable-inline-array-node (drawable-inline-array)
-;;   ()
-;;   :flag-assert #x1100000044
-;;   )
+#|
+(deftype drawable-inline-array-node (drawable-inline-array)
+  ()
+  :method-count-assert 17
+  :size-assert         #x44
+  :flag-assert         #x1100000044
+  ;; Failed to read fields.
+  (:methods
+    )
+  )
+|#
 
 #|
 (deftype draw-node-dma (structure)
@@ -9313,10 +9320,19 @@
   )
 |#
 
-;; (deftype art-group (art)
-;;   ()
-;;   :flag-assert #xf00000020
-;;   )
+#|
+(deftype art-group (art)
+  ()
+  :method-count-assert 15
+  :size-assert         #x20
+  :flag-assert         #xf00000020
+  ;; Failed to read fields.
+  (:methods
+    (art-group-method-13 () none 13) ;; (link-art! (_type_) art-group 13)
+    (art-group-method-14 () none 14) ;; (unlink-art! (_type_) int 14)
+    )
+  )
+|#
 
 ;; (deftype art-mesh-geo (art-element)
 ;;   ()
@@ -11010,10 +11026,33 @@
   )
 |#
 
-;; (deftype gui-control (basic)
-;;   ()
-;;   :flag-assert #x1900000cd0
-;;   )
+#|
+(deftype gui-control (basic)
+  ()
+  :method-count-assert 25
+  :size-assert         #xcd0
+  :flag-assert         #x1900000cd0
+  ;; Failed to read fields.
+  (:methods
+    (gui-control-method-9 () none 9)
+    (gui-control-method-10 () none 10)
+    (gui-control-method-11 () none 11)
+    (gui-control-method-12 () none 12)
+    (gui-control-method-13 () none 13)
+    (gui-control-method-14 () none 14)
+    (gui-control-method-15 () none 15)
+    (gui-control-method-16 () none 16)
+    (gui-control-method-17 () none 17)
+    (gui-control-method-18 () none 18)
+    (gui-control-method-19 () none 19)
+    (gui-control-method-20 () none 20)
+    (gui-control-method-21 () none 21)
+    (gui-control-method-22 () none 22)
+    (gui-control-method-23 () none 23)
+    (gui-control-method-24 () none 24)
+    )
+  )
+|#
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -15221,10 +15260,17 @@
   )
 |#
 
-;; (deftype prototype-shrubbery (drawable-inline-array)
-;;   ()
-;;   :flag-assert #x1100000044
-;;   )
+#|
+(deftype prototype-shrubbery (drawable-inline-array)
+  ()
+  :method-count-assert 17
+  :size-assert         #x44
+  :flag-assert         #x1100000044
+  ;; Failed to read fields.
+  (:methods
+    )
+  )
+|#
 
 ;; (deftype prototype-trans-shrubbery (prototype-shrubbery)
 ;;   ()
@@ -15413,10 +15459,17 @@
   )
 |#
 
-;; (deftype drawable-inline-array-instance-tie (drawable-inline-array)
-;;   ()
-;;   :flag-assert #x1100000064
-;;   )
+#|
+(deftype drawable-inline-array-instance-tie (drawable-inline-array)
+  ()
+  :method-count-assert 17
+  :size-assert         #x64
+  :flag-assert         #x1100000064
+  ;; Failed to read fields.
+  (:methods
+    )
+  )
+|#
 
 #|
 (deftype drawable-tree-instance-tie (drawable-tree)
@@ -15430,10 +15483,18 @@
   )
 |#
 
-;; (deftype prototype-tie (drawable-inline-array)
-;;   ()
-;;   :flag-assert #x1100000064
-;;   )
+#|
+(deftype prototype-tie (drawable-inline-array)
+  ()
+  :method-count-assert 17
+  :size-assert         #x64
+  :flag-assert         #x1100000064
+  ;; Failed to read fields.
+  (:methods
+    )
+  )
+|#
+
 
 #|
 (deftype tie-matrix (structure)
@@ -15762,10 +15823,17 @@
   )
 |#
 
-;; (deftype drawable-inline-array-tfrag (drawable-inline-array)
-;;   ()
-;;   :flag-assert #x1100000064
-;;   )
+#|
+(deftype drawable-inline-array-tfrag (drawable-inline-array)
+  ()
+  :method-count-assert 17
+  :size-assert         #x64
+  :flag-assert         #x1100000064
+  ;; Failed to read fields.
+  (:methods
+    )
+  )
+|#
 
 ;; (deftype drawable-inline-array-tfrag-trans (drawable-inline-array-tfrag)
 ;;   ()
@@ -16231,30 +16299,63 @@
   )
 |#
 
-;; (deftype entity (res-lump)
-;;   ()
-;;   :flag-assert #x1b00000034
-;;   )
+(deftype entity (res-lump)
+  ((pad uint32 5))
+  :method-count-assert 27
+  :size-assert         #x34
+  :flag-assert         #x1b00000034
+  ;; Failed to read fields.
+  (:methods
+    (entity-method-22 () none 22) ;; (birth! (_type_) _type_ 22)
+    (entity-method-23 () none 23) ;; (kill! (_type_) _type_ 23)
+    (entity-method-24 () none 24) ;; (add-to-level! (_type_ level-group level actor-id) none 24)
+    (entity-method-25 () none 25) ;; (remove-from-level! (_type_ level-group) _type_ 25)
+    (entity-method-26 () none 26) ;; (get-level (_type_) level 26)
+    )
+  )
 
 ;; (deftype entity-camera (entity)
 ;;   ()
 ;;   :flag-assert #x1b00000050
 ;;   )
 
-;; (deftype entity-nav-mesh (entity)
-;;   ()
-;;   :flag-assert #x1d00000038
-;;   )
+#|
+(deftype entity-nav-mesh (entity)
+  ()
+  :method-count-assert 29
+  :size-assert         #x38
+  :flag-assert         #x1d00000038
+  ;; Failed to read fields.
+  (:methods
+    (entity-nav-mesh-method-27 () none 27)
+    (entity-nav-mesh-method-28 () none 28)
+    )
+  )
+|#
 
 ;; (deftype entity-race-mesh (entity)
 ;;   ()
 ;;   :flag-assert #x1d00000038
 ;;   )
 
-;; (deftype entity-actor (entity)
-;;   ()
-;;   :flag-assert #x2100000050
-;;   )
+(declare-type entity-actor entity)
+#|
+(deftype entity-actor (entity)
+  ()
+  :method-count-assert 33
+  :size-assert         #x50
+  :flag-assert         #x2100000050
+  ;; Failed to read fields.
+  (:methods
+    (entity-actor-method-27 () none 27) ;; (next-actor (_type_) entity-actor 27)
+    (entity-actor-method-28 () none 28) ;; (prev-actor (_type_) entity-actor 28)
+    (entity-actor-method-29 () none 29) ;; (debug-print (_type_ symbol type) none 29)
+    (entity-actor-method-30 () none 30) ;; (dummy-30 (_type_ entity-perm-status symbol) none 30)
+    (entity-actor-method-31 () none 31)
+    (entity-actor-method-32 () none 32)
+    )
+  )
+|#
 
 #|
 (deftype actor-reference (structure)
@@ -19432,19 +19533,6 @@
 ;; joint                          ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-#|
-(deftype art-group (art)
-  ()
-  :method-count-assert 15
-  :size-assert         #x20
-  :flag-assert         #xf00000020
-  ;; Failed to read fields.
-  (:methods
-    (art-group-method-13 () none 13) ;; (link-art! (_type_) art-group 13)
-    (art-group-method-14 () none 14) ;; (unlink-art! (_type_) int 14)
-    )
-  )
-|#
 
 ;; (define-extern joint-anim-login function) ;; (function joint-anim-drawable joint-anim-drawable)
 ;; (define-extern joint-anim-inspect-elt function) ;; (function joint-anim float joint-anim)
@@ -20718,35 +20806,12 @@
 ;; draw-node                      ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-#|
-(deftype drawable-inline-array-node (drawable-inline-array)
-  ()
-  :method-count-assert 17
-  :size-assert         #x44
-  :flag-assert         #x1100000044
-  ;; Failed to read fields.
-  (:methods
-    )
-  )
-|#
-
 ;; (define-extern draw-node-cull function) ;; (function pointer pointer (inline-array draw-node) int none)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; shrubbery                      ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-#|
-(deftype prototype-shrubbery (drawable-inline-array)
-  ()
-  :method-count-assert 17
-  :size-assert         #x44
-  :flag-assert         #x1100000044
-  ;; Failed to read fields.
-  (:methods
-    )
-  )
-|#
 
 #|
 (deftype dma-test (structure)
@@ -20807,18 +20872,6 @@
 ;; tfrag                          ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-#|
-(deftype drawable-inline-array-tfrag (drawable-inline-array)
-  ()
-  :method-count-assert 17
-  :size-assert         #x64
-  :flag-assert         #x1100000064
-  ;; Failed to read fields.
-  (:methods
-    )
-  )
-|#
-
 ;; (define-extern *tfrag-display-stats* object) ;; symbol
 ;; (define-extern tfrag-vu1-block object) ;; vu-function
 ;; (define-extern tfrag-data-setup function) ;; (function tfrag-data int none)
@@ -20873,29 +20926,6 @@
 ;; tie                            ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-#|
-(deftype drawable-inline-array-instance-tie (drawable-inline-array)
-  ()
-  :method-count-assert 17
-  :size-assert         #x64
-  :flag-assert         #x1100000064
-  ;; Failed to read fields.
-  (:methods
-    )
-  )
-|#
-
-#|
-(deftype prototype-tie (drawable-inline-array)
-  ()
-  :method-count-assert 17
-  :size-assert         #x64
-  :flag-assert         #x1100000064
-  ;; Failed to read fields.
-  (:methods
-    )
-  )
-|#
 
 #|
 (deftype tie-consts (structure)
@@ -21390,34 +21420,6 @@
   :method-count-assert 9
   :size-assert         #x4c
   :flag-assert         #x90000004c
-  )
-|#
-
-#|
-(deftype gui-control (basic)
-  ()
-  :method-count-assert 25
-  :size-assert         #xcd0
-  :flag-assert         #x1900000cd0
-  ;; Failed to read fields.
-  (:methods
-    (gui-control-method-9 () none 9)
-    (gui-control-method-10 () none 10)
-    (gui-control-method-11 () none 11)
-    (gui-control-method-12 () none 12)
-    (gui-control-method-13 () none 13)
-    (gui-control-method-14 () none 14)
-    (gui-control-method-15 () none 15)
-    (gui-control-method-16 () none 16)
-    (gui-control-method-17 () none 17)
-    (gui-control-method-18 () none 18)
-    (gui-control-method-19 () none 19)
-    (gui-control-method-20 () none 20)
-    (gui-control-method-21 () none 21)
-    (gui-control-method-22 () none 22)
-    (gui-control-method-23 () none 23)
-    (gui-control-method-24 () none 24)
-    )
   )
 |#
 
@@ -25860,55 +25862,6 @@
   )
 |#
 
-
-(deftype entity (res-lump)
-  ((pad uint32 5))
-  :method-count-assert 27
-  :size-assert         #x34
-  :flag-assert         #x1b00000034
-  ;; Failed to read fields.
-  (:methods
-    (entity-method-22 () none 22) ;; (birth! (_type_) _type_ 22)
-    (entity-method-23 () none 23) ;; (kill! (_type_) _type_ 23)
-    (entity-method-24 () none 24) ;; (add-to-level! (_type_ level-group level actor-id) none 24)
-    (entity-method-25 () none 25) ;; (remove-from-level! (_type_ level-group) _type_ 25)
-    (entity-method-26 () none 26) ;; (get-level (_type_) level 26)
-    )
-  )
-
-
-#|
-(deftype entity-nav-mesh (entity)
-  ()
-  :method-count-assert 29
-  :size-assert         #x38
-  :flag-assert         #x1d00000038
-  ;; Failed to read fields.
-  (:methods
-    (entity-nav-mesh-method-27 () none 27)
-    (entity-nav-mesh-method-28 () none 28)
-    )
-  )
-|#
-
-(declare-type entity-actor entity)
-#|
-(deftype entity-actor (entity)
-  ()
-  :method-count-assert 33
-  :size-assert         #x50
-  :flag-assert         #x2100000050
-  ;; Failed to read fields.
-  (:methods
-    (entity-actor-method-27 () none 27) ;; (next-actor (_type_) entity-actor 27)
-    (entity-actor-method-28 () none 28) ;; (prev-actor (_type_) entity-actor 28)
-    (entity-actor-method-29 () none 29) ;; (debug-print (_type_ symbol type) none 29)
-    (entity-actor-method-30 () none 30) ;; (dummy-30 (_type_ entity-perm-status symbol) none 30)
-    (entity-actor-method-31 () none 31)
-    (entity-actor-method-32 () none 32)
-    )
-  )
-|#
 
 #|
 (deftype debug-actor-info (basic)


### PR DESCRIPTION
This moves some types to the right files, and gives them parents/flag-asserts.

There weren't as many as I thought, which is nice.