### PR TITLE
goal_src: Get rid of `*OLD*` files in jak1's goal_src

### DIFF
--- a/.github/workflows/inform-pages-repo.yaml
+++ b/.github/workflows/inform-pages-repo.yaml
@@ -1,9 +1,5 @@
 name: Inform Pages Repo
 
-# This action triggers an action on our other repo, which will:
-# - clone this repo
-# - use the latest files to update our progress
-
 on:
   push:
     branches:
@@ -16,7 +12,6 @@ jobs:
     name: Inform Pages Repo
     if: github.repository == 'open-goal/jak-project'
     runs-on: ubuntu-latest
-    # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
     timeout-minutes: 10
     steps:
       - name: Send Dispatch

--- a/.github/workflows/update-controller-db.yaml
+++ b/.github/workflows/update-controller-db.yaml
@@ -20,4 +20,7 @@ jobs:
       - name: commit version bump
         uses: EndBug/add-and-commit@v9
         with:
+          default_author: github_actor
+          author_name: 'OpenGOALBot'
+          author_email: 'OpenGOALBot@users.noreply.github.com'
           message: "Updating Controller Database"

--- a/goal_src/jak1/old/citb-drop-plat-OLD.gc
+++ b/goal_src/jak1/old/citb-drop-plat-OLD.gc
@@ -1,6 +1,0 @@
-;;-*-Lisp-*-
-(in-package goal)
-
-;; name: citb-drop-plat-L1.gc
-;; name in dgo: citb-drop-plat
-;; dgos: L1

--- a/goal_src/jak1/old/fisher-OLD.gc
+++ b/goal_src/jak1/old/fisher-OLD.gc
@@ -1,6 +1,0 @@
-;;-*-Lisp-*-
-(in-package goal)
-
-;; name: fisher-JUNGLE-L1.gc
-;; name in dgo: fisher
-;; dgos: JUNGLE, L1

--- a/goal_src/jak1/old/lava/lava.gc
+++ b/goal_src/jak1/old/lava/lava.gc
@@ -1,7 +1,0 @@
-;;-*-Lisp-*-
-(in-package goal)
-
-;; name: lava.gc
-;; name in dgo: lava
-;; dgos: WATER-AN
-

--- a/goal_src/jak1/old/racer-states-OLD.gc
+++ b/goal_src/jak1/old/racer-states-OLD.gc
@@ -1,6 +1,0 @@
-;;-*-Lisp-*-
-(in-package goal)
-
-;; name: racer-states-L1-RACERP.gc
-;; name in dgo: racer-states
-;; dgos: L1, RACERP

--- a/goal_src/jak1/old/sage-finalboss-OLD.gc
+++ b/goal_src/jak1/old/sage-finalboss-OLD.gc
@@ -1,6 +1,0 @@
-;;-*-Lisp-*-
-(in-package goal)
-
-;; name: sage-finalboss-L1.gc
-;; name in dgo: sage-finalboss
-;; dgos: L1

--- a/goal_src/jak1/old/target-racer-OLD.gc
+++ b/goal_src/jak1/old/target-racer-OLD.gc
@@ -1,6 +1,0 @@
-;;-*-Lisp-*-
-(in-package goal)
-
-;; name: target-racer-L1-RACERP.gc
-;; name in dgo: target-racer
-;; dgos: L1, RACERP

--- a/goal_src/jak1/old/target-racer-h-OLD.gc
+++ b/goal_src/jak1/old/target-racer-h-OLD.gc
@@ -1,6 +1,0 @@
-;;-*-Lisp-*-
-(in-package goal)
-
-;; name: target-racer-h-L1-RACERP.gc
-;; name in dgo: target-racer-h
-;; dgos: L1, RACERP

--- a/goal_src/jak1/old/village-obs-OLD.gc
+++ b/goal_src/jak1/old/village-obs-OLD.gc
@@ -1,6 +1,0 @@
-;;-*-Lisp-*-
-(in-package goal)
-
-;; name: village-obs-L1.gc
-;; name in dgo: village-obs
-;; dgos: L1

--- a/goal_src/jak2/kernel/dgo-h.gc
+++ b/goal_src/jak2/kernel/dgo-h.gc
@@ -5,6 +5,8 @@
 ;; name in dgo: dgo-h
 ;; dgos: KERNEL
 
+;; DECOMP BEGINS
+
 ;; I suspect that these are unused, and were for an older version of DGO.
 ;; All DGO stuff is handled on the IOP.
 

--- a/goal_src/jak2/kernel/gcommon.gc
+++ b/goal_src/jak2/kernel/gcommon.gc
@@ -5,6 +5,8 @@
 ;; name in dgo: gcommon
 ;; dgos: KERNEL
 
+;; DECOMP BEGINS
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Game constants
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/goal_src/jak2/kernel/gkernel-h.gc
+++ b/goal_src/jak2/kernel/gkernel-h.gc
@@ -5,6 +5,8 @@
 ;; name in dgo: gkernel-h
 ;; dgos: KERNEL
 
+;; DECOMP BEGINS
+
 (defconstant *kernel-major-version* 2)
 (defconstant *kernel-minor-version* 0)
 

--- a/goal_src/jak2/kernel/gkernel.gc
+++ b/goal_src/jak2/kernel/gkernel.gc
@@ -5,6 +5,8 @@
 ;; name in dgo: gkernel
 ;; dgos: KERNEL
 
+;; DECOMP BEGINS
+
 ;; Version constants
 (define *kernel-version* (the binteger (logior (ash *kernel-major-version* 16) *kernel-minor-version*)))
 (define *irx-version* (the-as binteger #x200000))

--- a/goal_src/jak2/kernel/gstate.gc
+++ b/goal_src/jak2/kernel/gstate.gc
@@ -5,6 +5,8 @@
 ;; name in dgo: gstate
 ;; dgos: KERNEL
 
+;; DECOMP BEGINS
+
 #|
 Summary of state system:
 

--- a/goal_src/jak2/kernel/gstring-h.gc
+++ b/goal_src/jak2/kernel/gstring-h.gc
@@ -5,6 +5,8 @@
 ;; name in dgo: gstring-h
 ;; dgos: KERNEL
 
+;; DECOMP BEGINS
+
 (define-extern *string-tmp-str* string)
 (define-extern *temp-string* string)
 (define-extern *stdcon0* string)

--- a/goal_src/jak2/kernel/gstring.gc
+++ b/goal_src/jak2/kernel/gstring.gc
@@ -5,6 +5,8 @@
 ;; name in dgo: gstring
 ;; dgos: KERNEL
 
+;; DECOMP BEGINS
+
 (defmethod length string ((obj string))
   "Get the length of a string. Like strlen"
   (let ((v1-0 (-> obj data)))


### PR DESCRIPTION
I also missed adding the placeholder to the only files we've done in jak 2 ( the kernel ones )