### PR TITLE
custom levels: add support for more res types in actor lumps

### DIFF
--- a/custom_levels/test-zone/test-zone.jsonc
+++ b/custom_levels/test-zone/test-zone.jsonc
@@ -20,6 +20,17 @@
   // this makes collision 2x slower and bigger, so only use if really needed
   "double_sided_collide": false,
 
+  // available res-lump tag data types:
+  // int32, float, floatm (meters), vector, vector4m (meters)
+  //
+  // examples:
+  //
+  // adds a float tag 'spring-height' with value of 200 meters (1 meter = 4096.0 units):
+  // "spring-height": ["floatm", 200.0]
+  //
+  // adds a vector tag 'movie-pos':
+  // "movie-pos": ["vector", [4096000.0, -176128.0, 1353973.76, 1.0]]
+
   "actors" : [
     {
       "trans": [-21.6238, 20.0496, 17.1191], // translation

--- a/custom_levels/test-zone/test-zone.jsonc
+++ b/custom_levels/test-zone/test-zone.jsonc
@@ -21,12 +21,12 @@
   "double_sided_collide": false,
 
   // available res-lump tag data types:
-  // int32, float, floatm (meters), vector, vector4m (meters)
+  // int32, float, meters, vector, vector4m (meters)
   //
   // examples:
   //
   // adds a float tag 'spring-height' with value of 200 meters (1 meter = 4096.0 units):
-  // "spring-height": ["floatm", 200.0]
+  // "spring-height": ["meters", 200.0]
   //
   // adds a vector tag 'movie-pos':
   // "movie-pos": ["vector", [4096000.0, -176128.0, 1353973.76, 1.0]]

--- a/goalc/build_level/Entity.cpp
+++ b/goalc/build_level/Entity.cpp
@@ -131,7 +131,7 @@ std::unique_ptr<Res> res_from_json_array(const std::string& name,
       data.push_back(json_array[i].get<float>());
     }
     return std::make_unique<ResFloat>(name, data, -1000000000.0000);
-  } else if (array_type == "floatm") {
+  } else if (array_type == "meters") {
     std::vector<float> data;
     for (size_t i = 1; i < json_array.size(); i++) {
       data.push_back(json_array[i].get<float>() * METER_LENGTH);

--- a/goalc/build_level/Entity.cpp
+++ b/goalc/build_level/Entity.cpp
@@ -113,6 +113,30 @@ std::unique_ptr<Res> res_from_json_array(const std::string& name,
       data.push_back(json_array[i].get<int>());
     }
     return std::make_unique<ResInt32>(name, data, -1000000000.0000);
+  } else if (array_type == "vector") {
+    std::vector<math::Vector4f> data;
+    for (size_t i = 1; i < json_array.size(); i++) {
+      data.push_back(vector_from_json(json_array[i]));
+    }
+    return std::make_unique<ResVector>(name, data, -1000000000.0000);
+  } else if (array_type == "vector4m") {
+    std::vector<math::Vector4f> data;
+    for (size_t i = 1; i < json_array.size(); i++) {
+      data.push_back(vectorm4_from_json(json_array[i]));
+    }
+    return std::make_unique<ResVector>(name, data, -1000000000.0000);
+  } else if (array_type == "float") {
+    std::vector<float> data;
+    for (size_t i = 1; i < json_array.size(); i++) {
+      data.push_back(json_array[i].get<float>());
+    }
+    return std::make_unique<ResFloat>(name, data, -1000000000.0000);
+  } else if (array_type == "floatm") {
+    std::vector<float> data;
+    for (size_t i = 1; i < json_array.size(); i++) {
+      data.push_back(json_array[i].get<float>() * METER_LENGTH);
+    }
+    return std::make_unique<ResFloat>(name, data, -1000000000.0000);
   } else {
     ASSERT_MSG(false, fmt::format("unsupported array type: {}\n", array_type));
   }


### PR DESCRIPTION
Adds support for `vector` and `float` in actor `res-lump` tags in custom level JSON files.
Also added some small documentation for currently available types to use in the `test-zone` JSON file.