### PR TITLE
fix bug in knuth RNG

### DIFF
--- a/goal_src/jak1/pc/util/knuth-rand.gc
+++ b/goal_src/jak1/pc/util/knuth-rand.gc
@@ -59,11 +59,13 @@
          (bits 0)
          (val 0))
 
+    #|  For some reason this doesn't seem to be working correctly :(
     ;; if ((bound & -bound) == bound)  // i.e., bound is a power of 2
     (if (= (logand bound (* -1 bound)) bound)
       ;; return (int)((bound * (long)next(31)) >> 31);
-      (return (sar (* bound (knuth-rand-next 31)) 31))
+      (return (+ min (sar (* bound (knuth-rand-next 31)) 31)))
       )
+    |#
 
     ;;  do {
     ;;      bits = next(31);

--- a/goal_src/jak1/pc/util/knuth-rand.gc
+++ b/goal_src/jak1/pc/util/knuth-rand.gc
@@ -59,13 +59,11 @@
          (bits 0)
          (val 0))
 
-    #|  For some reason this doesn't seem to be working correctly :(
     ;; if ((bound & -bound) == bound)  // i.e., bound is a power of 2
     (if (= (logand bound (* -1 bound)) bound)
       ;; return (int)((bound * (long)next(31)) >> 31);
-      (return (+ min (sar (* bound (knuth-rand-next 31)) 31)))
+      (return (+ min (sar (imul64 bound (knuth-rand-next 31)) 31)))
       )
-    |#
 
     ;;  do {
     ;;      bits = next(31);

--- a/goal_src/jak1/pc/util/knuth-rand.gc
+++ b/goal_src/jak1/pc/util/knuth-rand.gc
@@ -60,7 +60,7 @@
          (val 0))
 
     ;; if ((bound & -bound) == bound)  // i.e., bound is a power of 2
-    (if (= (logand bound (* -1 bound)) bound)
+    (if (= (logand bound (- bound)) bound)
       ;; return (int)((bound * (long)next(31)) >> 31);
       (return (+ min (sar (imul64 bound (knuth-rand-next 31)) 31)))
       )


### PR DESCRIPTION
- I had a bug where I wasn't adding the min back
- `(sar (* bound (knuth-rand-next 31)) 31)` will always returns -1 or 0 when bound is a power of 2, should use `imul64` instead here
