### PR TITLE
tests: allow the binary prep steps in the linux release script to be skipped

### DIFF
--- a/.github/scripts/releases/extract_build_linux.sh
+++ b/.github/scripts/releases/extract_build_linux.sh
@@ -8,17 +8,21 @@ SOURCE=${3}
 
 mkdir -p $DEST
 
-cp $BIN_SOURCE/game/gk $DEST
-cp $BIN_SOURCE/goalc/goalc $DEST
-cp $BIN_SOURCE/decompiler/extractor $DEST
+PREP_BIN="${PREP_BIN:-true}"
 
-strip $DEST/gk
-strip $DEST/goalc
-strip $DEST/extractor
+if [ "$PREP_BIN" = "true" ]; then
+  cp $BIN_SOURCE/game/gk $DEST
+  cp $BIN_SOURCE/goalc/goalc $DEST
+  cp $BIN_SOURCE/decompiler/extractor $DEST
 
-chmod +x $DEST/gk
-chmod +x $DEST/goalc
-chmod +x $DEST/extractor
+  strip $DEST/gk
+  strip $DEST/goalc
+  strip $DEST/extractor
+
+  chmod +x $DEST/gk
+  chmod +x $DEST/goalc
+  chmod +x $DEST/extractor
+fi
 
 mkdir -p $DEST/data
 mkdir -p $DEST/data/launcher/


### PR DESCRIPTION
This is for a regression test for the extractor I'm adding in the jenkins server.  I'm only doing a minimal build over there (only offline-tests and extractor) so these steps fail since there is no gk/goalc executables.

This technically is only a partial regression test, as it doesn't cover windows.  But it increases confidence that we havn't broken something obvious.