### PR TITLE
game: add a speedrunner mode which enables a faster new-game/resetting experience

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,12 +36,19 @@ tasks:
     cmds:
       - '{{.DECOMP_BIN_RELEASE_DIR}}/decompiler "./decompiler/config/{{.DECOMP_CONFIG}}" ./iso_data ./decompiler_out --config-override "{\\\"decompile_code\\\": false}"'
   boot-game:
-    desc: "Boots the game, it will fail if it's not already booted!"
+    desc: "Boots the game, it will fail if it's not already compiled!"
     preconditions:
       - sh: test -f {{.GK_BIN_RELEASE_DIR}}/gk{{.EXE_FILE_EXTENSION}}
         msg: "Couldn't locate runtime executable in '{{.GK_BIN_RELEASE_DIR}}/gk'"
     cmds:
       - "{{.GK_BIN_RELEASE_DIR}}/gk -boot -fakeiso -debug -v"
+  boot-game-retail:
+    desc: "Boots the game without debug mode, it will fail if it's not already compiled!"
+    preconditions:
+      - sh: test -f {{.GK_BIN_RELEASE_DIR}}/gk{{.EXE_FILE_EXTENSION}}
+        msg: "Couldn't locate runtime executable in '{{.GK_BIN_RELEASE_DIR}}/gk'"
+    cmds:
+      - "{{.GK_BIN_RELEASE_DIR}}/gk -boot -fakeiso -v"
   run-game:
     desc: "Start the game's runtime, to start the game itself the REPL is required"
     preconditions:

--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -1601,6 +1601,7 @@
   (scene-255                    #x12ff)
   (hint-0                       #x1300)
   (hint-511                     #x14ff)
+  (speedrunner-mode             #x1500)
 ;; GAME-TEXT-ID ENUM ENDS
   )
 

--- a/game/assets/jak1/text/game_text_en.gs
+++ b/game/assets/jak1/text/game_text_en.gs
@@ -342,6 +342,9 @@
 (#x1116 "NORSK"
         "NORSK")
 
+(#x1500 "SPEEDRUNNER MODE"
+        "SPEEDRUNNER MODE")
+
 ;; -----------------
 ;; test
 

--- a/goal_src/jak1/engine/debug/default-menu.gc
+++ b/goal_src/jak1/engine/debug/default-menu.gc
@@ -4668,6 +4668,7 @@
             (flag "uk-english" 6 dm-text-language)
             )
          (flag "Discord RPC" #t ,(dm-lambda-boolean-flag (-> *pc-settings* discord-rpc?)))
+         (flag "Speedrunner Mode" #t ,(dm-lambda-boolean-flag (-> *pc-settings* speedrunner-mode?)))
          (menu "PS2 settings"
             ;(flag "PS2 Load speed" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-read-speed?)))
             (flag "PS2 Particles" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-parts?)))

--- a/goal_src/jak1/engine/game/game-save.gc
+++ b/goal_src/jak1/engine/game/game-save.gc
@@ -1726,7 +1726,9 @@
                )
            (suspend)
            )
-         (activate-progress *dproc* (progress-screen auto-save))
+         ;; Don't display the auto-save warning prompt if speedrunning
+         (when (= (-> *pc-settings* speedrunner-mode?) #f)
+               (activate-progress *dproc* (progress-screen auto-save)))
          )
        )
       )

--- a/goal_src/jak1/engine/ui/progress/progress.gc
+++ b/goal_src/jak1/engine/ui/progress/progress.gc
@@ -1727,11 +1727,21 @@
                                  (let ((gp-1 (-> *setting-control* default auto-save)))
                                    (sound-volume-off)
                                    (set! (-> *game-info* mode) 'play)
-                                   (initialize! *game-info* 'game (the-as game-save #f) "intro-start")
-                                   (set! (-> *setting-control* default auto-save) gp-1)
-                                   )
-                                 (set-master-mode 'game)
-                                 )
+                                   ;; Start a new game differently if speedrunning mode is active
+                                   (cond ((= (-> *pc-settings* speedrunner-mode?) #t)
+                                          ;; spawn at the warp gate
+                                          (initialize! *game-info* 'game (the-as game-save #f) "game-start")
+                                          ;; disable hints (this seems to be overriden by your slot 1 save though)
+                                          (set! (-> *setting-control* default play-hints) #f)
+                                          ;; skip intro cutscene
+                                          (close-specific-task! (game-task intro) (task-status need-resolution))
+                                          ;; enable auto saving by default
+                                          (set! (-> *setting-control* default auto-save) #t))
+                                         ;; start the game normally
+                                         (else
+                                          (initialize! *game-info* 'game (the-as game-save #f) "intro-start")
+                                          (set! (-> *setting-control* default auto-save) gp-1))))
+                                 (set-master-mode 'game))
                                 (else
                                   (set! v0-0 (the-as none -1))
                                   (set! (-> self next-display-state) (the-as progress-screen v0-0))

--- a/goal_src/jak1/engine/ui/text-h.gc
+++ b/goal_src/jak1/engine/ui/text-h.gc
@@ -751,6 +751,7 @@
   (scene-255                    #x12ff)
   (hint-0                       #x1300)
   (hint-511                     #x14ff)
+  (speedrunner-mode             #x1500)
 ;; GAME-TEXT-ID ENUM ENDS
   )
 

--- a/goal_src/jak1/pc/pckernel-h.gc
+++ b/goal_src/jak1/pc/pckernel-h.gc
@@ -302,6 +302,7 @@
    (scenes-seen uint8 PC_SPOOL_LOG_LENGTH) ;; cutscenes that have been seen, by spool-anim (maybe use 8-char name or bits instead?)
 
    (discord-rpc? symbol) ;; enable discord rich presence integration
+   (speedrunner-mode? symbol) ;; enable speedrunner mode
 
    (cheats pc-cheats)
    (cheats-known pc-cheats)
@@ -404,6 +405,7 @@
   (set! (-> obj aspect-custom-x) 4)
   (set! (-> obj aspect-custom-y) 3)
   (set! (-> obj discord-rpc?) #t)
+  (set! (-> obj speedrunner-mode?) #f)
   (set! (-> obj window-lock?) #t)
 
   (reset-gfx obj)

--- a/goal_src/jak1/pc/pckernel.gc
+++ b/goal_src/jak1/pc/pckernel.gc
@@ -793,7 +793,7 @@
                   (set! (-> obj aspect-custom-y) (file-stream-read-int file))
                   ;; aspect auto
                   (set! (-> obj aspect-ratio-auto?) (file-stream-read-symbol file))
-                  
+
                   (unless (-> obj aspect-ratio-auto?)
                       (set-aspect! obj (-> obj aspect-custom-x) (-> obj aspect-custom-y))
                       )
@@ -833,6 +833,7 @@
                 (("subtitles?") (set! (-> obj subtitles?) (file-stream-read-symbol file)))
                 (("hinttitles?") (set! (-> obj hinttitles?) (file-stream-read-symbol file)))
                 (("discord-rpc?") (set! (-> obj discord-rpc?) (file-stream-read-symbol file)))
+                (("speedrunner-mode?") (set! (-> obj speedrunner-mode?) (file-stream-read-symbol file)))
                 (("first-camera-h-inverted?") (set! (-> obj first-camera-h-inverted?) (file-stream-read-symbol file)))
                 (("first-camera-v-inverted?") (set! (-> obj first-camera-v-inverted?) (file-stream-read-symbol file)))
                 (("third-camera-h-inverted?") (set! (-> obj third-camera-h-inverted?) (file-stream-read-symbol file)))
@@ -954,6 +955,7 @@
     (format file "  (use-vis? ~A)~%" (-> obj use-vis?))
     (format file "  (skip-movies? ~A)~%" (-> obj skip-movies?))
     (format file "  (discord-rpc? ~A)~%" (-> obj discord-rpc?))
+    (format file "  (speedrunner-mode? ~A)~%" (-> obj speedrunner-mode?))
     (format file "  (first-camera-h-inverted? ~A)~%" (-> obj first-camera-h-inverted?))
     (format file "  (first-camera-v-inverted? ~A)~%" (-> obj first-camera-v-inverted?))
     (format file "  (third-camera-h-inverted? ~A)~%" (-> obj third-camera-h-inverted?))

--- a/goal_src/jak1/pc/progress-pc.gc
+++ b/goal_src/jak1/pc/progress-pc.gc
@@ -162,6 +162,7 @@
 (define *misc-options* (new 'static 'boxed-array :type game-option
     (new 'static 'game-option :option-type (game-option-type on-off) :name (game-text-id money-starburst) :scale #t)
     (new 'static 'game-option :option-type (game-option-type on-off) :name (game-text-id discord-rpc) :scale #t)
+    (new 'static 'game-option :option-type (game-option-type on-off) :name (game-text-id speedrunner-mode) :scale #t)
     (new 'static 'game-option :option-type (game-option-type button) :name (game-text-id back) :scale #t)
     )
   )
@@ -743,6 +744,7 @@
   (set! (-> *graphic-options-no-frame-rate-pc* 4 value-to-modify) (&-> *progress-carousell* int-backup))
   (set! (-> *misc-options* 0 value-to-modify) (&-> *pc-settings* money-starburst?))
   (set! (-> *misc-options* 1 value-to-modify) (&-> *pc-settings* discord-rpc?))
+  (set! (-> *misc-options* 2 value-to-modify) (&-> *pc-settings* speedrunner-mode?))
   (set! (-> *camera-options* 0 value-to-modify) (&-> *pc-settings* first-camera-h-inverted?))
   (set! (-> *camera-options* 1 value-to-modify) (&-> *pc-settings* first-camera-v-inverted?))
   (set! (-> *camera-options* 2 value-to-modify) (&-> *pc-settings* third-camera-h-inverted?))
@@ -1477,11 +1479,13 @@
              ((< (-> obj option-index) 4)
               (sound-play "start-options")
               (set! (-> *progress-state* which) (-> obj option-index))
+              ;; save slot selected
               (if (zero? (-> s5-0 file (-> obj option-index) present))
                   (set! (-> obj next-display-state) (progress-screen memcard-saving))
                   (set! (-> obj next-display-state) (progress-screen memcard-data-exists))
                   )
               )
+             ;; continue without saving
              ((and (= (-> obj display-state) (progress-screen save-game-title)) (= (-> obj option-index) 4))
               (sound-play "starts-options")
               (sound-volume-off)
@@ -1524,7 +1528,19 @@
                (sound-play "cursor-options")
                (sound-volume-off)
                (set! (-> *game-info* mode) 'play)
-               (initialize! *game-info* 'game (the-as game-save #f) "intro-start")
+               ;; Start a new game differently if speedrunning mode is active
+               (cond ((= (-> *pc-settings* speedrunner-mode?) #t)
+                      ;; spawn at the warp gate
+                      (initialize! *game-info* 'game (the-as game-save #f) "game-start")
+                      ;; disable hints (this seems to be overriden by your slot 1 save though)
+                      (set! (-> *setting-control* default play-hints) #f)
+                      ;; skip intro cutscene
+                      (close-specific-task! (game-task intro) (task-status need-resolution))
+                      ;; enable auto saving by default
+                      (set! (-> *setting-control* default auto-save) #t))
+                      ;; start the game normally
+                      (else
+                       (initialize! *game-info* 'game (the-as game-save #f) "intro-start")))
                (set-master-mode 'game)
                )
              )
@@ -1538,7 +1554,19 @@
               (sound-play "start-options")
               (sound-volume-off)
               (set! (-> *game-info* mode) 'play)
-              (initialize! *game-info* 'game (the-as game-save #f) "intro-start")
+              ;; Start a new game differently if speedrunning mode is active
+              (cond ((= (-> *pc-settings* speedrunner-mode?) #t)
+                     ;; spawn at the warp gate
+                     (initialize! *game-info* 'game (the-as game-save #f) "game-start")
+                     ;; disable hints (this seems to be overriden by your slot 1 save though)
+                     (set! (-> *setting-control* default play-hints) #f)
+                     ;; skip intro cutscene
+                     (close-specific-task! (game-task intro) (task-status need-resolution))
+                     ;; enable auto saving by default
+                     (set! (-> *setting-control* default auto-save) #t))
+                     ;; start the game normally
+                     (else
+                      (initialize! *game-info* 'game (the-as game-save #f) "intro-start")))
               (set-master-mode 'game)
               )
              ((nonzero? (-> obj display-state-stack 0))
@@ -1621,7 +1649,19 @@
               (sound-play "start-options")
               (sound-volume-off)
               (set! (-> *game-info* mode) 'play)
-              (initialize! *game-info* 'game (the-as game-save #f) "intro-start")
+              ;; Start a new game differently if speedrunning mode is active
+              (cond ((= (-> *pc-settings* speedrunner-mode?) #t)
+                     ;; spawn at the warp gate
+                     (initialize! *game-info* 'game (the-as game-save #f) "game-start")
+                     ;; disable hints (this seems to be overriden by your slot 1 save though)
+                     (set! (-> *setting-control* default play-hints) #f)
+                     ;; skip intro cutscene
+                     (close-specific-task! (game-task intro) (task-status need-resolution))
+                     ;; enable auto saving by default
+                     (set! (-> *setting-control* default auto-save) #t))
+                     ;; start the game normally
+                     (else
+                      (initialize! *game-info* 'game (the-as game-save #f) "intro-start")))
               (set-master-mode 'game)
               )
              (else


### PR DESCRIPTION
- skips intro cutscene
- removes auto-save prompt

https://www.youtube.com/watch?v=kyLDUQR_UbY

closes #1670 

Other ideas that im not 100% sure on yet (so didn't implement):
- constant fish rng seed
- an even faster way to reset the current save file (couldn't easily figure this out, very coupled with the progress screen right now it seems)
- skipping the "good training boys..." cutscene as well