### PR TITLE
game: fix transition from fullscreen (not borderless) to windowed

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -98,16 +98,6 @@ tasks:
   offline-tests:
     cmds:
       - '{{.OFFLINETEST_BIN_RELEASE_DIR}}/offline-test --iso_data_path "./iso_data/{{.GAME}}" --game {{.GAME}}'
-  # TODO - update or replace
-  # add-reference-test:
-  #   cmds:
-  #     - task: decomp-file
-  #     - python ./scripts/add-reference-test.py --file "{{.FILES}}"
-  #     - task: offline-tests
-  # add-reference-test-no-decomp:
-  #   cmds:
-  #     - python ./scripts/add-reference-test.py --file "{{.FILES}}"
-  #     - task: offline-tests
   update-ref-tests:
     cmds:
       - cmd: python ./scripts/tasks/default-file-or-folder.py --path failures

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -552,23 +552,14 @@ void GLDisplay::update_fullscreen(GfxDisplayMode mode, int screen) {
 
         width = m_last_windowed_width;
         height = m_last_windowed_height;
-        x = monitorX + (monitorWidth / 2) - (width / 2);
-        y = monitorY + (monitorHeight / 2) - (height / 2);
+        x = m_last_windowed_xpos;
+        y = m_last_windowed_ypos;
       }
 
       glfwSetWindowAttrib(m_window, GLFW_DECORATED, GLFW_TRUE);
       glfwSetWindowFocusCallback(m_window, NULL);
       glfwSetWindowAttrib(m_window, GLFW_FLOATING, GLFW_FALSE);
-
       glfwSetWindowMonitor(m_window, NULL, x, y, width, height, GLFW_DONT_CARE);
-
-      // these might have changed, only store them on a legit change, not on the initial update
-      if (m_last_fullscreen_mode != GfxDisplayMode::ForceUpdate) {
-        m_last_windowed_width = width;
-        m_last_windowed_height = height;
-        m_last_windowed_xpos = x;
-        m_last_windowed_ypos = y;
-      }
     } break;
     case GfxDisplayMode::Fullscreen: {
       // fullscreen

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -536,6 +536,7 @@ void GLDisplay::update_fullscreen(GfxDisplayMode mode, int screen) {
   switch (mode) {
     case GfxDisplayMode::Windowed: {
       // windowed
+      // TODO - display mode doesn't re-position the window
       int x, y, width, height;
 
       if (m_last_fullscreen_mode == GfxDisplayMode::Windowed) {
@@ -544,16 +545,33 @@ void GLDisplay::update_fullscreen(GfxDisplayMode mode, int screen) {
         height = m_last_windowed_height;
         x = m_last_windowed_xpos;
         y = m_last_windowed_ypos;
+        lg::debug("Windowed -> Windowed - x:{} | y:{}", x, y);
       } else {
-        // fullscreen -> windowed, use last windowed size but on the monitor previously
-        // fullscreened
+        // fullscreen -> windowed, use last windowed size but on the monitor previously fullscreened
+        //
+        // glfwGetMonitorWorkarea will return the width/height of the scaled fullscreen window
+        // - for example, you full screened a 1280x720 game on a 4K monitor -- you won't get the 4k
+        // resolution!
+        //
+        // Additionally, the coordinates for the top left seem very weird in stacked displays (you
+        // get a negative Y coordinate)
         int monitorX, monitorY, monitorWidth, monitorHeight;
         glfwGetMonitorWorkarea(monitor, &monitorX, &monitorY, &monitorWidth, &monitorHeight);
 
         width = m_last_windowed_width;
         height = m_last_windowed_height;
-        x = m_last_windowed_xpos;
-        y = m_last_windowed_ypos;
+        if (monitorX < 0) {
+          x = monitorX - 50;
+        } else {
+          x = monitorX + 50;
+        }
+        if (monitorY < 0) {
+          y = monitorY - 50;
+        } else {
+          y = monitorY + 50;
+        }
+        lg::debug("FS -> Windowed screen: {} - x:{}:{}/{} | y:{}:{}/{}", screen, monitorX, x, width,
+                  monitorY, y, height);
       }
 
       glfwSetWindowAttrib(m_window, GLFW_DECORATED, GLFW_TRUE);
@@ -562,6 +580,8 @@ void GLDisplay::update_fullscreen(GfxDisplayMode mode, int screen) {
       glfwSetWindowMonitor(m_window, NULL, x, y, width, height, GLFW_DONT_CARE);
     } break;
     case GfxDisplayMode::Fullscreen: {
+      // TODO - when transitioning from fullscreen to windowed, it will use the old primary display
+      // which is to say, dragging the window to a different monitor won't update the used display
       // fullscreen
       const GLFWvidmode* vmode = glfwGetVideoMode(monitor);
       glfwSetWindowAttrib(m_window, GLFW_DECORATED, GLFW_FALSE);
@@ -570,6 +590,8 @@ void GLDisplay::update_fullscreen(GfxDisplayMode mode, int screen) {
       glfwSetWindowMonitor(m_window, monitor, 0, 0, vmode->width, vmode->height, GLFW_DONT_CARE);
     } break;
     case GfxDisplayMode::Borderless: {
+      // TODO - when transitioning from fullscreen to windowed, it will use the old primary display
+      // which is to say, dragging the window to a different monitor won't update the used display
       // borderless fullscreen
       int x, y;
       glfwGetMonitorPos(monitor, &x, &y);


### PR DESCRIPTION
There seems to be no reason to update the values here, they are updated by callbacks when moving the window.

There might be value in adding a check to reset to defaults if the monitor changes and it's off-screen, but that's a bit out of scope for this fix (original code only did this by accident).

When restoring to windowed mode, actually use the last position instead of the center of the monitor.