### PR TITLE
jak1: put the auto-splitting marker in C++ so it can be quickly found

### DIFF
--- a/game/kernel/jak1/kmachine.cpp
+++ b/game/kernel/jak1/kmachine.cpp
@@ -292,6 +292,8 @@ void InitIOP() {
   }
 }
 
+AutoSplitterBlock gAutoSplitterBlock;
+
 /*!
  * Initialize GOAL Runtime. This is the main initialization which is called before entering
  * the GOAL kernel dispatch loop (KernelCheckAndDispatch).
@@ -353,6 +355,10 @@ int InitMachine() {
   if (goal_status < 0) {
     return goal_status;
   }
+
+  // TODO - better place to put this?
+  gAutoSplitterBlock.pointer_to_symbol =
+      (u64)g_ee_main_mem + intern_from_c("*autosplit-info-jak1*")->value;
 
   lg::info("InitListenerConnect");
   InitListenerConnect();

--- a/game/kernel/jak1/kmachine.h
+++ b/game/kernel/jak1/kmachine.h
@@ -39,4 +39,13 @@ struct DiscordInfo {
   u32 flutflut;   // are we riding on flut flut?
   u32 time_of_day;
 };
+
+// To speedup finding the auto-splitter block in GOAL memory
+// all this has is a marker for LiveSplit to find, and then the pointer
+// to the symbol
+struct AutoSplitterBlock {
+  const char marker[20] = "UnLiStEdStRaTs_JaK1";
+  u64 pointer_to_symbol = 0;
+};
+extern AutoSplitterBlock gAutoSplitterBlock;
 }  // namespace jak1

--- a/goal_src/jak1/pc/features/autosplit-h.gc
+++ b/goal_src/jak1/pc/features/autosplit-h.gc
@@ -7,8 +7,7 @@
 ;;
 ;; DO NOT change the order, appending to the end is safe!
 (deftype autosplit-info-jak1 (structure)
-  ((marker uint8 20) ;; UnLiStEdStRaTs_JaK1 - DONT EVER CHANGE THIS
-   ;; General stats
+  (;; General stats
    (num-power-cells uint32)
    (num-orbs uint32)
    (num-scout-flies uint32)

--- a/goal_src/jak1/pc/features/autosplit.gc
+++ b/goal_src/jak1/pc/features/autosplit.gc
@@ -3,7 +3,6 @@
 
 (define *autosplit-info-jak1* (new 'static 'autosplit-info-jak1))
 ;; Setup markers
-(charp<-string (-> *autosplit-info-jak1* marker) "UnLiStEdStRaTs_JaK1")
 (charp<-string (-> *autosplit-info-jak1* end-marker) "end")
 ;; Setup Padding
 (charp<-string (-> *autosplit-info-jak1* padding-stats) "padding-stats!")


### PR DESCRIPTION
Searching the entire address range was just too slow, this keeps the struct in GOAL but puts a pointer to it inside the C++ side.  The ASL script can quickly scan these modules in memory and the potential range is much smaller.

This takes the average search from 1000-10000ms to 5-100ms.