### PR TITLE
[goalc] Fix error when putting #f in an array of symbols

### DIFF
--- a/goalc/compiler/compilation/Static.cpp
+++ b/goalc/compiler/compilation/Static.cpp
@@ -848,8 +848,10 @@ void Compiler::fill_static_array_inline(const goos::Object& form,
       typecheck(form, TypeSpec("integer"), sr.typespec());
     } else {
       if (sr.is_symbol() && sr.symbol_name() == "#f") {
-        // allow #f for any structure.
-        typecheck(form, TypeSpec("structure"), content_type);
+        // allow #f for any structure, or symbol (no longer a structure in jak 2)
+        if (content_type.base_type() != "symbol") {
+          typecheck(form, TypeSpec("structure"), content_type);
+        }
       } else {
         typecheck(form, content_type, sr.typespec());
       }

--- a/test/goalc/source_templates/jak2/jak2-mega-test.gc
+++ b/test/goalc/source_templates/jak2/jak2-mega-test.gc
@@ -26,6 +26,9 @@
         (-> type parent parent parent)
         (-> type parent parent parent parent))
 
+(define *array-of-syms* (new 'static 'array symbol 2 'asdf #f))
+(format #t "array: ~A ~A~%" (-> *array-of-syms* 0) (-> *array-of-syms* 1))
+
 #|
 empty pair: () () () #t #f\
 empty pair type: pair
@@ -34,4 +37,5 @@ basic types: type symbol string function
 bools: #t #f #t #f #f #t
 zero: 0
 parent of type: basic structure object object
+array: asdf #f
 |#

--- a/test/goalc/test_jak2_compiler.cpp
+++ b/test/goalc/test_jak2_compiler.cpp
@@ -51,5 +51,6 @@ TEST_F(Jak2GoalcTests, All) {
                            "basic types: type symbol string function\n"
                            "bools: #t #f #t #f #f #t\n"
                            "zero: 0\n"
-                           "parent of type: basic structure object object\n0\n"});
+                           "parent of type: basic structure object object\n"
+                           "array: asdf #f\n0\n"});
 }


### PR DESCRIPTION
Will fix the symbol array issue mentioned here: https://github.com/open-goal/jak-project/pull/1802

We do already support symbol arrays, there was just a jak2-specific bug in the logic that special cases `#f` (which can be used without a quote, and in place of any structure, not just a symbol).

Also adds a test.