### PR TITLE
Make the citadel elevator come up when cutscene is skipped

### DIFF
--- a/goal_src/jak1/levels/citadel/citadel-sages.gc
+++ b/goal_src/jak1/levels/citadel/citadel-sages.gc
@@ -1070,6 +1070,7 @@
       (when (and (= (get-response (-> self query)) 'no) (or (not (= *cheat-mode* 'debug)) (not (cpad-hold? 0 r1))) (= (-> self which-movie) 1))
           (format #t "skipped green-sagecage~%")
           (start 'play (get-continue-by-name *game-info* "citadel-elevator"))
+          (send-event (process-by-name "citb-exit-plat-4" *active-pool*) 'trigger)
           (set! (-> self draw bounds w) 10240.0)
           ((-> (method-of-type process-taskable play-anim) exit))
           (set! (-> self which-movie) 2)


### PR DESCRIPTION
Still comes up from the bottom, but its probably the "correct" way to do it?

The other alternative would be killing Jak when the cutscene is skipped instead of `(start 'play (get-continue-by-name *game-info* "citadel-elevator"))`  To automatically force that reset and have the elevator at base height.
This would make the elevator at the top instantly, however it might mess with hp values and stored levels.

Credit to Barg/dallmeyer

Closes #1831