### PR TITLE
lsp: re-analyze IR2 files when they change

### DIFF
--- a/decompiler/ObjectFile/ObjectFileDB_IR2.cpp
+++ b/decompiler/ObjectFile/ObjectFileDB_IR2.cpp
@@ -552,7 +552,7 @@ void ObjectFileDB::ir2_type_analysis_pass(int seg, const Config& config, ObjectF
             func.ir2.env.set_types(out.block_init_types, out.op_end_types, *func.ir2.atomic_ops,
                                    ts);
           } catch (const std::exception& e) {
-            func.warnings.warning("Type analysis failed: {}", e.what());
+            func.warnings.error("Type analysis failed: {}", e.what());
           }
           func.ir2.env.types_succeeded = out.succeeded;
         } else {
@@ -560,7 +560,7 @@ void ObjectFileDB::ir2_type_analysis_pass(int seg, const Config& config, ObjectF
           if (run_type_analysis_ir2(ts, dts, func)) {
             func.ir2.env.types_succeeded = true;
           } else {
-            func.warnings.warning("Type analysis failed");
+            func.warnings.error("Type analysis failed");
           }
         }
       } else {

--- a/lsp/handlers/lsp_router.cpp
+++ b/lsp/handlers/lsp_router.cpp
@@ -108,7 +108,6 @@ std::optional<std::vector<std::string>> LSPRouter::route_message(
     if (route.m_post_notification_publish) {
       auto resp = route.m_post_notification_publish.value()(appstate.workspace, body["params"]);
       if (resp) {
-        lg::info("adding publish resp");
         resp_bodies.push_back(resp.value());
       }
     }

--- a/lsp/main.cpp
+++ b/lsp/main.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
         for (const auto& response : responses.value()) {
           std::cout << response.c_str() << std::flush;
           if (appstate.verbose) {
-            lg::debug("<<< Sending message: {}", response);
+            lg::trace("<<< Sending message: {}", response);
           } else {
             lg::info("<<< Sending message of method '{}'", method_name);
           }

--- a/lsp/protocol/document_synchronization.cpp
+++ b/lsp/protocol/document_synchronization.cpp
@@ -17,11 +17,12 @@ void LSPSpec::from_json(const json& j, TextDocumentContentChangeEvent& obj) {
 }
 
 void LSPSpec::to_json(json& j, const DidChangeTextDocumentParams& obj) {
-  j = json{{"textDocument", obj.m_textDocument}};
+  j = json{{"textDocument", obj.m_textDocument}, {"contentChanges", obj.m_contentChanges}};
 }
 
 void LSPSpec::from_json(const json& j, DidChangeTextDocumentParams& obj) {
   j.at("textDocument").get_to(obj.m_textDocument);
+  j.at("contentChanges").get_to(obj.m_contentChanges);
 }
 
 void LSPSpec::to_json(json& j, const DidCloseTextDocumentParams& obj) {

--- a/lsp/transport/stdio.cpp
+++ b/lsp/transport/stdio.cpp
@@ -41,7 +41,7 @@ void MessageBuffer::handle_char(char c) {
     // If so, add it to our known headers.
     // We'll also reset our string then.
     if (!header_name.empty()) {
-      lg::debug("found header!");
+      lg::trace("found header!");
       m_headers[header_name] = header_value;
       m_raw_message.clear();
     }
@@ -53,7 +53,7 @@ void MessageBuffer::handle_char(char c) {
     m_raw_message.clear();
     m_is_header_done = true;
     m_reading_content = true;
-    lg::debug("Header complete, content length: {}", m_headers["Content-Length"]);
+    lg::trace("Header complete, content length: {}", m_headers["Content-Length"]);
   }
 
   if (m_is_header_done) {

--- a/test/decompiler/reference/jak1/engine/anim/joint_REF.gc
+++ b/test/decompiler/reference/jak1/engine/anim/joint_REF.gc
@@ -541,7 +541,7 @@
 
 ;; definition for method 9 of type art-mesh-geo
 ;; ERROR: Type Propagation failed: Failed type prop at op 20 ((set! v1 (l.h (+ s4 6)))): Could not get type of load: (set! v1 (l.h (+ s4 6))). 
-;; WARN: Type analysis failed
+;; ERROR: Type analysis failed
 (defmethod login art-mesh-geo ((a0-0 art-mesh-geo))
   (local-vars
     (v0-0 none)

--- a/test/decompiler/reference/jak1/engine/draw/drawable_REF.gc
+++ b/test/decompiler/reference/jak1/engine/draw/drawable_REF.gc
@@ -134,7 +134,7 @@
 
 ;; definition for function vis-cull
 ;; ERROR: Type Propagation failed: Failed type prop at op 3 ((set! v1 (l.b (+ v1 #x38b0)))): Could not get type of load: (set! v1 (l.b (+ v1 #x38b0))). 
-;; WARN: Type analysis failed
+;; ERROR: Type analysis failed
 ;; ERROR: Unsupported inline assembly instruction kind - [addiu a0, a0, 56]
 (defun vis-cull ((a0-0 int))
   (local-vars (v0-0 none) (v1-0 int) (v1-1 int) (v1-2 none) (v1-3 none) (a0-1 none) (a0-2 none) (a1-0 int))

--- a/test/decompiler/reference/jak1/engine/gfx/sky/sky_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/sky/sky_REF.gc
@@ -139,7 +139,7 @@
 
 ;; definition for function sky-draw
 ;; ERROR: Type Propagation failed: Failed type prop at op 12 ((set! a0 (+ a0 16))): Cannot get_type_int2: (+ a0 16), args float and <integer 16>
-;; WARN: Type analysis failed
+;; ERROR: Type analysis failed
 (defun sky-draw ((a0-0 sky-parms))
   (local-vars
     (v0-0 none)

--- a/test/decompiler/reference/jak1/engine/util/glist_REF.gc
+++ b/test/decompiler/reference/jak1/engine/util/glist_REF.gc
@@ -112,7 +112,7 @@
 
 ;; definition for function glst-find-node-by-name
 ;; ERROR: Type Propagation failed: Failed type prop at op 7 ((set! a0 (l.wu (+ v1 8)))): Could not get type of load: (set! a0 (l.wu (+ v1 8))). 
-;; WARN: Type analysis failed
+;; ERROR: Type analysis failed
 (defun glst-find-node-by-name ((a0-0 glst-list) (a1-0 string))
   (local-vars
     (v0-0 none)
@@ -173,7 +173,7 @@
 
 ;; definition for function glst-length-of-longest-name
 ;; ERROR: Type Propagation failed: Failed type prop at op 6 ((set! a0 (l.wu (+ v1 8)))): Could not get type of load: (set! a0 (l.wu (+ v1 8))). 
-;; WARN: Type analysis failed
+;; ERROR: Type analysis failed
 (defun glst-length-of-longest-name ((a0-0 glst-list))
   (local-vars
     (v0-0 none)

--- a/test/decompiler/reference/jak1/levels/rolling/rolling-obs_REF.gc
+++ b/test/decompiler/reference/jak1/levels/rolling/rolling-obs_REF.gc
@@ -872,7 +872,7 @@
 
 ;; definition for function race-time-save
 ;; ERROR: Type Propagation failed: Failed type prop at op 6 ((set! v1 (l.wu (+ a0 -4)))): Could not get type of load: (set! v1 (l.wu (+ a0 -4))). 
-;; WARN: Type analysis failed
+;; ERROR: Type analysis failed
 ;; ERROR: Function may read a register that is not set: a2
 (defun race-time-save ((a0-0 race-time) (a1-0 task-control))
   (local-vars

--- a/test/decompiler/reference/jak2/engine/anim/joint_REF.gc
+++ b/test/decompiler/reference/jak2/engine/anim/joint_REF.gc
@@ -2160,7 +2160,3 @@
 
 ;; failed to figure out what this is:
 (kmemclose)
-
-
-
-


### PR DESCRIPTION
I wasn't fully parsing the JSON LSP request so files weren't being updated -- seems to have fixed it.  Also cleaned up some logs / made `type analysis failed:...` warnings errors instead