### PR TITLE
[speedrun] Show speedrun information at start of run

### DIFF
--- a/goal_src/jak1/engine/game/main.gc
+++ b/goal_src/jak1/engine/game/main.gc
@@ -695,13 +695,9 @@
 
       (with-profiler "menu"
         (with-pc
-          (cond ((and (= (-> *pc-settings* speedrunner-mode?) #t)
-                      (< (-> *autosplit-info-jak1* num-power-cells) 1))
-                 ;; display the revision before you collect your first powercell
-                 (draw-build-revision))
-                ((and (-> *pc-settings* display-sha) *debug-segment*)
-                 ;; otherwise, only draw if we are in debug mode and the setting isn't enabled
-                 (draw-build-revision))))
+          (if 
+            (and (-> *pc-settings* display-sha) *debug-segment*)
+            (draw-build-revision)))
         (*menu-hook*)
         (add-ee-profile-frame 'draw :g #x40)
 

--- a/goal_src/jak1/pc/features/autosplit.gc
+++ b/goal_src/jak1/pc/features/autosplit.gc
@@ -1,6 +1,6 @@
 ;;-*-Lisp-*-
 (in-package goal)
-
+(defun-extern draw-speedrun-settings (none))
 (define *autosplit-info-jak1* (new 'static 'autosplit-info-jak1))
 ;; Setup markers
 (charp<-string (-> *autosplit-info-jak1* end-marker) "end")
@@ -132,6 +132,7 @@
   (set! (-> *autosplit-info-jak1* int-jungle-fishgame) (if (task-closed? (game-task jungle-fishgame) (task-status need-introduction)) 1 0))
 
   ;; end
+  (draw-speedrun-settings)
   (none))
 
 

--- a/goal_src/jak1/pc/features/speedruns-h.gc
+++ b/goal_src/jak1/pc/features/speedruns-h.gc
@@ -2,3 +2,22 @@
 (in-package goal)
 
 (define-extern speedrun-start-run (function none))
+
+
+(defun draw-speedrun-settings ()
+  "debug draw"
+(if (and (-> *pc-settings* speedrunner-mode?)(< (-> *autosplit-info-jak1* num-power-cells) 1))
+(begin
+(format *pc-temp-string* "OpenGOAL Version: ~S ~%Speedrun mode: ~A ~%Cutscene Skips ~A" *pc-settings-built-sha* (-> *pc-settings* speedrunner-mode?) (-> *pc-settings* cutscene-skips?))
+  (with-dma-buffer-add-bucket ((buf (-> (current-frame) global-buf))
+                                     (bucket-id debug-no-zbuf))
+          (draw-string-xy *pc-temp-string*
+                          buf
+                          0
+                          (* 200 (-> *video-parms* relative-y-scale))
+                          (font-color flat-yellow)
+                          (font-flags shadow kerning)))
+                          (clear *pc-temp-string*)))
+                          (none)
+                          )
+


### PR DESCRIPTION
This shows the current settings needed to help provide information when verifying a run, also it removes the two calls to show the version in main.gc and instead does it within the speedrun/auto splitting scope.

- Shows Version
- Shows if Speedrunner mode is on (technically pointless since the text only displays when it is enabled this more just serves to show that there IS a speedrunner mode to viewers and stuff (josh) So hopefully it may cut down on submissions with the mode off)
- Shows if cutscene skips is enabled/disabled.

Tested on 16x9 4x3 the really weird one and borderless/fullscreen

[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/qDC-beEg5Es/0.jpg)](https://www.youtube.com/watch?v=qDC-beEg5Es)