### PR TITLE
Turn off hints by default and fix the description of hints

### DIFF
--- a/goal_src/jak1/pc/pckernel-h.gc
+++ b/goal_src/jak1/pc/pckernel-h.gc
@@ -279,7 +279,7 @@
    (ps2-parts? symbol) ;; if off, increase particle cap
    (ps2-music? symbol) ;; if off, use .wav files stored somewhere
    (ps2-se? symbol) ;; if off, use adjusted sound effects
-   (ps2-hints? symbol) ;; if off, enables extra game hints
+   (ps2-hints? symbol) ;; if on, enables extra game hints
 
    ;; lod settings
    (ps2-lod-dist? symbol) ;; use original lod distances
@@ -480,7 +480,7 @@
   (set! (-> obj ps2-parts?) #f)
   (set! (-> obj ps2-music?) #t)
   (set! (-> obj ps2-se?) #t)
-  (set! (-> obj ps2-hints?) #t)
+  (set! (-> obj ps2-hints?) #f)
 
   (set! (-> obj ps2-lod-dist?) #f)
   (set! (-> obj force-envmap?) #f)


### PR DESCRIPTION
This is just my preference. I get if this change is rejected. But the description of ps2-hints was just backwards either way.