### PR TITLE
[decompiler] fix local_vars assert on static lambda

### DIFF
--- a/decompiler/util/data_decompile.cpp
+++ b/decompiler/util/data_decompile.cpp
@@ -163,7 +163,8 @@ goos::Object decompile_function_at_label(const DecompilerLabel& label,
                                          const LinkedObjectFile* file) {
   if (file) {
     auto other_func = file->try_get_function_at_label(label);
-    if (other_func) {
+    if (other_func && other_func->ir2.env.has_local_vars() && other_func->ir2.top_form &&
+        other_func->ir2.expressions_succeeded) {
       return final_output_lambda(*other_func);
     }
   }


### PR DESCRIPTION
Fixes a crash when there's a `(new 'static 'something :field <some anonymous function with a particular set of errors in the decompler>)`.  The output will now be
```
 (set! *duck-mods* (new 'static 'surface
                      :name 'duck
...
                      :mult-hook <lambda at L615>
                      :flags (surface-flag duck)
                      )
```

fixes https://github.com/open-goal/jak-project/issues/1882