### PR TITLE
tests: allow for a single file to be tested in the offline-tests at a time

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -110,6 +110,9 @@ tasks:
   offline-tests:
     cmds:
       - '{{.OFFLINETEST_BIN_RELEASE_DIR}}/offline-test --iso_data_path "./iso_data/{{.GAME}}" --game {{.GAME}}'
+  offline-test-file:
+    cmds:
+      - '{{.OFFLINETEST_BIN_RELEASE_DIR}}/offline-test --iso_data_path "./iso_data/{{.GAME}}" --game {{.GAME}} --file {{.FILE}}'
   update-ref-tests:
     cmds:
       - cmd: python ./scripts/tasks/default-file-or-folder.py --path failures
@@ -117,6 +120,13 @@ tasks:
         ignore_error: true
       - python ./scripts/update_decomp_reference.py ./failures ./test/decompiler/reference/ --game {{.GAME}}
       - task: offline-tests
+  update-ref-file:
+    cmds:
+      - cmd: python ./scripts/tasks/default-file-or-folder.py --path failures
+      - cmd: '{{.OFFLINETEST_BIN_RELEASE_DIR}}/offline-test --iso_data_path "./iso_data/{{.GAME}}" --file {{.FILE}} --game {{.GAME}} --dump_current_output'
+        ignore_error: true
+      - python ./scripts/update_decomp_reference.py ./failures ./test/decompiler/reference/ --game {{.GAME}}
+      - task: offline-test-file
   # check-gsrc-file:
   #   cmds:
   #     - python ./scripts/check-gsrc-file.py --files "{{.FILES}}"


### PR DESCRIPTION
A small quality of life increase that is more impactful since jak 2 has double the file count.

I often use the offline-tests to find compiler errors / automatically resolve them when i am finalizing a file.  As more and more files are completed this becomes increasingly more inefficient.  When I know that only 1 file needs to be decompiled / compared / compiled, I'd prefer to have a feature like this.