### PR TITLE
fix test failure and stop running manual tests in CI

### DIFF
--- a/decompiler/config/jak2/all-types.gc
+++ b/decompiler/config/jak2/all-types.gc
@@ -47561,6 +47561,7 @@
     )
   )
 
+;; +++nav-graph-h:nav-node-flag-byte
 (defenum nav-node-flag-byte
   "The same as [[nav-node-flag]] but more compact"
   :type uint8
@@ -47570,6 +47571,7 @@
   (pedestrian 2)
   (selected 3)
   (hidden 4))
+;; ---nav-graph-h:nav-node-flag-byte
 
 (deftype nav-node (structure)
   (

--- a/goal_src/jak2/levels/city/common/nav-graph-h.gc
+++ b/goal_src/jak2/levels/city/common/nav-graph-h.gc
@@ -5,6 +5,21 @@
 ;; name in dgo: nav-graph-h
 ;; dgos: CWI
 
+(declare-type nav-node structure)
+
+;; +++nav-node-flag-byte
+(defenum nav-node-flag-byte
+  "The same as [[nav-node-flag]] but more compact"
+  :type uint8
+  :bitfield #t
+  (visited 0)
+  (blocked 1)
+  (pedestrian 2)
+  (selected 3)
+  (hidden 4))
+;; ---nav-node-flag-byte
+
+
 ;; DECOMP BEGINS
 
 (deftype nav-branch (structure)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,7 +51,7 @@ if(UNIX AND CMAKE_COMPILER_IS_GNUCXX AND CODE_COVERAGE)
   include(CodeCoverage)
   append_coverage_compiler_flags()
   setup_target_for_coverage_lcov(NAME goalc-test_coverage
-                                 EXECUTABLE goalc-test --gtest_color=yes --gtest_brief=1
+                                 EXECUTABLE goalc-test --gtest_color=yes --gtest_brief=1 --gtest_filter="-*MANUAL_TEST*"
                                  DEPENDENCIES goalc-test
                                  EXCLUDE "third-party/*" "/usr/include/*")
 endif()


### PR DESCRIPTION
Turns out the GCC test was running these MANUAL_TESTs which are essentially the same as running an `mi`

I'm kinda torn on whether or not these should go away, as it would have caught this mistake before merging, but it was decided a long time ago that they shouldn't be run (why they are marked MANUAL).

Either way, this fixes the current test failure in master