### PR TITLE
Ignore backups from OpenMaya

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ __pycache__/
 # sqlite stuff
 *.db
 *.db-journal
+
+# backup files from OpenMaya
+*.bak


### PR DESCRIPTION
For the level builder, I use .bak files whenever I modify a core file in the project. These let you undo changes, but they don't need to be pushed. I also couldn't find a nice way to do this, but we should also ignore all contents of custom_levels besides test-zone.