### PR TITLE
tests: run tests in gcc runner again

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,7 +51,7 @@ if(UNIX AND CMAKE_COMPILER_IS_GNUCXX AND CODE_COVERAGE)
   include(CodeCoverage)
   append_coverage_compiler_flags()
   setup_target_for_coverage_lcov(NAME goalc-test_coverage
-                                 EXECUTABLE goalc-test --gtest_color=yes --gtest_brief=0 --gtest_filter=\"-*MANUAL_TEST*\"
+                                 EXECUTABLE goalc-test --gtest_color=yes
                                  DEPENDENCIES goalc-test
                                  EXCLUDE "third-party/*" "/usr/include/*")
 endif()


### PR DESCRIPTION
Not sure why this stopped working because i added extra args, might be due to the ninja warning about a duplicate target name