### PR TITLE
vscode: add snippets for supported `;; og:...` comments

### DIFF
--- a/.vscode/opengoal.code-snippets
+++ b/.vscode/opengoal.code-snippets
@@ -1,0 +1,20 @@
+{
+	"og:ignore-from-loc": {
+		"scope": "opengoal",
+    "prefix": ["og:ignore-from-loc"],
+    "body": [";; og:ignore-from-loc"],
+    "description": "Marks the file to be excluded from the LoC count"
+  },
+  "og:ignore-errors": {
+		"scope": "opengoal",
+    "prefix": ["og:ignore-errors"],
+    "body": [";; og:ignore-errors"],
+    "description": "Ignore lines beginning with ';; ERROR:' or ';; WARN:' when copying decompiled code into it"
+  },
+  "og:ignore-form": {
+		"scope": "opengoal",
+    "prefix": ["og:ignore-form"],
+    "body": [";; og:ignore-form:${1:substr}"],
+    "description": "If the provided substr is found in the starting line of a form, the entire form will be omitted when copying decompiled code into the file"
+  },
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,12 @@
 {
-  "terminal.integrated.scrollback": 32000,
+  "[opengoal]": {
+    "editor.quickSuggestions": {
+      "other": true,
+      "comments": true,
+      "strings": true
+    },
+    "editor.wordBasedSuggestions": true,
+    "editor.snippetSuggestions": "top"
+  },
   "python.formatting.provider": "black",
 }

--- a/lsp/CMakeLists.txt
+++ b/lsp/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(lsp
   state/workspace.cpp
   handlers/lsp_router.cpp
   protocol/common_types.cpp
+  protocol/completion.cpp
   protocol/document_symbols.cpp
   protocol/document_synchronization.cpp
   protocol/document_diagnostics.cpp

--- a/lsp/handlers/lsp_router.cpp
+++ b/lsp/handlers/lsp_router.cpp
@@ -4,11 +4,11 @@
 
 #include "lsp/handlers/initialize.h"
 #include "lsp/protocol/error_codes.h"
+#include "text_document/completion.h"
 #include "text_document/document_symbol.h"
 #include "text_document/document_synchronization.h"
 #include "text_document/go_to.h"
 #include "text_document/hover.h"
-#include "text_document/completion.h"
 
 #include "third-party/fmt/core.h"
 

--- a/lsp/handlers/lsp_router.cpp
+++ b/lsp/handlers/lsp_router.cpp
@@ -8,6 +8,7 @@
 #include "text_document/document_synchronization.h"
 #include "text_document/go_to.h"
 #include "text_document/hover.h"
+#include "text_document/completion.h"
 
 #include "third-party/fmt/core.h"
 
@@ -37,6 +38,7 @@ void LSPRouter::init_routes() {
   m_routes["textDocument/didClose"] = LSPRoute(did_close_handler);
   m_routes["textDocument/hover"] = LSPRoute(hover_handler);
   m_routes["textDocument/definition"] = LSPRoute(go_to_definition_handler);
+  m_routes["textDocument/completion"] = LSPRoute(get_completions_handler);
 }
 
 json error_resp(ErrorCodes error_code, const std::string& error_message) {

--- a/lsp/handlers/text_document/completion.h
+++ b/lsp/handlers/text_document/completion.h
@@ -1,0 +1,14 @@
+#include <optional>
+
+#include "lsp/protocol/common_types.h"
+#include "lsp/protocol/completion.h"
+#include "lsp/state/data/mips_instructions.h"
+#include "lsp/state/workspace.h"
+
+std::optional<json> get_completions_handler(Workspace& workspace, int id, json params) {
+  auto converted_params = params.get<LSPSpec::CompletionParams>();
+
+  // TODO - implement response object
+
+  return json::array();;
+}

--- a/lsp/handlers/text_document/completion.h
+++ b/lsp/handlers/text_document/completion.h
@@ -10,5 +10,6 @@ std::optional<json> get_completions_handler(Workspace& workspace, int id, json p
 
   // TODO - implement response object
 
-  return json::array();;
+  return json::array();
+  ;
 }

--- a/lsp/protocol/completion.cpp
+++ b/lsp/protocol/completion.cpp
@@ -1,0 +1,10 @@
+#include "completion.h"
+
+void LSPSpec::to_json(json& j, const CompletionParams& obj) {
+  j = json{{"textDocument", obj.m_textDocument}, {"position", obj.m_position}};
+}
+
+void LSPSpec::from_json(const json& j, CompletionParams& obj) {
+  j.at("textDocument").get_to(obj.m_textDocument);
+  j.at("position").get_to(obj.m_position);
+}

--- a/lsp/protocol/completion.h
+++ b/lsp/protocol/completion.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "common_types.h"
+
+// TODO - not fully implemented!
+
+namespace LSPSpec {
+
+/// @brief How a completion was triggered
+enum class CompletionTriggerKind {
+  /// Completion was triggered by typing an identifier (24x7 code complete), manual invocation (e.g Ctrl+Space) or via API.
+  Invoked = 1,
+  /// Completion was triggered by a trigger character specified by the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
+  TriggerCharacter = 2,
+  /// Completion was re-triggered as the current completion list is incomplete.
+  TriggerForIncompleteCompletions = 3,
+};
+
+// TODO - look into inheriting structs?
+struct CompletionParams {
+  /// @brief The text document.
+  TextDocumentIdentifier m_textDocument;
+  /// @brief The position inside the text document.
+  Position m_position;
+};
+
+void to_json(json& j, const CompletionParams& obj);
+void from_json(const json& j, CompletionParams& obj);
+
+}  // namespace LSPSpec

--- a/lsp/protocol/completion.h
+++ b/lsp/protocol/completion.h
@@ -8,9 +8,11 @@ namespace LSPSpec {
 
 /// @brief How a completion was triggered
 enum class CompletionTriggerKind {
-  /// Completion was triggered by typing an identifier (24x7 code complete), manual invocation (e.g Ctrl+Space) or via API.
+  /// Completion was triggered by typing an identifier (24x7 code complete), manual invocation (e.g
+  /// Ctrl+Space) or via API.
   Invoked = 1,
-  /// Completion was triggered by a trigger character specified by the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
+  /// Completion was triggered by a trigger character specified by the `triggerCharacters`
+  /// properties of the `CompletionRegistrationOptions`.
   TriggerCharacter = 2,
   /// Completion was re-triggered as the current completion list is incomplete.
   TriggerForIncompleteCompletions = 3,


### PR DESCRIPTION
Better documentation on what is supported / makes it faster to type them without making mistakes.

![image](https://user-images.githubusercontent.com/13153231/195737915-1ed0fc15-e91d-4b35-a7df-0c31ebdc07d1.png)
