### PR TITLE
[decompiler] nicer static giftags

### DIFF
--- a/decompiler/config/all-types.gc
+++ b/decompiler/config/all-types.gc
@@ -4099,8 +4099,8 @@
 (deftype dma-gif-packet (structure)
   ((dma-vif dma-packet :inline :offset-assert 0)
    (gif     uint64    2       :offset-assert 16) ;; guess
-   (gif0    uint64 :offset 16)
-   (gif1    uint64 :offset 24)
+   (gif0    uint64 :offset 16 :score 1)
+   (gif1    uint64 :offset 24 :score 1)
    (quad    uint128    2       :offset 0)
    )
   :method-count-assert 9

--- a/decompiler/config/jak2/all-types.gc
+++ b/decompiler/config/jak2/all-types.gc
@@ -3336,6 +3336,9 @@
 (deftype dma-gif (structure)
   ((gif  uint64 2  :offset-assert 0)
    (quad uint128   :offset        0)
+   ;; added these two
+   (gif0    uint64 :offset 0 :score 1)
+   (gif1    uint64 :offset 8 :score 1)
    )
   :method-count-assert 9
   :size-assert         #x10
@@ -3344,7 +3347,7 @@
 
 (deftype dma-gif-packet (structure)
   ((dma-vif dma-packet :inline :offset-assert 0)
-   (gif     uint64     2       :offset-assert 16)
+   (gif     uint64     2       :offset-assert 16 :score -1)
    ;; added these two
    (gif0    uint64 :offset 16)
    (gif1    uint64 :offset 24)

--- a/decompiler/util/data_decompile.cpp
+++ b/decompiler/util/data_decompile.cpp
@@ -996,7 +996,20 @@ goos::Object decompile_structure(const TypeSpec& type,
             for (int byte_idx = field_start; byte_idx < field_end; byte_idx++) {
               bytes_out.push_back(obj_words.at(byte_idx / 4).get_byte(byte_idx % 4));
             }
-            field_defs_out.emplace_back(field.name(), decompile_value(field.type(), bytes_out, ts));
+
+            // use more specific types for gif tags.
+            bool is_gif_type =
+                type.base_type() == "dma-gif-packet" || type.base_type() == "dma-gif";
+            if (is_gif_type && field.name() == "gif0") {
+              field_defs_out.emplace_back(field.name(),
+                                          decompile_value(TypeSpec("gif-tag64"), bytes_out, ts));
+            } else if (is_gif_type && field.name() == "gif1") {
+              field_defs_out.emplace_back(field.name(),
+                                          decompile_value(TypeSpec("gif-tag-regs"), bytes_out, ts));
+            } else {
+              field_defs_out.emplace_back(field.name(),
+                                          decompile_value(field.type(), bytes_out, ts));
+            }
           }
         }
       }

--- a/goal_src/jak2/engine/dma/dma-buffer.gc
+++ b/goal_src/jak2/engine/dma/dma-buffer.gc
@@ -55,6 +55,9 @@
 (deftype dma-gif (structure)
   ((gif  uint64  2 :offset-assert   0)
    (quad uint128   :offset          0)
+   ;; added these two
+   (gif0    uint64 :offset 0 :score 1)
+   (gif1    uint64 :offset 8 :score 1)
    )
   :method-count-assert 9
   :size-assert         #x10

--- a/goal_src/jak2/engine/gfx/ocean/ocean-h.gc
+++ b/goal_src/jak2/engine/gfx/ocean/ocean-h.gc
@@ -599,248 +599,342 @@
 
 (define *ocean-map* (the-as ocean-map #f))
 
-(define *ocean* (new 'static 'ocean
-                  :sprite-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x508b400000008001 #x53531)
-                    )
-                  :sprite-tmpl2 (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x4 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x4 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x3023400000008001 #x551)
-                    )
-                  :sprite-tmpl3 (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x50ab400000008001 #x53531)
-                    )
-                  :adgif-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x1000000000008005 #xe)
-                    )
-                  :line-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x141 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x141 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x5008c00000008040 #x52521)
-                    )
-                  :sun-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x502b400000008001 #x52521)
-                    )
-                  :erase-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x4 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x4 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x3003400000008001 #x551)
-                    )
-                  :haze-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x45 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x45 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x4026400000008011 #x4141)
-                    )
-                  :cloud-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x25 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x25 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x602e400000008006 #x421421)
-                    )
-                  :clut-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x41 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x41 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x800000000008040 #x0)
-                    )
-                  :constant (new 'static 'vector :x 1.0 :y 1.0 :z 1.0)
-                  :haze-verts (new 'static 'inline-array vector4w 32
-                    (new 'static 'vector4w :x #x400 :y #x5c0 :z #xffffff)
-                    (new 'static 'vector4w :x #x400 :y #x600 :z #xffffff)
-                    (new 'static 'vector4w :x #x4a0 :y #x590 :z #xffffff)
-                    (new 'static 'vector4w :x #x4c0 :y #x5e0 :z #xffffff)
-                    (new 'static 'vector4w :x #x530 :y #x530 :z #xffffff)
-                    (new 'static 'vector4w :x #x560 :y #x560 :z #xffffff)
-                    (new 'static 'vector4w :x #x590 :y #x4a0 :z #xffffff)
-                    (new 'static 'vector4w :x #x5e0 :y #x4c0 :z #xffffff)
-                    (new 'static 'vector4w :x #x5c0 :y #x3f0 :z #xffffff)
-                    (new 'static 'vector4w :x #x600 :y #x3f0 :z #xffffff)
-                    (new 'static 'vector4w :x #x590 :y #x350 :z #xffffff)
-                    (new 'static 'vector4w :x #x5e0 :y #x330 :z #xffffff)
-                    (new 'static 'vector4w :x #x530 :y #x2c0 :z #xffffff)
-                    (new 'static 'vector4w :x #x560 :y #x290 :z #xffffff)
-                    (new 'static 'vector4w :x #x4a0 :y #x260 :z #xffffff)
-                    (new 'static 'vector4w :x #x4c0 :y #x210 :z #xffffff)
-                    (new 'static 'vector4w :x #x3f0 :y #x240 :z #xffffff)
-                    (new 'static 'vector4w :x #x3f0 :y #x1f0 :z #xffffff)
-                    (new 'static 'vector4w :x #x350 :y #x260 :z #xffffff)
-                    (new 'static 'vector4w :x #x330 :y #x210 :z #xffffff)
-                    (new 'static 'vector4w :x #x2c0 :y #x2c0 :z #xffffff)
-                    (new 'static 'vector4w :x #x290 :y #x290 :z #xffffff)
-                    (new 'static 'vector4w :x #x260 :y #x350 :z #xffffff)
-                    (new 'static 'vector4w :x #x210 :y #x330 :z #xffffff)
-                    (new 'static 'vector4w :x #x240 :y #x400 :z #xffffff)
-                    (new 'static 'vector4w :x #x1f0 :y #x400 :z #xffffff)
-                    (new 'static 'vector4w :x #x260 :y #x4a0 :z #xffffff)
-                    (new 'static 'vector4w :x #x210 :y #x4c0 :z #xffffff)
-                    (new 'static 'vector4w :x #x2c0 :y #x530 :z #xffffff)
-                    (new 'static 'vector4w :x #x290 :y #x560 :z #xffffff)
-                    (new 'static 'vector4w :x #x350 :y #x590 :z #xffffff)
-                    (new 'static 'vector4w :x #x330 :y #x5e0 :z #xffffff)
-                    )
-                  :cloud-verts (new 'static 'inline-array vector4w 36
-                    (new 'static 'vector4w :x #x290 :y #x290 :z #xffffff)
-                    (new 'static 'vector4w :x #x310 :y #x230 :z #xffffff)
-                    (new 'static 'vector4w :x #x3a0 :y #x200 :z #xffffff)
-                    (new 'static 'vector4w :x #x450 :y #x200 :z #xffffff)
-                    (new 'static 'vector4w :x #x4e0 :y #x230 :z #xffffff)
-                    (new 'static 'vector4w :x #x560 :y #x290 :z #xffffff)
-                    (new 'static 'vector4w :x #x230 :y #x310 :z #xffffff)
-                    (new 'static 'vector4w :x #x300 :y #x300 :z #xffffff)
-                    (new 'static 'vector4w :x #x3a0 :y #x2b0 :z #xffffff)
-                    (new 'static 'vector4w :x #x450 :y #x2b0 :z #xffffff)
-                    (new 'static 'vector4w :x #x4f0 :y #x300 :z #xffffff)
-                    (new 'static 'vector4w :x #x5c0 :y #x310 :z #xffffff)
-                    (new 'static 'vector4w :x #x200 :y #x3a0 :z #xffffff)
-                    (new 'static 'vector4w :x #x2b0 :y #x3a0 :z #xffffff)
-                    (new 'static 'vector4w :x #x380 :y #x380 :z #xffffff)
-                    (new 'static 'vector4w :x #x470 :y #x380 :z #xffffff)
-                    (new 'static 'vector4w :x #x540 :y #x3a0 :z #xffffff)
-                    (new 'static 'vector4w :x #x5f0 :y #x3a0 :z #xffffff)
-                    (new 'static 'vector4w :x #x200 :y #x450 :z #xffffff)
-                    (new 'static 'vector4w :x #x2b0 :y #x450 :z #xffffff)
-                    (new 'static 'vector4w :x #x380 :y #x470 :z #xffffff)
-                    (new 'static 'vector4w :x #x470 :y #x470 :z #xffffff)
-                    (new 'static 'vector4w :x #x540 :y #x450 :z #xffffff)
-                    (new 'static 'vector4w :x #x5f0 :y #x450 :z #xffffff)
-                    (new 'static 'vector4w :x #x230 :y #x4e0 :z #xffffff)
-                    (new 'static 'vector4w :x #x300 :y #x4f0 :z #xffffff)
-                    (new 'static 'vector4w :x #x3a0 :y #x540 :z #xffffff)
-                    (new 'static 'vector4w :x #x450 :y #x540 :z #xffffff)
-                    (new 'static 'vector4w :x #x4f0 :y #x4f0 :z #xffffff)
-                    (new 'static 'vector4w :x #x5c0 :y #x4e0 :z #xffffff)
-                    (new 'static 'vector4w :x #x290 :y #x560 :z #xffffff)
-                    (new 'static 'vector4w :x #x310 :y #x5c0 :z #xffffff)
-                    (new 'static 'vector4w :x #x3a0 :y #x5f0 :z #xffffff)
-                    (new 'static 'vector4w :x #x450 :y #x5f0 :z #xffffff)
-                    (new 'static 'vector4w :x #x4e0 :y #x5c0 :z #xffffff)
-                    (new 'static 'vector4w :x #x560 :y #x560 :z #xffffff)
-                    )
-                  :cloud-nrms (new 'static 'inline-array vector 36
-                    (new 'static 'vector :x -0.4999 :y 0.7071 :z -0.5)
-                    (new 'static 'vector :x -0.3209 :y 0.7071 :z -0.63)
-                    (new 'static 'vector :x -0.1105 :y 0.7071 :z -0.6984)
-                    (new 'static 'vector :x 0.1105 :y 0.7071 :z -0.6983)
-                    (new 'static 'vector :x 0.321 :y 0.7071 :z -0.63)
-                    (new 'static 'vector :x 0.5 :y 0.7071 :z -0.4999)
-                    (new 'static 'vector :x -0.63 :y 0.7071 :z -0.321)
-                    (new 'static 'vector :x -0.3921 :y 0.832 :z -0.3922)
-                    (new 'static 'vector :x -0.1434 :y 0.832 :z -0.5358)
-                    (new 'static 'vector :x 0.1435 :y 0.832 :z -0.5357)
-                    (new 'static 'vector :x 0.3922 :y 0.832 :z -0.3921)
-                    (new 'static 'vector :x 0.63 :y 0.7071 :z -0.3209)
-                    (new 'static 'vector :x -0.6983 :y 0.7071 :z -0.1106)
-                    (new 'static 'vector :x -0.5357 :y 0.832 :z -0.1435)
-                    (new 'static 'vector :x -0.334 :y 0.8814 :z -0.334)
-                    (new 'static 'vector :x 0.334 :y 0.8814 :z -0.334)
-                    (new 'static 'vector :x 0.5358 :y 0.832 :z -0.1434)
-                    (new 'static 'vector :x 0.6984 :y 0.7071 :z -0.1105)
-                    (new 'static 'vector :x -0.6984 :y 0.7071 :z 0.1105)
-                    (new 'static 'vector :x -0.5358 :y 0.832 :z 0.1435)
-                    (new 'static 'vector :x -0.334 :y 0.8814 :z 0.334)
-                    (new 'static 'vector :x 0.334 :y 0.8814 :z 0.334)
-                    (new 'static 'vector :x 0.5357 :y 0.832 :z 0.1435)
-                    (new 'static 'vector :x 0.6983 :y 0.7071 :z 0.1105)
-                    (new 'static 'vector :x -0.63 :y 0.7071 :z 0.321)
-                    (new 'static 'vector :x -0.3922 :y 0.832 :z 0.3921)
-                    (new 'static 'vector :x -0.1435 :y 0.832 :z 0.5357)
-                    (new 'static 'vector :x 0.1435 :y 0.832 :z 0.5358)
-                    (new 'static 'vector :x 0.3922 :y 0.832 :z 0.3922)
-                    (new 'static 'vector :x 0.63 :y 0.7071 :z 0.321)
-                    (new 'static 'vector :x -0.5 :y 0.7071 :z 0.4999)
-                    (new 'static 'vector :x -0.321 :y 0.7071 :z 0.63)
-                    (new 'static 'vector :x -0.1106 :y 0.7071 :z 0.6983)
-                    (new 'static 'vector :x 0.1105 :y 0.7071 :z 0.6984)
-                    (new 'static 'vector :x 0.321 :y 0.7071 :z 0.63)
-                    (new 'static 'vector :x 0.4999 :y 0.7071 :z 0.5)
-                    )
-                  :color80808080 (new 'static 'vector4w :x #x80 :y #x80 :z #x80 :w #x80)
-                  :color80808040 (new 'static 'vector4w :x #x80 :y #x80 :z #x80 :w 64)
-                  :color80808000 (new 'static 'vector4w :x #x80 :y #x80 :z #x80)
-                  :st0000 (new 'static 'vector :z 1.0)
-                  :st0505 (new 'static 'vector :x 0.5 :y 0.5 :z 1.0)
-                  :st1010 (new 'static 'vector :x 1.0 :y 1.0 :z 1.0)
-                  :uv44 (new 'static 'vector4w :x 64 :y 64)
-                  :uv88 (new 'static 'vector4w :x #x80 :y #x80)
-                  :uv1010 (new 'static 'vector4w :x #x100 :y #x100)
-                  :uv2020 (new 'static 'vector4w :x #x200 :y #x200)
-                  :uv4040 (new 'static 'vector4w :x #x400 :y #x400)
-                  :uv8080 (new 'static 'vector4w :x #x800 :y #x800)
-                  :xy00 (new 'static 'vector4w :z #xffffff)
-                  :xy88 (new 'static 'vector4w :x #x80 :y #x80 :z #xffffff)
-                  :xy1010 (new 'static 'vector4w :x #x100 :y #x100 :z #xffffff)
-                  :xy2020 (new 'static 'vector4w :x #x200 :y #x200 :z #xffffff)
-                  :xy4040 (new 'static 'vector4w :x #x400 :y #x400 :z #xffffff)
-                  :xy8080 (new 'static 'vector4w :x #x800 :y #x800 :z #xffffff)
-                  :cloud-alpha (new 'static 'array uint8 36
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    )
-                  :tex1 #xeed00080178
-                  :tex1-near #xeed0008016c
-                  :scales (new 'static 'vector :x -0.00012207031 :y 255.0 :z -0.00012207031 :w 128.0)
-                  :mask-hi (new 'static 'vector4w :x -65536 :y -65536 :z -65536 :w -65536)
-                  :mask-lo (new 'static 'vector4w :x #xffff :y #xffff :z #xffff :w #xffff)
-                  )
+(define *ocean*
+  (new 'static 'ocean
+    :sprite-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :fst #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id uv)
+        :regs2 (gif-reg-id xyz2)
+        :regs3 (gif-reg-id uv)
+        :regs4 (gif-reg-id xyz2)
+        )
+      )
+    :sprite-tmpl2 (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x4 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x4 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :abe #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id rgbaq) :regs1 (gif-reg-id xyz2) :regs2 (gif-reg-id xyz2))
+      )
+    :sprite-tmpl3 (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1 :fst #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id uv)
+        :regs2 (gif-reg-id xyz2)
+        :regs3 (gif-reg-id uv)
+        :regs4 (gif-reg-id xyz2)
+        )
+      )
+    :adgif-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64 :nloop #x5 :eop #x1 :nreg #x1)
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id a+d))
+      )
+    :line-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x141 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x141 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x40
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type line) :tme #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id st)
+        :regs2 (gif-reg-id xyz2)
+        :regs3 (gif-reg-id st)
+        :regs4 (gif-reg-id xyz2)
+        )
+      )
+    :sun-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id st)
+        :regs2 (gif-reg-id xyz2)
+        :regs3 (gif-reg-id st)
+        :regs4 (gif-reg-id xyz2)
+        )
+      )
+    :erase-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x4 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x4 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite))
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id rgbaq) :regs1 (gif-reg-id xyz2) :regs2 (gif-reg-id xyz2))
+      )
+    :haze-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x45 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x45 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x11
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :iip #x1 :abe #x1)
+        :nreg #x4
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id xyzf2)
+        :regs2 (gif-reg-id rgbaq)
+        :regs3 (gif-reg-id xyzf2)
+        )
+      )
+    :cloud-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x25 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x25 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x6
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :iip #x1 :tme #x1 :abe #x1)
+        :nreg #x6
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id st)
+        :regs2 (gif-reg-id xyzf2)
+        :regs3 (gif-reg-id rgbaq)
+        :regs4 (gif-reg-id st)
+        :regs5 (gif-reg-id xyzf2)
+        )
+      )
+    :clut-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x41 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x41 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64 :nloop #x40 :eop #x1 :flg (gif-flag image))
+      )
+    :constant (new 'static 'vector :x 1.0 :y 1.0 :z 1.0)
+    :haze-verts (new 'static 'inline-array vector4w 32
+      (new 'static 'vector4w :x #x400 :y #x5c0 :z #xffffff)
+      (new 'static 'vector4w :x #x400 :y #x600 :z #xffffff)
+      (new 'static 'vector4w :x #x4a0 :y #x590 :z #xffffff)
+      (new 'static 'vector4w :x #x4c0 :y #x5e0 :z #xffffff)
+      (new 'static 'vector4w :x #x530 :y #x530 :z #xffffff)
+      (new 'static 'vector4w :x #x560 :y #x560 :z #xffffff)
+      (new 'static 'vector4w :x #x590 :y #x4a0 :z #xffffff)
+      (new 'static 'vector4w :x #x5e0 :y #x4c0 :z #xffffff)
+      (new 'static 'vector4w :x #x5c0 :y #x3f0 :z #xffffff)
+      (new 'static 'vector4w :x #x600 :y #x3f0 :z #xffffff)
+      (new 'static 'vector4w :x #x590 :y #x350 :z #xffffff)
+      (new 'static 'vector4w :x #x5e0 :y #x330 :z #xffffff)
+      (new 'static 'vector4w :x #x530 :y #x2c0 :z #xffffff)
+      (new 'static 'vector4w :x #x560 :y #x290 :z #xffffff)
+      (new 'static 'vector4w :x #x4a0 :y #x260 :z #xffffff)
+      (new 'static 'vector4w :x #x4c0 :y #x210 :z #xffffff)
+      (new 'static 'vector4w :x #x3f0 :y #x240 :z #xffffff)
+      (new 'static 'vector4w :x #x3f0 :y #x1f0 :z #xffffff)
+      (new 'static 'vector4w :x #x350 :y #x260 :z #xffffff)
+      (new 'static 'vector4w :x #x330 :y #x210 :z #xffffff)
+      (new 'static 'vector4w :x #x2c0 :y #x2c0 :z #xffffff)
+      (new 'static 'vector4w :x #x290 :y #x290 :z #xffffff)
+      (new 'static 'vector4w :x #x260 :y #x350 :z #xffffff)
+      (new 'static 'vector4w :x #x210 :y #x330 :z #xffffff)
+      (new 'static 'vector4w :x #x240 :y #x400 :z #xffffff)
+      (new 'static 'vector4w :x #x1f0 :y #x400 :z #xffffff)
+      (new 'static 'vector4w :x #x260 :y #x4a0 :z #xffffff)
+      (new 'static 'vector4w :x #x210 :y #x4c0 :z #xffffff)
+      (new 'static 'vector4w :x #x2c0 :y #x530 :z #xffffff)
+      (new 'static 'vector4w :x #x290 :y #x560 :z #xffffff)
+      (new 'static 'vector4w :x #x350 :y #x590 :z #xffffff)
+      (new 'static 'vector4w :x #x330 :y #x5e0 :z #xffffff)
+      )
+    :cloud-verts (new 'static 'inline-array vector4w 36
+      (new 'static 'vector4w :x #x290 :y #x290 :z #xffffff)
+      (new 'static 'vector4w :x #x310 :y #x230 :z #xffffff)
+      (new 'static 'vector4w :x #x3a0 :y #x200 :z #xffffff)
+      (new 'static 'vector4w :x #x450 :y #x200 :z #xffffff)
+      (new 'static 'vector4w :x #x4e0 :y #x230 :z #xffffff)
+      (new 'static 'vector4w :x #x560 :y #x290 :z #xffffff)
+      (new 'static 'vector4w :x #x230 :y #x310 :z #xffffff)
+      (new 'static 'vector4w :x #x300 :y #x300 :z #xffffff)
+      (new 'static 'vector4w :x #x3a0 :y #x2b0 :z #xffffff)
+      (new 'static 'vector4w :x #x450 :y #x2b0 :z #xffffff)
+      (new 'static 'vector4w :x #x4f0 :y #x300 :z #xffffff)
+      (new 'static 'vector4w :x #x5c0 :y #x310 :z #xffffff)
+      (new 'static 'vector4w :x #x200 :y #x3a0 :z #xffffff)
+      (new 'static 'vector4w :x #x2b0 :y #x3a0 :z #xffffff)
+      (new 'static 'vector4w :x #x380 :y #x380 :z #xffffff)
+      (new 'static 'vector4w :x #x470 :y #x380 :z #xffffff)
+      (new 'static 'vector4w :x #x540 :y #x3a0 :z #xffffff)
+      (new 'static 'vector4w :x #x5f0 :y #x3a0 :z #xffffff)
+      (new 'static 'vector4w :x #x200 :y #x450 :z #xffffff)
+      (new 'static 'vector4w :x #x2b0 :y #x450 :z #xffffff)
+      (new 'static 'vector4w :x #x380 :y #x470 :z #xffffff)
+      (new 'static 'vector4w :x #x470 :y #x470 :z #xffffff)
+      (new 'static 'vector4w :x #x540 :y #x450 :z #xffffff)
+      (new 'static 'vector4w :x #x5f0 :y #x450 :z #xffffff)
+      (new 'static 'vector4w :x #x230 :y #x4e0 :z #xffffff)
+      (new 'static 'vector4w :x #x300 :y #x4f0 :z #xffffff)
+      (new 'static 'vector4w :x #x3a0 :y #x540 :z #xffffff)
+      (new 'static 'vector4w :x #x450 :y #x540 :z #xffffff)
+      (new 'static 'vector4w :x #x4f0 :y #x4f0 :z #xffffff)
+      (new 'static 'vector4w :x #x5c0 :y #x4e0 :z #xffffff)
+      (new 'static 'vector4w :x #x290 :y #x560 :z #xffffff)
+      (new 'static 'vector4w :x #x310 :y #x5c0 :z #xffffff)
+      (new 'static 'vector4w :x #x3a0 :y #x5f0 :z #xffffff)
+      (new 'static 'vector4w :x #x450 :y #x5f0 :z #xffffff)
+      (new 'static 'vector4w :x #x4e0 :y #x5c0 :z #xffffff)
+      (new 'static 'vector4w :x #x560 :y #x560 :z #xffffff)
+      )
+    :cloud-nrms (new 'static 'inline-array vector 36
+      (new 'static 'vector :x -0.4999 :y 0.7071 :z -0.5)
+      (new 'static 'vector :x -0.3209 :y 0.7071 :z -0.63)
+      (new 'static 'vector :x -0.1105 :y 0.7071 :z -0.6984)
+      (new 'static 'vector :x 0.1105 :y 0.7071 :z -0.6983)
+      (new 'static 'vector :x 0.321 :y 0.7071 :z -0.63)
+      (new 'static 'vector :x 0.5 :y 0.7071 :z -0.4999)
+      (new 'static 'vector :x -0.63 :y 0.7071 :z -0.321)
+      (new 'static 'vector :x -0.3921 :y 0.832 :z -0.3922)
+      (new 'static 'vector :x -0.1434 :y 0.832 :z -0.5358)
+      (new 'static 'vector :x 0.1435 :y 0.832 :z -0.5357)
+      (new 'static 'vector :x 0.3922 :y 0.832 :z -0.3921)
+      (new 'static 'vector :x 0.63 :y 0.7071 :z -0.3209)
+      (new 'static 'vector :x -0.6983 :y 0.7071 :z -0.1106)
+      (new 'static 'vector :x -0.5357 :y 0.832 :z -0.1435)
+      (new 'static 'vector :x -0.334 :y 0.8814 :z -0.334)
+      (new 'static 'vector :x 0.334 :y 0.8814 :z -0.334)
+      (new 'static 'vector :x 0.5358 :y 0.832 :z -0.1434)
+      (new 'static 'vector :x 0.6984 :y 0.7071 :z -0.1105)
+      (new 'static 'vector :x -0.6984 :y 0.7071 :z 0.1105)
+      (new 'static 'vector :x -0.5358 :y 0.832 :z 0.1435)
+      (new 'static 'vector :x -0.334 :y 0.8814 :z 0.334)
+      (new 'static 'vector :x 0.334 :y 0.8814 :z 0.334)
+      (new 'static 'vector :x 0.5357 :y 0.832 :z 0.1435)
+      (new 'static 'vector :x 0.6983 :y 0.7071 :z 0.1105)
+      (new 'static 'vector :x -0.63 :y 0.7071 :z 0.321)
+      (new 'static 'vector :x -0.3922 :y 0.832 :z 0.3921)
+      (new 'static 'vector :x -0.1435 :y 0.832 :z 0.5357)
+      (new 'static 'vector :x 0.1435 :y 0.832 :z 0.5358)
+      (new 'static 'vector :x 0.3922 :y 0.832 :z 0.3922)
+      (new 'static 'vector :x 0.63 :y 0.7071 :z 0.321)
+      (new 'static 'vector :x -0.5 :y 0.7071 :z 0.4999)
+      (new 'static 'vector :x -0.321 :y 0.7071 :z 0.63)
+      (new 'static 'vector :x -0.1106 :y 0.7071 :z 0.6983)
+      (new 'static 'vector :x 0.1105 :y 0.7071 :z 0.6984)
+      (new 'static 'vector :x 0.321 :y 0.7071 :z 0.63)
+      (new 'static 'vector :x 0.4999 :y 0.7071 :z 0.5)
+      )
+    :color80808080 (new 'static 'vector4w :x #x80 :y #x80 :z #x80 :w #x80)
+    :color80808040 (new 'static 'vector4w :x #x80 :y #x80 :z #x80 :w 64)
+    :color80808000 (new 'static 'vector4w :x #x80 :y #x80 :z #x80)
+    :st0000 (new 'static 'vector :z 1.0)
+    :st0505 (new 'static 'vector :x 0.5 :y 0.5 :z 1.0)
+    :st1010 (new 'static 'vector :x 1.0 :y 1.0 :z 1.0)
+    :uv44 (new 'static 'vector4w :x 64 :y 64)
+    :uv88 (new 'static 'vector4w :x #x80 :y #x80)
+    :uv1010 (new 'static 'vector4w :x #x100 :y #x100)
+    :uv2020 (new 'static 'vector4w :x #x200 :y #x200)
+    :uv4040 (new 'static 'vector4w :x #x400 :y #x400)
+    :uv8080 (new 'static 'vector4w :x #x800 :y #x800)
+    :xy00 (new 'static 'vector4w :z #xffffff)
+    :xy88 (new 'static 'vector4w :x #x80 :y #x80 :z #xffffff)
+    :xy1010 (new 'static 'vector4w :x #x100 :y #x100 :z #xffffff)
+    :xy2020 (new 'static 'vector4w :x #x200 :y #x200 :z #xffffff)
+    :xy4040 (new 'static 'vector4w :x #x400 :y #x400 :z #xffffff)
+    :xy8080 (new 'static 'vector4w :x #x800 :y #x800 :z #xffffff)
+    :cloud-alpha (new 'static 'array uint8 36
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      )
+    :tex1 #xeed00080178
+    :tex1-near #xeed0008016c
+    :scales (new 'static 'vector :x -0.00012207031 :y 255.0 :z -0.00012207031 :w 128.0)
+    :mask-hi (new 'static 'vector4w :x -65536 :y -65536 :z -65536 :w -65536)
+    :mask-lo (new 'static 'vector4w :x #xffff :y #xffff :z #xffff :w #xffff)
+    )
+  )

--- a/goal_src/jak2/engine/gfx/shrub/shrub-work.gc
+++ b/goal_src/jak2/engine/gfx/shrub/shrub-work.gc
@@ -70,14 +70,22 @@
         :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id next))
         :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x1000000000008005 #xe)
+      :gif0 (new 'static 'gif-tag64 :nloop #x5 :eop #x1 :nreg #x1)
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id a+d))
       )
     :billboard-tmpl (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #xd :id (dma-tag-id next))
         :vif1 (new 'static 'vif-tag :imm #xd :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x303e400000008004 #x412)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x4
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :iip #x1 :tme #x1 :fge #x1 :abe #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id st) :regs1 (gif-reg-id rgbaq) :regs2 (gif-reg-id xyzf2))
       )
     :shrub-near-packets (new 'static 'inline-array shrub-near-packet 6
       (new 'static 'shrub-near-packet

--- a/goal_src/jak2/engine/gfx/sky/sky-data.gc
+++ b/goal_src/jak2/engine/gfx/sky/sky-data.gc
@@ -14,49 +14,120 @@
         :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x1000000000008005 #xe)
+      :gif0 (new 'static 'gif-tag64 :nloop #x5 :eop #x1 :nreg #x1)
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id a+d))
       )
     :draw-tmpl (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x502b400000008001 #x42421)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id st)
+        :regs2 (gif-reg-id xyzf2)
+        :regs3 (gif-reg-id st)
+        :regs4 (gif-reg-id xyzf2)
+        )
       )
     :draw-tmpl2 (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x50ab400000008001 #x43431)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1 :fst #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id uv)
+        :regs2 (gif-reg-id xyzf2)
+        :regs3 (gif-reg-id uv)
+        :regs4 (gif-reg-id xyzf2)
+        )
       )
     :fog-tmpl (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #xa :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #xa :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x902a400000008001 #x424242421)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :tme #x1 :abe #x1)
+        :nreg #x9
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id st)
+        :regs2 (gif-reg-id xyzf2)
+        :regs3 (gif-reg-id st)
+        :regs4 (gif-reg-id xyzf2)
+        :regs5 (gif-reg-id st)
+        :regs6 (gif-reg-id xyzf2)
+        :regs7 (gif-reg-id st)
+        :regs8 (gif-reg-id xyzf2)
+        )
       )
     :blend-tmpl (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x50ab400000008001 #x43431)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1 :fst #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id uv)
+        :regs2 (gif-reg-id xyzf2)
+        :regs3 (gif-reg-id uv)
+        :regs4 (gif-reg-id xyzf2)
+        )
       )
     :sprite-tmpl (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #x3 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x3 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x2003400000008001 #x55)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite))
+        :nreg #x2
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id xyz2) :regs1 (gif-reg-id xyz2))
       )
     :sprite-tmpl2 (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #x21 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x21 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x2003400000008010 #x55)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x10
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite))
+        :nreg #x2
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id xyz2) :regs1 (gif-reg-id xyz2))
       )
     :sun-coords (new 'static 'inline-array vector 2
       (new 'static 'vector :x -267.0 :y -267.0 :w 1.0)
@@ -103,10 +174,46 @@
       (new 'static 'vector4w :x #x387528 :y #x723099 :z #x140983 :w #x874310)
       (new 'static 'vector4w :x #x2387 :y #x129818 :z #x219810 :w #x623790)
       )
-    :giftag-base (new 'static 'dma-gif :gif (new 'static 'array uint64 2 #x3002c00000008001 #x412))
-    :giftag-haze (new 'static 'dma-gif :gif (new 'static 'array uint64 2 #x3026c00000008001 #x412))
-    :giftag-roof (new 'static 'dma-gif :gif (new 'static 'array uint64 2 #x302ec00000008001 #x412))
-    :giftag-ocean (new 'static 'dma-gif :gif (new 'static 'array uint64 2 #x301ec00000008001 #x412))
+    :giftag-base (new 'static 'dma-gif
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-fan))
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id st) :regs1 (gif-reg-id rgbaq) :regs2 (gif-reg-id xyzf2))
+      )
+    :giftag-haze (new 'static 'dma-gif
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-fan) :iip #x1 :abe #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id st) :regs1 (gif-reg-id rgbaq) :regs2 (gif-reg-id xyzf2))
+      )
+    :giftag-roof (new 'static 'dma-gif
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-fan) :iip #x1 :tme #x1 :abe #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id st) :regs1 (gif-reg-id rgbaq) :regs2 (gif-reg-id xyzf2))
+      )
+    :giftag-ocean (new 'static 'dma-gif
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-fan) :iip #x1 :tme #x1 :fge #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id st) :regs1 (gif-reg-id rgbaq) :regs2 (gif-reg-id xyzf2))
+      )
     :draw-vortex #f
     )
   )

--- a/test/decompiler/reference/jak1/engine/dma/dma-buffer_REF.gc
+++ b/test/decompiler/reference/jak1/engine/dma/dma-buffer_REF.gc
@@ -61,7 +61,7 @@
 (defmethod inspect dma-gif-packet ((obj dma-gif-packet))
   (format #t "[~8x] ~A~%" obj 'dma-gif-packet)
   (format #t "~Tdma-vif: #<dma-packet @ #x~X>~%" (-> obj dma-vif))
-  (format #t "~Tgif[2] @ #x~X~%" (-> obj gif))
+  (format #t "~Tgif[2] @ #x~X~%" (&-> obj gif0))
   (format #t "~Tquad[2] @ #x~X~%" (-> obj dma-vif))
   obj
   )

--- a/test/decompiler/reference/jak1/engine/gfx/depth-cue_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/depth-cue_REF.gc
@@ -9,21 +9,66 @@
         :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x50ab400000008001 #x43431)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1 :fst #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id uv)
+        :regs2 (gif-reg-id xyzf2)
+        :regs3 (gif-reg-id uv)
+        :regs4 (gif-reg-id xyzf2)
+        )
       )
     :temp-strip-tmpl (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x508b400000008001 #x43431)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :fst #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id uv)
+        :regs2 (gif-reg-id xyzf2)
+        :regs3 (gif-reg-id uv)
+        :regs4 (gif-reg-id xyzf2)
+        )
       )
     :stencil-tmpl (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #x17 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x17 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #xb003400000008002 #x44444444441)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x2
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite))
+        :nreg #xb
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id xyzf2)
+        :regs2 (gif-reg-id xyzf2)
+        :regs3 (gif-reg-id xyzf2)
+        :regs4 (gif-reg-id xyzf2)
+        :regs5 (gif-reg-id xyzf2)
+        :regs6 (gif-reg-id xyzf2)
+        :regs7 (gif-reg-id xyzf2)
+        :regs8 (gif-reg-id xyzf2)
+        :regs9 (gif-reg-id xyzf2)
+        :regs10 (gif-reg-id xyzf2)
+        )
       )
     :set-color (new 'static 'vector4w :x #x80 :y #x80 :z #x80 :w #x80)
     :draw-color (new 'static 'vector4w :x #x84 :y #x84 :z #x84 :w #x80)

--- a/test/decompiler/reference/jak1/engine/gfx/eye_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/eye_REF.gc
@@ -8,21 +8,48 @@
                          :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
                          :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
                          )
-                       :gif (new 'static 'array uint64 2 #x508b400000008001 #x53531)
+                       :gif0 (new 'static 'gif-tag64
+                         :nloop #x1
+                         :eop #x1
+                         :pre #x1
+                         :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :fst #x1)
+                         :nreg #x5
+                         )
+                       :gif1 (new 'static 'gif-tag-regs
+                         :regs0 (gif-reg-id rgbaq)
+                         :regs1 (gif-reg-id uv)
+                         :regs2 (gif-reg-id xyz2)
+                         :regs3 (gif-reg-id uv)
+                         :regs4 (gif-reg-id xyz2)
+                         )
                        )
                      :sprite-tmpl2 (new 'static 'dma-gif-packet
                        :dma-vif (new 'static 'dma-packet
                          :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
                          :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
                          )
-                       :gif (new 'static 'array uint64 2 #x50ab400000008001 #x53531)
+                       :gif0 (new 'static 'gif-tag64
+                         :nloop #x1
+                         :eop #x1
+                         :pre #x1
+                         :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1 :fst #x1)
+                         :nreg #x5
+                         )
+                       :gif1 (new 'static 'gif-tag-regs
+                         :regs0 (gif-reg-id rgbaq)
+                         :regs1 (gif-reg-id uv)
+                         :regs2 (gif-reg-id xyz2)
+                         :regs3 (gif-reg-id uv)
+                         :regs4 (gif-reg-id xyz2)
+                         )
                        )
                      :adgif-tmpl (new 'static 'dma-gif-packet
                        :dma-vif (new 'static 'dma-packet
                          :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
                          :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
                          )
-                       :gif (new 'static 'array uint64 2 #x1000000000008005 #xe)
+                       :gif0 (new 'static 'gif-tag64 :nloop #x5 :eop #x1 :nreg #x1)
+                       :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id a+d))
                        )
                      :blink-table (new 'static 'array float 10 0.0 0.667 0.9 1.0 1.0 1.0 1.0 0.333 0.1 0.0)
                      )
@@ -345,7 +372,7 @@
           (set! (-> s0-2 prims 9) (gs-reg64 alpha-1))
           )
         )
-      (set! (-> arg0 base) (-> (the-as (inline-array dma-gif-packet) (-> arg0 base)) 3 gif))
+      (set! (-> arg0 base) (&-> (the-as (inline-array dma-gif-packet) (-> arg0 base)) 3 gif0))
       (let ((v1-50 (ash 16 (-> s1-2 tex0 tw)))
             (a0-66 (ash 16 (-> s1-2 tex0 th)))
             )

--- a/test/decompiler/reference/jak1/engine/gfx/font-h_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/font-h_REF.gc
@@ -307,14 +307,42 @@
         :dma (new 'static 'dma-tag :qwc #x2 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x2 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x102e400000008001 #xe)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :iip #x1 :tme #x1 :abe #x1)
+        :nreg #x1
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id a+d))
       )
     :char-tmpl (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #xe :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #xe :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #xd02e400000008001 #x412412412412e)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :iip #x1 :tme #x1 :abe #x1)
+        :nreg #xd
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id a+d)
+        :regs1 (gif-reg-id st)
+        :regs2 (gif-reg-id rgbaq)
+        :regs3 (gif-reg-id xyzf2)
+        :regs4 (gif-reg-id st)
+        :regs5 (gif-reg-id rgbaq)
+        :regs6 (gif-reg-id xyzf2)
+        :regs7 (gif-reg-id st)
+        :regs8 (gif-reg-id rgbaq)
+        :regs9 (gif-reg-id xyzf2)
+        :regs10 (gif-reg-id st)
+        :regs11 (gif-reg-id rgbaq)
+        :regs12 (gif-reg-id xyzf2)
+        )
       )
     :tex1-tmpl (new 'static 'array uint64 2 #x60 #x14)
     :small-font-lo-tmpl (new 'static 'array uint64 2 #x0 #x6)

--- a/test/decompiler/reference/jak1/engine/gfx/ocean/ocean-texture_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/ocean/ocean-texture_REF.gc
@@ -2,30 +2,52 @@
 (in-package goal)
 
 ;; definition for symbol *ocean-texture-work*, type ocean-texture-work
-(define *ocean-texture-work* (new 'static 'ocean-texture-work
-                               :sprite-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x508b400000008001 #x53531)
-                                 )
-                               :sprite-tmpl2 (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x4 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x4 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x3023400000008001 #x551)
-                                 )
-                               :adgif-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x1000000000008005 #xe)
-                                 )
-                               )
+(define *ocean-texture-work*
+  (new 'static 'ocean-texture-work
+    :sprite-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :fst #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id uv)
+        :regs2 (gif-reg-id xyz2)
+        :regs3 (gif-reg-id uv)
+        :regs4 (gif-reg-id xyz2)
+        )
+      )
+    :sprite-tmpl2 (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x4 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x4 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :abe #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id rgbaq) :regs1 (gif-reg-id xyz2) :regs2 (gif-reg-id xyz2))
+      )
+    :adgif-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64 :nloop #x5 :eop #x1 :nreg #x1)
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id a+d))
+      )
+    )
+  )
 
 ;; definition for symbol ocean-texture-vu1-block, type vu-function
 (define ocean-texture-vu1-block (new 'static 'vu-function :length #x92 :qlength 73))

--- a/test/decompiler/reference/jak1/engine/gfx/shrub/shrub-work_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/shrub/shrub-work_REF.gc
@@ -61,14 +61,22 @@
         :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id next))
         :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x1000000000008005 #xe)
+      :gif0 (new 'static 'gif-tag64 :nloop #x5 :eop #x1 :nreg #x1)
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id a+d))
       )
     :billboard-tmpl (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #xd :id (dma-tag-id next))
         :vif1 (new 'static 'vif-tag :imm #xd :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x303e400000008004 #x412)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x4
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :iip #x1 :tme #x1 :fge #x1 :abe #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id st) :regs1 (gif-reg-id rgbaq) :regs2 (gif-reg-id xyzf2))
       )
     :shrub-near-packets (new 'static 'inline-array shrub-near-packet 6
       (new 'static 'shrub-near-packet

--- a/test/decompiler/reference/jak1/engine/gfx/sky/sky-tng_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/sky/sky-tng_REF.gc
@@ -8,21 +8,48 @@
                          :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
                          :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
                          )
-                       :gif (new 'static 'array uint64 2 #x1000000000008005 #xe)
+                       :gif0 (new 'static 'gif-tag64 :nloop #x5 :eop #x1 :nreg #x1)
+                       :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id a+d))
                        )
                      :draw-tmpl (new 'static 'dma-gif-packet
                        :dma-vif (new 'static 'dma-packet
                          :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
                          :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
                          )
-                       :gif (new 'static 'array uint64 2 #x508b400000008001 #x43431)
+                       :gif0 (new 'static 'gif-tag64
+                         :nloop #x1
+                         :eop #x1
+                         :pre #x1
+                         :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :fst #x1)
+                         :nreg #x5
+                         )
+                       :gif1 (new 'static 'gif-tag-regs
+                         :regs0 (gif-reg-id rgbaq)
+                         :regs1 (gif-reg-id uv)
+                         :regs2 (gif-reg-id xyzf2)
+                         :regs3 (gif-reg-id uv)
+                         :regs4 (gif-reg-id xyzf2)
+                         )
                        )
                      :blend-tmpl (new 'static 'dma-gif-packet
                        :dma-vif (new 'static 'dma-packet
                          :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
                          :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
                          )
-                       :gif (new 'static 'array uint64 2 #x50ab400000008001 #x43431)
+                       :gif0 (new 'static 'gif-tag64
+                         :nloop #x1
+                         :eop #x1
+                         :pre #x1
+                         :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1 :fst #x1)
+                         :nreg #x5
+                         )
+                       :gif1 (new 'static 'gif-tag-regs
+                         :regs0 (gif-reg-id rgbaq)
+                         :regs1 (gif-reg-id uv)
+                         :regs2 (gif-reg-id xyzf2)
+                         :regs3 (gif-reg-id uv)
+                         :regs4 (gif-reg-id xyzf2)
+                         )
                        )
                      :sky-data (new 'static 'inline-array qword 5
                        (new 'static 'qword :data (new 'static 'array uint32 4 #x0 #x0 #x0 #x80))

--- a/test/decompiler/reference/jak2/engine/dma/dma-buffer_REF.gc
+++ b/test/decompiler/reference/jak2/engine/dma/dma-buffer_REF.gc
@@ -59,6 +59,8 @@
 (deftype dma-gif (structure)
   ((gif  uint64  2 :offset-assert   0)
    (quad uint128   :offset          0)
+   (gif0 uint64    :offset          0)
+   (gif1 uint64    :offset          8)
    )
   :method-count-assert 9
   :size-assert         #x10
@@ -73,7 +75,7 @@
     (goto cfg-4)
     )
   (format #t "[~8x] ~A~%" obj 'dma-gif)
-  (format #t "~1Tgif[2] @ #x~X~%" (-> obj gif))
+  (format #t "~1Tgif[2] @ #x~X~%" (&-> obj gif0))
   (format #t "~1Tquad: ~D~%" (-> obj quad))
   (label cfg-4)
   obj
@@ -100,7 +102,7 @@
     )
   (format #t "[~8x] ~A~%" obj 'dma-gif-packet)
   (format #t "~1Tdma-vif: #<dma-packet @ #x~X>~%" (-> obj dma-vif))
-  (format #t "~1Tgif[2] @ #x~X~%" (-> obj gif))
+  (format #t "~1Tgif[2] @ #x~X~%" (&-> obj gif0))
   (format #t "~1Tquad[2] @ #x~X~%" (-> obj dma-vif))
   (label cfg-4)
   obj
@@ -219,7 +221,3 @@
   (dma-send-chain arg0 (the-as uint (-> arg1 data)))
   (none)
   )
-
-
-
-

--- a/test/decompiler/reference/jak2/engine/gfx/ocean/ocean-h_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/ocean/ocean-h_REF.gc
@@ -1195,251 +1195,345 @@
 (define *ocean-map* (the-as ocean-map #f))
 
 ;; definition for symbol *ocean*, type ocean
-(define *ocean* (new 'static 'ocean
-                  :sprite-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x508b400000008001 #x53531)
-                    )
-                  :sprite-tmpl2 (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x4 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x4 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x3023400000008001 #x551)
-                    )
-                  :sprite-tmpl3 (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x50ab400000008001 #x53531)
-                    )
-                  :adgif-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x1000000000008005 #xe)
-                    )
-                  :line-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x141 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x141 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x5008c00000008040 #x52521)
-                    )
-                  :sun-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x502b400000008001 #x52521)
-                    )
-                  :erase-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x4 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x4 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x3003400000008001 #x551)
-                    )
-                  :haze-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x45 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x45 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x4026400000008011 #x4141)
-                    )
-                  :cloud-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x25 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x25 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x602e400000008006 #x421421)
-                    )
-                  :clut-tmpl (new 'static 'dma-gif-packet
-                    :dma-vif (new 'static 'dma-packet
-                      :dma (new 'static 'dma-tag :qwc #x41 :id (dma-tag-id cnt))
-                      :vif1 (new 'static 'vif-tag :imm #x41 :cmd (vif-cmd direct) :msk #x1)
-                      )
-                    :gif (new 'static 'array uint64 2 #x800000000008040 #x0)
-                    )
-                  :constant (new 'static 'vector :x 1.0 :y 1.0 :z 1.0)
-                  :haze-verts (new 'static 'inline-array vector4w 32
-                    (new 'static 'vector4w :x #x400 :y #x5c0 :z #xffffff)
-                    (new 'static 'vector4w :x #x400 :y #x600 :z #xffffff)
-                    (new 'static 'vector4w :x #x4a0 :y #x590 :z #xffffff)
-                    (new 'static 'vector4w :x #x4c0 :y #x5e0 :z #xffffff)
-                    (new 'static 'vector4w :x #x530 :y #x530 :z #xffffff)
-                    (new 'static 'vector4w :x #x560 :y #x560 :z #xffffff)
-                    (new 'static 'vector4w :x #x590 :y #x4a0 :z #xffffff)
-                    (new 'static 'vector4w :x #x5e0 :y #x4c0 :z #xffffff)
-                    (new 'static 'vector4w :x #x5c0 :y #x3f0 :z #xffffff)
-                    (new 'static 'vector4w :x #x600 :y #x3f0 :z #xffffff)
-                    (new 'static 'vector4w :x #x590 :y #x350 :z #xffffff)
-                    (new 'static 'vector4w :x #x5e0 :y #x330 :z #xffffff)
-                    (new 'static 'vector4w :x #x530 :y #x2c0 :z #xffffff)
-                    (new 'static 'vector4w :x #x560 :y #x290 :z #xffffff)
-                    (new 'static 'vector4w :x #x4a0 :y #x260 :z #xffffff)
-                    (new 'static 'vector4w :x #x4c0 :y #x210 :z #xffffff)
-                    (new 'static 'vector4w :x #x3f0 :y #x240 :z #xffffff)
-                    (new 'static 'vector4w :x #x3f0 :y #x1f0 :z #xffffff)
-                    (new 'static 'vector4w :x #x350 :y #x260 :z #xffffff)
-                    (new 'static 'vector4w :x #x330 :y #x210 :z #xffffff)
-                    (new 'static 'vector4w :x #x2c0 :y #x2c0 :z #xffffff)
-                    (new 'static 'vector4w :x #x290 :y #x290 :z #xffffff)
-                    (new 'static 'vector4w :x #x260 :y #x350 :z #xffffff)
-                    (new 'static 'vector4w :x #x210 :y #x330 :z #xffffff)
-                    (new 'static 'vector4w :x #x240 :y #x400 :z #xffffff)
-                    (new 'static 'vector4w :x #x1f0 :y #x400 :z #xffffff)
-                    (new 'static 'vector4w :x #x260 :y #x4a0 :z #xffffff)
-                    (new 'static 'vector4w :x #x210 :y #x4c0 :z #xffffff)
-                    (new 'static 'vector4w :x #x2c0 :y #x530 :z #xffffff)
-                    (new 'static 'vector4w :x #x290 :y #x560 :z #xffffff)
-                    (new 'static 'vector4w :x #x350 :y #x590 :z #xffffff)
-                    (new 'static 'vector4w :x #x330 :y #x5e0 :z #xffffff)
-                    )
-                  :cloud-verts (new 'static 'inline-array vector4w 36
-                    (new 'static 'vector4w :x #x290 :y #x290 :z #xffffff)
-                    (new 'static 'vector4w :x #x310 :y #x230 :z #xffffff)
-                    (new 'static 'vector4w :x #x3a0 :y #x200 :z #xffffff)
-                    (new 'static 'vector4w :x #x450 :y #x200 :z #xffffff)
-                    (new 'static 'vector4w :x #x4e0 :y #x230 :z #xffffff)
-                    (new 'static 'vector4w :x #x560 :y #x290 :z #xffffff)
-                    (new 'static 'vector4w :x #x230 :y #x310 :z #xffffff)
-                    (new 'static 'vector4w :x #x300 :y #x300 :z #xffffff)
-                    (new 'static 'vector4w :x #x3a0 :y #x2b0 :z #xffffff)
-                    (new 'static 'vector4w :x #x450 :y #x2b0 :z #xffffff)
-                    (new 'static 'vector4w :x #x4f0 :y #x300 :z #xffffff)
-                    (new 'static 'vector4w :x #x5c0 :y #x310 :z #xffffff)
-                    (new 'static 'vector4w :x #x200 :y #x3a0 :z #xffffff)
-                    (new 'static 'vector4w :x #x2b0 :y #x3a0 :z #xffffff)
-                    (new 'static 'vector4w :x #x380 :y #x380 :z #xffffff)
-                    (new 'static 'vector4w :x #x470 :y #x380 :z #xffffff)
-                    (new 'static 'vector4w :x #x540 :y #x3a0 :z #xffffff)
-                    (new 'static 'vector4w :x #x5f0 :y #x3a0 :z #xffffff)
-                    (new 'static 'vector4w :x #x200 :y #x450 :z #xffffff)
-                    (new 'static 'vector4w :x #x2b0 :y #x450 :z #xffffff)
-                    (new 'static 'vector4w :x #x380 :y #x470 :z #xffffff)
-                    (new 'static 'vector4w :x #x470 :y #x470 :z #xffffff)
-                    (new 'static 'vector4w :x #x540 :y #x450 :z #xffffff)
-                    (new 'static 'vector4w :x #x5f0 :y #x450 :z #xffffff)
-                    (new 'static 'vector4w :x #x230 :y #x4e0 :z #xffffff)
-                    (new 'static 'vector4w :x #x300 :y #x4f0 :z #xffffff)
-                    (new 'static 'vector4w :x #x3a0 :y #x540 :z #xffffff)
-                    (new 'static 'vector4w :x #x450 :y #x540 :z #xffffff)
-                    (new 'static 'vector4w :x #x4f0 :y #x4f0 :z #xffffff)
-                    (new 'static 'vector4w :x #x5c0 :y #x4e0 :z #xffffff)
-                    (new 'static 'vector4w :x #x290 :y #x560 :z #xffffff)
-                    (new 'static 'vector4w :x #x310 :y #x5c0 :z #xffffff)
-                    (new 'static 'vector4w :x #x3a0 :y #x5f0 :z #xffffff)
-                    (new 'static 'vector4w :x #x450 :y #x5f0 :z #xffffff)
-                    (new 'static 'vector4w :x #x4e0 :y #x5c0 :z #xffffff)
-                    (new 'static 'vector4w :x #x560 :y #x560 :z #xffffff)
-                    )
-                  :cloud-nrms (new 'static 'inline-array vector 36
-                    (new 'static 'vector :x -0.4999 :y 0.7071 :z -0.5)
-                    (new 'static 'vector :x -0.3209 :y 0.7071 :z -0.63)
-                    (new 'static 'vector :x -0.1105 :y 0.7071 :z -0.6984)
-                    (new 'static 'vector :x 0.1105 :y 0.7071 :z -0.6983)
-                    (new 'static 'vector :x 0.321 :y 0.7071 :z -0.63)
-                    (new 'static 'vector :x 0.5 :y 0.7071 :z -0.4999)
-                    (new 'static 'vector :x -0.63 :y 0.7071 :z -0.321)
-                    (new 'static 'vector :x -0.3921 :y 0.832 :z -0.3922)
-                    (new 'static 'vector :x -0.1434 :y 0.832 :z -0.5358)
-                    (new 'static 'vector :x 0.1435 :y 0.832 :z -0.5357)
-                    (new 'static 'vector :x 0.3922 :y 0.832 :z -0.3921)
-                    (new 'static 'vector :x 0.63 :y 0.7071 :z -0.3209)
-                    (new 'static 'vector :x -0.6983 :y 0.7071 :z -0.1106)
-                    (new 'static 'vector :x -0.5357 :y 0.832 :z -0.1435)
-                    (new 'static 'vector :x -0.334 :y 0.8814 :z -0.334)
-                    (new 'static 'vector :x 0.334 :y 0.8814 :z -0.334)
-                    (new 'static 'vector :x 0.5358 :y 0.832 :z -0.1434)
-                    (new 'static 'vector :x 0.6984 :y 0.7071 :z -0.1105)
-                    (new 'static 'vector :x -0.6984 :y 0.7071 :z 0.1105)
-                    (new 'static 'vector :x -0.5358 :y 0.832 :z 0.1435)
-                    (new 'static 'vector :x -0.334 :y 0.8814 :z 0.334)
-                    (new 'static 'vector :x 0.334 :y 0.8814 :z 0.334)
-                    (new 'static 'vector :x 0.5357 :y 0.832 :z 0.1435)
-                    (new 'static 'vector :x 0.6983 :y 0.7071 :z 0.1105)
-                    (new 'static 'vector :x -0.63 :y 0.7071 :z 0.321)
-                    (new 'static 'vector :x -0.3922 :y 0.832 :z 0.3921)
-                    (new 'static 'vector :x -0.1435 :y 0.832 :z 0.5357)
-                    (new 'static 'vector :x 0.1435 :y 0.832 :z 0.5358)
-                    (new 'static 'vector :x 0.3922 :y 0.832 :z 0.3922)
-                    (new 'static 'vector :x 0.63 :y 0.7071 :z 0.321)
-                    (new 'static 'vector :x -0.5 :y 0.7071 :z 0.4999)
-                    (new 'static 'vector :x -0.321 :y 0.7071 :z 0.63)
-                    (new 'static 'vector :x -0.1106 :y 0.7071 :z 0.6983)
-                    (new 'static 'vector :x 0.1105 :y 0.7071 :z 0.6984)
-                    (new 'static 'vector :x 0.321 :y 0.7071 :z 0.63)
-                    (new 'static 'vector :x 0.4999 :y 0.7071 :z 0.5)
-                    )
-                  :color80808080 (new 'static 'vector4w :x #x80 :y #x80 :z #x80 :w #x80)
-                  :color80808040 (new 'static 'vector4w :x #x80 :y #x80 :z #x80 :w 64)
-                  :color80808000 (new 'static 'vector4w :x #x80 :y #x80 :z #x80)
-                  :st0000 (new 'static 'vector :z 1.0)
-                  :st0505 (new 'static 'vector :x 0.5 :y 0.5 :z 1.0)
-                  :st1010 (new 'static 'vector :x 1.0 :y 1.0 :z 1.0)
-                  :uv44 (new 'static 'vector4w :x 64 :y 64)
-                  :uv88 (new 'static 'vector4w :x #x80 :y #x80)
-                  :uv1010 (new 'static 'vector4w :x #x100 :y #x100)
-                  :uv2020 (new 'static 'vector4w :x #x200 :y #x200)
-                  :uv4040 (new 'static 'vector4w :x #x400 :y #x400)
-                  :uv8080 (new 'static 'vector4w :x #x800 :y #x800)
-                  :xy00 (new 'static 'vector4w :z #xffffff)
-                  :xy88 (new 'static 'vector4w :x #x80 :y #x80 :z #xffffff)
-                  :xy1010 (new 'static 'vector4w :x #x100 :y #x100 :z #xffffff)
-                  :xy2020 (new 'static 'vector4w :x #x200 :y #x200 :z #xffffff)
-                  :xy4040 (new 'static 'vector4w :x #x400 :y #x400 :z #xffffff)
-                  :xy8080 (new 'static 'vector4w :x #x800 :y #x800 :z #xffffff)
-                  :cloud-alpha (new 'static 'array uint8 36
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    #x80
-                    )
-                  :tex1 #xeed00080178
-                  :tex1-near #xeed0008016c
-                  :scales (new 'static 'vector :x -0.00012207031 :y 255.0 :z -0.00012207031 :w 128.0)
-                  :mask-hi (new 'static 'vector4w :x -65536 :y -65536 :z -65536 :w -65536)
-                  :mask-lo (new 'static 'vector4w :x #xffff :y #xffff :z #xffff :w #xffff)
-                  )
+(define *ocean*
+  (new 'static 'ocean
+    :sprite-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :fst #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id uv)
+        :regs2 (gif-reg-id xyz2)
+        :regs3 (gif-reg-id uv)
+        :regs4 (gif-reg-id xyz2)
+        )
+      )
+    :sprite-tmpl2 (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x4 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x4 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :abe #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id rgbaq) :regs1 (gif-reg-id xyz2) :regs2 (gif-reg-id xyz2))
+      )
+    :sprite-tmpl3 (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1 :fst #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id uv)
+        :regs2 (gif-reg-id xyz2)
+        :regs3 (gif-reg-id uv)
+        :regs4 (gif-reg-id xyz2)
+        )
+      )
+    :adgif-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64 :nloop #x5 :eop #x1 :nreg #x1)
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id a+d))
+      )
+    :line-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x141 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x141 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x40
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type line) :tme #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id st)
+        :regs2 (gif-reg-id xyz2)
+        :regs3 (gif-reg-id st)
+        :regs4 (gif-reg-id xyz2)
+        )
+      )
+    :sun-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id st)
+        :regs2 (gif-reg-id xyz2)
+        :regs3 (gif-reg-id st)
+        :regs4 (gif-reg-id xyz2)
+        )
+      )
+    :erase-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x4 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x4 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite))
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id rgbaq) :regs1 (gif-reg-id xyz2) :regs2 (gif-reg-id xyz2))
+      )
+    :haze-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x45 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x45 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x11
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :iip #x1 :abe #x1)
+        :nreg #x4
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id xyzf2)
+        :regs2 (gif-reg-id rgbaq)
+        :regs3 (gif-reg-id xyzf2)
+        )
+      )
+    :cloud-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x25 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x25 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x6
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :iip #x1 :tme #x1 :abe #x1)
+        :nreg #x6
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id st)
+        :regs2 (gif-reg-id xyzf2)
+        :regs3 (gif-reg-id rgbaq)
+        :regs4 (gif-reg-id st)
+        :regs5 (gif-reg-id xyzf2)
+        )
+      )
+    :clut-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x41 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x41 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64 :nloop #x40 :eop #x1 :flg (gif-flag image))
+      )
+    :constant (new 'static 'vector :x 1.0 :y 1.0 :z 1.0)
+    :haze-verts (new 'static 'inline-array vector4w 32
+      (new 'static 'vector4w :x #x400 :y #x5c0 :z #xffffff)
+      (new 'static 'vector4w :x #x400 :y #x600 :z #xffffff)
+      (new 'static 'vector4w :x #x4a0 :y #x590 :z #xffffff)
+      (new 'static 'vector4w :x #x4c0 :y #x5e0 :z #xffffff)
+      (new 'static 'vector4w :x #x530 :y #x530 :z #xffffff)
+      (new 'static 'vector4w :x #x560 :y #x560 :z #xffffff)
+      (new 'static 'vector4w :x #x590 :y #x4a0 :z #xffffff)
+      (new 'static 'vector4w :x #x5e0 :y #x4c0 :z #xffffff)
+      (new 'static 'vector4w :x #x5c0 :y #x3f0 :z #xffffff)
+      (new 'static 'vector4w :x #x600 :y #x3f0 :z #xffffff)
+      (new 'static 'vector4w :x #x590 :y #x350 :z #xffffff)
+      (new 'static 'vector4w :x #x5e0 :y #x330 :z #xffffff)
+      (new 'static 'vector4w :x #x530 :y #x2c0 :z #xffffff)
+      (new 'static 'vector4w :x #x560 :y #x290 :z #xffffff)
+      (new 'static 'vector4w :x #x4a0 :y #x260 :z #xffffff)
+      (new 'static 'vector4w :x #x4c0 :y #x210 :z #xffffff)
+      (new 'static 'vector4w :x #x3f0 :y #x240 :z #xffffff)
+      (new 'static 'vector4w :x #x3f0 :y #x1f0 :z #xffffff)
+      (new 'static 'vector4w :x #x350 :y #x260 :z #xffffff)
+      (new 'static 'vector4w :x #x330 :y #x210 :z #xffffff)
+      (new 'static 'vector4w :x #x2c0 :y #x2c0 :z #xffffff)
+      (new 'static 'vector4w :x #x290 :y #x290 :z #xffffff)
+      (new 'static 'vector4w :x #x260 :y #x350 :z #xffffff)
+      (new 'static 'vector4w :x #x210 :y #x330 :z #xffffff)
+      (new 'static 'vector4w :x #x240 :y #x400 :z #xffffff)
+      (new 'static 'vector4w :x #x1f0 :y #x400 :z #xffffff)
+      (new 'static 'vector4w :x #x260 :y #x4a0 :z #xffffff)
+      (new 'static 'vector4w :x #x210 :y #x4c0 :z #xffffff)
+      (new 'static 'vector4w :x #x2c0 :y #x530 :z #xffffff)
+      (new 'static 'vector4w :x #x290 :y #x560 :z #xffffff)
+      (new 'static 'vector4w :x #x350 :y #x590 :z #xffffff)
+      (new 'static 'vector4w :x #x330 :y #x5e0 :z #xffffff)
+      )
+    :cloud-verts (new 'static 'inline-array vector4w 36
+      (new 'static 'vector4w :x #x290 :y #x290 :z #xffffff)
+      (new 'static 'vector4w :x #x310 :y #x230 :z #xffffff)
+      (new 'static 'vector4w :x #x3a0 :y #x200 :z #xffffff)
+      (new 'static 'vector4w :x #x450 :y #x200 :z #xffffff)
+      (new 'static 'vector4w :x #x4e0 :y #x230 :z #xffffff)
+      (new 'static 'vector4w :x #x560 :y #x290 :z #xffffff)
+      (new 'static 'vector4w :x #x230 :y #x310 :z #xffffff)
+      (new 'static 'vector4w :x #x300 :y #x300 :z #xffffff)
+      (new 'static 'vector4w :x #x3a0 :y #x2b0 :z #xffffff)
+      (new 'static 'vector4w :x #x450 :y #x2b0 :z #xffffff)
+      (new 'static 'vector4w :x #x4f0 :y #x300 :z #xffffff)
+      (new 'static 'vector4w :x #x5c0 :y #x310 :z #xffffff)
+      (new 'static 'vector4w :x #x200 :y #x3a0 :z #xffffff)
+      (new 'static 'vector4w :x #x2b0 :y #x3a0 :z #xffffff)
+      (new 'static 'vector4w :x #x380 :y #x380 :z #xffffff)
+      (new 'static 'vector4w :x #x470 :y #x380 :z #xffffff)
+      (new 'static 'vector4w :x #x540 :y #x3a0 :z #xffffff)
+      (new 'static 'vector4w :x #x5f0 :y #x3a0 :z #xffffff)
+      (new 'static 'vector4w :x #x200 :y #x450 :z #xffffff)
+      (new 'static 'vector4w :x #x2b0 :y #x450 :z #xffffff)
+      (new 'static 'vector4w :x #x380 :y #x470 :z #xffffff)
+      (new 'static 'vector4w :x #x470 :y #x470 :z #xffffff)
+      (new 'static 'vector4w :x #x540 :y #x450 :z #xffffff)
+      (new 'static 'vector4w :x #x5f0 :y #x450 :z #xffffff)
+      (new 'static 'vector4w :x #x230 :y #x4e0 :z #xffffff)
+      (new 'static 'vector4w :x #x300 :y #x4f0 :z #xffffff)
+      (new 'static 'vector4w :x #x3a0 :y #x540 :z #xffffff)
+      (new 'static 'vector4w :x #x450 :y #x540 :z #xffffff)
+      (new 'static 'vector4w :x #x4f0 :y #x4f0 :z #xffffff)
+      (new 'static 'vector4w :x #x5c0 :y #x4e0 :z #xffffff)
+      (new 'static 'vector4w :x #x290 :y #x560 :z #xffffff)
+      (new 'static 'vector4w :x #x310 :y #x5c0 :z #xffffff)
+      (new 'static 'vector4w :x #x3a0 :y #x5f0 :z #xffffff)
+      (new 'static 'vector4w :x #x450 :y #x5f0 :z #xffffff)
+      (new 'static 'vector4w :x #x4e0 :y #x5c0 :z #xffffff)
+      (new 'static 'vector4w :x #x560 :y #x560 :z #xffffff)
+      )
+    :cloud-nrms (new 'static 'inline-array vector 36
+      (new 'static 'vector :x -0.4999 :y 0.7071 :z -0.5)
+      (new 'static 'vector :x -0.3209 :y 0.7071 :z -0.63)
+      (new 'static 'vector :x -0.1105 :y 0.7071 :z -0.6984)
+      (new 'static 'vector :x 0.1105 :y 0.7071 :z -0.6983)
+      (new 'static 'vector :x 0.321 :y 0.7071 :z -0.63)
+      (new 'static 'vector :x 0.5 :y 0.7071 :z -0.4999)
+      (new 'static 'vector :x -0.63 :y 0.7071 :z -0.321)
+      (new 'static 'vector :x -0.3921 :y 0.832 :z -0.3922)
+      (new 'static 'vector :x -0.1434 :y 0.832 :z -0.5358)
+      (new 'static 'vector :x 0.1435 :y 0.832 :z -0.5357)
+      (new 'static 'vector :x 0.3922 :y 0.832 :z -0.3921)
+      (new 'static 'vector :x 0.63 :y 0.7071 :z -0.3209)
+      (new 'static 'vector :x -0.6983 :y 0.7071 :z -0.1106)
+      (new 'static 'vector :x -0.5357 :y 0.832 :z -0.1435)
+      (new 'static 'vector :x -0.334 :y 0.8814 :z -0.334)
+      (new 'static 'vector :x 0.334 :y 0.8814 :z -0.334)
+      (new 'static 'vector :x 0.5358 :y 0.832 :z -0.1434)
+      (new 'static 'vector :x 0.6984 :y 0.7071 :z -0.1105)
+      (new 'static 'vector :x -0.6984 :y 0.7071 :z 0.1105)
+      (new 'static 'vector :x -0.5358 :y 0.832 :z 0.1435)
+      (new 'static 'vector :x -0.334 :y 0.8814 :z 0.334)
+      (new 'static 'vector :x 0.334 :y 0.8814 :z 0.334)
+      (new 'static 'vector :x 0.5357 :y 0.832 :z 0.1435)
+      (new 'static 'vector :x 0.6983 :y 0.7071 :z 0.1105)
+      (new 'static 'vector :x -0.63 :y 0.7071 :z 0.321)
+      (new 'static 'vector :x -0.3922 :y 0.832 :z 0.3921)
+      (new 'static 'vector :x -0.1435 :y 0.832 :z 0.5357)
+      (new 'static 'vector :x 0.1435 :y 0.832 :z 0.5358)
+      (new 'static 'vector :x 0.3922 :y 0.832 :z 0.3922)
+      (new 'static 'vector :x 0.63 :y 0.7071 :z 0.321)
+      (new 'static 'vector :x -0.5 :y 0.7071 :z 0.4999)
+      (new 'static 'vector :x -0.321 :y 0.7071 :z 0.63)
+      (new 'static 'vector :x -0.1106 :y 0.7071 :z 0.6983)
+      (new 'static 'vector :x 0.1105 :y 0.7071 :z 0.6984)
+      (new 'static 'vector :x 0.321 :y 0.7071 :z 0.63)
+      (new 'static 'vector :x 0.4999 :y 0.7071 :z 0.5)
+      )
+    :color80808080 (new 'static 'vector4w :x #x80 :y #x80 :z #x80 :w #x80)
+    :color80808040 (new 'static 'vector4w :x #x80 :y #x80 :z #x80 :w 64)
+    :color80808000 (new 'static 'vector4w :x #x80 :y #x80 :z #x80)
+    :st0000 (new 'static 'vector :z 1.0)
+    :st0505 (new 'static 'vector :x 0.5 :y 0.5 :z 1.0)
+    :st1010 (new 'static 'vector :x 1.0 :y 1.0 :z 1.0)
+    :uv44 (new 'static 'vector4w :x 64 :y 64)
+    :uv88 (new 'static 'vector4w :x #x80 :y #x80)
+    :uv1010 (new 'static 'vector4w :x #x100 :y #x100)
+    :uv2020 (new 'static 'vector4w :x #x200 :y #x200)
+    :uv4040 (new 'static 'vector4w :x #x400 :y #x400)
+    :uv8080 (new 'static 'vector4w :x #x800 :y #x800)
+    :xy00 (new 'static 'vector4w :z #xffffff)
+    :xy88 (new 'static 'vector4w :x #x80 :y #x80 :z #xffffff)
+    :xy1010 (new 'static 'vector4w :x #x100 :y #x100 :z #xffffff)
+    :xy2020 (new 'static 'vector4w :x #x200 :y #x200 :z #xffffff)
+    :xy4040 (new 'static 'vector4w :x #x400 :y #x400 :z #xffffff)
+    :xy8080 (new 'static 'vector4w :x #x800 :y #x800 :z #xffffff)
+    :cloud-alpha (new 'static 'array uint8 36
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      #x80
+      )
+    :tex1 #xeed00080178
+    :tex1-near #xeed0008016c
+    :scales (new 'static 'vector :x -0.00012207031 :y 255.0 :z -0.00012207031 :w 128.0)
+    :mask-hi (new 'static 'vector4w :x -65536 :y -65536 :z -65536 :w -65536)
+    :mask-lo (new 'static 'vector4w :x #xffff :y #xffff :z #xffff :w #xffff)
+    )
+  )
 
 ;; failed to figure out what this is:
 0

--- a/test/decompiler/reference/jak2/engine/gfx/shrub/shrub-work_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/shrub/shrub-work_REF.gc
@@ -61,14 +61,22 @@
         :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id next))
         :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x1000000000008005 #xe)
+      :gif0 (new 'static 'gif-tag64 :nloop #x5 :eop #x1 :nreg #x1)
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id a+d))
       )
     :billboard-tmpl (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #xd :id (dma-tag-id next))
         :vif1 (new 'static 'vif-tag :imm #xd :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x303e400000008004 #x412)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x4
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :iip #x1 :tme #x1 :fge #x1 :abe #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id st) :regs1 (gif-reg-id rgbaq) :regs2 (gif-reg-id xyzf2))
       )
     :shrub-near-packets (new 'static 'inline-array shrub-near-packet 6
       (new 'static 'shrub-near-packet
@@ -412,7 +420,3 @@
     )
   arg0
   )
-
-
-
-

--- a/test/decompiler/reference/jak2/engine/gfx/sky/sky-data_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/sky/sky-data_REF.gc
@@ -9,49 +9,120 @@
         :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x1000000000008005 #xe)
+      :gif0 (new 'static 'gif-tag64 :nloop #x5 :eop #x1 :nreg #x1)
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id a+d))
       )
     :draw-tmpl (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x502b400000008001 #x42421)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id st)
+        :regs2 (gif-reg-id xyzf2)
+        :regs3 (gif-reg-id st)
+        :regs4 (gif-reg-id xyzf2)
+        )
       )
     :draw-tmpl2 (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x50ab400000008001 #x43431)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1 :fst #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id uv)
+        :regs2 (gif-reg-id xyzf2)
+        :regs3 (gif-reg-id uv)
+        :regs4 (gif-reg-id xyzf2)
+        )
       )
     :fog-tmpl (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #xa :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #xa :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x902a400000008001 #x424242421)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :tme #x1 :abe #x1)
+        :nreg #x9
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id st)
+        :regs2 (gif-reg-id xyzf2)
+        :regs3 (gif-reg-id st)
+        :regs4 (gif-reg-id xyzf2)
+        :regs5 (gif-reg-id st)
+        :regs6 (gif-reg-id xyzf2)
+        :regs7 (gif-reg-id st)
+        :regs8 (gif-reg-id xyzf2)
+        )
       )
     :blend-tmpl (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x50ab400000008001 #x43431)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1 :fst #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id uv)
+        :regs2 (gif-reg-id xyzf2)
+        :regs3 (gif-reg-id uv)
+        :regs4 (gif-reg-id xyzf2)
+        )
       )
     :sprite-tmpl (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #x3 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x3 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x2003400000008001 #x55)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite))
+        :nreg #x2
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id xyz2) :regs1 (gif-reg-id xyz2))
       )
     :sprite-tmpl2 (new 'static 'dma-gif-packet
       :dma-vif (new 'static 'dma-packet
         :dma (new 'static 'dma-tag :qwc #x21 :id (dma-tag-id cnt))
         :vif1 (new 'static 'vif-tag :imm #x21 :cmd (vif-cmd direct) :msk #x1)
         )
-      :gif (new 'static 'array uint64 2 #x2003400000008010 #x55)
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x10
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite))
+        :nreg #x2
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id xyz2) :regs1 (gif-reg-id xyz2))
       )
     :sun-coords (new 'static 'inline-array vector 2
       (new 'static 'vector :x -267.0 :y -267.0 :w 1.0)
@@ -98,10 +169,46 @@
       (new 'static 'vector4w :x #x387528 :y #x723099 :z #x140983 :w #x874310)
       (new 'static 'vector4w :x #x2387 :y #x129818 :z #x219810 :w #x623790)
       )
-    :giftag-base (new 'static 'dma-gif :gif (new 'static 'array uint64 2 #x3002c00000008001 #x412))
-    :giftag-haze (new 'static 'dma-gif :gif (new 'static 'array uint64 2 #x3026c00000008001 #x412))
-    :giftag-roof (new 'static 'dma-gif :gif (new 'static 'array uint64 2 #x302ec00000008001 #x412))
-    :giftag-ocean (new 'static 'dma-gif :gif (new 'static 'array uint64 2 #x301ec00000008001 #x412))
+    :giftag-base (new 'static 'dma-gif
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-fan))
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id st) :regs1 (gif-reg-id rgbaq) :regs2 (gif-reg-id xyzf2))
+      )
+    :giftag-haze (new 'static 'dma-gif
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-fan) :iip #x1 :abe #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id st) :regs1 (gif-reg-id rgbaq) :regs2 (gif-reg-id xyzf2))
+      )
+    :giftag-roof (new 'static 'dma-gif
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-fan) :iip #x1 :tme #x1 :abe #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id st) :regs1 (gif-reg-id rgbaq) :regs2 (gif-reg-id xyzf2))
+      )
+    :giftag-ocean (new 'static 'dma-gif
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-fan) :iip #x1 :tme #x1 :fge #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id st) :regs1 (gif-reg-id rgbaq) :regs2 (gif-reg-id xyzf2))
+      )
     :draw-vortex #f
     )
   )

--- a/test/decompiler/reference/jak2/engine/util/profile_REF.gc
+++ b/test/decompiler/reference/jak2/engine/util/profile_REF.gc
@@ -27,23 +27,38 @@
   )
 
 ;; definition for symbol *profile-work*, type profile-work
-(define *profile-work* (new 'static 'profile-work
-                         :sprite-tmpl (new 'static 'dma-gif-packet
-                           :dma-vif (new 'static 'dma-packet
-                             :dma (new 'static 'dma-tag :qwc #x4 :id (dma-tag-id cnt))
-                             :vif1 (new 'static 'vif-tag :imm #x4 :cmd (vif-cmd direct) :msk #x1)
-                             )
-                           :gif (new 'static 'array uint64 2 #x3023400000008001 #x551)
-                           )
-                         :line-tmpl (new 'static 'dma-gif-packet
-                           :dma-vif (new 'static 'dma-packet
-                             :dma (new 'static 'dma-tag :qwc #x4 :id (dma-tag-id cnt))
-                             :vif1 (new 'static 'vif-tag :imm #x4 :cmd (vif-cmd direct) :msk #x1)
-                             )
-                           :gif (new 'static 'array uint64 2 #x3020c00000008001 #x551)
-                           )
-                         )
+(define *profile-work*
+  (new 'static 'profile-work
+    :sprite-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x4 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x4 :cmd (vif-cmd direct) :msk #x1)
         )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :abe #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id rgbaq) :regs1 (gif-reg-id xyz2) :regs2 (gif-reg-id xyz2))
+      )
+    :line-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x4 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x4 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type line) :abe #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id rgbaq) :regs1 (gif-reg-id xyz2) :regs2 (gif-reg-id xyz2))
+      )
+    )
+  )
 
 ;; definition for symbol *profile-x*, type int
 (define *profile-x* 1808)


### PR DESCRIPTION
```
      :gif0 (new 'static 'gif-tag64
        :nloop #x4
        :eop #x1
        :pre #x1
        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-strip) :iip #x1 :tme #x1 :fge #x1 :abe #x1)
        :nreg #x3
        )
      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id st) :regs1 (gif-reg-id rgbaq) :regs2 (gif-reg-id xyzf2))
```
instead of
```
:gif (new 'static 'array uint64 2 #x303e400000008004 #x412)
```