### PR TITLE
ci: rollback to previous buildcache version

### DIFF
--- a/.github/workflows/linux-build-clang.yaml
+++ b/.github/workflows/linux-build-clang.yaml
@@ -35,9 +35,10 @@ jobs:
           libxi-dev zip ninja-build
 
       - name: Setup Buildcache
-        uses: mikehardy/buildcache-action@v1.3.0
+        uses: xTVaser/buildcache-action@version-flag
         with:
           cache_key: linux-ubuntu-20.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          buildcache_tag: v0.27.6
 
       - name: CMake Generation
         env:

--- a/.github/workflows/linux-build-gcc.yaml
+++ b/.github/workflows/linux-build-gcc.yaml
@@ -35,9 +35,10 @@ jobs:
           libxi-dev zip ninja-build
 
       - name: Setup Buildcache
-        uses: mikehardy/buildcache-action@v1.3.0
+        uses: xTVaser/buildcache-action@version-flag
         with:
           cache_key: linux-ubuntu-20.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          buildcache_tag: v0.27.6
 
       - name: CMake Generation
         env:


### PR DESCRIPTION
buildcache's latest release changes to be built on Ubuntu22.04, which breaks our 20.04 runners

