### PR TITLE
ci: update buildcache back now that things have stabilized

### DIFF
--- a/.github/workflows/linux-build-clang.yaml
+++ b/.github/workflows/linux-build-clang.yaml
@@ -35,10 +35,10 @@ jobs:
           libxi-dev zip ninja-build
 
       - name: Setup Buildcache
-        uses: xTVaser/buildcache-action@version-flag
+        uses: mikehardy/buildcache-action@v2
         with:
           cache_key: linux-ubuntu-20.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
-          buildcache_tag: v0.27.6
+          buildcache_tag: v0.28.1
 
       - name: CMake Generation
         env:

--- a/.github/workflows/linux-build-gcc.yaml
+++ b/.github/workflows/linux-build-gcc.yaml
@@ -35,10 +35,10 @@ jobs:
           libxi-dev zip ninja-build
 
       - name: Setup Buildcache
-        uses: xTVaser/buildcache-action@version-flag
+        uses: mikehardy/buildcache-action@v2
         with:
           cache_key: linux-ubuntu-20.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
-          buildcache_tag: v0.27.6
+          buildcache_tag: v0.28.1
 
       - name: CMake Generation
         env:


### PR DESCRIPTION
My changes for allowing an explicit tag have now been merged to the original action, so no need to use my fork.

Additionally, buildcache itself reverted to using ubuntu 20.04 to fix this issue, but we'll leave the explicit tag there anyway to avoid sudden breakage in the future.