### PR TITLE
fix the game_subtitle.gp path

### DIFF
--- a/common/serialization/subtitles/subtitles_ser.cpp
+++ b/common/serialization/subtitles/subtitles_ser.cpp
@@ -477,7 +477,7 @@ GameSubtitleDB load_subtitle_project() {
     goos::Reader reader;
     std::vector<std::string> inputs;
     std::string subtitle_project =
-        (file_util::get_jak_project_dir() / "game" / "assets" / "game_subtitle.gp").string();
+        (file_util::get_jak_project_dir() / "game" / "assets" / "jak1" / "game_subtitle.gp").string();
     open_text_project("subtitle", subtitle_project, inputs);
     for (auto& filename : inputs) {
       auto code = reader.read_from_file({filename});

--- a/goal_src/jak1/pc/subtitle.gc
+++ b/goal_src/jak1/pc/subtitle.gc
@@ -294,7 +294,7 @@
 (defmacro reload-subtitles ()
   "rebuild and reload subtitles."
   `(begin
-      (asm-text-file subtitle :files ("game/assets/game_subtitle.gp"))
+      (asm-text-file subtitle :files ("game/assets/jak1/game_subtitle.gp"))
       (if *subtitle-text*
           (+! (-> *subtitle-text* lang) (the-as pc-subtitle-lang 1)))
       (load-level-subtitle-files 0)))


### PR DESCRIPTION
Which cause the subtitle editor for jak1 to crash, since you guys started to work on jak2 assets were moved into jak1 and jak2 folders.