### PR TITLE
decomp: output mips2c method/function declarations to the `_disasm.gc` file

### DIFF
--- a/decompiler/ObjectFile/ObjectFileDB_IR2.cpp
+++ b/decompiler/ObjectFile/ObjectFileDB_IR2.cpp
@@ -1049,7 +1049,9 @@ std::string ObjectFileDB::ir2_function_to_string(ObjectFileData& data, Function&
   }
 
   if (func.mips2c_output) {
+    result += ";;-*-MIPS2C-Start-*-\n";
     result += *func.mips2c_output;
+    result += ";;-*-MIPS2C-End-*-\n";
   }
 
   result += "\n";

--- a/decompiler/analysis/final_output.cpp
+++ b/decompiler/analysis/final_output.cpp
@@ -218,7 +218,25 @@ std::string careful_function_to_string(
   }
 
   if (!func->ir2.top_form) {
-    return ";; ERROR: function was not converted to expressions. Cannot decompile.\n\n";
+    if (func->mips2c_output) {
+      std::string output = ";; INFO: function output is handled by mips2c\n";
+      // Attempt to automatically generate the OpenGOAL code for calling the mips2c varient
+      // For methods this is - (defmethod-mips2c "(method <METHOD_ID> <TYPE>)" <METHOD_ID>)
+      if (func->guessed_name.kind == FunctionName::FunctionKind::METHOD) {
+        output += fmt::format("(defmethod-mips2c \"(method {} {})\" {} {})\n",
+                              func->guessed_name.method_id, func->guessed_name.type_name,
+                              func->guessed_name.method_id, func->guessed_name.type_name);
+      } else if (func->guessed_name.kind == FunctionName::FunctionKind::GLOBAL) {
+        // For functions it is - (def-mips2c <FUNC_NAME> (function <ARGS> <RET>))
+        // TODO - is it possible to easily get the args from `all-types` to this point?
+        output += fmt::format(";; (def-mips2c {} (function ARGS RET))\n",
+                              func->guessed_name.function_name);
+      }
+
+      return output + "\n";
+    } else {
+      return ";; ERROR: function was not converted to expressions. Cannot decompile.\n\n";
+    }
   }
   if (!env.has_type_analysis()) {
     return ";; ERROR: function has no type analysis. Cannot decompile.\n\n";

--- a/decompiler/analysis/final_output.cpp
+++ b/decompiler/analysis/final_output.cpp
@@ -227,10 +227,9 @@ std::string careful_function_to_string(
                               func->guessed_name.method_id, func->guessed_name.type_name,
                               func->guessed_name.method_id, func->guessed_name.type_name);
       } else if (func->guessed_name.kind == FunctionName::FunctionKind::GLOBAL) {
-        // For functions it is - (def-mips2c <FUNC_NAME> (function <ARGS> <RET>))
-        // TODO - is it possible to easily get the args from `all-types` to this point?
-        output += fmt::format(";; (def-mips2c {} (function ARGS RET))\n",
-                              func->guessed_name.function_name);
+        // For functions it is - (def-mips2c <FUNC_NAME> (function <SIGNATURE>))
+        output += fmt::format("(def-mips2c {} {})\n", func->guessed_name.function_name,
+                              func->type.print());
       }
 
       return output + "\n";

--- a/test/decompiler/reference/jak1/decompiler-macros.gc
+++ b/test/decompiler/reference/jak1/decompiler-macros.gc
@@ -1360,3 +1360,16 @@
 (defmacro current-frame ()
   `(-> *display* frames (-> *display* on-screen))
   )
+
+(defmacro def-mips2c (name type)
+  "Define a mips2c object (typically a function)."
+  `(begin
+     (define-extern ,name ,type)
+     (set! ,name (the-as ,type (__pc-get-mips2c ,(symbol->string name))))
+     )
+  )
+
+(defmacro defmethod-mips2c (name method-id method-type)
+  "Define a mips2c method."
+  `(method-set! ,method-type ,method-id (__pc-get-mips2c ,name))
+  )

--- a/test/decompiler/reference/jak1/engine/anim/joint_REF.gc
+++ b/test/decompiler/reference/jak1/engine/anim/joint_REF.gc
@@ -1261,22 +1261,28 @@
   )
 
 ;; definition for function cspace<-parented-transformq-joint!
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c cspace<-parented-transformq-joint! (function cspace transformq none))
 
 ;; definition for function clear-frame-accumulator
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c clear-frame-accumulator (function (inline-array vector) none))
 
 ;; definition for function normalize-frame-quaternions
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c normalize-frame-quaternions function)
 
 ;; definition for function decompress-fixed-data-to-accumulator
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c decompress-fixed-data-to-accumulator (function none))
 
 ;; definition for function decompress-frame-data-to-accumulator
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c decompress-frame-data-to-accumulator (function none))
 
 ;; definition for function decompress-frame-data-pair-to-accumulator
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c decompress-frame-data-pair-to-accumulator (function none))
 
 ;; definition for function make-joint-jump-tables
 (defun make-joint-jump-tables ()
@@ -1428,7 +1434,8 @@
   )
 
 ;; definition for function calc-animation-from-spr
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c calc-animation-from-spr (function (inline-array vector) int none))
 
 ;; definition for function create-interpolated-joint-animation-frame
 (defun create-interpolated-joint-animation-frame ((arg0 (inline-array vector)) (arg1 int) (arg2 process-drawable))

--- a/test/decompiler/reference/jak1/engine/collide/collide-edge-grab_REF.gc
+++ b/test/decompiler/reference/jak1/engine/collide/collide-edge-grab_REF.gc
@@ -99,7 +99,8 @@
   )
 
 ;; definition for method 10 of type collide-edge-hold-list
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 10 collide-edge-hold-list)" 10 collide-edge-hold-list)
 
 ;; definition of type pbhp-stack-vars
 (deftype pbhp-stack-vars (structure)
@@ -124,7 +125,8 @@
   )
 
 ;; definition for method 18 of type collide-edge-work
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 18 collide-edge-work)" 18 collide-edge-work)
 
 ;; definition for method 19 of type collide-edge-work
 ;; INFO: Used lq/sq
@@ -355,10 +357,12 @@
   )
 
 ;; definition for method 16 of type collide-edge-work
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 16 collide-edge-work)" 16 collide-edge-work)
 
 ;; definition for method 15 of type collide-edge-work
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 15 collide-edge-work)" 15 collide-edge-work)
 
 ;; definition for method 14 of type collide-edge-work
 ;; INFO: Used lq/sq

--- a/test/decompiler/reference/jak1/engine/collide/collide-func_REF.gc
+++ b/test/decompiler/reference/jak1/engine/collide/collide-func_REF.gc
@@ -345,10 +345,12 @@
   )
 
 ;; definition for function collide-do-primitives
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c collide-do-primitives (function float))
 
 ;; definition for function moving-sphere-triangle-intersect
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c moving-sphere-triangle-intersect (function vector vector float collide-cache-tri vector vector float))
 
 ;; definition for function moving-sphere-sphere-intersect
 ;; INFO: Used lq/sq

--- a/test/decompiler/reference/jak1/engine/collide/collide-mesh_REF.gc
+++ b/test/decompiler/reference/jak1/engine/collide/collide-mesh_REF.gc
@@ -102,7 +102,8 @@
   )
 
 ;; definition for method 12 of type collide-mesh
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 12 collide-mesh)" 12 collide-mesh)
 
 ;; definition of type spat-work
 (deftype spat-work (structure)
@@ -123,13 +124,16 @@
   )
 
 ;; definition for method 11 of type collide-mesh
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 11 collide-mesh)" 11 collide-mesh)
 
 ;; definition for method 14 of type collide-mesh
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 14 collide-mesh)" 14 collide-mesh)
 
 ;; definition for method 15 of type collide-mesh
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 15 collide-mesh)" 15 collide-mesh)
 
 ;; definition for method 9 of type collide-mesh-cache
 ;; INFO: Return type mismatch (pointer uint8) vs int.

--- a/test/decompiler/reference/jak1/engine/collide/collide-probe_REF.gc
+++ b/test/decompiler/reference/jak1/engine/collide/collide-probe_REF.gc
@@ -153,7 +153,8 @@
 (define collide-vu0-block (the-as vu-function 0))
 
 ;; definition for function collide-probe-node
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c collide-probe-node (function (inline-array draw-node) int collide-list int))
 
 ;; definition for function print-out
 (defun print-out ((arg0 int))
@@ -168,7 +169,8 @@
   )
 
 ;; definition for function collide-probe-instance-tie
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c collide-probe-instance-tie (function object int collide-list int int))
 
 ;; definition for function collide-probe-collide-fragment-tree-make-list
 ;; INFO: Return type mismatch int vs none.

--- a/test/decompiler/reference/jak1/engine/gfx/generic/generic-merc_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/generic/generic-merc_REF.gc
@@ -1,7 +1,10 @@
+;;-*-Lisp-*-
 (in-package goal)
 
+;; definition for symbol mercneric-vu0-block, type vu-function
 (define mercneric-vu0-block (new 'static 'vu-function :length #xbe :origin #x118 :qlength 95))
 
+;; definition of type invinitdata
 (deftype invinitdata (structure)
   ((count     uint8   :offset-assert   0)
    (init-data uint8   :offset-assert   1)
@@ -13,6 +16,7 @@
   :flag-assert         #x900000004
   )
 
+;; definition for method 3 of type invinitdata
 (defmethod inspect invinitdata ((obj invinitdata))
   (format #t "[~8x] ~A~%" obj 'invinitdata)
   (format #t "~Tcount: ~D~%" (-> obj count))
@@ -21,6 +25,7 @@
   obj
   )
 
+;; definition for symbol *inv-init-table*, type (inline-array invinitdata)
 (define *inv-init-table* (new 'static 'inline-array invinitdata 8
                            (new 'static 'invinitdata :count #x48 :init-addr #x1)
                            (new 'static 'invinitdata :count #x43 :init-data #xc :init-addr #x11)
@@ -33,13 +38,36 @@
                            )
         )
 
+;; definition for function generic-merc-init-asm
+;; INFO: function output is handled by mips2c
+(def-mips2c generic-merc-init-asm (function none))
 
+;; definition for function mercneric-matrix-asm
+;; INFO: function output is handled by mips2c
+(def-mips2c mercneric-matrix-asm function)
 
+;; definition for function mercneric-shader-asm
+;; INFO: function output is handled by mips2c
+(def-mips2c mercneric-shader-asm function)
 
+;; definition for function mercneric-bittable-asm
+;; INFO: function output is handled by mips2c
+(def-mips2c mercneric-bittable-asm function)
 
+;; definition for function mercneric-convert
+;; INFO: function output is handled by mips2c
+(def-mips2c mercneric-convert function)
 
+;; definition for function high-speed-reject
+;; INFO: function output is handled by mips2c
+(def-mips2c high-speed-reject (function none))
 
+;; definition for function generic-merc-execute-asm
+;; INFO: function output is handled by mips2c
+(def-mips2c generic-merc-execute-asm (function none))
 
+;; definition for function generic-merc-add-to-cue
+;; INFO: Return type mismatch merc-globals vs none.
 (defun generic-merc-add-to-cue ((arg0 generic-dma-foreground-sink))
   (set! (-> *merc-globals* sink) arg0)
   (+! (-> *merc-global-array* count) 1)
@@ -47,6 +75,11 @@
   (none)
   )
 
+;; definition for function generic-merc-execute-all
+;; INFO: Return type mismatch profile-frame vs none.
+;; WARN: Failed store: (s.w! (the-as int a0-19) a1-7) at op 109
+;; ERROR: Unsupported inline assembly instruction kind - [cache dxwbin v1, 0]
+;; ERROR: Unsupported inline assembly instruction kind - [cache dxwbin v1, 1]
 (defun generic-merc-execute-all ((arg0 dma-buffer))
   (local-vars (a0-26 int) (a0-28 int))
   (when (nonzero? (-> *merc-global-array* count))

--- a/test/decompiler/reference/jak1/engine/gfx/ocean/ocean-vu0_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/ocean/ocean-vu0_REF.gc
@@ -10,10 +10,12 @@
         )
 
 ;; definition for function ocean-interp-wave
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c ocean-interp-wave (function ocean-wave-info uint none))
 
 ;; definition for symbol ocean-vu0-block, type vu-function
 (define ocean-vu0-block (new 'static 'vu-function :length 72 :qlength 36))
 
 ;; definition for function ocean-generate-verts
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c ocean-generate-verts (function (inline-array vector) ocean-wave-info none))

--- a/test/decompiler/reference/jak1/engine/gfx/ripple_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/ripple_REF.gc
@@ -84,13 +84,16 @@
   )
 
 ;; definition for function ripple-execute-init
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c ripple-execute-init (function none))
 
 ;; definition for function ripple-create-wave-table
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c ripple-create-wave-table (function ripple-wave-set int))
 
 ;; definition for function ripple-apply-wave-table
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c ripple-apply-wave-table (function merc-effect symbol))
 
 ;; definition for function ripple-execute
 ;; INFO: Return type mismatch int vs none.
@@ -126,7 +129,8 @@
   )
 
 ;; definition for function ripple-matrix-scale
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c ripple-matrix-scale function)
 
 ;; definition (debug) for function ripple-add-debug-sphere
 ;; INFO: Used lq/sq

--- a/test/decompiler/reference/jak1/engine/gfx/sky/sky-tng_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/sky/sky-tng_REF.gc
@@ -150,25 +150,32 @@
   )
 
 ;; definition for function init-sky-regs
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c init-sky-regs (function none))
 
 ;; definition for function set-tex-offset
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c set-tex-offset (function int int none))
 
 ;; definition for function draw-large-polygon
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c draw-large-polygon function)
 
 ;; definition for function clip-polygon-against-positive-hyperplane
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c clip-polygon-against-positive-hyperplane function)
 
 ;; definition for function clip-polygon-against-negative-hyperplane
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c clip-polygon-against-negative-hyperplane function)
 
 ;; definition for function render-sky-quad
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c render-sky-quad (function int dma-buffer none))
 
 ;; definition for function render-sky-tri
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c render-sky-tri (function (inline-array sky-vertex) dma-buffer none))
 
 ;; definition for function sky-duplicate-polys
 ;; ERROR: function has no type analysis. Cannot decompile.

--- a/test/decompiler/reference/jak1/engine/gfx/texture_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/texture_REF.gc
@@ -2385,7 +2385,8 @@
   )
 
 ;; definition for function adgif-shader<-texture-with-update!
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c adgif-shader<-texture-with-update! (function adgif-shader texture adgif-shader))
 
 ;; definition for function adgif-shader-login
 (defun adgif-shader-login ((shader adgif-shader))

--- a/test/decompiler/reference/jak1/engine/gfx/tfrag/tfrag_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/tfrag/tfrag_REF.gc
@@ -429,7 +429,8 @@
   )
 
 ;; definition for function draw-inline-array-tfrag
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c draw-inline-array-tfrag (function pointer drawable-inline-array int dma-buffer none))
 
 ;; definition for function tfrag-near-init-buffer
 ;; INFO: Return type mismatch symbol vs none.
@@ -505,4 +506,5 @@
 ;; ERROR: function was not converted to expressions. Cannot decompile.
 
 ;; definition for function stats-tfrag-asm
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c stats-tfrag-asm (function tfragment none))

--- a/test/decompiler/reference/jak1/engine/gfx/tie/tie-methods_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/tie/tie-methods_REF.gc
@@ -221,10 +221,12 @@
 (define *pke-hack* (new 'global 'vector))
 
 ;; definition for function draw-inline-array-instance-tie
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c draw-inline-array-instance-tie (function pointer (inline-array instance-tie) int dma-buffer none))
 
 ;; definition for function draw-inline-array-prototype-tie-generic-asm
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c draw-inline-array-prototype-tie-generic-asm (function dma-buffer int prototype-array-tie none))
 
 ;; definition for function draw-inline-array-prototype-tie-asm
 ;; ERROR: function was not converted to expressions. Cannot decompile.

--- a/test/decompiler/reference/jak1/engine/gfx/time-of-day_REF.gc
+++ b/test/decompiler/reference/jak1/engine/gfx/time-of-day_REF.gc
@@ -217,7 +217,8 @@
 ;; ERROR: function was not converted to expressions. Cannot decompile.
 
 ;; definition for function time-of-day-interp-colors-scratch
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c time-of-day-interp-colors-scratch (function (pointer rgba) time-of-day-palette mood-context none))
 
 ;; definition for function init-time-of-day-context
 ;; INFO: Return type mismatch float vs none.

--- a/test/decompiler/reference/jak1/engine/level/load-boundary_REF.gc
+++ b/test/decompiler/reference/jak1/engine/level/load-boundary_REF.gc
@@ -30,7 +30,8 @@
 (set! (-> *lb-editor-parms* boundary) #f)
 
 ;; definition (debug) for function init-boundary-regs
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c init-boundary-regs (function none))
 
 ;; definition (debug) for function add-boundary-shader
 ;; INFO: Return type mismatch pointer vs none.
@@ -62,13 +63,16 @@
   )
 
 ;; definition (debug) for function draw-boundary-polygon
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c draw-boundary-polygon function)
 
 ;; definition (debug) for function render-boundary-quad
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c render-boundary-quad (function lbvtx dma-buffer none))
 
 ;; definition (debug) for function render-boundary-tri
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c render-boundary-tri (function lbvtx dma-buffer none))
 
 ;; definition for symbol *boundary-polygon*, type (inline-array lbvtx)
 (define *boundary-polygon* (new 'static 'inline-array lbvtx 12

--- a/test/decompiler/reference/jak1/engine/sparticle/sparticle-launcher_REF.gc
+++ b/test/decompiler/reference/jak1/engine/sparticle/sparticle-launcher_REF.gc
@@ -339,7 +339,8 @@
   )
 
 ;; definition for function sp-init-fields!
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c sp-init-fields! (function object (inline-array sp-field-init-spec) sp-field-id sp-field-id symbol object))
 
 ;; definition of type sp-queued-launch-particles
 (deftype sp-queued-launch-particles (structure)
@@ -440,7 +441,8 @@
 (set! (-> *particle-adgif-cache* used) 0)
 
 ;; definition for function particle-adgif
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c particle-adgif (function adgif-shader texture-id none))
 
 ;; definition for function sp-queue-launch
 ;; INFO: Used lq/sq
@@ -585,7 +587,8 @@
   )
 
 ;; definition for function sp-launch-particles-var
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c sp-launch-particles-var (function sparticle-system sparticle-launcher vector sparticle-launch-state sparticle-launch-control float none))
 
 ;; definition for symbol *death-adgif*, type adgif-shader
 (define *death-adgif* (the-as adgif-shader #f))

--- a/test/decompiler/reference/jak1/engine/sparticle/sparticle_REF.gc
+++ b/test/decompiler/reference/jak1/engine/sparticle/sparticle_REF.gc
@@ -324,10 +324,12 @@
   )
 
 ;; definition for function sp-process-block-2d
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c sp-process-block-2d (function sparticle-system int int int int symbol none))
 
 ;; definition for function sp-process-block-3d
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c sp-process-block-3d (function sparticle-system int int int int symbol none))
 
 ;; definition for function sp-copy-to-spr
 ;; INFO: Return type mismatch int vs none.

--- a/test/decompiler/reference/jak2/decompiler-macros.gc
+++ b/test/decompiler/reference/jak2/decompiler-macros.gc
@@ -1272,3 +1272,16 @@
 (defmacro current-frame ()
   `(-> *display* frames (-> *display* on-screen))
   )
+
+(defmacro def-mips2c (name type)
+  "Define a mips2c object (typically a function)."
+  `(begin
+     (define-extern ,name ,type)
+     (set! ,name (the-as ,type (__pc-get-mips2c ,(symbol->string name))))
+     )
+  )
+
+(defmacro defmethod-mips2c (name method-id method-type)
+  "Define a mips2c method."
+  `(method-set! ,method-type ,method-id (__pc-get-mips2c ,name))
+  )

--- a/test/decompiler/reference/jak2/engine/anim/joint_REF.gc
+++ b/test/decompiler/reference/jak2/engine/anim/joint_REF.gc
@@ -1941,7 +1941,8 @@
   )
 
 ;; definition for function calc-animation-from-spr
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c calc-animation-from-spr (function joint-anim-frame int none))
 
 ;; definition for function create-interpolated-joint-animation-frame
 (defun create-interpolated-joint-animation-frame ((arg0 joint-anim-frame) (arg1 int) (arg2 joint-control))

--- a/test/decompiler/reference/jak2/engine/collide/collide-edge-grab_REF.gc
+++ b/test/decompiler/reference/jak2/engine/collide/collide-edge-grab_REF.gc
@@ -115,7 +115,8 @@
   )
 
 ;; definition for method 10 of type collide-edge-hold-list
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 10 collide-edge-hold-list)" 10 collide-edge-hold-list)
 
 ;; definition of type pbhp-stack-vars
 (deftype pbhp-stack-vars (structure)
@@ -145,7 +146,8 @@
   )
 
 ;; definition for method 19 of type collide-edge-work
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 19 collide-edge-work)" 19 collide-edge-work)
 
 ;; definition for method 20 of type collide-edge-work
 ;; INFO: Used lq/sq
@@ -417,13 +419,16 @@
   )
 
 ;; definition for method 9 of type edge-grab-info
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 9 edge-grab-info)" 9 edge-grab-info)
 
 ;; definition for method 17 of type collide-edge-work
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 17 collide-edge-work)" 17 collide-edge-work)
 
 ;; definition for method 16 of type collide-edge-work
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 16 collide-edge-work)" 16 collide-edge-work)
 
 ;; definition for method 15 of type collide-edge-work
 ;; INFO: Used lq/sq
@@ -450,7 +455,8 @@
   )
 
 ;; definition for method 18 of type collide-edge-work
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 18 collide-edge-work)" 18 collide-edge-work)
 
 ;; definition for method 14 of type collide-edge-work
 (defmethod compute-center-point! collide-edge-work ((obj collide-edge-work) (arg0 collide-edge-edge) (arg1 vector))

--- a/test/decompiler/reference/jak2/engine/collide/collide-mesh_REF.gc
+++ b/test/decompiler/reference/jak2/engine/collide/collide-mesh_REF.gc
@@ -107,7 +107,8 @@
   )
 
 ;; definition for method 12 of type collide-mesh
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 12 collide-mesh)" 12 collide-mesh)
 
 ;; definition of type spat-work
 (deftype spat-work (structure)
@@ -133,13 +134,16 @@
   )
 
 ;; definition for method 11 of type collide-mesh
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 11 collide-mesh)" 11 collide-mesh)
 
 ;; definition for method 14 of type collide-mesh
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 14 collide-mesh)" 14 collide-mesh)
 
 ;; definition for method 15 of type collide-mesh
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 15 collide-mesh)" 15 collide-mesh)
 
 ;; definition for method 9 of type collide-mesh-cache
 ;; INFO: Used lq/sq

--- a/test/decompiler/reference/jak2/engine/debug/debug_REF.gc
+++ b/test/decompiler/reference/jak2/engine/debug/debug_REF.gc
@@ -1785,7 +1785,8 @@
 
 )
 ;; definition (debug) for function init-boundary-regs
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c init-boundary-regs (function none))
 
 ;; definition (debug) for function add-boundary-shader
 ;; WARN: Return type mismatch pointer vs none.
@@ -1821,13 +1822,16 @@
   )
 
 ;; definition (debug) for function draw-boundary-polygon
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c draw-boundary-polygon function)
 
 ;; definition (debug) for function render-boundary-quad
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c render-boundary-quad function)
 
 ;; definition (debug) for function render-boundary-tri
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c render-boundary-tri (function sky-vertex dma-buffer none))
 
 ;; definition (debug) for function add-debug-bound-internal
 ;; INFO: Used lq/sq

--- a/test/decompiler/reference/jak2/engine/gfx/foreground/bones_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/foreground/bones_REF.gc
@@ -92,7 +92,8 @@
   )
 
 ;; definition for function bones-mtx-calc
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c bones-mtx-calc (function (inline-array pris-mtx) (inline-array joint) (inline-array bone) uint object none))
 
 ;; definition for function bones-mtx-calc-execute
 ;; INFO: Used lq/sq

--- a/test/decompiler/reference/jak2/engine/gfx/lights_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/lights_REF.gc
@@ -69,10 +69,12 @@
 (init-light-hash)
 
 ;; definition (debug) for function light-hash-count-items
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c light-hash-count-items (function light-hash light-sphere none))
 
 ;; definition (debug) for function light-hash-add-items
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c light-hash-add-items (function light-hash light-sphere integer object))
 
 ;; definition (debug) for function reset-light-hash
 ;; WARN: Return type mismatch int vs none.
@@ -183,11 +185,9 @@
   )
 
 ;; definition for function light-hash-get-bucket-index
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c light-hash-get-bucket-index (function light-hash vector int))
 
 ;; definition for function add-light-sphere-to-light-group
-;; ERROR: function was not converted to expressions. Cannot decompile.
-
-
-
-
+;; INFO: function output is handled by mips2c
+(def-mips2c add-light-sphere-to-light-group (function object object object object object))

--- a/test/decompiler/reference/jak2/engine/gfx/ocean/ocean-vu0_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/ocean/ocean-vu0_REF.gc
@@ -2,17 +2,16 @@
 (in-package goal)
 
 ;; definition for method 14 of type ocean
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 14 ocean)" 14 ocean)
 
 ;; definition for method 15 of type ocean
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 15 ocean)" 15 ocean)
 
 ;; definition for symbol ocean-vu0-block, type vu-function
 (define ocean-vu0-block (new 'static 'vu-function :length 64 :qlength 32))
 
 ;; definition for method 16 of type ocean
-;; ERROR: function was not converted to expressions. Cannot decompile.
-
-
-
-
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 16 ocean)" 16 ocean)

--- a/test/decompiler/reference/jak2/engine/gfx/ocean/ocean_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/ocean/ocean_REF.gc
@@ -96,13 +96,16 @@
   )
 
 ;; definition for function init-ocean-far-regs
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c init-ocean-far-regs (function none))
 
 ;; definition for function draw-large-polygon-ocean
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c draw-large-polygon-ocean (function none))
 
 ;; definition for function render-ocean-quad
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c render-ocean-quad (function (inline-array ocean-vertex) dma-buffer symbol))
 
 ;; definition for method 17 of type ocean
 ;; INFO: Used lq/sq

--- a/test/decompiler/reference/jak2/engine/gfx/sky/sky-tng_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/sky/sky-tng_REF.gc
@@ -3,27 +3,27 @@
 
 ;; definition for function set-tex-offset
 ;; INFO: function output is handled by mips2c
-;; (def-mips2c set-tex-offset (function ARGS RET))
+(def-mips2c set-tex-offset (function int int none))
 
 ;; definition for function draw-large-polygon
 ;; INFO: function output is handled by mips2c
-;; (def-mips2c draw-large-polygon (function ARGS RET))
+(def-mips2c draw-large-polygon function)
 
 ;; definition for function clip-polygon-against-positive-hyperplane
 ;; INFO: function output is handled by mips2c
-;; (def-mips2c clip-polygon-against-positive-hyperplane (function ARGS RET))
+(def-mips2c clip-polygon-against-positive-hyperplane function)
 
 ;; definition for function clip-polygon-against-negative-hyperplane
 ;; INFO: function output is handled by mips2c
-;; (def-mips2c clip-polygon-against-negative-hyperplane (function ARGS RET))
+(def-mips2c clip-polygon-against-negative-hyperplane function)
 
 ;; definition for function render-sky-quad
 ;; INFO: function output is handled by mips2c
-;; (def-mips2c render-sky-quad (function ARGS RET))
+(def-mips2c render-sky-quad (function (inline-array sky-vertex) dma-buffer none))
 
 ;; definition for function render-sky-tri
 ;; INFO: function output is handled by mips2c
-;; (def-mips2c render-sky-tri (function ARGS RET))
+(def-mips2c render-sky-tri (function (inline-array sky-vertex) dma-buffer none))
 
 ;; definition for function close-sky-buffer
 ;; INFO: Used lq/sq

--- a/test/decompiler/reference/jak2/engine/gfx/sky/sky-tng_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/sky/sky-tng_REF.gc
@@ -2,22 +2,28 @@
 (in-package goal)
 
 ;; definition for function set-tex-offset
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+;; (def-mips2c set-tex-offset (function ARGS RET))
 
 ;; definition for function draw-large-polygon
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+;; (def-mips2c draw-large-polygon (function ARGS RET))
 
 ;; definition for function clip-polygon-against-positive-hyperplane
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+;; (def-mips2c clip-polygon-against-positive-hyperplane (function ARGS RET))
 
 ;; definition for function clip-polygon-against-negative-hyperplane
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+;; (def-mips2c clip-polygon-against-negative-hyperplane (function ARGS RET))
 
 ;; definition for function render-sky-quad
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+;; (def-mips2c render-sky-quad (function ARGS RET))
 
 ;; definition for function render-sky-tri
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+;; (def-mips2c render-sky-tri (function ARGS RET))
 
 ;; definition for function close-sky-buffer
 ;; INFO: Used lq/sq
@@ -101,10 +107,12 @@
   )
 
 ;; definition for method 16 of type sky-work
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 16 sky-work)" 16 sky-work)
 
 ;; definition for method 17 of type sky-work
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 17 sky-work)" 17 sky-work)
 
 ;; definition for method 11 of type sky-work
 ;; INFO: Used lq/sq
@@ -537,13 +545,16 @@
   )
 
 ;; definition for method 28 of type sky-work
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 28 sky-work)" 28 sky-work)
 
 ;; definition for method 29 of type sky-work
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 29 sky-work)" 29 sky-work)
 
 ;; definition for method 30 of type sky-work
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 30 sky-work)" 30 sky-work)
 
 ;; definition for method 31 of type sky-work
 ;; INFO: Used lq/sq
@@ -571,10 +582,12 @@
   )
 
 ;; definition for method 32 of type sky-work
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 32 sky-work)" 32 sky-work)
 
 ;; definition for method 33 of type sky-work
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 33 sky-work)" 33 sky-work)
 
 ;; definition for method 34 of type sky-work
 ;; WARN: Return type mismatch int vs none.

--- a/test/decompiler/reference/jak2/engine/gfx/sprite/particles/sparticle-launcher_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/sprite/particles/sparticle-launcher_REF.gc
@@ -330,7 +330,8 @@
   )
 
 ;; definition for function sp-init-fields!
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c sp-init-fields! (function object (inline-array sp-field-init-spec) sp-field-id sp-field-id symbol object))
 
 ;; definition of type sp-queued-launch-particles
 (deftype sp-queued-launch-particles (structure)
@@ -475,7 +476,8 @@
   )
 
 ;; definition for function particle-adgif
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c particle-adgif (function adgif-shader texture-id none))
 
 ;; definition for function particle-adgif-callback
 ;; WARN: Return type mismatch int vs none.
@@ -718,7 +720,8 @@
   )
 
 ;; definition for function sp-launch-particles-var
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c sp-launch-particles-var (function sparticle-system sparticle-launcher matrix sparticle-launch-state sparticle-launch-control float none))
 
 ;; definition for symbol *death-adgif*, type adgif-shader
 (define *death-adgif* (the-as adgif-shader #f))
@@ -2122,7 +2125,8 @@
   )
 
 ;; definition for function sparticle-motion-blur
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c sparticle-motion-blur (function sparticle-system sparticle-cpuinfo vector none))
 
 ;; definition (debug) for function sparticle-motion-blur-old
 ;; WARN: Return type mismatch int vs object.

--- a/test/decompiler/reference/jak2/engine/gfx/sprite/particles/sparticle_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/sprite/particles/sparticle_REF.gc
@@ -327,10 +327,12 @@
   )
 
 ;; definition for function sp-process-block-2d
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c sp-process-block-2d (function sparticle-system int int int int symbol none))
 
 ;; definition for function sp-process-block-3d
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(def-mips2c sp-process-block-3d (function sparticle-system int int int int symbol none))
 
 ;; definition for function sp-copy-to-spr
 ;; WARN: Return type mismatch int vs none.

--- a/test/decompiler/reference/jak2/engine/gfx/texture/texture_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/texture/texture_REF.gc
@@ -1,5 +1,7 @@
+;;-*-Lisp-*-
 (in-package goal)
 
+;; definition for method 2 of type texture-page
 (defmethod print texture-page ((obj texture-page))
   (format
     #t
@@ -13,14 +15,18 @@
   obj
   )
 
+;; definition for method 4 of type texture-page
 (defmethod length texture-page ((obj texture-page))
   (-> obj length)
   )
 
+;; definition for method 5 of type texture-page
+;; WARN: Return type mismatch uint vs int.
 (defmethod asize-of texture-page ((obj texture-page))
   (the-as int (+ (-> obj type size) (* (-> obj length) 4)))
   )
 
+;; definition for method 8 of type texture-page
 (defmethod mem-usage texture-page ((obj texture-page) (arg0 memory-usage-block) (arg1 int))
   (set! (-> arg0 length) (max 83 (-> arg0 length)))
   (set! (-> arg0 data 82 name) "texture")
@@ -37,6 +43,7 @@
   obj
   )
 
+;; definition for function texture-bpp
 (defun texture-bpp ((tex-fmt gs-psm))
   (case tex-fmt
     (((gs-psm mt8))
@@ -54,16 +61,20 @@
     )
   )
 
+;; definition for function texture-qwc
 (defun texture-qwc ((width int) (height int) (tex-fmt gs-psm))
   (let ((v1-0 (texture-bpp tex-fmt)))
     (/ (+ (* (* width height) v1-0) 127) 128)
     )
   )
 
+;; definition for function physical-address
 (defun physical-address ((ptr pointer))
   (logand #xfffffff ptr)
   )
 
+;; definition for function dma-buffer-add-ref-texture
+;; WARN: Return type mismatch symbol vs none.
 (defun dma-buffer-add-ref-texture ((dma-buf dma-buffer) (tex-data-ptr pointer) (width int) (height int) (tex-fmt gs-psm))
   (let ((padr (physical-address tex-data-ptr))
         (qwc-remaining (texture-qwc width height tex-fmt))
@@ -114,6 +125,7 @@
   (none)
   )
 
+;; definition for method 2 of type texture
 (defmethod print texture ((obj texture))
   (format
     #t
@@ -135,6 +147,7 @@
   obj
   )
 
+;; definition for function gs-find-block
 (defun gs-find-block ((bx int) (by int) (fmt gs-psm))
   (cond
     ((= fmt (gs-psm ct32))
@@ -173,6 +186,7 @@
     )
   )
 
+;; definition for function gs-page-width
 (defun gs-page-width ((arg0 gs-psm))
   (case arg0
     (((gs-psm ct32) (gs-psm ct24) (gs-psm ct16) (gs-psm ct16s))
@@ -188,6 +202,7 @@
     )
   )
 
+;; definition for function gs-page-height
 (defun gs-page-height ((arg0 gs-psm))
   (case arg0
     (((gs-psm ct32) (gs-psm ct24))
@@ -209,6 +224,7 @@
     )
   )
 
+;; definition for function gs-block-width
 (defun gs-block-width ((arg0 gs-psm))
   (case arg0
     (((gs-psm ct32) (gs-psm ct24))
@@ -227,6 +243,7 @@
     )
   )
 
+;; definition for function gs-block-height
 (defun gs-block-height ((arg0 gs-psm))
   (case arg0
     (((gs-psm ct32) (gs-psm ct24) (gs-psm ct16) (gs-psm ct16s))
@@ -242,6 +259,7 @@
     )
   )
 
+;; definition for function gs-largest-block
 (defun gs-largest-block ((arg0 int) (arg1 int) (arg2 gs-psm))
   (let* ((s5-0 (gs-block-width arg2))
          (v1-0 (gs-block-height arg2))
@@ -260,6 +278,7 @@
     )
   )
 
+;; definition for function gs-blocks-used
 (defun gs-blocks-used ((arg0 int) (arg1 int) (arg2 gs-psm))
   (let* ((s4-0 (gs-page-width arg2))
          (v1-0 (gs-page-height arg2))
@@ -277,10 +296,12 @@
     )
   )
 
+;; definition for method 0 of type texture-pool
 (defmethod new texture-pool ((allocation symbol) (type-to-make type))
   (initialize! (object-new allocation type-to-make (the-as int (-> type-to-make size))))
   )
 
+;; definition for method 15 of type texture-pool
 (defmethod allocate-vram-words! texture-pool ((obj texture-pool) (arg0 int))
   (let ((v0-0 (-> obj cur)))
     (+! (-> obj cur) arg0)
@@ -288,6 +309,7 @@
     )
   )
 
+;; definition for method 18 of type texture-pool
 (defmethod get-common-page-slot-by-id texture-pool ((obj texture-pool) (tpage-id int))
   (case tpage-id
     ((33)
@@ -302,6 +324,7 @@
     )
   )
 
+;; definition for method 9 of type texture-pool
 (defmethod initialize! texture-pool ((obj texture-pool))
   (set! (-> obj cur) 0)
   (set! (-> obj top) (-> obj cur))
@@ -324,6 +347,7 @@
   obj
   )
 
+;; definition for method 10 of type texture-page
 (defmethod get-leftover-block-count texture-page ((obj texture-page) (num-segments int) (upload-offset int))
   (let ((offset upload-offset))
     (dotimes (i num-segments)
@@ -333,6 +357,7 @@
     )
   )
 
+;; definition for method 10 of type texture-pool
 (defmethod print-usage texture-pool ((obj texture-pool))
   (format #t "--------------------~%")
   (format
@@ -347,12 +372,15 @@
   obj
   )
 
+;; definition for method 16 of type texture-pool
 (defmethod allocate-segment texture-pool ((obj texture-pool) (seg texture-pool-segment) (num-words int))
   (set! (-> seg size) (the-as uint num-words))
   (set! (-> seg dest) (the-as uint (allocate-vram-words! obj num-words)))
   seg
   )
 
+;; definition for method 12 of type texture-pool
+;; WARN: Return type mismatch int vs none.
 (defmethod allocate-defaults texture-pool ((obj texture-pool))
   (format #t "texture start #x~x~%" (/ (-> obj cur) 64))
   (allocate-segment obj (-> obj segment-common) #x3e000)
@@ -380,11 +408,13 @@
   (none)
   )
 
+;; definition for method 9 of type texture-page
 (defmethod remove-data-from-heap texture-page ((obj texture-page) (heap kheap))
   (set! (-> heap current) (-> obj segment 0 block-data))
   obj
   )
 
+;; definition for function texture-page-default-allocate
 (defun texture-page-default-allocate ((pool texture-pool) (tpage texture-page) (heap kheap) (tpage-id int))
   (dotimes (seg 3)
     (let ((vram-loc (allocate-vram-words! pool (the-as int (-> tpage segment seg size)))))
@@ -408,6 +438,7 @@
   tpage
   )
 
+;; definition for function texture-page-common-allocate
 (defun texture-page-common-allocate ((pool texture-pool) (tpage texture-page) (heap kheap) (tpage-id int))
   (let ((vram-loc (-> pool segment-common dest)))
     (dotimes (seg 3)
@@ -419,6 +450,7 @@
   tpage
   )
 
+;; definition for function texture-page-font-allocate
 (defun texture-page-font-allocate ((pool texture-pool) (tpage texture-page) (heap kheap) (tpage-id int))
   (texture-page-common-allocate pool tpage heap tpage-id)
   (upload-now! tpage (tex-upload-mode seg0-1-2))
@@ -438,6 +470,8 @@
   tpage
   )
 
+;; definition for method 22 of type texture-pool
+;; WARN: Return type mismatch int vs none.
 (defmethod lay-out-sprite-tex texture-pool ((obj texture-pool))
   (let ((vram-loc 0))
     (countdown (level-idx 7)
@@ -467,6 +501,8 @@
   (none)
   )
 
+;; definition for method 23 of type texture-pool
+;; WARN: Return type mismatch int vs none.
 (defmethod lay-out-hud-tex texture-pool ((obj texture-pool))
   (let ((level-idx 0))
     (countdown (vram-loc 7)
@@ -496,6 +532,8 @@
   (none)
   )
 
+;; definition for method 24 of type texture-pool
+;; WARN: Return type mismatch int vs none.
 (defmethod lay-out-warp-tex texture-pool ((obj texture-pool))
   (let ((vram-loc 0))
     (countdown (level-idx 7)
@@ -548,6 +586,8 @@
   (none)
   )
 
+;; definition for method 25 of type texture-pool
+;; WARN: Return type mismatch int vs none.
 (defmethod clear-ids texture-pool ((obj texture-pool))
   (dotimes (v1-0 128)
     (set! (-> obj ids v1-0) (the-as uint 0))
@@ -556,6 +596,8 @@
   (none)
   )
 
+;; definition for method 20 of type texture-pool
+;; WARN: Return type mismatch symbol vs none.
 (defmethod update-sprites texture-pool ((obj texture-pool))
   (lay-out-sprite-tex obj)
   (clear-ids obj)
@@ -563,6 +605,8 @@
   (none)
   )
 
+;; definition for method 19 of type texture-pool
+;; WARN: Return type mismatch symbol vs none.
 (defmethod update-warp-and-hud texture-pool ((obj texture-pool))
   (lay-out-hud-tex obj)
   (lay-out-warp-tex obj)
@@ -571,12 +615,15 @@
   (none)
   )
 
+;; definition for method 21 of type texture-pool
+;; WARN: Return type mismatch symbol vs none.
 (defmethod mark-hud-warp-sprite-dirty texture-pool ((obj texture-pool))
   (set! (-> obj update-sprites-flag) #t)
   (set! (-> obj update-flag) #t)
   (none)
   )
 
+;; definition for function texture-page-common-boot-allocate
 (defun texture-page-common-boot-allocate ((pool texture-pool) (tpage texture-page) (heap kheap) (tpage-id int))
   (let ((common-page-slot-id (get-common-page-slot-by-id pool tpage-id)))
     (cond
@@ -633,6 +680,8 @@
   tpage
   )
 
+;; definition for function upload-vram-data
+;; WARN: Return type mismatch symbol vs none.
 (defun upload-vram-data ((buf dma-buffer) (dest int) (data pointer) (height int) (width int))
   (while (> height 0)
     (let ((height-this-time (min 2048 height)))
@@ -673,6 +722,9 @@
   (none)
   )
 
+;; definition for function upload-vram-pages
+;; WARN: Failed store: (s.w! (+ v1-54 8) 0) at op 169
+;; WARN: Failed store: (s.w! (+ v1-54 12) 0) at op 170
 (defun upload-vram-pages ((pool texture-pool)
                  (dest-seg texture-pool-segment)
                  (tpage texture-page)
@@ -785,6 +837,7 @@
     )
   )
 
+;; definition for function update-vram-pages
 (defun update-vram-pages ((pool texture-pool) (dest-seg texture-pool-segment) (tpage texture-page) (mode tex-upload-mode))
   (-> tpage segment 0 block-data)
   (let ((vram-ptr (shr (-> tpage segment 0 dest) 12))
@@ -837,6 +890,9 @@
   0
   )
 
+;; definition for function upload-vram-pages-pris
+;; WARN: Failed store: (s.w! (+ v1-43 8) 0) at op 163
+;; WARN: Failed store: (s.w! (+ v1-43 12) 0) at op 164
 (defun upload-vram-pages-pris ((pool texture-pool)
                       (dest-seg texture-pool-segment)
                       (tpage texture-page)
@@ -935,6 +991,7 @@
     )
   )
 
+;; definition for function texture-page-level-allocate
 (defun texture-page-level-allocate ((pool texture-pool) (tpage texture-page) (heap kheap) (tpage-id int))
   (if (zero? (-> *level* loading-level code-memory-end))
       (set! (-> *level* loading-level code-memory-end) (the-as pointer tpage))
@@ -953,6 +1010,7 @@
   tpage
   )
 
+;; definition for function texture-page-size-check
 (defun texture-page-size-check ((pool texture-pool) (lev level) (silent symbol))
   (let ((gp-0 0))
     (let ((v1-0 (-> lev texture-page 0)))
@@ -1082,6 +1140,8 @@
     )
   )
 
+;; definition for method 13 of type texture-pool
+;; WARN: Return type mismatch int vs none.
 (defmethod login-level-textures texture-pool ((pool texture-pool) (lev level) (num-tpage-ids int) (tpage-ids (pointer texture-id)))
   (dotimes (v1-0 18)
     (set! (-> lev texture-page v1-0) #f)
@@ -1114,6 +1174,9 @@
   (none)
   )
 
+;; definition for method 14 of type texture-pool
+;; INFO: Used lq/sq
+;; WARN: Return type mismatch int vs none.
 (defmethod add-level-tpage-dma texture-pool ((pool texture-pool) (lev level) (cat tpage-category) (bucket bucket-id))
   (with-pp
     (let ((tpage (-> lev texture-page cat)))
@@ -1305,6 +1368,9 @@
     )
   )
 
+;; definition for function set-skull-gem-masks
+;; INFO: Used lq/sq
+;; WARN: Return type mismatch uint128 vs none.
 (defun set-skull-gem-masks ()
   (local-vars (v0-3 uint128) (v1-2 uint128) (v1-3 uint128))
   (let ((gp-0 (-> *level* default-level texture-mask)))
@@ -1325,6 +1391,9 @@
   (none)
   )
 
+;; definition for function upload-textures
+;; INFO: Used lq/sq
+;; WARN: Return type mismatch int vs none.
 (defun upload-textures ((arg0 texture-pool))
   (cond
     ((not (-> *blit-displays-work* screen-copied))
@@ -1394,12 +1463,17 @@
   (none)
   )
 
+;; failed to figure out what this is:
 (kmemopen global "texture-dma-buffers")
 
+;; definition for symbol *txt-dma-list*, type dma-buffer
 (define *txt-dma-list* (new 'global 'dma-buffer 4096))
 
+;; failed to figure out what this is:
 (kmemclose)
 
+;; definition for method 13 of type texture-page
+;; WARN: Return type mismatch int vs none.
 (defmethod upload-now! texture-page ((obj texture-page) (arg0 tex-upload-mode))
   (let ((gp-0 *txt-dma-list*))
     (let ((v1-0 gp-0))
@@ -1442,6 +1516,7 @@
   (none)
   )
 
+;; definition for method 12 of type texture-page
 (defmethod add-to-dma-buffer texture-page ((obj texture-page) (arg0 dma-buffer) (arg1 tex-upload-mode))
   (local-vars (sv-16 int))
   (let ((v1-0 arg1))
@@ -1471,6 +1546,7 @@
   sv-16
   )
 
+;; definition for function texture-relocate
 (defun texture-relocate ((dma-buff dma-buffer) (tex texture) (dest-loc int) (dest-fmt gs-psm) (clut-dst int))
   (dotimes (v1-0 (the-as int (-> tex num-mips)))
     (let ((t1-1 (ash (-> tex w) (- v1-0)))
@@ -1601,6 +1677,30 @@
   dma-buff
   )
 
+;; definition for method 11 of type texture-pool
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 16 signed mismatch
+;; WARN: Stack slot offset 16 signed mismatch
+;; WARN: Stack slot offset 16 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 20 signed mismatch
+;; WARN: Stack slot offset 16 signed mismatch
+;; WARN: Stack slot offset 16 signed mismatch
+;; WARN: Stack slot offset 16 signed mismatch
+;; WARN: Return type mismatch int vs none.
 (defmethod setup-font-texture texture-pool ((obj texture-pool))
   (local-vars (sv-16 int) (sv-20 int))
   (let ((s3-0 (-> obj font-palette)))
@@ -1710,19 +1810,26 @@
   (none)
   )
 
+;; definition for method 5 of type texture-page-dir
+;; WARN: Return type mismatch uint vs int.
 (defmethod asize-of texture-page-dir ((obj texture-page-dir))
   (the-as int (+ (-> texture-page-dir size) (* 12 (+ (-> obj length) -1))))
   )
 
+;; definition for method 4 of type texture-page-dir
 (defmethod length texture-page-dir ((obj texture-page-dir))
   (-> obj length)
   )
 
+;; definition for method 7 of type texture-page-dir
+;; WARN: Return type mismatch texture-page-dir vs none.
 (defmethod relocate texture-page-dir ((obj texture-page-dir) (arg0 kheap) (arg1 (pointer uint8)))
   (set! *texture-page-dir* obj)
   (none)
   )
 
+;; definition for method 11 of type texture-page
+;; WARN: Return type mismatch texture-page vs none.
 (defmethod relocate-dests! texture-page ((obj texture-page) (new-dest int) (segs int))
   (let ((new-tbp (shr new-dest 6))
         (old-tbp (shr (-> obj segment segs dest) 6))
@@ -1758,6 +1865,7 @@
   (none)
   )
 
+;; definition for method 7 of type texture-page
 (defmethod relocate texture-page ((obj texture-page) (loading-heap kheap) (name (pointer uint8)))
   (cond
     ((or (not obj) (not (file-info-correct-version? (-> obj info) (file-kind tpage) 0)))
@@ -1802,6 +1910,7 @@
     )
   )
 
+;; definition for function relocate-later
 (defun relocate-later ()
   (let ((gp-0 *texture-relocate-later*))
     (let ((s5-0 (-> gp-0 entry))
@@ -1820,6 +1929,7 @@
   #f
   )
 
+;; definition for function texture-page-login
 (defun texture-page-login ((tex-id texture-id) (alloc-func (function texture-pool texture-page kheap int texture-page)) (heap kheap))
   (when (and (nonzero? (-> tex-id page)) (< (-> tex-id page) (the-as uint (-> *texture-page-dir* length))))
     (let ((dir-entry (-> *texture-page-dir* entries (-> tex-id page))))
@@ -1841,6 +1951,7 @@
     )
   )
 
+;; definition for function lookup-texture-by-id
 (defun lookup-texture-by-id ((arg0 texture-id))
   (let ((a0-2 (texture-page-login arg0 texture-page-default-allocate loading-level))
         (v1-0 (the-as texture-page #f))
@@ -1851,6 +1962,7 @@
     )
   )
 
+;; definition for function lookup-texture-by-id-fast
 (defun lookup-texture-by-id-fast ((arg0 texture-id))
   (let ((a1-2 (if (and (nonzero? (-> arg0 page)) (< (-> arg0 page) (the-as uint (-> *texture-page-dir* length))))
                   (-> *texture-page-dir* entries (-> arg0 page))
@@ -1864,6 +1976,7 @@
     )
   )
 
+;; definition for function lookup-texture-by-name
 (defun lookup-texture-by-name ((arg0 string) (arg1 string) (arg2 (pointer texture-page)))
   (local-vars (sv-16 texture-page-dir))
   (set! sv-16 *texture-page-dir*)
@@ -1886,6 +1999,8 @@
   (the-as texture #f)
   )
 
+;; definition for function lookup-texture-id-by-name
+;; WARN: Return type mismatch int vs texture-id.
 (defun lookup-texture-id-by-name ((arg0 string) (arg1 string))
   (local-vars (sv-16 texture-page-dir))
   (set! sv-16 *texture-page-dir*)
@@ -1905,6 +2020,7 @@
   (the-as texture-id 0)
   )
 
+;; definition for function lookup-level-texture-by-name
 (defun lookup-level-texture-by-name ((arg0 string) (arg1 level) (arg2 (pointer texture-page)))
   (dotimes (s3-0 18)
     (let ((s2-0 (-> arg1 texture-page s3-0)))
@@ -1925,6 +2041,8 @@
   (lookup-texture-by-name arg0 (the-as string #f) arg2)
   )
 
+;; definition for method 17 of type texture-pool
+;; WARN: Return type mismatch int vs none.
 (defmethod unload-page texture-pool ((obj texture-pool) (arg0 texture-page))
   (local-vars (a0-2 int))
   (let ((v1-0 *texture-page-dir*))
@@ -1945,10 +2063,13 @@
   (none)
   )
 
+;; definition for symbol *shader-list*, type pair
 (define *shader-list* '())
 
+;; definition for symbol *edit-shader*, type texture-id
 (define *edit-shader* (new 'static 'texture-id))
 
+;; definition for function link-texture-by-id
 (defun link-texture-by-id ((arg0 texture-id) (arg1 adgif-shader))
   (when (not (or (zero? (-> arg0 page)) (>= (-> arg0 page) (the-as uint (-> *texture-page-dir* length)))))
     (let ((s4-0 (-> *texture-page-dir* entries (-> arg0 page))))
@@ -1964,6 +2085,7 @@
     )
   )
 
+;; definition for method 9 of type texture-page-dir
 (defmethod unlink-shaders-in-heap texture-page-dir ((obj texture-page-dir) (heap kheap))
   (local-vars (dist-past-end uint))
   (let ((mem-start (-> heap base))
@@ -2010,7 +2132,11 @@
   0
   )
 
+;; definition for function adgif-shader<-texture!
+;; ERROR: function was not converted to expressions. Cannot decompile.
 
+;; definition for function adgif-shader-update!
+;; WARN: Return type mismatch gs-tex1 vs none.
 (defun adgif-shader-update! ((arg0 adgif-shader) (arg1 texture))
   (let ((s5-0 (the int (/ 256.0 (-> arg1 uv-dist)))))
     (case (-> arg0 tex1 l)
@@ -2025,13 +2151,18 @@
   (none)
   )
 
+;; definition for function adgif-shader<-texture-with-update!
+;; INFO: function output is handled by mips2c
+(def-mips2c adgif-shader<-texture-with-update! (function adgif-shader texture adgif-shader))
 
+;; definition for function hack-texture
 (defun hack-texture ((arg0 texture))
   (set! (-> arg0 uv-dist) 1000000.0)
   (set! (-> arg0 masks data 0 dist) (+ 40960000.0 (-> arg0 masks data 0 dist)))
   (set! (-> arg0 masks data 1 dist) (+ 40960000.0 (-> arg0 masks data 1 dist)))
   )
 
+;; definition for function adgif-shader-login
 (defun adgif-shader-login ((arg0 adgif-shader))
   (when (logtest? (-> arg0 link-test) (link-test-flags needs-log-in))
     (logclear! (-> arg0 link-test) (link-test-flags needs-log-in bit-9))
@@ -2065,6 +2196,7 @@
     )
   )
 
+;; definition for function adgif-shader-login-no-remap
 (defun adgif-shader-login-no-remap ((arg0 adgif-shader))
   (when (logtest? (-> arg0 link-test) (link-test-flags needs-log-in))
     (logclear! (-> arg0 link-test) (link-test-flags needs-log-in bit-9))
@@ -2092,6 +2224,7 @@
     )
   )
 
+;; definition for function adgif-shader-login-fast
 (defun adgif-shader-login-fast ((arg0 adgif-shader))
   (when (logtest? (-> arg0 link-test) (link-test-flags needs-log-in))
     (logclear! (-> arg0 link-test) (link-test-flags needs-log-in bit-9))
@@ -2120,6 +2253,7 @@
     )
   )
 
+;; definition for function adgif-shader-login-no-remap-fast
 (defun adgif-shader-login-no-remap-fast ((arg0 adgif-shader))
   (when (logtest? (-> arg0 link-test) (link-test-flags needs-log-in))
     (logclear! (-> arg0 link-test) (link-test-flags needs-log-in bit-9))
@@ -2147,11 +2281,13 @@
     )
   )
 
+;; failed to figure out what this is:
 (when (not *debug-segment*)
   (set! adgif-shader-login adgif-shader-login-fast)
   (set! adgif-shader-login-no-remap adgif-shader-login-no-remap-fast)
   )
 
+;; definition for function adgif-shader<-texture-simple!
 (defun adgif-shader<-texture-simple! ((arg0 adgif-shader) (arg1 texture))
   (set! (-> arg0 tex1) (new 'static 'gs-tex1 :mmag #x1 :mmin #x1))
   (set! (-> arg0 tex0 tfx) 0)
@@ -2168,6 +2304,8 @@
   arg0
   )
 
+;; definition for function set-dirty-mask!
+;; WARN: Return type mismatch int vs none.
 (defun set-dirty-mask! ((arg0 level) (arg1 int) (arg2 int) (arg3 int))
   (let ((s4-0 (sar (+ arg2 #x3fff) 14))
         (s5-0 (sar (+ arg3 #x3fff) 14))
@@ -2196,6 +2334,8 @@
   (none)
   )
 
+;; definition (debug) for function texture-page-dir-inspect
+;; WARN: Return type mismatch texture-page-dir vs none.
 (defun-debug texture-page-dir-inspect ((arg0 texture-page-dir) (arg1 symbol))
   (format #t "[~8x] ~A~%" arg0 (-> arg0 type))
   (let ((v1-0 *texture-pool*))
@@ -2292,9 +2432,11 @@
   (none)
   )
 
+;; definition for method 3 of type texture-page-dir
 (defmethod inspect texture-page-dir ((obj texture-page-dir))
   (texture-page-dir-inspect obj #f)
   obj
   )
 
+;; definition for symbol *texture-pool*, type texture-pool
 (define *texture-pool* (new 'global 'texture-pool))

--- a/test/decompiler/reference/jak2/engine/spatial-hash/collide-hash_REF.gc
+++ b/test/decompiler/reference/jak2/engine/spatial-hash/collide-hash_REF.gc
@@ -75,16 +75,20 @@
   )
 
 ;; definition for method 11 of type collide-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 11 collide-hash)" 11 collide-hash)
 
 ;; definition for method 12 of type collide-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 12 collide-hash)" 12 collide-hash)
 
 ;; definition for function fill-bg-using-box-new
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+;; (def-mips2c fill-bg-using-box-new (function ARGS RET))
 
 ;; definition for function fill-bg-using-line-sphere-new
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+;; (def-mips2c fill-bg-using-line-sphere-new (function ARGS RET))
 
 ;; definition for function collide-list-fill-bg-using-box
 ;; INFO: Used lq/sq

--- a/test/decompiler/reference/jak2/engine/spatial-hash/collide-hash_REF.gc
+++ b/test/decompiler/reference/jak2/engine/spatial-hash/collide-hash_REF.gc
@@ -84,11 +84,11 @@
 
 ;; definition for function fill-bg-using-box-new
 ;; INFO: function output is handled by mips2c
-;; (def-mips2c fill-bg-using-box-new (function ARGS RET))
+(def-mips2c fill-bg-using-box-new (function collide-cache object collide-query none))
 
 ;; definition for function fill-bg-using-line-sphere-new
 ;; INFO: function output is handled by mips2c
-;; (def-mips2c fill-bg-using-line-sphere-new (function ARGS RET))
+(def-mips2c fill-bg-using-line-sphere-new (function collide-cache object collide-query none))
 
 ;; definition for function collide-list-fill-bg-using-box
 ;; INFO: Used lq/sq

--- a/test/decompiler/reference/jak2/engine/spatial-hash/spatial-hash_REF.gc
+++ b/test/decompiler/reference/jak2/engine/spatial-hash/spatial-hash_REF.gc
@@ -173,13 +173,16 @@
   )
 
 ;; definition for method 18 of type grid-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 18 grid-hash)" 18 grid-hash)
 
 ;; definition for method 19 of type grid-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 19 grid-hash)" 19 grid-hash)
 
 ;; definition for method 20 of type grid-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 20 grid-hash)" 20 grid-hash)
 
 ;; definition for method 21 of type grid-hash
 ;; WARN: Return type mismatch int vs none.
@@ -210,7 +213,8 @@
   )
 
 ;; definition for method 22 of type grid-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 22 grid-hash)" 22 grid-hash)
 
 ;; definition for method 23 of type grid-hash
 ;; INFO: Used lq/sq
@@ -736,7 +740,8 @@
   )
 
 ;; definition for method 28 of type sphere-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 28 sphere-hash)" 28 sphere-hash)
 
 ;; definition for method 26 of type sphere-hash
 (defmethod add-a-sphere sphere-hash ((obj sphere-hash) (arg0 vector))
@@ -784,19 +789,24 @@
   )
 
 ;; definition for method 33 of type sphere-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 33 sphere-hash)" 33 sphere-hash)
 
 ;; definition for method 29 of type sphere-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 29 sphere-hash)" 29 sphere-hash)
 
 ;; definition for method 30 of type sphere-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 30 sphere-hash)" 30 sphere-hash)
 
 ;; definition for method 31 of type sphere-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 31 sphere-hash)" 31 sphere-hash)
 
 ;; definition for method 32 of type sphere-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 32 sphere-hash)" 32 sphere-hash)
 
 ;; definition for method 15 of type sphere-hash
 ;; INFO: Used lq/sq
@@ -880,7 +890,8 @@
   )
 
 ;; definition for method 33 of type spatial-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 33 spatial-hash)" 33 spatial-hash)
 
 ;; definition for method 34 of type spatial-hash
 (defmethod add-an-object spatial-hash ((obj spatial-hash) (arg0 vector) (arg1 hash-object-info))
@@ -908,16 +919,20 @@
   )
 
 ;; definition for method 39 of type spatial-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 39 spatial-hash)" 39 spatial-hash)
 
 ;; definition for method 36 of type spatial-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 36 spatial-hash)" 36 spatial-hash)
 
 ;; definition for method 37 of type spatial-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 37 spatial-hash)" 37 spatial-hash)
 
 ;; definition for method 35 of type spatial-hash
-;; ERROR: function was not converted to expressions. Cannot decompile.
+;; INFO: function output is handled by mips2c
+(defmethod-mips2c "(method 35 spatial-hash)" 35 spatial-hash)
 
 ;; definition for method 38 of type spatial-hash
 ;; INFO: Used lq/sq


### PR DESCRIPTION
When working with mips2c recently, I noticed adding the `defmethod-mips2c` or `def-mips2c` code was a manual step.  This is a bit tedious to have to go and do yourself, but more importantly you have to manually go and find the right spot in the source file else you might be declaring it too early or too late.

This will automatically output the declaration for methods, and a half-finished comment for the functions.  I wasn't able to fully output the function one because it seems the signature info from `all-types` doesn't make it all the way through -- but maybe I'm wrong or this is an easy fix?