### PR TITLE
jak1: fix debug menu regression around `lambda`s

### DIFF
--- a/goal_src/jak1/engine/debug/default-menu.gc
+++ b/goal_src/jak1/engine/debug/default-menu.gc
@@ -4211,7 +4211,7 @@
 
 (defmacro dm-lambda-boolean-flag (val)
   "helper macro for making boolean buttons that don't just access symbols directly"
-  `(lambda (arg (msg debug-menu-msg))
+  `,(lambda (arg (msg debug-menu-msg))
                             (if (= msg (debug-menu-msg press))
                                 (not! ,val)
                                 )
@@ -4220,7 +4220,7 @@
 
 (defmacro dm-lambda-int-var (val)
   "helper macro for making int buttons"
-  `(lambda (arg (msg debug-menu-msg) (newval int))
+  `,(lambda (arg (msg debug-menu-msg) (newval int))
     (cond
       ((= msg (debug-menu-msg press))
        (set! ,val newval)
@@ -4246,7 +4246,7 @@
 
 (defmacro dm-lambda-meters-var (val)
   "helper macro for making meters buttons"
-  `(lambda (arg (msg debug-menu-msg) (newval float))
+  `,(lambda (arg (msg debug-menu-msg) (newval float))
     (cond
       ((= msg (debug-menu-msg press))
        (set! ,val (meters newval))


### PR DESCRIPTION
The macros used to create the menus in jak1 were not quoted.  I didn't change the `dm-lambda-float-var` one because it resulted in a compiler error / It seems unused anyway (i couldn't figure out how to show the anim tester menu)