### PR TITLE
[jak2] split up big dgos, some minor cleanup

### DIFF
--- a/decompiler/Disasm/Register.cpp
+++ b/decompiler/Disasm/Register.cpp
@@ -9,7 +9,7 @@
 
 #include "common/util/Assert.h"
 
-#include "third-party/fmt/core.h"
+#include "third-party/fmt/format.h"
 
 namespace decompiler {
 namespace Reg {
@@ -128,12 +128,14 @@ Register::Register(Reg::RegisterKind kind, uint32_t num) {
     case Reg::COP0:
     case Reg::VI:
       if (num > 32) {
-        ASSERT_MSG(false, fmt::format("RegisterKind: {}, greater than 32: {}", kind, num));
+        ASSERT_MSG(false, fmt::format("RegisterKind: {}, greater than 32: {}",
+                                      fmt::underlying(kind), num));
       }
       break;
     case Reg::SPECIAL:
       if (num > 4) {
-        ASSERT_MSG(false, fmt::format("Special RegisterKind: {}, greater than 4: {}", kind, num));
+        ASSERT_MSG(false, fmt::format("Special RegisterKind: {}, greater than 4: {}",
+                                      fmt::underlying(kind), num));
       }
       break;
     default:

--- a/decompiler/config/jak2/all-types.gc
+++ b/decompiler/config/jak2/all-types.gc
@@ -38889,7 +38889,7 @@
   )
 
 (deftype sig-path-sample (structure)
-  ((bytes  uint8      32      :offset-assert 0)
+  ((bytes  uint8      32      :offset-assert 0 :do-not-decompile)
    (pos    vector     :inline :offset-assert 32)
    (quat   quaternion :inline :offset-assert 48)
    (flags  uint8              :offset 12)
@@ -43092,7 +43092,7 @@
 ;; credits                        ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-extern draw-end-credits (function level float symbol)) ;; 
+(define-extern draw-end-credits (function level float symbol)) ;;
 (define-extern start-credits (function process none))
 (define-extern check-pop-level-firework-userdata (function sparticle-system sparticle-cpuinfo sparticle-launchinfo none))
 (define-extern check-pop-level-firework-red-userdata (function sparticle-system sparticle-cpuinfo sparticle-launchinfo none))

--- a/decompiler/util/data_decompile.cpp
+++ b/decompiler/util/data_decompile.cpp
@@ -1545,8 +1545,8 @@ goos::Object decompile_boxed_array(const DecompilerLabel& label,
       for (int j = start; j < end; j++) {
         auto& word = words.at(label.target_segment).at(j / 4);
         if (word.kind() != LinkedWord::PLAIN_DATA) {
-          throw std::runtime_error(
-              fmt::format("Got bad word of kind {} in boxed array of values", word.kind()));
+          throw std::runtime_error(fmt::format("Got bad word of kind {} in boxed array of values",
+                                               fmt::underlying(word.kind())));
         }
         elt_bytes.push_back(word.get_byte(j % 4));
       }

--- a/game/mips2c/jak2_functions/lights.cpp
+++ b/game/mips2c/jak2_functions/lights.cpp
@@ -8,7 +8,6 @@ namespace add_light_sphere_to_light_group {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   bool cop1_bc = false;
   // nop                                            // sll r0, r0, 0
   // nop                                            // sll r0, r0, 0
@@ -418,7 +417,6 @@ struct Cache {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   c->daddiu(sp, sp, -48);                           // daddiu sp, sp, -48
   c->sd(ra, 0, sp);                                 // sd ra, 0(sp)
   c->daddiu(t0, sp, 16);                            // daddiu t0, sp, 16
@@ -564,7 +562,6 @@ struct Cache {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   c->daddiu(sp, sp, -48);                           // daddiu sp, sp, -48
   c->daddiu(v1, sp, 16);                            // daddiu v1, sp, 16
   // nop                                            // sll r0, r0, 0
@@ -700,7 +697,6 @@ namespace light_hash_get_bucket_index {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   c->daddiu(sp, sp, -32);                           // daddiu sp, sp, -32
   c->daddiu(v1, sp, 16);                            // daddiu v1, sp, 16
   // nop                                            // sll r0, r0, 0

--- a/game/overlord/sbank.cpp
+++ b/game/overlord/sbank.cpp
@@ -114,7 +114,7 @@ s32 LookupSoundIndex(const char* name, SoundBank** bank_out) {
       continue;
     }
 
-    for (int i = 0; i < bank->sound_count; i++) {
+    for (int i = 0; i < (int)bank->sound_count; i++) {
       if (memcmp(bank->sound[i].name, name, 16) == 0) {
         *bank_out = bank;
         return i;

--- a/game/overlord/srpc.cpp
+++ b/game/overlord/srpc.cpp
@@ -751,7 +751,7 @@ static void UnLoadMusic(s32* handle) {
   *handle = 0;
 }
 
-void* RPC_Loader2(unsigned int fno, void* data, int size) {
+void* RPC_Loader2(unsigned int /*fno*/, void* data, int size) {
   int n_messages = size / SRPC_MESSAGE_SIZE;
   SoundRpcCommand* cmd = (SoundRpcCommand*)(data);
   if (!gSoundEnable) {

--- a/game/sound/989snd/sfxgrain.cpp
+++ b/game/sound/989snd/sfxgrain.cpp
@@ -228,7 +228,7 @@ SFXGrain_LoopContinue::SFXGrain_LoopContinue(SFXGrain& grain) : Grain(grain) {}
 SFXGrain_LoopContinue::SFXGrain_LoopContinue(SFXGrain2& grain, u8* data) : Grain(grain) {}
 s32 SFXGrain_LoopContinue::execute(blocksound_handler& handler) {
   bool found = false;
-  for (int i = handler.m_next_grain + 1; i < handler.m_sfx.grains.size() && !found; i++) {
+  for (int i = handler.m_next_grain + 1; i < (int)handler.m_sfx.grains.size() && !found; i++) {
     if (handler.m_sfx.grains[i]->type() == grain_type::LOOP_END) {
       handler.m_next_grain = i;
       found = true;
@@ -453,7 +453,7 @@ SFXGrain_GotoMarker::SFXGrain_GotoMarker(SFXGrain2& grain, u8* data) : Grain(gra
 }
 s32 SFXGrain_GotoMarker::execute(blocksound_handler& handler) {
   bool found = false;
-  for (int i = 0; i < handler.m_sfx.grains.size() && !found; i++) {
+  for (int i = 0; i < (int)handler.m_sfx.grains.size() && !found; i++) {
     if (handler.m_sfx.grains.at(i)->type() == grain_type::MARKER) {
       if (static_cast<SFXGrain_Marker*>(handler.m_sfx.grains.at(i).get())->marker() == m_mark) {
         handler.m_next_grain = i - 1;
@@ -482,7 +482,7 @@ s32 SFXGrain_GotoRandomMarker::execute(blocksound_handler& handler) {
   s32 range = m_upper_bound - m_lower_bound + 1;
   s32 mark = (rand() % range) + m_lower_bound;
 
-  for (int i = 0; i < handler.m_sfx.grains.size() && !found; i++) {
+  for (int i = 0; i < (int)handler.m_sfx.grains.size() && !found; i++) {
     if (handler.m_sfx.grains.at(i)->type() == grain_type::MARKER) {
       if (static_cast<SFXGrain_Marker*>(handler.m_sfx.grains.at(i).get())->marker() == mark) {
         handler.m_next_grain = i - 1;

--- a/game/sound/989snd/sfxgrain.h
+++ b/game/sound/989snd/sfxgrain.h
@@ -132,7 +132,7 @@ class Grain {
 
   virtual ~Grain() = default;
 
-  virtual s32 execute(blocksound_handler& handler) { return 0; };
+  virtual s32 execute(blocksound_handler& /*handler*/) { return 0; };
   virtual std::string_view inspect() { return magic_enum::enum_name(type()); };
   s32 delay() { return m_delay; }
   grain_type type() { return m_type; }
@@ -218,13 +218,13 @@ class SFXGrain_Branch : public Grain {
 class SFXGrain_ControlNull : public Grain {
  public:
   SFXGrain_ControlNull(SFXGrain& grain) : Grain(grain){};
-  SFXGrain_ControlNull(SFXGrain2& grain, u8* data) : Grain(grain){};
+  SFXGrain_ControlNull(SFXGrain2& grain, u8* /*data*/) : Grain(grain){};
 };
 
 class SFXGrain_LoopStart : public Grain {
  public:
   SFXGrain_LoopStart(SFXGrain& grain) : Grain(grain){};
-  SFXGrain_LoopStart(SFXGrain2& grain, u8* data) : Grain(grain){};
+  SFXGrain_LoopStart(SFXGrain2& grain, u8* /*data*/) : Grain(grain){};
 };
 
 class SFXGrain_LoopEnd : public Grain {
@@ -358,7 +358,7 @@ class SFXGrain_TestRegister : public Grain {
 class SFXGrain_Marker : public Grain {
  public:
   SFXGrain_Marker(SFXGrain& grain) : Grain(grain), m_mark(grain.GrainParams.control.param[0]) {}
-  SFXGrain_Marker(SFXGrain2& grain, u8* data) : Grain(grain), m_mark(grain.OpcodeData.arg[0]) {}
+  SFXGrain_Marker(SFXGrain2& grain, u8* /*data*/) : Grain(grain), m_mark(grain.OpcodeData.arg[0]) {}
   int marker() { return m_mark; }
 
  private:

--- a/game/sound/989snd/sound_handler.h
+++ b/game/sound/989snd/sound_handler.h
@@ -22,7 +22,7 @@ class sound_handler {
   virtual void stop() = 0;
   virtual void set_vol_pan(s32 vol, s32 pan) = 0;
   virtual void set_pmod(s32 mod) = 0;
-  virtual void set_pbend(s32 mod){};
+  virtual void set_pbend(s32 /*mod*/){};
   virtual void set_register(u8 /*reg*/, u8 /*value*/) {}
 };
 }  // namespace snd

--- a/game/sound/989snd/soundbank.h
+++ b/game/sound/989snd/soundbank.h
@@ -60,8 +60,8 @@ class SoundBank {
                                                       SndPlayParams& params) = 0;
 
   virtual std::optional<std::string_view> get_name() { return std::nullopt; };
-  virtual std::optional<u32> get_sound_by_name(const char* name) { return std::nullopt; };
-  virtual std::optional<const SFXUserData*> get_sound_user_data(u32 sound_id) {
+  virtual std::optional<u32> get_sound_by_name(const char* /*name*/) { return std::nullopt; };
+  virtual std::optional<const SFXUserData*> get_sound_user_data(u32 /*sound_id*/) {
     return std::nullopt;
   };
 

--- a/goal_src/jak2/levels/underport/sig5-cent1-path0.gc
+++ b/goal_src/jak2/levels/underport/sig5-cent1-path0.gc
@@ -11,42 +11,9 @@
                              :sample-count #xfb
                              :samples (new 'static 'inline-array sig-path-sample 251
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x1
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -324352.8 :y -274439.38 :z 8362734.5)
                                  :quat (new 'static 'quaternion :y 0.1254 :w -0.9921)
+                                 :flags #x1
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -324352.8 :y -274439.78 :z 8362734.5)
@@ -101,384 +68,54 @@
                                  :quat (new 'static 'quaternion :y 0.2044 :w -0.9788)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -334386.78 :y -275121.34 :z 8384650.5)
                                  :quat (new 'static 'quaternion :y 0.1802 :w -0.9836)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -335159.28 :y -272610.1 :z 8387254.5)
                                  :quat (new 'static 'quaternion :y 0.1611 :w -0.9869)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -335894.12 :y -269008.9 :z 8389873.0)
                                  :quat (new 'static 'quaternion :y 0.1482 :w -0.9889)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -336567.9 :y -265442.9 :z 8392512.0)
                                  :quat (new 'static 'quaternion :y 0.136 :w -0.9907)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -337176.56 :y -262789.94 :z 8395170.0)
                                  :quat (new 'static 'quaternion :y 0.1226 :w -0.9924)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -337687.75 :y -261229.36 :z 8397850.0)
                                  :quat (new 'static 'quaternion :y 0.1075 :w -0.9941)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -338169.03 :y -261196.19 :z 8400536.0)
                                  :quat (new 'static 'quaternion :y 0.0976 :w -0.9952)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -338628.6 :y -263263.84 :z 8403226.0)
                                  :quat (new 'static 'quaternion :y 0.0908 :w -0.9958)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -339066.06 :y -266997.34 :z 8405919.0)
                                  :quat (new 'static 'quaternion :y 0.0853 :w -0.9963)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -339481.0 :y -271822.84 :z 8408616.0)
                                  :quat (new 'static 'quaternion :y 0.0805 :w -0.9967)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -339987.25 :y -274439.78 :z 8411288.0)
@@ -517,384 +154,54 @@
                                  :quat (new 'static 'quaternion :y 0.3718 :w -0.9282)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -356558.84 :y -275780.4 :z 8430416.0)
                                  :quat (new 'static 'quaternion :y 0.3951 :w -0.9186)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -358678.12 :y -273268.75 :z 8432136.0)
                                  :quat (new 'static 'quaternion :y 0.4133 :w -0.9105)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -360849.4 :y -269667.53 :z 8433789.0)
                                  :quat (new 'static 'quaternion :y 0.4294 :w -0.9031)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -363055.94 :y -266101.56 :z 8435394.0)
                                  :quat (new 'static 'quaternion :y 0.4422 :w -0.8968)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -365302.6 :y -263448.56 :z 8436944.0)
                                  :quat (new 'static 'quaternion :y 0.454 :w -0.8909)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -367577.5 :y -261888.0 :z 8438452.0)
                                  :quat (new 'static 'quaternion :y 0.464 :w -0.8857)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -369885.6 :y -261854.83 :z 8439909.0)
                                  :quat (new 'static 'quaternion :y 0.4738 :w -0.8805)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -372205.97 :y -263922.9 :z 8441347.0)
                                  :quat (new 'static 'quaternion :y 0.4799 :w -0.8772)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -374285.1 :y -267656.0 :z 8443105.0)
                                  :quat (new 'static 'quaternion :y 0.4619 :w -0.8868)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -375903.44 :y -272481.9 :z 8445277.0)
                                  :quat (new 'static 'quaternion :y 0.4262 :w -0.9046)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -377183.03 :y -274436.9 :z 8447669.0)
@@ -909,384 +216,54 @@
                                  :quat (new 'static 'quaternion :y 0.1492 :w -0.9887)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378525.7 :y -274529.9 :z 8455750.0)
                                  :quat (new 'static 'quaternion :y 0.091 :w -0.9958)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378642.03 :y -272946.78 :z 8458476.0)
                                  :quat (new 'static 'quaternion :y 0.0547 :w -0.9985)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378689.94 :y -269456.2 :z 8461204.0)
                                  :quat (new 'static 'quaternion :y 0.0306 :w -0.9995)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378668.66 :y -265834.5 :z 8463932.0)
                                  :quat (new 'static 'quaternion :y 0.0124 :w -0.9999)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378577.72 :y -262908.72 :z 8466660.0)
                                  :quat (new 'static 'quaternion :y -0.0029 :w -0.9999)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378458.94 :y -261074.94 :z 8469386.0)
                                  :quat (new 'static 'quaternion :y -0.0112 :w -0.9999)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378517.9 :y -260551.06 :z 8472112.0)
                                  :quat (new 'static 'quaternion :y 0.0086 :w -0.9999)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378781.28 :y -262059.22 :z 8474824.0)
                                  :quat (new 'static 'quaternion :y 0.043 :w -0.999)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -379300.25 :y -265519.5 :z 8477491.0)
                                  :quat (new 'static 'quaternion :y 0.0875 :w -0.9961)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -380388.56 :y -270071.8 :z 8479971.0)
                                  :quat (new 'static 'quaternion :y 0.1382 :w -0.9903)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -381684.12 :y -274148.97 :z 8482364.0)
@@ -1349,384 +326,54 @@
                                  :quat (new 'static 'quaternion :y 0.3033 :w -0.9528)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -404996.1 :y -274024.03 :z 8515859.0)
                                  :quat (new 'static 'quaternion :y 0.3185 :w -0.9479)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -406854.03 :y -271109.75 :z 8517858.0)
                                  :quat (new 'static 'quaternion :y 0.3428 :w -0.9393)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -408734.1 :y -267496.66 :z 8519837.0)
                                  :quat (new 'static 'quaternion :y 0.3573 :w -0.9339)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -410637.1 :y -264024.47 :z 8521793.0)
                                  :quat (new 'static 'quaternion :y 0.3671 :w -0.9301)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -412556.1 :y -261644.7 :z 8523733.0)
                                  :quat (new 'static 'quaternion :y 0.3736 :w -0.9275)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -414310.0 :y -260357.33 :z 8525822.0)
                                  :quat (new 'static 'quaternion :y 0.3581 :w -0.9336)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -415982.78 :y -260814.84 :z 8527967.0)
                                  :quat (new 'static 'quaternion :y 0.3408 :w -0.9401)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -417660.1 :y -263442.03 :z 8530108.0)
                                  :quat (new 'static 'quaternion :y 0.3332 :w -0.9428)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -419356.7 :y -267448.72 :z 8532235.0)
                                  :quat (new 'static 'quaternion :y 0.332 :w -0.9432)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -421139.66 :y -272260.72 :z 8534301.0)
                                  :quat (new 'static 'quaternion :y 0.3408 :w -0.9401)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -422814.94 :y -274340.25 :z 8536119.0)
@@ -1773,384 +420,54 @@
                                  :quat (new 'static 'quaternion :y 0.7654 :w -0.6434)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -452537.12 :y -274589.7 :z 8539009.0)
                                  :quat (new 'static 'quaternion :y 0.7736 :w -0.6335)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -455184.78 :y -273025.84 :z 8538341.0)
                                  :quat (new 'static 'quaternion :y 0.7815 :w -0.6238)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -457814.03 :y -269534.8 :z 8537605.0)
                                  :quat (new 'static 'quaternion :y 0.7897 :w -0.6134)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -460422.34 :y -265913.56 :z 8536797.0)
                                  :quat (new 'static 'quaternion :y 0.7977 :w -0.6029)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -463015.53 :y -262987.38 :z 8535943.0)
                                  :quat (new 'static 'quaternion :y 0.8042 :w -0.5943)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -465648.03 :y -261154.0 :z 8535219.0)
                                  :quat (new 'static 'quaternion :y 0.7991 :w -0.601)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -468280.12 :y -260630.12 :z 8534492.0)
                                  :quat (new 'static 'quaternion :y 0.7976 :w -0.603)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -470887.62 :y -262137.86 :z 8533682.0)
                                  :quat (new 'static 'quaternion :y 0.8017 :w -0.5976)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -473468.94 :y -265598.16 :z 8532792.0)
                                  :quat (new 'static 'quaternion :y 0.8085 :w -0.5884)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -476020.75 :y -270150.88 :z 8531822.0)
                                  :quat (new 'static 'quaternion :y 0.8164 :w -0.5773)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -478541.0 :y -274436.5 :z 8530772.0)
@@ -2197,384 +514,54 @@
                                  :quat (new 'static 'quaternion :y 0.8798 :w -0.4752)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -504420.75 :y -274641.3 :z 8515537.0)
                                  :quat (new 'static 'quaternion :y 0.8823 :w -0.4706)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -506719.84 :y -274083.03 :z 8514064.0)
                                  :quat (new 'static 'quaternion :y 0.8797 :w -0.4754)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -509030.0 :y -270853.75 :z 8512607.0)
                                  :quat (new 'static 'quaternion :y 0.8776 :w -0.4793)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -511331.94 :y -267176.75 :z 8511138.0)
                                  :quat (new 'static 'quaternion :y 0.8772 :w -0.4799)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -513606.44 :y -263977.78 :z 8509628.0)
                                  :quat (new 'static 'quaternion :y 0.8794 :w -0.4759)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -515848.2 :y -261870.8 :z 8508070.0)
                                  :quat (new 'static 'quaternion :y 0.8831 :w -0.4691)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -518055.94 :y -260856.62 :z 8506464.0)
                                  :quat (new 'static 'quaternion :y 0.8874 :w -0.4609)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -520229.28 :y -261804.44 :z 8504810.0)
                                  :quat (new 'static 'quaternion :y 0.8919 :w -0.452)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -522366.97 :y -264991.94 :z 8503112.0)
                                  :quat (new 'static 'quaternion :y 0.8965 :w -0.4428)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -524467.8 :y -269271.44 :z 8501367.0)
                                  :quat (new 'static 'quaternion :y 0.9012 :w -0.4333)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -526530.56 :y -274069.9 :z 8499578.0)
@@ -2609,384 +596,54 @@
                                  :quat (new 'static 'quaternion :y 0.9349 :w -0.3547)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -541649.7 :y -274431.6 :z 8483828.0)
                                  :quat (new 'static 'quaternion :y 0.9342 :w -0.3567)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -543530.6 :y -273600.1 :z 8481848.0)
                                  :quat (new 'static 'quaternion :y 0.9313 :w -0.3641)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -545404.5 :y -270370.8 :z 8479860.0)
                                  :quat (new 'static 'quaternion :y 0.9304 :w -0.3665)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -547244.9 :y -266693.84 :z 8477843.0)
                                  :quat (new 'static 'quaternion :y 0.9314 :w -0.3637)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -549052.0 :y -263494.88 :z 8475796.0)
                                  :quat (new 'static 'quaternion :y 0.9335 :w -0.3584)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -550826.0 :y -261388.28 :z 8473720.0)
                                  :quat (new 'static 'quaternion :y 0.9359 :w -0.352)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -552776.5 :y -260373.7 :z 8471827.0)
                                  :quat (new 'static 'quaternion :y 0.9334 :w -0.3586)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -555121.44 :y -261321.94 :z 8470470.0)
                                  :quat (new 'static 'quaternion :y 0.9209 :w -0.3896)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -557556.94 :y -264509.03 :z 8469297.0)
                                  :quat (new 'static 'quaternion :y 0.9019 :w -0.4318)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -560065.75 :y -268788.53 :z 8468315.0)
                                  :quat (new 'static 'quaternion :y 0.878 :w -0.4785)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -562636.0 :y -273587.0 :z 8467528.0)
@@ -3025,688 +682,94 @@
                                  :quat (new 'static 'quaternion :y 0.5832 :w -0.8122)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -592592.5 :y -275394.56 :z 8484615.0)
                                  :quat (new 'static 'quaternion :y 0.5701 :w -0.8215)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -595137.3 :y -275222.12 :z 8485603.0)
                                  :quat (new 'static 'quaternion :y 0.5677 :w -0.8232)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -597731.75 :y -271992.84 :z 8486451.0)
                                  :quat (new 'static 'quaternion :y 0.5789 :w -0.8153)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -600375.7 :y -268315.84 :z 8487130.0)
                                  :quat (new 'static 'quaternion :y 0.5976 :w -0.8017)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -603048.75 :y -265116.47 :z 8487684.0)
                                  :quat (new 'static 'quaternion :y 0.6152 :w -0.7882)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -605721.8 :y -263009.9 :z 8488240.0)
                                  :quat (new 'static 'quaternion :y 0.623 :w -0.7821)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -608385.8 :y -261995.31 :z 8488836.0)
                                  :quat (new 'static 'quaternion :y 0.623 :w -0.7822)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -611001.1 :y -262943.53 :z 8489596.0)
                                  :quat (new 'static 'quaternion :y 0.6024 :w -0.7981)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -613549.25 :y -266131.03 :z 8490548.0)
                                  :quat (new 'static 'quaternion :y 0.5724 :w -0.8199)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -616017.94 :y -268524.34 :z 8491674.0)
                                  :quat (new 'static 'quaternion :y 0.5532 :w -0.833)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -618316.2 :y -266312.5 :z 8492766.0)
                                  :quat (new 'static 'quaternion :y 0.5422 :w -0.8402)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -620428.9 :y -262918.16 :z 8493789.0)
                                  :quat (new 'static 'quaternion :y 0.5339 :w -0.8455)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -622378.2 :y -260542.05 :z 8494815.0)
                                  :quat (new 'static 'quaternion :y 0.5233 :w -0.8521)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -624294.7 :y -259257.95 :z 8495861.0)
                                  :quat (new 'static 'quaternion :y 0.5165 :w -0.8562)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -626247.25 :y -260021.86 :z 8496836.0)
                                  :quat (new 'static 'quaternion :y 0.5241 :w -0.8516)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -628255.56 :y -263025.06 :z 8497692.0)
                                  :quat (new 'static 'quaternion :y 0.5382 :w -0.8427)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -630255.6 :y -267120.62 :z 8498568.0)
                                  :quat (new 'static 'quaternion :y 0.5425 :w -0.84)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -632263.06 :y -271734.78 :z 8499427.0)
                                  :quat (new 'static 'quaternion :y 0.5469 :w -0.8371)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -633675.4 :y -274657.28 :z 8500297.0)
@@ -3841,650 +904,89 @@
                                  :quat (new 'static 'quaternion :y 0.7966 :w -0.6043)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -698236.94 :y -275113.97 :z 8445707.0)
                                  :quat (new 'static 'quaternion :y 0.7988 :w -0.6015)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -700854.7 :y -272602.3 :z 8444931.0)
                                  :quat (new 'static 'quaternion :y 0.8 :w -0.5999)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -703481.06 :y -269001.12 :z 8444184.0)
                                  :quat (new 'static 'quaternion :y 0.7988 :w -0.6015)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -706135.25 :y -265435.12 :z 8443545.0)
                                  :quat (new 'static 'quaternion :y 0.7913 :w -0.6113)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -708815.7 :y -262782.16 :z 8443023.0)
                                  :quat (new 'static 'quaternion :y 0.7811 :w -0.6243)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -711504.7 :y -261221.58 :z 8442549.0)
                                  :quat (new 'static 'quaternion :y 0.7732 :w -0.6341)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -714108.1 :y -261188.4 :z 8441763.0)
                                  :quat (new 'static 'quaternion :y 0.7791 :w -0.6268)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -716485.8 :y -263256.47 :z 8440463.0)
                                  :quat (new 'static 'quaternion :y 0.8004 :w -0.5994)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -718630.06 :y -263800.0 :z 8439150.0)
                                  :quat (new 'static 'quaternion :y 0.8275 :w -0.5613)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -720458.94 :y -261165.47 :z 8437982.0)
                                  :quat (new 'static 'quaternion :y 0.8529 :w -0.5219)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -722303.8 :y -258267.14 :z 8436841.0)
                                  :quat (new 'static 'quaternion :y 0.8637 :w -0.5039)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -724146.56 :y -256460.8 :z 8435697.0)
                                  :quat (new 'static 'quaternion :y 0.869 :w -0.4947)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -725987.75 :y -255985.66 :z 8434550.0)
                                  :quat (new 'static 'quaternion :y 0.8716 :w -0.49)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -727827.25 :y -257606.45 :z 8433400.0)
                                  :quat (new 'static 'quaternion :y 0.8731 :w -0.4873)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -729664.7 :y -261179.39 :z 8432248.0)
                                  :quat (new 'static 'quaternion :y 0.8741 :w -0.4856)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -731500.1 :y -265844.75 :z 8431092.0)
                                  :quat (new 'static 'quaternion :y 0.8747 :w -0.4845)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -733333.5 :y -270741.9 :z 8429933.0)
                                  :quat (new 'static 'quaternion :y 0.8752 :w -0.4835)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -735201.7 :y -274436.5 :z 8428749.0)
@@ -4563,384 +1065,54 @@
                                  :quat (new 'static 'quaternion :y 0.8837 :w -0.4679)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -778130.6 :y -274436.5 :z 8400396.0)
                                  :quat (new 'static 'quaternion :y 0.8841 :w -0.4671)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -780363.4 :y -272703.9 :z 8398858.0)
                                  :quat (new 'static 'quaternion :y 0.8846 :w -0.4661)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -782592.8 :y -269213.28 :z 8397315.0)
                                  :quat (new 'static 'quaternion :y 0.8851 :w -0.4652)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -784819.8 :y -265591.6 :z 8395768.0)
                                  :quat (new 'static 'quaternion :y 0.8856 :w -0.4643)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -787055.0 :y -262665.84 :z 8394235.0)
                                  :quat (new 'static 'quaternion :y 0.885 :w -0.4655)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -789298.8 :y -260832.05 :z 8392716.0)
                                  :quat (new 'static 'quaternion :y 0.8842 :w -0.4671)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -791540.94 :y -260308.17 :z 8391194.0)
                                  :quat (new 'static 'quaternion :y 0.8839 :w -0.4675)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -793781.44 :y -261816.31 :z 8389670.0)
                                  :quat (new 'static 'quaternion :y 0.8839 :w -0.4675)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -796019.94 :y -265276.62 :z 8388142.5)
                                  :quat (new 'static 'quaternion :y 0.884 :w -0.4674)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -798256.75 :y -269829.3 :z 8386613.0)
                                  :quat (new 'static 'quaternion :y 0.8842 :w -0.467)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -800491.94 :y -274436.5 :z 8385080.0)

--- a/goal_src/jak2/levels/underport/sig5-cent2-path0.gc
+++ b/goal_src/jak2/levels/underport/sig5-cent2-path0.gc
@@ -91,612 +91,84 @@
                                  :quat (new 'static 'quaternion :y 0.5036 :w 0.8638)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -813869.06 :y -290555.9 :z 8019219.5)
                                  :quat (new 'static 'quaternion :y 0.504 :w 0.8636)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -811462.6 :y -288029.1 :z 8020572.0)
                                  :quat (new 'static 'quaternion :y 0.5044 :w 0.8634)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -809131.2 :y -284611.38 :z 8021879.0)
                                  :quat (new 'static 'quaternion :y 0.5047 :w 0.8632)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -806730.94 :y -281158.44 :z 8023222.5)
                                  :quat (new 'static 'quaternion :y 0.505 :w 0.863)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -804404.8 :y -278584.94 :z 8024522.5)
                                  :quat (new 'static 'quaternion :y 0.5054 :w 0.8628)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -802004.56 :y -277191.88 :z 8025861.0)
                                  :quat (new 'static 'quaternion :y 0.5057 :w 0.8626)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -799658.4 :y -277495.0 :z 8027166.5)
                                  :quat (new 'static 'quaternion :y 0.5061 :w 0.8624)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -797658.75 :y -275646.88 :z 8028278.5)
                                  :quat (new 'static 'quaternion :y 0.5064 :w 0.8622)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -795729.5 :y -272526.53 :z 8029348.5)
                                  :quat (new 'static 'quaternion :y 0.5067 :w 0.862)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -793871.1 :y -269754.38 :z 8030378.0)
                                  :quat (new 'static 'quaternion :y 0.507 :w 0.8619)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -791934.2 :y -267939.03 :z 8031449.5)
                                  :quat (new 'static 'quaternion :y 0.5073 :w 0.8617)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -790075.4 :y -267824.34 :z 8032476.0)
                                  :quat (new 'static 'quaternion :y 0.5076 :w 0.8615)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -788145.4 :y -270044.38 :z 8033540.0)
                                  :quat (new 'static 'quaternion :y 0.5079 :w 0.8614)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -786266.94 :y -273842.6 :z 8034576.0)
                                  :quat (new 'static 'quaternion :y 0.5082 :w 0.8612)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -784381.56 :y -278505.06 :z 8035612.5)
                                  :quat (new 'static 'quaternion :y 0.5084 :w 0.861)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -782488.75 :y -283301.47 :z 8036652.0)
                                  :quat (new 'static 'quaternion :y 0.5086 :w 0.8609)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -780612.4 :y -288990.0 :z 8037682.0)
@@ -783,612 +255,84 @@
                                  :quat (new 'static 'quaternion :y 0.5153 :w 0.8569)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x6
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -730725.56 :y -290373.22 :z 8064483.0)
                                  :quat (new 'static 'quaternion :y 0.5157 :w 0.8567)
+                                 :flags #x6
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -728306.5 :y -287443.34 :z 8065756.5)
                                  :quat (new 'static 'quaternion :y 0.5161 :w 0.8565)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -725927.94 :y -283819.62 :z 8067055.5)
                                  :quat (new 'static 'quaternion :y 0.513 :w 0.8583)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -723540.4 :y -280342.53 :z 8068359.5)
                                  :quat (new 'static 'quaternion :y 0.5115 :w 0.8592)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -721121.7 :y -277916.06 :z 8069680.5)
                                  :quat (new 'static 'quaternion :y 0.5109 :w 0.8596)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -718744.4 :y -276652.84 :z 8070978.5)
                                  :quat (new 'static 'quaternion :y 0.5105 :w 0.8598)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -716414.2 :y -277169.34 :z 8072250.0)
                                  :quat (new 'static 'quaternion :y 0.5104 :w 0.8599)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -713982.75 :y -279874.34 :z 8073577.5)
                                  :quat (new 'static 'quaternion :y 0.5103 :w 0.8599)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -711865.1 :y -279534.78 :z 8074606.0)
                                  :quat (new 'static 'quaternion :y 0.5187 :w 0.8549)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -709781.5 :y -276654.9 :z 8075430.5)
                                  :quat (new 'static 'quaternion :y 0.5402 :w 0.8415)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -707780.2 :y -273814.3 :z 8076148.5)
                                  :quat (new 'static 'quaternion :y 0.5572 :w 0.8303)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -705589.25 :y -271912.97 :z 8076646.5)
                                  :quat (new 'static 'quaternion :y 0.5877 :w 0.809)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -703473.7 :y -271607.0 :z 8076905.0)
                                  :quat (new 'static 'quaternion :y 0.6227 :w 0.7824)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -701273.7 :y -273347.38 :z 8076848.5)
                                  :quat (new 'static 'quaternion :y 0.6618 :w 0.7496)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -699097.94 :y -276987.9 :z 8076461.5)
                                  :quat (new 'static 'quaternion :y 0.7032 :w 0.7109)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -697077.4 :y -281638.5 :z 8075730.0)
                                  :quat (new 'static 'quaternion :y 0.7414 :w 0.6709)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -695090.8 :y -286363.25 :z 8074855.0)
@@ -1403,498 +347,69 @@
                                  :quat (new 'static 'quaternion :y 0.7344 :w 0.6786)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -687166.7 :y -290336.78 :z 8072274.5)
                                  :quat (new 'static 'quaternion :y 0.6943 :w 0.7196)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -684086.5 :y -289645.38 :z 8072016.5)
                                  :quat (new 'static 'quaternion :y 0.6697 :w 0.7425)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -681369.6 :y -286400.5 :z 8072493.5)
                                  :quat (new 'static 'quaternion :y 0.6564 :w 0.7544)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -678654.4 :y -282954.56 :z 8072990.5)
                                  :quat (new 'static 'quaternion :y 0.6484 :w 0.7612)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -675963.7 :y -279912.03 :z 8073498.0)
                                  :quat (new 'static 'quaternion :y 0.6432 :w 0.7656)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -673276.3 :y -278004.94 :z 8074011.5)
                                  :quat (new 'static 'quaternion :y 0.6402 :w 0.7682)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -670679.44 :y -277038.28 :z 8074525.5)
                                  :quat (new 'static 'quaternion :y 0.6373 :w 0.7705)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -668414.4 :y -275017.3 :z 8074978.0)
                                  :quat (new 'static 'quaternion :y 0.6355 :w 0.772)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -666320.5 :y -271846.6 :z 8075391.5)
                                  :quat (new 'static 'quaternion :y 0.635 :w 0.7724)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -664138.56 :y -269153.5 :z 8075835.0)
                                  :quat (new 'static 'quaternion :y 0.6335 :w 0.7737)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -662066.0 :y -267642.47 :z 8076497.5)
                                  :quat (new 'static 'quaternion :y 0.6165 :w 0.7873)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -660126.5 :y -267900.1 :z 8077481.0)
                                  :quat (new 'static 'quaternion :y 0.5834 :w 0.8121)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -658266.94 :y -270403.2 :z 8078532.5)
                                  :quat (new 'static 'quaternion :y 0.5469 :w 0.8371)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -656417.56 :y -274181.75 :z 8079592.0)
@@ -1905,270 +420,39 @@
                                  :quat (new 'static 'quaternion :y 0.5128 :w 0.8584)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -651757.2 :y -274435.7 :z 8081808.0)
                                  :quat (new 'static 'quaternion :y 0.5524 :w 0.8335)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -649046.44 :y -273504.25 :z 8082224.5)
                                  :quat (new 'static 'quaternion :y 0.6212 :w 0.7835)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -646341.44 :y -270322.47 :z 8082386.0)
                                  :quat (new 'static 'quaternion :y 0.6695 :w 0.7427)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -643603.25 :y -266938.38 :z 8082347.5)
                                  :quat (new 'static 'quaternion :y 0.6981 :w 0.7159)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -640862.6 :y -263973.28 :z 8082172.5)
                                  :quat (new 'static 'quaternion :y 0.7147 :w 0.6993)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -638185.9 :y -262127.61 :z 8081939.0)
                                  :quat (new 'static 'quaternion :y 0.7261 :w 0.6874)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -635468.2 :y -261681.16 :z 8081628.0)
                                  :quat (new 'static 'quaternion :y 0.7364 :w 0.6764)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -632801.25 :y -263012.75 :z 8081252.0)
@@ -2187,346 +471,49 @@
                                  :quat (new 'static 'quaternion :y 0.7712 :w 0.6364)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -622270.06 :y -265887.75 :z 8078695.0)
                                  :quat (new 'static 'quaternion :y 0.7942 :w 0.6075)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -619838.25 :y -265062.8 :z 8077417.5)
                                  :quat (new 'static 'quaternion :y 0.8243 :w 0.566)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -617499.06 :y -262095.25 :z 8076041.5)
                                  :quat (new 'static 'quaternion :y 0.8447 :w 0.5352)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -615194.6 :y -258894.23 :z 8074572.0)
                                  :quat (new 'static 'quaternion :y 0.8593 :w 0.5113)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -612949.2 :y -255756.28 :z 8073025.0)
                                  :quat (new 'static 'quaternion :y 0.871 :w 0.4911)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -610698.9 :y -253577.22 :z 8071484.0)
                                  :quat (new 'static 'quaternion :y 0.8767 :w 0.4809)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -608444.0 :y -252794.06 :z 8069941.0)
                                  :quat (new 'static 'quaternion :y 0.8799 :w 0.4749)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -606183.44 :y -254136.31 :z 8068411.5)
                                  :quat (new 'static 'quaternion :y 0.8814 :w 0.4722)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -603984.3 :y -258101.66 :z 8066828.5)
                                  :quat (new 'static 'quaternion :y 0.8848 :w 0.4658)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -601808.06 :y -263374.03 :z 8065157.0)
@@ -2565,346 +552,49 @@
                                  :quat (new 'static 'quaternion :y 0.9774 :w 0.2112)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -581805.25 :y -265959.84 :z 8048587.0)
                                  :quat (new 'static 'quaternion :y 0.9886 :w 0.1505)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -581509.5 :y -263710.72 :z 8045927.5)
                                  :quat (new 'static 'quaternion :y 0.9941 :w 0.108)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -581173.7 :y -260199.22 :z 8043224.5)
                                  :quat (new 'static 'quaternion :y 0.9959 :w 0.09)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -580901.7 :y -256735.23 :z 8040516.5)
                                  :quat (new 'static 'quaternion :y 0.9972 :w 0.0746)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -580748.06 :y -253640.3 :z 8037793.0)
                                  :quat (new 'static 'quaternion :y 0.9984 :w 0.0564)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -580728.8 :y -251647.19 :z 8035093.5)
                                  :quat (new 'static 'quaternion :y 0.9993 :w 0.0356)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -580827.1 :y -251336.3 :z 8032372.0)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0128)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -580827.94 :y -253310.16 :z 8029559.5)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0077)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -580767.3 :y -257432.78 :z 8026842.0)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0091)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -580715.3 :y -262652.72 :z 8024125.5)
@@ -2951,574 +641,79 @@
                                  :quat (new 'static 'quaternion :y 0.9986 :w -0.0514)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -569254.7 :y -265945.5 :z 8001267.5)
                                  :quat (new 'static 'quaternion :y 0.9982 :w -0.0584)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -569450.5 :y -263305.62 :z 7998664.5)
                                  :quat (new 'static 'quaternion :y 0.9977 :w -0.0665)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -569918.25 :y -259987.05 :z 7995963.0)
                                  :quat (new 'static 'quaternion :y 0.997 :w -0.0765)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -570484.3 :y -256668.88 :z 7993272.5)
                                  :quat (new 'static 'quaternion :y 0.9958 :w -0.0908)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -571110.6 :y -254427.14 :z 7990605.5)
                                  :quat (new 'static 'quaternion :y 0.9946 :w -0.1034)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -571645.94 :y -253331.86 :z 7987928.5)
                                  :quat (new 'static 'quaternion :y 0.995 :w -0.0993)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -571992.06 :y -254224.8 :z 7985207.5)
                                  :quat (new 'static 'quaternion :y 0.9973 :w -0.0721)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -572098.56 :y -254679.86 :z 7982636.0)
                                  :quat (new 'static 'quaternion :y 0.9992 :w -0.0374)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -571797.5 :y -252205.47 :z 7980572.5)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0065)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -571399.4 :y -249192.45 :z 7978425.0)
                                  :quat (new 'static 'quaternion :y 0.9988 :w 0.0488)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -571024.2 :y -247228.0 :z 7976274.0)
                                  :quat (new 'static 'quaternion :y 0.9976 :w 0.0679)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -570670.7 :y -246530.05 :z 7974118.0)
                                  :quat (new 'static 'quaternion :y 0.9972 :w 0.0745)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -570186.1 :y -247887.88 :z 7971989.0)
                                  :quat (new 'static 'quaternion :y 0.9955 :w 0.0937)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -569616.8 :y -251270.34 :z 7969880.5)
                                  :quat (new 'static 'quaternion :y 0.9935 :w 0.1131)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -569058.5 :y -255777.17 :z 7967768.0)
                                  :quat (new 'static 'quaternion :y 0.9926 :w 0.1211)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -568512.5 :y -260623.56 :z 7965653.0)
@@ -3565,460 +760,64 @@
                                  :quat (new 'static 'quaternion :y 0.9799 :w -0.1992)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -573850.0 :y -274443.47 :z 7937625.0)
                                  :quat (new 'static 'quaternion :y 0.973 :w -0.2307)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -575327.0 :y -272968.5 :z 7935328.5)
                                  :quat (new 'static 'quaternion :y 0.9661 :w -0.2578)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -576869.56 :y -269594.62 :z 7933074.5)
                                  :quat (new 'static 'quaternion :y 0.9607 :w -0.2774)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -578454.3 :y -265963.94 :z 7930851.5)
                                  :quat (new 'static 'quaternion :y 0.9564 :w -0.2919)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -580091.5 :y -262935.34 :z 7928666.0)
                                  :quat (new 'static 'quaternion :y 0.9524 :w -0.3047)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -581702.9 :y -260992.2 :z 7926462.5)
                                  :quat (new 'static 'quaternion :y 0.9516 :w -0.3072)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -583187.7 :y -260297.11 :z 7924171.0)
                                  :quat (new 'static 'quaternion :y 0.9555 :w -0.2948)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -584707.7 :y -261646.75 :z 7921856.0)
                                  :quat (new 'static 'quaternion :y 0.9568 :w -0.2906)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -586099.5 :y -265220.9 :z 7919465.5)
                                  :quat (new 'static 'quaternion :y 0.9605 :w -0.2782)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -587479.9 :y -269938.28 :z 7917088.0)
                                  :quat (new 'static 'quaternion :y 0.9628 :w -0.2699)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -588697.2 :y -274794.1 :z 7914692.5)
                                  :quat (new 'static 'quaternion :y 0.9651 :w -0.2617)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -589139.94 :y -280308.12 :z 7912029.0)
                                  :quat (new 'static 'quaternion :y 0.973 :w -0.2306)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -589293.2 :y -286907.6 :z 7909344.5)
@@ -4061,612 +860,84 @@
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0029)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x6
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -588591.94 :y -290827.47 :z 7882143.0)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0027)
+                                 :flags #x6
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -588578.8 :y -288672.16 :z 7879490.5)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0026)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -588553.0 :y -285091.44 :z 7876713.5)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0049)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -588364.6 :y -281747.47 :z 7874042.0)
                                  :quat (new 'static 'quaternion :y 0.9996 :w 0.0253)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -587981.6 :y -279036.3 :z 7871329.5)
                                  :quat (new 'static 'quaternion :y 0.9987 :w 0.049)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -587450.75 :y -277469.6 :z 7868650.0)
                                  :quat (new 'static 'quaternion :y 0.9972 :w 0.0739)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -586702.44 :y -277569.53 :z 7865999.0)
                                  :quat (new 'static 'quaternion :y 0.9945 :w 0.1039)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -585607.56 :y -275708.3 :z 7863881.5)
                                  :quat (new 'static 'quaternion :y 0.9894 :w 0.1447)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -584317.75 :y -272701.84 :z 7862169.0)
                                  :quat (new 'static 'quaternion :y 0.9812 :w 0.1926)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -582916.94 :y -269946.47 :z 7860548.5)
                                  :quat (new 'static 'quaternion :y 0.9696 :w 0.2445)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -581412.06 :y -268192.56 :z 7858967.5)
                                  :quat (new 'static 'quaternion :y 0.9544 :w 0.2984)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -579871.56 :y -268084.03 :z 7857418.0)
                                  :quat (new 'static 'quaternion :y 0.9406 :w 0.3393)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -578342.06 :y -270119.72 :z 7855857.5)
                                  :quat (new 'static 'quaternion :y 0.9331 :w 0.3595)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -576748.75 :y -273722.97 :z 7854365.5)
                                  :quat (new 'static 'quaternion :y 0.9256 :w 0.3782)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -575032.5 :y -278263.4 :z 7853015.5)
                                  :quat (new 'static 'quaternion :y 0.9132 :w 0.4074)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -573306.06 :y -283045.88 :z 7851659.5)
                                  :quat (new 'static 'quaternion :y 0.9065 :w 0.422)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -571713.56 :y -288834.75 :z 7850154.5)
@@ -4677,688 +948,94 @@
                                  :quat (new 'static 'quaternion :y 0.9597 :w 0.2807)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x6
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -568066.44 :y -290262.22 :z 7846672.0)
                                  :quat (new 'static 'quaternion :y 0.9898 :w 0.1421)
+                                 :flags #x6
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567199.3 :y -289271.8 :z 7844376.0)
                                  :quat (new 'static 'quaternion :y 0.9977 :w 0.0667)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567190.75 :y -286378.8 :z 7841691.0)
                                  :quat (new 'static 'quaternion :y 0.9997 :w 0.0234)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567316.06 :y -282765.3 :z 7838965.5)
                                  :quat (new 'static 'quaternion :y 0.9999 :w -0.001)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567469.25 :y -279421.75 :z 7836239.5)
                                  :quat (new 'static 'quaternion :y 0.9998 :w -0.015)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567631.06 :y -277097.28 :z 7833508.5)
                                  :quat (new 'static 'quaternion :y 0.9997 :w -0.0224)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567765.4 :y -275808.66 :z 7830876.0)
                                  :quat (new 'static 'quaternion :y 0.9997 :w -0.0237)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567802.25 :y -276319.03 :z 7828147.5)
                                  :quat (new 'static 'quaternion :y 0.9999 :w -0.0136)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567602.0 :y -278965.03 :z 7825442.0)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0125)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567362.75 :y -279654.8 :z 7822939.5)
                                  :quat (new 'static 'quaternion :y 0.9995 :w 0.0307)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567009.25 :y -277020.25 :z 7820800.5)
                                  :quat (new 'static 'quaternion :y 0.9981 :w 0.0601)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -566455.5 :y -273824.97 :z 7818705.0)
                                  :quat (new 'static 'quaternion :y 0.9945 :w 0.1042)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -565709.6 :y -271721.7 :z 7816658.0)
                                  :quat (new 'static 'quaternion :y 0.9892 :w 0.1459)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -564863.0 :y -270949.6 :z 7814645.0)
                                  :quat (new 'static 'quaternion :y 0.9848 :w 0.1735)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -563800.06 :y -272273.4 :z 7812741.0)
                                  :quat (new 'static 'quaternion :y 0.9783 :w 0.207)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -562525.8 :y -275549.8 :z 7810999.0)
                                  :quat (new 'static 'quaternion :y 0.9676 :w 0.2523)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -561127.44 :y -279918.2 :z 7809420.5)
                                  :quat (new 'static 'quaternion :y 0.953 :w 0.3028)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -559625.8 :y -284518.8 :z 7808017.5)
                                  :quat (new 'static 'quaternion :y 0.9347 :w 0.3551)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -558023.9 :y -289924.72 :z 7806793.5)
@@ -5377,612 +1054,84 @@
                                  :quat (new 'static 'quaternion :y 0.93 :w 0.3673)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -547489.8 :y -290367.1 :z 7801440.5)
                                  :quat (new 'static 'quaternion :y 0.9413 :w 0.3374)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -545890.7 :y -287452.78 :z 7799227.0)
                                  :quat (new 'static 'quaternion :y 0.9466 :w 0.3221)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -544311.3 :y -283839.7 :z 7797000.0)
                                  :quat (new 'static 'quaternion :y 0.9499 :w 0.3123)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -542842.5 :y -280367.94 :z 7794698.0)
                                  :quat (new 'static 'quaternion :y 0.9559 :w 0.2936)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -541473.2 :y -277988.16 :z 7792335.5)
                                  :quat (new 'static 'quaternion :y 0.9611 :w 0.2759)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -540117.8 :y -276700.38 :z 7789965.5)
                                  :quat (new 'static 'quaternion :y 0.9639 :w 0.266)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -538780.9 :y -276172.8 :z 7787663.5)
                                  :quat (new 'static 'quaternion :y 0.9647 :w 0.2632)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -537664.3 :y -273960.97 :z 7785778.5)
                                  :quat (new 'static 'quaternion :y 0.9645 :w 0.2638)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -536553.06 :y -270567.0 :z 7783897.5)
                                  :quat (new 'static 'quaternion :y 0.9645 :w 0.2637)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -535432.0 :y -268190.5 :z 7782022.0)
                                  :quat (new 'static 'quaternion :y 0.9642 :w 0.265)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -534303.94 :y -266906.84 :z 7780151.5)
                                  :quat (new 'static 'quaternion :y 0.9638 :w 0.2665)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -533171.0 :y -267670.72 :z 7778284.0)
                                  :quat (new 'static 'quaternion :y 0.9634 :w 0.2679)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -532064.7 :y -270673.9 :z 7776401.0)
                                  :quat (new 'static 'quaternion :y 0.9642 :w 0.2648)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -531056.25 :y -274769.1 :z 7774464.0)
                                  :quat (new 'static 'quaternion :y 0.9683 :w 0.2495)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -530219.44 :y -279383.66 :z 7772446.5)
                                  :quat (new 'static 'quaternion :y 0.9755 :w 0.2199)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -529501.0 :y -284516.34 :z 7770385.0)
                                  :quat (new 'static 'quaternion :y 0.9813 :w 0.1924)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -528778.9 :y -290741.88 :z 7768326.0)
@@ -6001,650 +1150,89 @@
                                  :quat (new 'static 'quaternion :y 0.9943 :w 0.106)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -526663.7 :y -290383.47 :z 7757989.5)
                                  :quat (new 'static 'quaternion :y 0.9964 :w 0.084)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -526406.9 :y -287469.16 :z 7755270.0)
                                  :quat (new 'static 'quaternion :y 0.9979 :w 0.0647)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -526293.4 :y -283856.06 :z 7752544.0)
                                  :quat (new 'static 'quaternion :y 0.9994 :w 0.0339)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -526384.75 :y -280383.9 :z 7749819.0)
                                  :quat (new 'static 'quaternion :y 0.9999 :w -0.0055)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -526680.5 :y -278004.12 :z 7747107.0)
                                  :quat (new 'static 'quaternion :y 0.9992 :w -0.0381)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -527178.94 :y -276716.75 :z 7744423.0)
                                  :quat (new 'static 'quaternion :y 0.9975 :w -0.0696)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -527870.75 :y -277174.28 :z 7741782.5)
                                  :quat (new 'static 'quaternion :y 0.9947 :w -0.102)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -528703.9 :y -279801.44 :z 7739182.0)
                                  :quat (new 'static 'quaternion :y 0.9915 :w -0.13)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -529642.3 :y -283808.16 :z 7736618.0)
                                  :quat (new 'static 'quaternion :y 0.9881 :w -0.1534)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -530479.1 :y -281504.97 :z 7734518.0)
                                  :quat (new 'static 'quaternion :y 0.9849 :w -0.1727)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -531336.8 :y -278252.75 :z 7732508.5)
                                  :quat (new 'static 'quaternion :y 0.9823 :w -0.1872)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -532233.8 :y -275603.47 :z 7730517.0)
                                  :quat (new 'static 'quaternion :y 0.9799 :w -0.1993)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -533169.75 :y -274046.56 :z 7728543.0)
                                  :quat (new 'static 'quaternion :y 0.9777 :w -0.2099)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -534118.8 :y -274298.47 :z 7726575.0)
                                  :quat (new 'static 'quaternion :y 0.9762 :w -0.2168)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -535105.56 :y -276741.75 :z 7724626.5)
                                  :quat (new 'static 'quaternion :y 0.9743 :w -0.2249)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -536129.1 :y -280564.12 :z 7722696.5)
                                  :quat (new 'static 'quaternion :y 0.9723 :w -0.2336)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -537188.4 :y -285192.2 :z 7720786.0)
                                  :quat (new 'static 'quaternion :y 0.9701 :w -0.2425)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -538283.2 :y -290052.1 :z 7718895.5)
@@ -6723,574 +1311,79 @@
                                  :quat (new 'static 'quaternion :y 0.8731 :w -0.4875)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -574435.75 :y -290827.47 :z 7682996.0)
                                  :quat (new 'static 'quaternion :y 0.8607 :w -0.509)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -576942.06 :y -289074.38 :z 7681850.0)
                                  :quat (new 'static 'quaternion :y 0.8506 :w -0.5256)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -579457.8 :y -285589.1 :z 7680789.5)
                                  :quat (new 'static 'quaternion :y 0.8415 :w -0.5401)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -582003.5 :y -281958.8 :z 7679802.0)
                                  :quat (new 'static 'quaternion :y 0.8329 :w -0.5534)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -584577.0 :y -279042.06 :z 7678889.0)
                                  :quat (new 'static 'quaternion :y 0.8244 :w -0.5659)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -587193.94 :y -277205.4 :z 7678047.5)
                                  :quat (new 'static 'quaternion :y 0.8158 :w -0.5782)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -589752.3 :y -275850.03 :z 7677303.5)
                                  :quat (new 'static 'quaternion :y 0.8072 :w -0.5902)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -591879.8 :y -273631.22 :z 7676752.0)
                                  :quat (new 'static 'quaternion :y 0.7986 :w -0.6018)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -594007.25 :y -270239.34 :z 7676258.0)
                                  :quat (new 'static 'quaternion :y 0.7904 :w -0.6125)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -596081.9 :y -267918.94 :z 7675828.5)
                                  :quat (new 'static 'quaternion :y 0.7828 :w -0.6221)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -598229.4 :y -266618.06 :z 7675436.5)
                                  :quat (new 'static 'quaternion :y 0.7752 :w -0.6316)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -600433.9 :y -267434.4 :z 7675090.0)
                                  :quat (new 'static 'quaternion :y 0.7678 :w -0.6406)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -602535.1 :y -270273.75 :z 7674808.0)
                                  :quat (new 'static 'quaternion :y 0.7602 :w -0.6496)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -604734.7 :y -274412.34 :z 7674566.0)
                                  :quat (new 'static 'quaternion :y 0.752 :w -0.659)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -606955.94 :y -279135.03 :z 7674375.5)
                                  :quat (new 'static 'quaternion :y 0.7439 :w -0.6681)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -609153.8 :y -284328.75 :z 7674240.0)
@@ -7345,574 +1438,79 @@
                                  :quat (new 'static 'quaternion :y 0.8441 :w -0.536)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -637892.6 :y -290815.6 :z 7657080.5)
                                  :quat (new 'static 'quaternion :y 0.8477 :w -0.5303)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -639710.8 :y -289927.16 :z 7654797.0)
                                  :quat (new 'static 'quaternion :y 0.8536 :w -0.5208)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -641699.44 :y -286681.1 :z 7652598.0)
                                  :quat (new 'static 'quaternion :y 0.8627 :w -0.5057)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -643639.3 :y -283403.47 :z 7650592.5)
                                  :quat (new 'static 'quaternion :y 0.8685 :w -0.4956)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -645680.3 :y -280434.28 :z 7648618.5)
                                  :quat (new 'static 'quaternion :y 0.8727 :w -0.4882)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -647775.0 :y -278533.75 :z 7646737.0)
                                  :quat (new 'static 'quaternion :y 0.8756 :w -0.4829)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -649857.8 :y -278070.47 :z 7645010.5)
                                  :quat (new 'static 'quaternion :y 0.8776 :w -0.4793)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -651679.3 :y -276311.66 :z 7643544.5)
                                  :quat (new 'static 'quaternion :y 0.8811 :w -0.4727)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -653354.6 :y -273222.03 :z 7642017.5)
                                  :quat (new 'static 'quaternion :y 0.8952 :w -0.4456)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -654858.6 :y -270623.53 :z 7640443.0)
                                  :quat (new 'static 'quaternion :y 0.9143 :w -0.4049)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -656205.8 :y -269122.75 :z 7638737.0)
                                  :quat (new 'static 'quaternion :y 0.934 :w -0.3571)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -657349.44 :y -269243.2 :z 7636970.0)
                                  :quat (new 'static 'quaternion :y 0.9515 :w -0.3075)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -658351.3 :y -271560.72 :z 7635045.0)
                                  :quat (new 'static 'quaternion :y 0.9671 :w -0.2541)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -659162.3 :y -275610.4 :z 7633023.0)
                                  :quat (new 'static 'quaternion :y 0.9797 :w -0.2003)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -659771.8 :y -280427.72 :z 7631010.0)
                                  :quat (new 'static 'quaternion :y 0.9878 :w -0.1555)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -660338.7 :y -285360.12 :z 7628882.5)
@@ -7943,612 +1541,84 @@
                                  :quat (new 'static 'quaternion :y 0.8906 :w -0.4547)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -670290.3 :y -290566.56 :z 7611263.0)
                                  :quat (new 'static 'quaternion :y 0.8781 :w -0.4783)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -672281.8 :y -288049.16 :z 7609100.5)
                                  :quat (new 'static 'quaternion :y 0.8664 :w -0.4993)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -674386.3 :y -284501.2 :z 7607227.0)
                                  :quat (new 'static 'quaternion :y 0.8581 :w -0.5134)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -676462.2 :y -281063.44 :z 7605568.5)
                                  :quat (new 'static 'quaternion :y 0.8527 :w -0.5222)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -678788.3 :y -278355.97 :z 7603969.5)
                                  :quat (new 'static 'quaternion :y 0.8471 :w -0.5313)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -681173.4 :y -276822.44 :z 7602576.0)
                                  :quat (new 'static 'quaternion :y 0.8414 :w -0.5402)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -683504.0 :y -276876.1 :z 7601411.5)
                                  :quat (new 'static 'quaternion :y 0.8369 :w -0.5472)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -685853.9 :y -276482.06 :z 7600421.5)
                                  :quat (new 'static 'quaternion :y 0.8322 :w -0.5544)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -687903.1 :y -273920.4 :z 7599655.5)
                                  :quat (new 'static 'quaternion :y 0.8266 :w -0.5627)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -689960.1 :y -270697.28 :z 7598919.5)
                                  :quat (new 'static 'quaternion :y 0.8217 :w -0.5697)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -692032.3 :y -268539.5 :z 7598229.0)
                                  :quat (new 'static 'quaternion :y 0.8162 :w -0.5777)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -694116.4 :y -267673.2 :z 7597574.0)
                                  :quat (new 'static 'quaternion :y 0.8109 :w -0.5851)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -696279.06 :y -268978.2 :z 7596936.5)
                                  :quat (new 'static 'quaternion :y 0.8056 :w -0.5923)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -698400.75 :y -272270.53 :z 7596350.5)
                                  :quat (new 'static 'quaternion :y 0.8003 :w -0.5995)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -700443.06 :y -276488.2 :z 7595824.5)
                                  :quat (new 'static 'quaternion :y 0.7953 :w -0.6061)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -702588.1 :y -281141.25 :z 7595308.5)
                                  :quat (new 'static 'quaternion :y 0.7901 :w -0.6129)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -704725.4 :y -286524.62 :z 7594834.5)

--- a/test/decompiler/reference/jak2/levels/underport/sig5-cent1-path0_REF.gc
+++ b/test/decompiler/reference/jak2/levels/underport/sig5-cent1-path0_REF.gc
@@ -6,42 +6,9 @@
                              :sample-count #xfb
                              :samples (new 'static 'inline-array sig-path-sample 251
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x1
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -324352.8 :y -274439.38 :z 8362734.5)
                                  :quat (new 'static 'quaternion :y 0.1254 :w -0.9921)
+                                 :flags #x1
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -324352.8 :y -274439.78 :z 8362734.5)
@@ -96,384 +63,54 @@
                                  :quat (new 'static 'quaternion :y 0.2044 :w -0.9788)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -334386.78 :y -275121.34 :z 8384650.5)
                                  :quat (new 'static 'quaternion :y 0.1802 :w -0.9836)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -335159.28 :y -272610.1 :z 8387254.5)
                                  :quat (new 'static 'quaternion :y 0.1611 :w -0.9869)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -335894.12 :y -269008.9 :z 8389873.0)
                                  :quat (new 'static 'quaternion :y 0.1482 :w -0.9889)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -336567.9 :y -265442.9 :z 8392512.0)
                                  :quat (new 'static 'quaternion :y 0.136 :w -0.9907)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -337176.56 :y -262789.94 :z 8395170.0)
                                  :quat (new 'static 'quaternion :y 0.1226 :w -0.9924)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -337687.75 :y -261229.36 :z 8397850.0)
                                  :quat (new 'static 'quaternion :y 0.1075 :w -0.9941)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -338169.03 :y -261196.19 :z 8400536.0)
                                  :quat (new 'static 'quaternion :y 0.0976 :w -0.9952)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -338628.6 :y -263263.84 :z 8403226.0)
                                  :quat (new 'static 'quaternion :y 0.0908 :w -0.9958)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -339066.06 :y -266997.34 :z 8405919.0)
                                  :quat (new 'static 'quaternion :y 0.0853 :w -0.9963)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -339481.0 :y -271822.84 :z 8408616.0)
                                  :quat (new 'static 'quaternion :y 0.0805 :w -0.9967)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -339987.25 :y -274439.78 :z 8411288.0)
@@ -512,384 +149,54 @@
                                  :quat (new 'static 'quaternion :y 0.3718 :w -0.9282)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -356558.84 :y -275780.4 :z 8430416.0)
                                  :quat (new 'static 'quaternion :y 0.3951 :w -0.9186)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -358678.12 :y -273268.75 :z 8432136.0)
                                  :quat (new 'static 'quaternion :y 0.4133 :w -0.9105)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -360849.4 :y -269667.53 :z 8433789.0)
                                  :quat (new 'static 'quaternion :y 0.4294 :w -0.9031)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -363055.94 :y -266101.56 :z 8435394.0)
                                  :quat (new 'static 'quaternion :y 0.4422 :w -0.8968)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -365302.6 :y -263448.56 :z 8436944.0)
                                  :quat (new 'static 'quaternion :y 0.454 :w -0.8909)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -367577.5 :y -261888.0 :z 8438452.0)
                                  :quat (new 'static 'quaternion :y 0.464 :w -0.8857)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -369885.6 :y -261854.83 :z 8439909.0)
                                  :quat (new 'static 'quaternion :y 0.4738 :w -0.8805)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -372205.97 :y -263922.9 :z 8441347.0)
                                  :quat (new 'static 'quaternion :y 0.4799 :w -0.8772)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -374285.1 :y -267656.0 :z 8443105.0)
                                  :quat (new 'static 'quaternion :y 0.4619 :w -0.8868)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -375903.44 :y -272481.9 :z 8445277.0)
                                  :quat (new 'static 'quaternion :y 0.4262 :w -0.9046)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -377183.03 :y -274436.9 :z 8447669.0)
@@ -904,384 +211,54 @@
                                  :quat (new 'static 'quaternion :y 0.1492 :w -0.9887)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378525.7 :y -274529.9 :z 8455750.0)
                                  :quat (new 'static 'quaternion :y 0.091 :w -0.9958)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378642.03 :y -272946.78 :z 8458476.0)
                                  :quat (new 'static 'quaternion :y 0.0547 :w -0.9985)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378689.94 :y -269456.2 :z 8461204.0)
                                  :quat (new 'static 'quaternion :y 0.0306 :w -0.9995)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378668.66 :y -265834.5 :z 8463932.0)
                                  :quat (new 'static 'quaternion :y 0.0124 :w -0.9999)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378577.72 :y -262908.72 :z 8466660.0)
                                  :quat (new 'static 'quaternion :y -0.0029 :w -0.9999)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378458.94 :y -261074.94 :z 8469386.0)
                                  :quat (new 'static 'quaternion :y -0.0112 :w -0.9999)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378517.9 :y -260551.06 :z 8472112.0)
                                  :quat (new 'static 'quaternion :y 0.0086 :w -0.9999)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -378781.28 :y -262059.22 :z 8474824.0)
                                  :quat (new 'static 'quaternion :y 0.043 :w -0.999)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -379300.25 :y -265519.5 :z 8477491.0)
                                  :quat (new 'static 'quaternion :y 0.0875 :w -0.9961)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -380388.56 :y -270071.8 :z 8479971.0)
                                  :quat (new 'static 'quaternion :y 0.1382 :w -0.9903)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -381684.12 :y -274148.97 :z 8482364.0)
@@ -1344,384 +321,54 @@
                                  :quat (new 'static 'quaternion :y 0.3033 :w -0.9528)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -404996.1 :y -274024.03 :z 8515859.0)
                                  :quat (new 'static 'quaternion :y 0.3185 :w -0.9479)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -406854.03 :y -271109.75 :z 8517858.0)
                                  :quat (new 'static 'quaternion :y 0.3428 :w -0.9393)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -408734.1 :y -267496.66 :z 8519837.0)
                                  :quat (new 'static 'quaternion :y 0.3573 :w -0.9339)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -410637.1 :y -264024.47 :z 8521793.0)
                                  :quat (new 'static 'quaternion :y 0.3671 :w -0.9301)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -412556.1 :y -261644.7 :z 8523733.0)
                                  :quat (new 'static 'quaternion :y 0.3736 :w -0.9275)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -414310.0 :y -260357.33 :z 8525822.0)
                                  :quat (new 'static 'quaternion :y 0.3581 :w -0.9336)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -415982.78 :y -260814.84 :z 8527967.0)
                                  :quat (new 'static 'quaternion :y 0.3408 :w -0.9401)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -417660.1 :y -263442.03 :z 8530108.0)
                                  :quat (new 'static 'quaternion :y 0.3332 :w -0.9428)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -419356.7 :y -267448.72 :z 8532235.0)
                                  :quat (new 'static 'quaternion :y 0.332 :w -0.9432)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -421139.66 :y -272260.72 :z 8534301.0)
                                  :quat (new 'static 'quaternion :y 0.3408 :w -0.9401)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -422814.94 :y -274340.25 :z 8536119.0)
@@ -1768,384 +415,54 @@
                                  :quat (new 'static 'quaternion :y 0.7654 :w -0.6434)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -452537.12 :y -274589.7 :z 8539009.0)
                                  :quat (new 'static 'quaternion :y 0.7736 :w -0.6335)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -455184.78 :y -273025.84 :z 8538341.0)
                                  :quat (new 'static 'quaternion :y 0.7815 :w -0.6238)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -457814.03 :y -269534.8 :z 8537605.0)
                                  :quat (new 'static 'quaternion :y 0.7897 :w -0.6134)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -460422.34 :y -265913.56 :z 8536797.0)
                                  :quat (new 'static 'quaternion :y 0.7977 :w -0.6029)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -463015.53 :y -262987.38 :z 8535943.0)
                                  :quat (new 'static 'quaternion :y 0.8042 :w -0.5943)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -465648.03 :y -261154.0 :z 8535219.0)
                                  :quat (new 'static 'quaternion :y 0.7991 :w -0.601)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -468280.12 :y -260630.12 :z 8534492.0)
                                  :quat (new 'static 'quaternion :y 0.7976 :w -0.603)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -470887.62 :y -262137.86 :z 8533682.0)
                                  :quat (new 'static 'quaternion :y 0.8017 :w -0.5976)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -473468.94 :y -265598.16 :z 8532792.0)
                                  :quat (new 'static 'quaternion :y 0.8085 :w -0.5884)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -476020.75 :y -270150.88 :z 8531822.0)
                                  :quat (new 'static 'quaternion :y 0.8164 :w -0.5773)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -478541.0 :y -274436.5 :z 8530772.0)
@@ -2192,384 +509,54 @@
                                  :quat (new 'static 'quaternion :y 0.8798 :w -0.4752)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -504420.75 :y -274641.3 :z 8515537.0)
                                  :quat (new 'static 'quaternion :y 0.8823 :w -0.4706)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -506719.84 :y -274083.03 :z 8514064.0)
                                  :quat (new 'static 'quaternion :y 0.8797 :w -0.4754)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -509030.0 :y -270853.75 :z 8512607.0)
                                  :quat (new 'static 'quaternion :y 0.8776 :w -0.4793)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -511331.94 :y -267176.75 :z 8511138.0)
                                  :quat (new 'static 'quaternion :y 0.8772 :w -0.4799)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -513606.44 :y -263977.78 :z 8509628.0)
                                  :quat (new 'static 'quaternion :y 0.8794 :w -0.4759)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -515848.2 :y -261870.8 :z 8508070.0)
                                  :quat (new 'static 'quaternion :y 0.8831 :w -0.4691)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -518055.94 :y -260856.62 :z 8506464.0)
                                  :quat (new 'static 'quaternion :y 0.8874 :w -0.4609)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -520229.28 :y -261804.44 :z 8504810.0)
                                  :quat (new 'static 'quaternion :y 0.8919 :w -0.452)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -522366.97 :y -264991.94 :z 8503112.0)
                                  :quat (new 'static 'quaternion :y 0.8965 :w -0.4428)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -524467.8 :y -269271.44 :z 8501367.0)
                                  :quat (new 'static 'quaternion :y 0.9012 :w -0.4333)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -526530.56 :y -274069.9 :z 8499578.0)
@@ -2604,384 +591,54 @@
                                  :quat (new 'static 'quaternion :y 0.9349 :w -0.3547)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -541649.7 :y -274431.6 :z 8483828.0)
                                  :quat (new 'static 'quaternion :y 0.9342 :w -0.3567)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -543530.6 :y -273600.1 :z 8481848.0)
                                  :quat (new 'static 'quaternion :y 0.9313 :w -0.3641)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -545404.5 :y -270370.8 :z 8479860.0)
                                  :quat (new 'static 'quaternion :y 0.9304 :w -0.3665)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -547244.9 :y -266693.84 :z 8477843.0)
                                  :quat (new 'static 'quaternion :y 0.9314 :w -0.3637)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -549052.0 :y -263494.88 :z 8475796.0)
                                  :quat (new 'static 'quaternion :y 0.9335 :w -0.3584)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -550826.0 :y -261388.28 :z 8473720.0)
                                  :quat (new 'static 'quaternion :y 0.9359 :w -0.352)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -552776.5 :y -260373.7 :z 8471827.0)
                                  :quat (new 'static 'quaternion :y 0.9334 :w -0.3586)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -555121.44 :y -261321.94 :z 8470470.0)
                                  :quat (new 'static 'quaternion :y 0.9209 :w -0.3896)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -557556.94 :y -264509.03 :z 8469297.0)
                                  :quat (new 'static 'quaternion :y 0.9019 :w -0.4318)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -560065.75 :y -268788.53 :z 8468315.0)
                                  :quat (new 'static 'quaternion :y 0.878 :w -0.4785)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -562636.0 :y -273587.0 :z 8467528.0)
@@ -3020,688 +677,94 @@
                                  :quat (new 'static 'quaternion :y 0.5832 :w -0.8122)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -592592.5 :y -275394.56 :z 8484615.0)
                                  :quat (new 'static 'quaternion :y 0.5701 :w -0.8215)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -595137.3 :y -275222.12 :z 8485603.0)
                                  :quat (new 'static 'quaternion :y 0.5677 :w -0.8232)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -597731.75 :y -271992.84 :z 8486451.0)
                                  :quat (new 'static 'quaternion :y 0.5789 :w -0.8153)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -600375.7 :y -268315.84 :z 8487130.0)
                                  :quat (new 'static 'quaternion :y 0.5976 :w -0.8017)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -603048.75 :y -265116.47 :z 8487684.0)
                                  :quat (new 'static 'quaternion :y 0.6152 :w -0.7882)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -605721.8 :y -263009.9 :z 8488240.0)
                                  :quat (new 'static 'quaternion :y 0.623 :w -0.7821)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -608385.8 :y -261995.31 :z 8488836.0)
                                  :quat (new 'static 'quaternion :y 0.623 :w -0.7822)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -611001.1 :y -262943.53 :z 8489596.0)
                                  :quat (new 'static 'quaternion :y 0.6024 :w -0.7981)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -613549.25 :y -266131.03 :z 8490548.0)
                                  :quat (new 'static 'quaternion :y 0.5724 :w -0.8199)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -616017.94 :y -268524.34 :z 8491674.0)
                                  :quat (new 'static 'quaternion :y 0.5532 :w -0.833)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -618316.2 :y -266312.5 :z 8492766.0)
                                  :quat (new 'static 'quaternion :y 0.5422 :w -0.8402)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -620428.9 :y -262918.16 :z 8493789.0)
                                  :quat (new 'static 'quaternion :y 0.5339 :w -0.8455)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -622378.2 :y -260542.05 :z 8494815.0)
                                  :quat (new 'static 'quaternion :y 0.5233 :w -0.8521)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -624294.7 :y -259257.95 :z 8495861.0)
                                  :quat (new 'static 'quaternion :y 0.5165 :w -0.8562)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -626247.25 :y -260021.86 :z 8496836.0)
                                  :quat (new 'static 'quaternion :y 0.5241 :w -0.8516)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -628255.56 :y -263025.06 :z 8497692.0)
                                  :quat (new 'static 'quaternion :y 0.5382 :w -0.8427)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -630255.6 :y -267120.62 :z 8498568.0)
                                  :quat (new 'static 'quaternion :y 0.5425 :w -0.84)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -632263.06 :y -271734.78 :z 8499427.0)
                                  :quat (new 'static 'quaternion :y 0.5469 :w -0.8371)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -633675.4 :y -274657.28 :z 8500297.0)
@@ -3836,650 +899,89 @@
                                  :quat (new 'static 'quaternion :y 0.7966 :w -0.6043)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -698236.94 :y -275113.97 :z 8445707.0)
                                  :quat (new 'static 'quaternion :y 0.7988 :w -0.6015)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -700854.7 :y -272602.3 :z 8444931.0)
                                  :quat (new 'static 'quaternion :y 0.8 :w -0.5999)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -703481.06 :y -269001.12 :z 8444184.0)
                                  :quat (new 'static 'quaternion :y 0.7988 :w -0.6015)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -706135.25 :y -265435.12 :z 8443545.0)
                                  :quat (new 'static 'quaternion :y 0.7913 :w -0.6113)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -708815.7 :y -262782.16 :z 8443023.0)
                                  :quat (new 'static 'quaternion :y 0.7811 :w -0.6243)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -711504.7 :y -261221.58 :z 8442549.0)
                                  :quat (new 'static 'quaternion :y 0.7732 :w -0.6341)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -714108.1 :y -261188.4 :z 8441763.0)
                                  :quat (new 'static 'quaternion :y 0.7791 :w -0.6268)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -716485.8 :y -263256.47 :z 8440463.0)
                                  :quat (new 'static 'quaternion :y 0.8004 :w -0.5994)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -718630.06 :y -263800.0 :z 8439150.0)
                                  :quat (new 'static 'quaternion :y 0.8275 :w -0.5613)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -720458.94 :y -261165.47 :z 8437982.0)
                                  :quat (new 'static 'quaternion :y 0.8529 :w -0.5219)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -722303.8 :y -258267.14 :z 8436841.0)
                                  :quat (new 'static 'quaternion :y 0.8637 :w -0.5039)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -724146.56 :y -256460.8 :z 8435697.0)
                                  :quat (new 'static 'quaternion :y 0.869 :w -0.4947)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -725987.75 :y -255985.66 :z 8434550.0)
                                  :quat (new 'static 'quaternion :y 0.8716 :w -0.49)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -727827.25 :y -257606.45 :z 8433400.0)
                                  :quat (new 'static 'quaternion :y 0.8731 :w -0.4873)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -729664.7 :y -261179.39 :z 8432248.0)
                                  :quat (new 'static 'quaternion :y 0.8741 :w -0.4856)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -731500.1 :y -265844.75 :z 8431092.0)
                                  :quat (new 'static 'quaternion :y 0.8747 :w -0.4845)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -733333.5 :y -270741.9 :z 8429933.0)
                                  :quat (new 'static 'quaternion :y 0.8752 :w -0.4835)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -735201.7 :y -274436.5 :z 8428749.0)
@@ -4558,384 +1060,54 @@
                                  :quat (new 'static 'quaternion :y 0.8837 :w -0.4679)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -778130.6 :y -274436.5 :z 8400396.0)
                                  :quat (new 'static 'quaternion :y 0.8841 :w -0.4671)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -780363.4 :y -272703.9 :z 8398858.0)
                                  :quat (new 'static 'quaternion :y 0.8846 :w -0.4661)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -782592.8 :y -269213.28 :z 8397315.0)
                                  :quat (new 'static 'quaternion :y 0.8851 :w -0.4652)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -784819.8 :y -265591.6 :z 8395768.0)
                                  :quat (new 'static 'quaternion :y 0.8856 :w -0.4643)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -787055.0 :y -262665.84 :z 8394235.0)
                                  :quat (new 'static 'quaternion :y 0.885 :w -0.4655)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -789298.8 :y -260832.05 :z 8392716.0)
                                  :quat (new 'static 'quaternion :y 0.8842 :w -0.4671)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -791540.94 :y -260308.17 :z 8391194.0)
                                  :quat (new 'static 'quaternion :y 0.8839 :w -0.4675)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -793781.44 :y -261816.31 :z 8389670.0)
                                  :quat (new 'static 'quaternion :y 0.8839 :w -0.4675)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -796019.94 :y -265276.62 :z 8388142.5)
                                  :quat (new 'static 'quaternion :y 0.884 :w -0.4674)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -798256.75 :y -269829.3 :z 8386613.0)
                                  :quat (new 'static 'quaternion :y 0.8842 :w -0.467)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -800491.94 :y -274436.5 :z 8385080.0)
@@ -4956,7 +1128,3 @@
                                )
                              )
         )
-
-
-
-

--- a/test/decompiler/reference/jak2/levels/underport/sig5-cent2-path0_REF.gc
+++ b/test/decompiler/reference/jak2/levels/underport/sig5-cent2-path0_REF.gc
@@ -86,612 +86,84 @@
                                  :quat (new 'static 'quaternion :y 0.5036 :w 0.8638)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -813869.06 :y -290555.9 :z 8019219.5)
                                  :quat (new 'static 'quaternion :y 0.504 :w 0.8636)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -811462.6 :y -288029.1 :z 8020572.0)
                                  :quat (new 'static 'quaternion :y 0.5044 :w 0.8634)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -809131.2 :y -284611.38 :z 8021879.0)
                                  :quat (new 'static 'quaternion :y 0.5047 :w 0.8632)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -806730.94 :y -281158.44 :z 8023222.5)
                                  :quat (new 'static 'quaternion :y 0.505 :w 0.863)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -804404.8 :y -278584.94 :z 8024522.5)
                                  :quat (new 'static 'quaternion :y 0.5054 :w 0.8628)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -802004.56 :y -277191.88 :z 8025861.0)
                                  :quat (new 'static 'quaternion :y 0.5057 :w 0.8626)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -799658.4 :y -277495.0 :z 8027166.5)
                                  :quat (new 'static 'quaternion :y 0.5061 :w 0.8624)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -797658.75 :y -275646.88 :z 8028278.5)
                                  :quat (new 'static 'quaternion :y 0.5064 :w 0.8622)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -795729.5 :y -272526.53 :z 8029348.5)
                                  :quat (new 'static 'quaternion :y 0.5067 :w 0.862)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -793871.1 :y -269754.38 :z 8030378.0)
                                  :quat (new 'static 'quaternion :y 0.507 :w 0.8619)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -791934.2 :y -267939.03 :z 8031449.5)
                                  :quat (new 'static 'quaternion :y 0.5073 :w 0.8617)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -790075.4 :y -267824.34 :z 8032476.0)
                                  :quat (new 'static 'quaternion :y 0.5076 :w 0.8615)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -788145.4 :y -270044.38 :z 8033540.0)
                                  :quat (new 'static 'quaternion :y 0.5079 :w 0.8614)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -786266.94 :y -273842.6 :z 8034576.0)
                                  :quat (new 'static 'quaternion :y 0.5082 :w 0.8612)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -784381.56 :y -278505.06 :z 8035612.5)
                                  :quat (new 'static 'quaternion :y 0.5084 :w 0.861)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -782488.75 :y -283301.47 :z 8036652.0)
                                  :quat (new 'static 'quaternion :y 0.5086 :w 0.8609)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -780612.4 :y -288990.0 :z 8037682.0)
@@ -778,612 +250,84 @@
                                  :quat (new 'static 'quaternion :y 0.5153 :w 0.8569)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x6
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -730725.56 :y -290373.22 :z 8064483.0)
                                  :quat (new 'static 'quaternion :y 0.5157 :w 0.8567)
+                                 :flags #x6
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -728306.5 :y -287443.34 :z 8065756.5)
                                  :quat (new 'static 'quaternion :y 0.5161 :w 0.8565)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -725927.94 :y -283819.62 :z 8067055.5)
                                  :quat (new 'static 'quaternion :y 0.513 :w 0.8583)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -723540.4 :y -280342.53 :z 8068359.5)
                                  :quat (new 'static 'quaternion :y 0.5115 :w 0.8592)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -721121.7 :y -277916.06 :z 8069680.5)
                                  :quat (new 'static 'quaternion :y 0.5109 :w 0.8596)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -718744.4 :y -276652.84 :z 8070978.5)
                                  :quat (new 'static 'quaternion :y 0.5105 :w 0.8598)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -716414.2 :y -277169.34 :z 8072250.0)
                                  :quat (new 'static 'quaternion :y 0.5104 :w 0.8599)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -713982.75 :y -279874.34 :z 8073577.5)
                                  :quat (new 'static 'quaternion :y 0.5103 :w 0.8599)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -711865.1 :y -279534.78 :z 8074606.0)
                                  :quat (new 'static 'quaternion :y 0.5187 :w 0.8549)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -709781.5 :y -276654.9 :z 8075430.5)
                                  :quat (new 'static 'quaternion :y 0.5402 :w 0.8415)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -707780.2 :y -273814.3 :z 8076148.5)
                                  :quat (new 'static 'quaternion :y 0.5572 :w 0.8303)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -705589.25 :y -271912.97 :z 8076646.5)
                                  :quat (new 'static 'quaternion :y 0.5877 :w 0.809)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -703473.7 :y -271607.0 :z 8076905.0)
                                  :quat (new 'static 'quaternion :y 0.6227 :w 0.7824)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -701273.7 :y -273347.38 :z 8076848.5)
                                  :quat (new 'static 'quaternion :y 0.6618 :w 0.7496)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -699097.94 :y -276987.9 :z 8076461.5)
                                  :quat (new 'static 'quaternion :y 0.7032 :w 0.7109)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -697077.4 :y -281638.5 :z 8075730.0)
                                  :quat (new 'static 'quaternion :y 0.7414 :w 0.6709)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -695090.8 :y -286363.25 :z 8074855.0)
@@ -1398,498 +342,69 @@
                                  :quat (new 'static 'quaternion :y 0.7344 :w 0.6786)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -687166.7 :y -290336.78 :z 8072274.5)
                                  :quat (new 'static 'quaternion :y 0.6943 :w 0.7196)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -684086.5 :y -289645.38 :z 8072016.5)
                                  :quat (new 'static 'quaternion :y 0.6697 :w 0.7425)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -681369.6 :y -286400.5 :z 8072493.5)
                                  :quat (new 'static 'quaternion :y 0.6564 :w 0.7544)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -678654.4 :y -282954.56 :z 8072990.5)
                                  :quat (new 'static 'quaternion :y 0.6484 :w 0.7612)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -675963.7 :y -279912.03 :z 8073498.0)
                                  :quat (new 'static 'quaternion :y 0.6432 :w 0.7656)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -673276.3 :y -278004.94 :z 8074011.5)
                                  :quat (new 'static 'quaternion :y 0.6402 :w 0.7682)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -670679.44 :y -277038.28 :z 8074525.5)
                                  :quat (new 'static 'quaternion :y 0.6373 :w 0.7705)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -668414.4 :y -275017.3 :z 8074978.0)
                                  :quat (new 'static 'quaternion :y 0.6355 :w 0.772)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -666320.5 :y -271846.6 :z 8075391.5)
                                  :quat (new 'static 'quaternion :y 0.635 :w 0.7724)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -664138.56 :y -269153.5 :z 8075835.0)
                                  :quat (new 'static 'quaternion :y 0.6335 :w 0.7737)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -662066.0 :y -267642.47 :z 8076497.5)
                                  :quat (new 'static 'quaternion :y 0.6165 :w 0.7873)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -660126.5 :y -267900.1 :z 8077481.0)
                                  :quat (new 'static 'quaternion :y 0.5834 :w 0.8121)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -658266.94 :y -270403.2 :z 8078532.5)
                                  :quat (new 'static 'quaternion :y 0.5469 :w 0.8371)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -656417.56 :y -274181.75 :z 8079592.0)
@@ -1900,270 +415,39 @@
                                  :quat (new 'static 'quaternion :y 0.5128 :w 0.8584)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -651757.2 :y -274435.7 :z 8081808.0)
                                  :quat (new 'static 'quaternion :y 0.5524 :w 0.8335)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -649046.44 :y -273504.25 :z 8082224.5)
                                  :quat (new 'static 'quaternion :y 0.6212 :w 0.7835)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -646341.44 :y -270322.47 :z 8082386.0)
                                  :quat (new 'static 'quaternion :y 0.6695 :w 0.7427)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -643603.25 :y -266938.38 :z 8082347.5)
                                  :quat (new 'static 'quaternion :y 0.6981 :w 0.7159)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -640862.6 :y -263973.28 :z 8082172.5)
                                  :quat (new 'static 'quaternion :y 0.7147 :w 0.6993)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -638185.9 :y -262127.61 :z 8081939.0)
                                  :quat (new 'static 'quaternion :y 0.7261 :w 0.6874)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -635468.2 :y -261681.16 :z 8081628.0)
                                  :quat (new 'static 'quaternion :y 0.7364 :w 0.6764)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -632801.25 :y -263012.75 :z 8081252.0)
@@ -2182,346 +466,49 @@
                                  :quat (new 'static 'quaternion :y 0.7712 :w 0.6364)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -622270.06 :y -265887.75 :z 8078695.0)
                                  :quat (new 'static 'quaternion :y 0.7942 :w 0.6075)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -619838.25 :y -265062.8 :z 8077417.5)
                                  :quat (new 'static 'quaternion :y 0.8243 :w 0.566)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -617499.06 :y -262095.25 :z 8076041.5)
                                  :quat (new 'static 'quaternion :y 0.8447 :w 0.5352)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -615194.6 :y -258894.23 :z 8074572.0)
                                  :quat (new 'static 'quaternion :y 0.8593 :w 0.5113)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -612949.2 :y -255756.28 :z 8073025.0)
                                  :quat (new 'static 'quaternion :y 0.871 :w 0.4911)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -610698.9 :y -253577.22 :z 8071484.0)
                                  :quat (new 'static 'quaternion :y 0.8767 :w 0.4809)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -608444.0 :y -252794.06 :z 8069941.0)
                                  :quat (new 'static 'quaternion :y 0.8799 :w 0.4749)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -606183.44 :y -254136.31 :z 8068411.5)
                                  :quat (new 'static 'quaternion :y 0.8814 :w 0.4722)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -603984.3 :y -258101.66 :z 8066828.5)
                                  :quat (new 'static 'quaternion :y 0.8848 :w 0.4658)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -601808.06 :y -263374.03 :z 8065157.0)
@@ -2560,346 +547,49 @@
                                  :quat (new 'static 'quaternion :y 0.9774 :w 0.2112)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -581805.25 :y -265959.84 :z 8048587.0)
                                  :quat (new 'static 'quaternion :y 0.9886 :w 0.1505)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -581509.5 :y -263710.72 :z 8045927.5)
                                  :quat (new 'static 'quaternion :y 0.9941 :w 0.108)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -581173.7 :y -260199.22 :z 8043224.5)
                                  :quat (new 'static 'quaternion :y 0.9959 :w 0.09)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -580901.7 :y -256735.23 :z 8040516.5)
                                  :quat (new 'static 'quaternion :y 0.9972 :w 0.0746)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -580748.06 :y -253640.3 :z 8037793.0)
                                  :quat (new 'static 'quaternion :y 0.9984 :w 0.0564)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -580728.8 :y -251647.19 :z 8035093.5)
                                  :quat (new 'static 'quaternion :y 0.9993 :w 0.0356)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -580827.1 :y -251336.3 :z 8032372.0)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0128)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -580827.94 :y -253310.16 :z 8029559.5)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0077)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -580767.3 :y -257432.78 :z 8026842.0)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0091)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -580715.3 :y -262652.72 :z 8024125.5)
@@ -2946,574 +636,79 @@
                                  :quat (new 'static 'quaternion :y 0.9986 :w -0.0514)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -569254.7 :y -265945.5 :z 8001267.5)
                                  :quat (new 'static 'quaternion :y 0.9982 :w -0.0584)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -569450.5 :y -263305.62 :z 7998664.5)
                                  :quat (new 'static 'quaternion :y 0.9977 :w -0.0665)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -569918.25 :y -259987.05 :z 7995963.0)
                                  :quat (new 'static 'quaternion :y 0.997 :w -0.0765)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -570484.3 :y -256668.88 :z 7993272.5)
                                  :quat (new 'static 'quaternion :y 0.9958 :w -0.0908)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -571110.6 :y -254427.14 :z 7990605.5)
                                  :quat (new 'static 'quaternion :y 0.9946 :w -0.1034)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -571645.94 :y -253331.86 :z 7987928.5)
                                  :quat (new 'static 'quaternion :y 0.995 :w -0.0993)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -571992.06 :y -254224.8 :z 7985207.5)
                                  :quat (new 'static 'quaternion :y 0.9973 :w -0.0721)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -572098.56 :y -254679.86 :z 7982636.0)
                                  :quat (new 'static 'quaternion :y 0.9992 :w -0.0374)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -571797.5 :y -252205.47 :z 7980572.5)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0065)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -571399.4 :y -249192.45 :z 7978425.0)
                                  :quat (new 'static 'quaternion :y 0.9988 :w 0.0488)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -571024.2 :y -247228.0 :z 7976274.0)
                                  :quat (new 'static 'quaternion :y 0.9976 :w 0.0679)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -570670.7 :y -246530.05 :z 7974118.0)
                                  :quat (new 'static 'quaternion :y 0.9972 :w 0.0745)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -570186.1 :y -247887.88 :z 7971989.0)
                                  :quat (new 'static 'quaternion :y 0.9955 :w 0.0937)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -569616.8 :y -251270.34 :z 7969880.5)
                                  :quat (new 'static 'quaternion :y 0.9935 :w 0.1131)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -569058.5 :y -255777.17 :z 7967768.0)
                                  :quat (new 'static 'quaternion :y 0.9926 :w 0.1211)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -568512.5 :y -260623.56 :z 7965653.0)
@@ -3560,460 +755,64 @@
                                  :quat (new 'static 'quaternion :y 0.9799 :w -0.1992)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -573850.0 :y -274443.47 :z 7937625.0)
                                  :quat (new 'static 'quaternion :y 0.973 :w -0.2307)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -575327.0 :y -272968.5 :z 7935328.5)
                                  :quat (new 'static 'quaternion :y 0.9661 :w -0.2578)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -576869.56 :y -269594.62 :z 7933074.5)
                                  :quat (new 'static 'quaternion :y 0.9607 :w -0.2774)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -578454.3 :y -265963.94 :z 7930851.5)
                                  :quat (new 'static 'quaternion :y 0.9564 :w -0.2919)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -580091.5 :y -262935.34 :z 7928666.0)
                                  :quat (new 'static 'quaternion :y 0.9524 :w -0.3047)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -581702.9 :y -260992.2 :z 7926462.5)
                                  :quat (new 'static 'quaternion :y 0.9516 :w -0.3072)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -583187.7 :y -260297.11 :z 7924171.0)
                                  :quat (new 'static 'quaternion :y 0.9555 :w -0.2948)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -584707.7 :y -261646.75 :z 7921856.0)
                                  :quat (new 'static 'quaternion :y 0.9568 :w -0.2906)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -586099.5 :y -265220.9 :z 7919465.5)
                                  :quat (new 'static 'quaternion :y 0.9605 :w -0.2782)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -587479.9 :y -269938.28 :z 7917088.0)
                                  :quat (new 'static 'quaternion :y 0.9628 :w -0.2699)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -588697.2 :y -274794.1 :z 7914692.5)
                                  :quat (new 'static 'quaternion :y 0.9651 :w -0.2617)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -589139.94 :y -280308.12 :z 7912029.0)
                                  :quat (new 'static 'quaternion :y 0.973 :w -0.2306)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -589293.2 :y -286907.6 :z 7909344.5)
@@ -4056,612 +855,84 @@
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0029)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x6
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -588591.94 :y -290827.47 :z 7882143.0)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0027)
+                                 :flags #x6
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -588578.8 :y -288672.16 :z 7879490.5)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0026)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -588553.0 :y -285091.44 :z 7876713.5)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0049)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -588364.6 :y -281747.47 :z 7874042.0)
                                  :quat (new 'static 'quaternion :y 0.9996 :w 0.0253)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -587981.6 :y -279036.3 :z 7871329.5)
                                  :quat (new 'static 'quaternion :y 0.9987 :w 0.049)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -587450.75 :y -277469.6 :z 7868650.0)
                                  :quat (new 'static 'quaternion :y 0.9972 :w 0.0739)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -586702.44 :y -277569.53 :z 7865999.0)
                                  :quat (new 'static 'quaternion :y 0.9945 :w 0.1039)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -585607.56 :y -275708.3 :z 7863881.5)
                                  :quat (new 'static 'quaternion :y 0.9894 :w 0.1447)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -584317.75 :y -272701.84 :z 7862169.0)
                                  :quat (new 'static 'quaternion :y 0.9812 :w 0.1926)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -582916.94 :y -269946.47 :z 7860548.5)
                                  :quat (new 'static 'quaternion :y 0.9696 :w 0.2445)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -581412.06 :y -268192.56 :z 7858967.5)
                                  :quat (new 'static 'quaternion :y 0.9544 :w 0.2984)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -579871.56 :y -268084.03 :z 7857418.0)
                                  :quat (new 'static 'quaternion :y 0.9406 :w 0.3393)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -578342.06 :y -270119.72 :z 7855857.5)
                                  :quat (new 'static 'quaternion :y 0.9331 :w 0.3595)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -576748.75 :y -273722.97 :z 7854365.5)
                                  :quat (new 'static 'quaternion :y 0.9256 :w 0.3782)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -575032.5 :y -278263.4 :z 7853015.5)
                                  :quat (new 'static 'quaternion :y 0.9132 :w 0.4074)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -573306.06 :y -283045.88 :z 7851659.5)
                                  :quat (new 'static 'quaternion :y 0.9065 :w 0.422)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -571713.56 :y -288834.75 :z 7850154.5)
@@ -4672,688 +943,94 @@
                                  :quat (new 'static 'quaternion :y 0.9597 :w 0.2807)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x6
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -568066.44 :y -290262.22 :z 7846672.0)
                                  :quat (new 'static 'quaternion :y 0.9898 :w 0.1421)
+                                 :flags #x6
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567199.3 :y -289271.8 :z 7844376.0)
                                  :quat (new 'static 'quaternion :y 0.9977 :w 0.0667)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567190.75 :y -286378.8 :z 7841691.0)
                                  :quat (new 'static 'quaternion :y 0.9997 :w 0.0234)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567316.06 :y -282765.3 :z 7838965.5)
                                  :quat (new 'static 'quaternion :y 0.9999 :w -0.001)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567469.25 :y -279421.75 :z 7836239.5)
                                  :quat (new 'static 'quaternion :y 0.9998 :w -0.015)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567631.06 :y -277097.28 :z 7833508.5)
                                  :quat (new 'static 'quaternion :y 0.9997 :w -0.0224)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567765.4 :y -275808.66 :z 7830876.0)
                                  :quat (new 'static 'quaternion :y 0.9997 :w -0.0237)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567802.25 :y -276319.03 :z 7828147.5)
                                  :quat (new 'static 'quaternion :y 0.9999 :w -0.0136)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567602.0 :y -278965.03 :z 7825442.0)
                                  :quat (new 'static 'quaternion :y 0.9999 :w 0.0125)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567362.75 :y -279654.8 :z 7822939.5)
                                  :quat (new 'static 'quaternion :y 0.9995 :w 0.0307)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -567009.25 :y -277020.25 :z 7820800.5)
                                  :quat (new 'static 'quaternion :y 0.9981 :w 0.0601)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -566455.5 :y -273824.97 :z 7818705.0)
                                  :quat (new 'static 'quaternion :y 0.9945 :w 0.1042)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -565709.6 :y -271721.7 :z 7816658.0)
                                  :quat (new 'static 'quaternion :y 0.9892 :w 0.1459)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -564863.0 :y -270949.6 :z 7814645.0)
                                  :quat (new 'static 'quaternion :y 0.9848 :w 0.1735)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -563800.06 :y -272273.4 :z 7812741.0)
                                  :quat (new 'static 'quaternion :y 0.9783 :w 0.207)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -562525.8 :y -275549.8 :z 7810999.0)
                                  :quat (new 'static 'quaternion :y 0.9676 :w 0.2523)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -561127.44 :y -279918.2 :z 7809420.5)
                                  :quat (new 'static 'quaternion :y 0.953 :w 0.3028)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -559625.8 :y -284518.8 :z 7808017.5)
                                  :quat (new 'static 'quaternion :y 0.9347 :w 0.3551)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -558023.9 :y -289924.72 :z 7806793.5)
@@ -5372,612 +1049,84 @@
                                  :quat (new 'static 'quaternion :y 0.93 :w 0.3673)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -547489.8 :y -290367.1 :z 7801440.5)
                                  :quat (new 'static 'quaternion :y 0.9413 :w 0.3374)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -545890.7 :y -287452.78 :z 7799227.0)
                                  :quat (new 'static 'quaternion :y 0.9466 :w 0.3221)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -544311.3 :y -283839.7 :z 7797000.0)
                                  :quat (new 'static 'quaternion :y 0.9499 :w 0.3123)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -542842.5 :y -280367.94 :z 7794698.0)
                                  :quat (new 'static 'quaternion :y 0.9559 :w 0.2936)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -541473.2 :y -277988.16 :z 7792335.5)
                                  :quat (new 'static 'quaternion :y 0.9611 :w 0.2759)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -540117.8 :y -276700.38 :z 7789965.5)
                                  :quat (new 'static 'quaternion :y 0.9639 :w 0.266)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -538780.9 :y -276172.8 :z 7787663.5)
                                  :quat (new 'static 'quaternion :y 0.9647 :w 0.2632)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -537664.3 :y -273960.97 :z 7785778.5)
                                  :quat (new 'static 'quaternion :y 0.9645 :w 0.2638)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -536553.06 :y -270567.0 :z 7783897.5)
                                  :quat (new 'static 'quaternion :y 0.9645 :w 0.2637)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -535432.0 :y -268190.5 :z 7782022.0)
                                  :quat (new 'static 'quaternion :y 0.9642 :w 0.265)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -534303.94 :y -266906.84 :z 7780151.5)
                                  :quat (new 'static 'quaternion :y 0.9638 :w 0.2665)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -533171.0 :y -267670.72 :z 7778284.0)
                                  :quat (new 'static 'quaternion :y 0.9634 :w 0.2679)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -532064.7 :y -270673.9 :z 7776401.0)
                                  :quat (new 'static 'quaternion :y 0.9642 :w 0.2648)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -531056.25 :y -274769.1 :z 7774464.0)
                                  :quat (new 'static 'quaternion :y 0.9683 :w 0.2495)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -530219.44 :y -279383.66 :z 7772446.5)
                                  :quat (new 'static 'quaternion :y 0.9755 :w 0.2199)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -529501.0 :y -284516.34 :z 7770385.0)
                                  :quat (new 'static 'quaternion :y 0.9813 :w 0.1924)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -528778.9 :y -290741.88 :z 7768326.0)
@@ -5996,650 +1145,89 @@
                                  :quat (new 'static 'quaternion :y 0.9943 :w 0.106)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -526663.7 :y -290383.47 :z 7757989.5)
                                  :quat (new 'static 'quaternion :y 0.9964 :w 0.084)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -526406.9 :y -287469.16 :z 7755270.0)
                                  :quat (new 'static 'quaternion :y 0.9979 :w 0.0647)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -526293.4 :y -283856.06 :z 7752544.0)
                                  :quat (new 'static 'quaternion :y 0.9994 :w 0.0339)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -526384.75 :y -280383.9 :z 7749819.0)
                                  :quat (new 'static 'quaternion :y 0.9999 :w -0.0055)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -526680.5 :y -278004.12 :z 7747107.0)
                                  :quat (new 'static 'quaternion :y 0.9992 :w -0.0381)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -527178.94 :y -276716.75 :z 7744423.0)
                                  :quat (new 'static 'quaternion :y 0.9975 :w -0.0696)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -527870.75 :y -277174.28 :z 7741782.5)
                                  :quat (new 'static 'quaternion :y 0.9947 :w -0.102)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -528703.9 :y -279801.44 :z 7739182.0)
                                  :quat (new 'static 'quaternion :y 0.9915 :w -0.13)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -529642.3 :y -283808.16 :z 7736618.0)
                                  :quat (new 'static 'quaternion :y 0.9881 :w -0.1534)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -530479.1 :y -281504.97 :z 7734518.0)
                                  :quat (new 'static 'quaternion :y 0.9849 :w -0.1727)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -531336.8 :y -278252.75 :z 7732508.5)
                                  :quat (new 'static 'quaternion :y 0.9823 :w -0.1872)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -532233.8 :y -275603.47 :z 7730517.0)
                                  :quat (new 'static 'quaternion :y 0.9799 :w -0.1993)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -533169.75 :y -274046.56 :z 7728543.0)
                                  :quat (new 'static 'quaternion :y 0.9777 :w -0.2099)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -534118.8 :y -274298.47 :z 7726575.0)
                                  :quat (new 'static 'quaternion :y 0.9762 :w -0.2168)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -535105.56 :y -276741.75 :z 7724626.5)
                                  :quat (new 'static 'quaternion :y 0.9743 :w -0.2249)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -536129.1 :y -280564.12 :z 7722696.5)
                                  :quat (new 'static 'quaternion :y 0.9723 :w -0.2336)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -537188.4 :y -285192.2 :z 7720786.0)
                                  :quat (new 'static 'quaternion :y 0.9701 :w -0.2425)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -538283.2 :y -290052.1 :z 7718895.5)
@@ -6718,574 +1306,79 @@
                                  :quat (new 'static 'quaternion :y 0.8731 :w -0.4875)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -574435.75 :y -290827.47 :z 7682996.0)
                                  :quat (new 'static 'quaternion :y 0.8607 :w -0.509)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -576942.06 :y -289074.38 :z 7681850.0)
                                  :quat (new 'static 'quaternion :y 0.8506 :w -0.5256)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -579457.8 :y -285589.1 :z 7680789.5)
                                  :quat (new 'static 'quaternion :y 0.8415 :w -0.5401)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -582003.5 :y -281958.8 :z 7679802.0)
                                  :quat (new 'static 'quaternion :y 0.8329 :w -0.5534)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -584577.0 :y -279042.06 :z 7678889.0)
                                  :quat (new 'static 'quaternion :y 0.8244 :w -0.5659)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -587193.94 :y -277205.4 :z 7678047.5)
                                  :quat (new 'static 'quaternion :y 0.8158 :w -0.5782)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -589752.3 :y -275850.03 :z 7677303.5)
                                  :quat (new 'static 'quaternion :y 0.8072 :w -0.5902)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -591879.8 :y -273631.22 :z 7676752.0)
                                  :quat (new 'static 'quaternion :y 0.7986 :w -0.6018)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -594007.25 :y -270239.34 :z 7676258.0)
                                  :quat (new 'static 'quaternion :y 0.7904 :w -0.6125)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -596081.9 :y -267918.94 :z 7675828.5)
                                  :quat (new 'static 'quaternion :y 0.7828 :w -0.6221)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -598229.4 :y -266618.06 :z 7675436.5)
                                  :quat (new 'static 'quaternion :y 0.7752 :w -0.6316)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -600433.9 :y -267434.4 :z 7675090.0)
                                  :quat (new 'static 'quaternion :y 0.7678 :w -0.6406)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -602535.1 :y -270273.75 :z 7674808.0)
                                  :quat (new 'static 'quaternion :y 0.7602 :w -0.6496)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -604734.7 :y -274412.34 :z 7674566.0)
                                  :quat (new 'static 'quaternion :y 0.752 :w -0.659)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -606955.94 :y -279135.03 :z 7674375.5)
                                  :quat (new 'static 'quaternion :y 0.7439 :w -0.6681)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -609153.8 :y -284328.75 :z 7674240.0)
@@ -7340,574 +1433,79 @@
                                  :quat (new 'static 'quaternion :y 0.8441 :w -0.536)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -637892.6 :y -290815.6 :z 7657080.5)
                                  :quat (new 'static 'quaternion :y 0.8477 :w -0.5303)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -639710.8 :y -289927.16 :z 7654797.0)
                                  :quat (new 'static 'quaternion :y 0.8536 :w -0.5208)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -641699.44 :y -286681.1 :z 7652598.0)
                                  :quat (new 'static 'quaternion :y 0.8627 :w -0.5057)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -643639.3 :y -283403.47 :z 7650592.5)
                                  :quat (new 'static 'quaternion :y 0.8685 :w -0.4956)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -645680.3 :y -280434.28 :z 7648618.5)
                                  :quat (new 'static 'quaternion :y 0.8727 :w -0.4882)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -647775.0 :y -278533.75 :z 7646737.0)
                                  :quat (new 'static 'quaternion :y 0.8756 :w -0.4829)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -649857.8 :y -278070.47 :z 7645010.5)
                                  :quat (new 'static 'quaternion :y 0.8776 :w -0.4793)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -651679.3 :y -276311.66 :z 7643544.5)
                                  :quat (new 'static 'quaternion :y 0.8811 :w -0.4727)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -653354.6 :y -273222.03 :z 7642017.5)
                                  :quat (new 'static 'quaternion :y 0.8952 :w -0.4456)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -654858.6 :y -270623.53 :z 7640443.0)
                                  :quat (new 'static 'quaternion :y 0.9143 :w -0.4049)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -656205.8 :y -269122.75 :z 7638737.0)
                                  :quat (new 'static 'quaternion :y 0.934 :w -0.3571)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -657349.44 :y -269243.2 :z 7636970.0)
                                  :quat (new 'static 'quaternion :y 0.9515 :w -0.3075)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -658351.3 :y -271560.72 :z 7635045.0)
                                  :quat (new 'static 'quaternion :y 0.9671 :w -0.2541)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -659162.3 :y -275610.4 :z 7633023.0)
                                  :quat (new 'static 'quaternion :y 0.9797 :w -0.2003)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -659771.8 :y -280427.72 :z 7631010.0)
                                  :quat (new 'static 'quaternion :y 0.9878 :w -0.1555)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -660338.7 :y -285360.12 :z 7628882.5)
@@ -7938,612 +1536,84 @@
                                  :quat (new 'static 'quaternion :y 0.8906 :w -0.4547)
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -670290.3 :y -290566.56 :z 7611263.0)
                                  :quat (new 'static 'quaternion :y 0.8781 :w -0.4783)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -672281.8 :y -288049.16 :z 7609100.5)
                                  :quat (new 'static 'quaternion :y 0.8664 :w -0.4993)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -674386.3 :y -284501.2 :z 7607227.0)
                                  :quat (new 'static 'quaternion :y 0.8581 :w -0.5134)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -676462.2 :y -281063.44 :z 7605568.5)
                                  :quat (new 'static 'quaternion :y 0.8527 :w -0.5222)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -678788.3 :y -278355.97 :z 7603969.5)
                                  :quat (new 'static 'quaternion :y 0.8471 :w -0.5313)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -681173.4 :y -276822.44 :z 7602576.0)
                                  :quat (new 'static 'quaternion :y 0.8414 :w -0.5402)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x5
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -683504.0 :y -276876.1 :z 7601411.5)
                                  :quat (new 'static 'quaternion :y 0.8369 :w -0.5472)
+                                 :flags #x5
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -685853.9 :y -276482.06 :z 7600421.5)
                                  :quat (new 'static 'quaternion :y 0.8322 :w -0.5544)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -687903.1 :y -273920.4 :z 7599655.5)
                                  :quat (new 'static 'quaternion :y 0.8266 :w -0.5627)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -689960.1 :y -270697.28 :z 7598919.5)
                                  :quat (new 'static 'quaternion :y 0.8217 :w -0.5697)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -692032.3 :y -268539.5 :z 7598229.0)
                                  :quat (new 'static 'quaternion :y 0.8162 :w -0.5777)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -694116.4 :y -267673.2 :z 7597574.0)
                                  :quat (new 'static 'quaternion :y 0.8109 :w -0.5851)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -696279.06 :y -268978.2 :z 7596936.5)
                                  :quat (new 'static 'quaternion :y 0.8056 :w -0.5923)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -698400.75 :y -272270.53 :z 7596350.5)
                                  :quat (new 'static 'quaternion :y 0.8003 :w -0.5995)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -700443.06 :y -276488.2 :z 7595824.5)
                                  :quat (new 'static 'quaternion :y 0.7953 :w -0.6061)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
-                                 :bytes (new 'static 'array uint8 32
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x4
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   #x0
-                                   )
                                  :pos (new 'static 'vector :x -702588.1 :y -281141.25 :z 7595308.5)
                                  :quat (new 'static 'quaternion :y 0.7901 :w -0.6129)
+                                 :flags #x4
                                  )
                                (new 'static 'sig-path-sample
                                  :pos (new 'static 'vector :x -704725.4 :y -286524.62 :z 7594834.5)
@@ -8604,7 +1674,3 @@
                                )
                              )
         )
-
-
-
-

--- a/test/offline/framework/execution.cpp
+++ b/test/offline/framework/execution.cpp
@@ -74,28 +74,26 @@ OfflineTestCompareResult compare(OfflineTestDecompiler& dc,
                                  const OfflineTestConfig& config) {
   OfflineTestCompareResult compare_result;
 
-  for (const auto& collection : work_group.work_collections) {
-    for (const auto& file : collection.source_files) {
-      work_group.status->update_curr_file(file.name_in_dgo);
-      auto& data = get_data(dc, file.unique_name, file.name_in_dgo);
-      std::string result = clean_decompilation_code(data.full_output);
-      std::string ref = clean_decompilation_code(file_util::read_text_file(file.path.string()));
-      compare_result.total_files++;
-      compare_result.total_lines += str_util::line_count(result);
-      if (result != ref) {
-        compare_result.failing_files.push_back({file.unique_name, diff_strings(ref, result)});
-        compare_result.total_pass = false;
-        if (config.dump_mode) {
-          auto failure_dir = file_util::get_jak_project_dir() / "failures";
-          file_util::create_dir_if_needed(failure_dir);
-          file_util::write_text_file(failure_dir / fmt::format("{}_REF.gc", file.unique_name),
-                                     clean_decompilation_code(data.full_output, true));
-        }
-      } else {
-        compare_result.ok_files++;
+  for (const auto& file : work_group.work_collection.source_files) {
+    work_group.status->update_curr_file(file.name_in_dgo);
+    auto& data = get_data(dc, file.unique_name, file.name_in_dgo);
+    std::string result = clean_decompilation_code(data.full_output);
+    std::string ref = clean_decompilation_code(file_util::read_text_file(file.path.string()));
+    compare_result.total_files++;
+    compare_result.total_lines += str_util::line_count(result);
+    if (result != ref) {
+      compare_result.failing_files.push_back({file.unique_name, diff_strings(ref, result)});
+      compare_result.total_pass = false;
+      if (config.dump_mode) {
+        auto failure_dir = file_util::get_jak_project_dir() / "failures";
+        file_util::create_dir_if_needed(failure_dir);
+        file_util::write_text_file(failure_dir / fmt::format("{}_REF.gc", file.unique_name),
+                                   clean_decompilation_code(data.full_output, true));
       }
-      work_group.status->complete_step();
+    } else {
+      compare_result.ok_files++;
     }
+    work_group.status->complete_step();
   }
 
   return compare_result;
@@ -114,28 +112,26 @@ OfflineTestCompileResult compile(OfflineTestDecompiler& dc,
 
   int total_lines = 0;
 
-  for (const auto& coll : work_group.work_collections) {
-    for (const auto& file : coll.source_files) {
-      work_group.status->update_curr_file(file.name_in_dgo);
-      if (config.skip_compile_files.count(file.name_in_dgo)) {
-        lg::warn("Skipping {}", file.name_in_dgo);
-        continue;
-      }
-
-      lg::info("Compiling {}...", file.unique_name);
-
-      auto& data = get_data(dc, file.unique_name, file.name_in_dgo);
-
-      try {
-        const auto& src = data.output_with_skips;
-        total_lines += str_util::line_count(src);
-        compiler.run_full_compiler_on_string_no_save(src, file.name_in_dgo);
-      } catch (const std::exception& e) {
-        result.ok = false;
-        result.failing_files.push_back({file.name_in_dgo, e.what()});
-      }
-      work_group.status->complete_step();
+  for (const auto& file : work_group.work_collection.source_files) {
+    work_group.status->update_curr_file(file.name_in_dgo);
+    if (config.skip_compile_files.count(file.name_in_dgo)) {
+      lg::warn("Skipping {}", file.name_in_dgo);
+      continue;
     }
+
+    lg::info("Compiling {}...", file.unique_name);
+
+    auto& data = get_data(dc, file.unique_name, file.name_in_dgo);
+
+    try {
+      const auto& src = data.output_with_skips;
+      total_lines += str_util::line_count(src);
+      compiler.run_full_compiler_on_string_no_save(src, file.name_in_dgo);
+    } catch (const std::exception& e) {
+      result.ok = false;
+      result.failing_files.push_back({file.name_in_dgo, e.what()});
+    }
+    work_group.status->complete_step();
   }
 
   result.num_lines = total_lines;

--- a/test/offline/framework/orchestration.h
+++ b/test/offline/framework/orchestration.h
@@ -2,6 +2,7 @@
 
 #include <future>
 #include <mutex>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -85,7 +86,7 @@ class OfflineTestThreadStatus {
   Stage stage = Stage::IDLE;
   uint32_t total_steps = 0;
   uint32_t curr_step = 0;
-  std::vector<std::string> dgos = {};
+  std::set<std::string> dgos;
   std::string curr_file;
   OfflineTestConfig config;
 
@@ -100,16 +101,12 @@ struct OfflineTestWorkCollection {
 };
 
 struct OfflineTestWorkGroup {
-  std::vector<std::string> dgos;
-  std::vector<OfflineTestWorkCollection> work_collections;
+  std::set<std::string> dgo_set;
+  OfflineTestWorkCollection work_collection;
   std::shared_ptr<OfflineTestThreadStatus> status;
 
   int work_size() const {
-    int i = 0;
-    for (const auto& coll : work_collections) {
-      i += coll.source_files.size() + coll.art_files.size();
-    }
-    return i;
+    return work_collection.source_files.size() + work_collection.art_files.size();
   }
 };
 


### PR DESCRIPTION
- Split up DGOs between threads in the multithreaded offline test
- fix some random warnings
- make the sig paths decompile a bit nicer to make some files smaller