### PR TITLE
Add base_id for custom levels.

### DIFF
--- a/custom_levels/test-zone/test-zone.jsonc
+++ b/custom_levels/test-zone/test-zone.jsonc
@@ -31,6 +31,9 @@
   // adds a vector tag 'movie-pos':
   // "movie-pos": ["vector", [4096000.0, -176128.0, 1353973.76, 1.0]]
 
+   // The base actor id for your custom level. If you have multiple levels this should be unique!
+   "base_id": 100,
+   
   "actors" : [
     {
       "trans": [-21.6238, 20.0496, 17.1191], // translation

--- a/goalc/build_level/build_level.cpp
+++ b/goalc/build_level/build_level.cpp
@@ -70,7 +70,7 @@ bool run_build_level(const std::string& input_file,
   // vis infos
   // actors
   std::vector<EntityActor> actors;
-  add_actors_from_json(level_json.at("actors"), actors, 1234);
+  add_actors_from_json(level_json.at("actors"), actors, level_json.value("base_id", 1234));
   file.actors = std::move(actors);
   // cameras
   // nodes


### PR DESCRIPTION
It used to automatically assign actor IDs, but reset in between custom levels, so it was possible for actors to share the same actor id with a actor in another level. With this the user can now specify a base_id to make sure that the custom levels never match! (or fix it if they do!)