### PR TITLE
lint: remove some debugging logs

### DIFF
--- a/decompiler/level_extractor/extract_tie.cpp
+++ b/decompiler/level_extractor/extract_tie.cpp
@@ -2056,7 +2056,9 @@ void add_vertices_and_static_draw(tfrag3::TieTree& tree,
         for (auto& vert : strip.verts) {
           tree.packed_vertices.vertices.push_back(
               {vert.pos.x(), vert.pos.y(), vert.pos.z(), vert.tex.x(), vert.tex.y()});
-          lg::warn("SKIPPING ASSERT in extract_tie! TODO!");
+          if (vert.tex.z() != 1.0) {
+            lg::warn("SKIPPING ASSERT in extract_tie! TODO!");
+          }
           // ASSERT(vert.tex.z() == 1.);
         }
         int end = tree.packed_vertices.vertices.size();

--- a/goal_src/jak2/levels/common/enemy/fodder/fodder.gc
+++ b/goal_src/jak2/levels/common/enemy/fodder/fodder.gc
@@ -1113,12 +1113,10 @@
   (set! (-> obj look-at-other-time) 0)
   (set! (-> obj neck-away-from) #f)
   (let ((v1-18 (-> obj nav)))
-    (format 0 "got here ~A" v1-18)
     (set! (-> v1-18 speed-scale) 1.0)
     )
   0
   (set-gravity-length (-> obj root-override2 dynam) 573440.0)
-  (format 0 "got here a")
   (fodder-method-181 obj #f)
   0
   (none)


### PR DESCRIPTION
I accidentally left some logs in, the extract_tie one was a bad one to leave as it makes the decompiler run significantly slower