### PR TITLE
[jak2] don't ignore disable-draw bits

### DIFF
--- a/decompiler/config/jak2/all-types.gc
+++ b/decompiler/config/jak2/all-types.gc
@@ -24088,7 +24088,7 @@
 (define-extern foreground-generic-merc-death (function object object none))
 (define-extern foreground-generic-merc-add-fragments (function object object object none))
 (define-extern foreground-generic-merc (function draw-control pointer int pointer))
-(define-extern foreground-merc (function draw-control (inline-array pris-mtx) pointer int int pointer))
+(define-extern foreground-merc (function draw-control (inline-array pris-mtx) pointer int int object pointer))
 (define-extern foreground-emerc (function draw-control (inline-array pris-mtx) pointer object int int pointer))
 (define-extern foreground-check-longest-edge-asm (function draw-control float symbol))
 (define-extern foreground-ripple (function draw-control merc-ctrl pointer int pointer))

--- a/goal_src/jak2/engine/gfx/foreground/foreground.gc
+++ b/goal_src/jak2/engine/gfx/foreground/foreground.gc
@@ -577,7 +577,7 @@
   arg1
   )
 
-(def-mips2c foreground-merc (function draw-control (inline-array pris-mtx) pointer int int pointer))
+(def-mips2c foreground-merc (function draw-control (inline-array pris-mtx) pointer int int object pointer))
 
 (define-extern foreground-emerc (function draw-control (inline-array pris-mtx) pointer object int int pointer))
 
@@ -1131,8 +1131,8 @@
                           (set! dma-ptr (pc-draw-bones dc dma-ptr))
 
                           (if (nonzero? (-> bucket-info need-mercprime-if-merc))
-                              (set! dma-ptr (foreground-merc dc (-> (scratchpad-object foreground-work) regs mtxs) dma-ptr 32 17))
-                              (set! dma-ptr (foreground-merc dc (-> (scratchpad-object foreground-work) regs mtxs) dma-ptr 35 20))
+                              (set! dma-ptr (foreground-merc dc (-> (scratchpad-object foreground-work) regs mtxs) dma-ptr 32 17 bucket-info))
+                              (set! dma-ptr (foreground-merc dc (-> (scratchpad-object foreground-work) regs mtxs) dma-ptr 35 20 bucket-info))
                               )
                           )
                         )


### PR DESCRIPTION
Same idea as what I did for jak 1, but now there's a mask that can be set by the user. It's used on the gun course dummies, for example.