### PR TITLE
Fix 'Load... border-mode' in default-menu

### DIFF
--- a/goal_src/jak1/engine/debug/default-menu.gc
+++ b/goal_src/jak1/engine/debug/default-menu.gc
@@ -4068,7 +4068,7 @@
       (debug-menu-append-item load-menu (debug-menu-make-from-template ctx '(flag
                "border-mode"
                #f
-               (lambda ((arg0 int) (arg1 debug-menu-msg))
+               ,(lambda ((arg0 int) (arg1 debug-menu-msg))
                  (if (= arg1 (debug-menu-msg press))
                      (set! (-> *setting-control* default border-mode) (not (-> *setting-control* default border-mode)))
                      )


### PR DESCRIPTION
This one was forgotten when the other similar menu entries were fixed. So I fixed this now.