### PR TITLE
jak2: tomb fixes

### DIFF
--- a/goal_src/jak2/engine/level/level.gc
+++ b/goal_src/jak2/engine/level/level.gc
@@ -1345,6 +1345,11 @@
   ;; name
   (set! (-> lev nickname) (the-as string (-> lev bsp nickname)))
 
+  ;; added: tombc has the wrong nickname in the bsp file...
+  (if (and (= (-> lev bsp name) 'tombc) (= (-> lev bsp nickname) 'toa))
+      (set! (-> lev nickname) (the-as string 'toc))
+      )
+
   ;; subdivide distances
   (let ((close-dist (-> lev bsp subdivide-close))
         (far-dist (-> lev bsp subdivide-far))

--- a/goal_src/jak2/levels/mars_tomb/tomb-obs.gc
+++ b/goal_src/jak2/levels/mars_tomb/tomb-obs.gc
@@ -1162,6 +1162,7 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
+  (stack-size-set! (-> obj main-thread) 1024)
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -1265,6 +1266,7 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
+  (stack-size-set! (-> obj main-thread) 1024)
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 3) 0)))


### PR DESCRIPTION
- Fix airlock crash
- Hack to fix wrong nickname for `tombc`