### PR TITLE
Disable cheats with speedrun mode

### DIFF
--- a/goal_src/jak1/pc/features/speedruns.gc
+++ b/goal_src/jak1/pc/features/speedruns.gc
@@ -7,16 +7,18 @@
     ;; Update auto-splitter
     (update-autosplit-info-jak1)
     ;; Draw info to the screen
-    (speedrun-draw-settings))
+    (speedrun-draw-settings)
+    ;;Disable any active cheats
+    (set! (-> *pc-settings* cheats) (the-as pc-cheats #x0)))
   (none))
 
 (defun speedrun-start-run ()
   ;; randomize game id so the autosplitter knows to restart
   (update-autosplit-jak1-new-game)
+   ;; disable hints
+  (set! (-> *setting-control* default play-hints) #f)
   ;; spawn at the warp gate checkpoint
   (initialize! *game-info* 'game (the-as game-save #f) "game-start")
-  ;; disable hints (this seems to be overriden by your slot 1 save though)
-  (set! (-> *setting-control* default play-hints) #f)
   ;; ensure `force actors` is not enabled
   (set! (-> *pc-settings* force-actors?) #f)
   ;; force FPS to `60`
@@ -30,7 +32,8 @@
 (defun speedrun-draw-settings ()
   "Draw speedrun related settings in the bottom left corner"
   (when (and (-> *pc-settings* speedrunner-mode?)
-             (< (-> *autosplit-info-jak1* num-power-cells) 1))
+            (or (< (-> *autosplit-info-jak1* num-power-cells) 1)
+                (movie?)))
     (with-dma-buffer-add-bucket ((buf (-> (current-frame) global-buf))
                                       (bucket-id debug-no-zbuf))
       (draw-string-xy (string-format "OpenGOAL Version: ~S ~%Speedrun mode: ~A ~%Cutscene Skips ~A"


### PR DESCRIPTION
Disables active cheats when `(-> *pc-settings* speedrunner-mode?)` is true, also draws speedrun verification text anytime that (movie?) is #t