### PR TITLE
scripts: update gsrc files with modifications using git merge

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -31,3 +31,6 @@ jobs:
         run: |
           chmod +x ./third-party/run-clang-format/run-clang-format.py
           ./third-party/run-clang-format/run-clang-format.py -r common decompiler game goalc test tools lsp --color always
+
+      - name: Check for Unresolved Conflicts
+        run: python ./scripts/gsrc/check-for-conflicts.py

--- a/.vscode/opengoal.code-snippets
+++ b/.vscode/opengoal.code-snippets
@@ -17,4 +17,10 @@
     "body": [";; og:ignore-form:${1:substr}"],
     "description": "If the provided substr is found in the starting line of a form, the entire form will be omitted when copying decompiled code into the file"
   },
+  "og:update-with-merge": {
+		"scope": "opengoal",
+    "prefix": ["og:update-with-merge"],
+    "body": [";; og:update-with-merge:${1:substr}"],
+    "description": "The file will be updated with a git merge-file instead of naive copy-paste"
+  },
 }

--- a/goal_src/jak2/levels/common/airlock.gc
+++ b/goal_src/jak2/levels/common/airlock.gc
@@ -5,6 +5,8 @@
 ;; name in dgo: airlock
 ;; dgos: GAME, COMMON
 
+;; og:update-with-merge
+
 ;; DECOMP BEGINS
 
 (deftype com-airlock (process-drawable)

--- a/goal_src/jak2/levels/common/airlock.gc
+++ b/goal_src/jak2/levels/common/airlock.gc
@@ -835,10 +835,7 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
-<<<<<<< Before Updating
   (stack-size-set! (-> obj main-thread) 1024)
-=======
->>>>>>> After Updating
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -909,10 +906,7 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
-<<<<<<< Before Updating
   (stack-size-set! (-> obj main-thread) 1024)
-=======
->>>>>>> After Updating
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -996,10 +990,7 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
-<<<<<<< Before Updating
   (stack-size-set! (-> obj main-thread) 1024)
-=======
->>>>>>> After Updating
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -1067,10 +1058,7 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
-<<<<<<< Before Updating
   (stack-size-set! (-> obj main-thread) 1024)
-=======
->>>>>>> After Updating
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -1140,10 +1128,7 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
-<<<<<<< Before Updating
   (stack-size-set! (-> obj main-thread) 1024)
-=======
->>>>>>> After Updating
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s5-0 (the-as uint 0) (the-as uint 0))))
@@ -1276,10 +1261,7 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
-<<<<<<< Before Updating
   (stack-size-set! (-> obj main-thread) 1024)
-=======
->>>>>>> After Updating
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -1413,10 +1395,7 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
-<<<<<<< Before Updating
   (stack-size-set! (-> obj main-thread) 1024)
-=======
->>>>>>> After Updating
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))

--- a/goal_src/jak2/levels/common/airlock.gc
+++ b/goal_src/jak2/levels/common/airlock.gc
@@ -835,7 +835,10 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
+<<<<<<< Before Updating
   (stack-size-set! (-> obj main-thread) 1024)
+=======
+>>>>>>> After Updating
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -906,7 +909,10 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
+<<<<<<< Before Updating
   (stack-size-set! (-> obj main-thread) 1024)
+=======
+>>>>>>> After Updating
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -990,7 +996,10 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
+<<<<<<< Before Updating
   (stack-size-set! (-> obj main-thread) 1024)
+=======
+>>>>>>> After Updating
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -1058,7 +1067,10 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
+<<<<<<< Before Updating
   (stack-size-set! (-> obj main-thread) 1024)
+=======
+>>>>>>> After Updating
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -1128,7 +1140,10 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
+<<<<<<< Before Updating
   (stack-size-set! (-> obj main-thread) 1024)
+=======
+>>>>>>> After Updating
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s5-0 (the-as uint 0) (the-as uint 0))))
@@ -1261,7 +1276,10 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
+<<<<<<< Before Updating
   (stack-size-set! (-> obj main-thread) 1024)
+=======
+>>>>>>> After Updating
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -1395,7 +1413,10 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
+<<<<<<< Before Updating
   (stack-size-set! (-> obj main-thread) 1024)
+=======
+>>>>>>> After Updating
   (let ((s5-0 (new 'process 'collide-shape obj (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))

--- a/scripts/gsrc/check-for-conflicts.py
+++ b/scripts/gsrc/check-for-conflicts.py
@@ -1,0 +1,25 @@
+# Merge tools use specific algorithms or assumptions to detect conflicts
+# and not all of them will obviously flag them, even if they use the standard format
+#
+# So this is to ensure no conflict markers get ignored in goal_src atleast
+import os
+
+files_with_unresolved_conflicts = []
+
+for dirpath, subdirs, files in os.walk("./goal_src"):
+  for filename in files:
+    # Get the file contents
+    with open(os.path.join(dirpath, filename), "r") as f:
+      lines = f.readlines()
+      for line in lines:
+        if "<<<<<<<" in line:
+          files_with_unresolved_conflicts.append(filename)
+          break
+
+if len(files_with_unresolved_conflicts) == 0:
+  exit(0)
+
+print("There are unresolved conflicts in ./goal_src/")
+for file in files_with_unresolved_conflicts:
+  print(file)
+exit(1)

--- a/scripts/gsrc/check-for-conflicts.py
+++ b/scripts/gsrc/check-for-conflicts.py
@@ -13,7 +13,7 @@ for dirpath, subdirs, files in os.walk("./goal_src"):
       lines = f.readlines()
       for line in lines:
         if "<<<<<<<" in line:
-          files_with_unresolved_conflicts.append(filename)
+          files_with_unresolved_conflicts.append(os.path.join(dirpath, filename))
           break
 
 if len(files_with_unresolved_conflicts) == 0:

--- a/scripts/gsrc/update-from-decomp.py
+++ b/scripts/gsrc/update-from-decomp.py
@@ -95,6 +95,13 @@ with open(gsrc_path) as f:
 # This means that all changes will be flagged as a conflict and will not be able to be
 # merged into the repo without being explicitly resolved
 if update_with_merge:
+    subprocess.run(
+        [
+            "git",
+            "restore",
+            gsrc_path
+        ]
+    )
     shutil.copyfile(gsrc_path, gsrc_path.replace(".gc", ".before.gc"))
     Path(gsrc_path.replace(".gc", ".empty.gc")).touch()
 
@@ -221,20 +228,26 @@ with open(gsrc_path, "w") as f:
 
 # If we need to merge, now is the time!
 if update_with_merge:
+    shutil.move(gsrc_path, gsrc_path.replace(".gc", ".after.gc"))
+    shutil.move(gsrc_path.replace(".gc", ".before.gc"), gsrc_path)
     subprocess.run(
         [
             "git",
             "merge-file",
             gsrc_path,
             gsrc_path.replace(".gc", ".empty.gc"),
-            gsrc_path.replace(".gc", ".before.gc"),
+            gsrc_path.replace(".gc", ".after.gc"),
             "-L",
-            "After Updating",
+            "Before Updating",
             "-L",
             "ignored",
             "-L",
-            "Before Updating",
+            "After Updating",
         ]
     )
-    os.remove(gsrc_path.replace(".gc", ".empty.gc"))
-    os.remove(gsrc_path.replace(".gc", ".before.gc"))
+    if os.path.exists(gsrc_path.replace(".gc", ".empty.gc")):
+        os.remove(gsrc_path.replace(".gc", ".empty.gc"))
+    if os.path.exists(gsrc_path.replace(".gc", ".before.gc")):
+        os.remove(gsrc_path.replace(".gc", ".before.gc"))
+    if os.path.exists(gsrc_path.replace(".gc", ".after.gc")):
+        os.remove(gsrc_path.replace(".gc", ".after.gc"))

--- a/scripts/gsrc/update-from-decomp.py
+++ b/scripts/gsrc/update-from-decomp.py
@@ -36,14 +36,22 @@
 # - there are likely ways to make this more efficient
 
 import argparse
+import os
 from code_retention.all_types_retention import update_alltypes_named_blocks
 from utils import get_gsrc_path_from_filename
 from code_retention.code_retention import *
+import shutil
+from pathlib import Path
+import subprocess
 
 parser = argparse.ArgumentParser("update-from-decomp")
 parser.add_argument("--game", help="The name of the game", type=str)
 parser.add_argument("--file", help="The name of the file", type=str)
-parser.add_argument("--preserve", help="Attempt to preserve comments and marked blocks", action="store_true")
+parser.add_argument(
+    "--preserve",
+    help="Attempt to preserve comments and marked blocks",
+    action="store_true",
+)
 parser.add_argument(
     "--debug", help="Output debug metadata on every block", action="store_true"
 )
@@ -61,6 +69,7 @@ comments = []
 debug_lines = []
 decomp_ignore_forms = ["defmethod inspect"]
 decomp_ignore_errors = False
+update_with_merge = False
 
 with open(gsrc_path) as f:
     lines_temp = f.readlines()
@@ -74,9 +83,20 @@ with open(gsrc_path) as f:
             decomp_ignore_errors = True
         if "og:ignore-form" in line:
             decomp_ignore_forms.append(line.partition("ignore-form:")[2].strip())
+        if "og:update-with-merge" in line:
+            update_with_merge = True
         lines.append(line)
     if args.preserve:
         comments, debug_lines = process_original_lines(lines)
+
+# If we are going to `update_with_merge` then make a backup of the file, and
+# an empty file to use as the common ancestor.
+#
+# This means that all changes will be flagged as a conflict and will not be able to be
+# merged into the repo without being explicitly resolved
+if update_with_merge:
+    shutil.copyfile(gsrc_path, gsrc_path.replace(".gc", ".before.gc"))
+    Path(gsrc_path.replace(".gc", ".empty.gc")).touch()
 
 if args.debug:
     with open(gsrc_path, "w") as f:
@@ -94,7 +114,7 @@ lines_to_ignore = [
     ";; Used lq/sq",
     ";; this part is debug only",
     ";; WARN: Return type mismatch int vs none",
-    ";; WARN: Stack slot offset"
+    ";; WARN: Stack slot offset",
 ]
 
 if decomp_ignore_errors:
@@ -112,6 +132,7 @@ def should_ignore_line(line):
         if line.lower().startswith(ignore_line.lower()):
             return True
     return False
+
 
 # TODO - ignore brackets inside strings!
 
@@ -197,3 +218,23 @@ with open(gsrc_path, "w") as f:
     while i + lines_to_ignore < len(final_lines):
         f.write(final_lines[i])
         i = i + 1
+
+# If we need to merge, now is the time!
+if update_with_merge:
+    subprocess.run(
+        [
+            "git",
+            "merge-file",
+            gsrc_path,
+            gsrc_path.replace(".gc", ".empty.gc"),
+            gsrc_path.replace(".gc", ".before.gc"),
+            "-L",
+            "After Updating",
+            "-L",
+            "ignored",
+            "-L",
+            "Before Updating",
+        ]
+    )
+    os.remove(gsrc_path.replace(".gc", ".empty.gc"))
+    os.remove(gsrc_path.replace(".gc", ".before.gc"))


### PR DESCRIPTION
It's easy to forget that a file has manual changes when updating things programmatically.  Now you can annotate said files with `;; og:update-with-merge` and it will use `git merge-file` instead of doing a naive copy-paste.

This will force you to explicitly handle any differences via typical conflict resolution.  And if you forget to do so, CI will detect and reject your PR.