### PR TITLE
Minor fix for Rock Village IL speedrun

### DIFF
--- a/goal_src/jak1/pc/features/speedruns.gc
+++ b/goal_src/jak1/pc/features/speedruns.gc
@@ -146,6 +146,7 @@
         ;; give enough orbs to buy all cells 120+120+90+90+90=510
         (set! (-> *game-info* money-total) 510.0)
         (set! (-> *game-info* money) 510.0)
+        (mark-text-as-seen *game-info* (game-text-id village2-level-name))
         )
       (((speedrun-category il-sunken))
         (mark-text-as-seen *game-info* (game-text-id sunken-level-name))


### PR DESCRIPTION
Forgot to mark the "Rock Village" HUD text as seen for this IL speedrun. Doesn't actually affect the run as far as I'm aware, this is more just for consistency with the other ILs.