### PR TITLE
ci: allow manually updating the controller db

### DIFF
--- a/.github/workflows/update-controller-db.yaml
+++ b/.github/workflows/update-controller-db.yaml
@@ -3,6 +3,7 @@ name: Update Controller Database
 on:
   schedule:
     - cron: "0 16 * * 1" # every monday @ 12pm EST - https://crontab.guru/#0_16_*_*_1
+  workflow_dispatch: {}
 
 jobs:
   update-controller-db:


### PR DESCRIPTION
Noticed this has been failing for a while for reasons.  I think I fixed them but can't re-run the current job (out of date from master).  This this gives me a way to manually re-run it.