### PR TITLE
ci: switch to a pull request instead of a direct commit for updating controller db

### DIFF
--- a/.github/workflows/update-controller-db.yaml
+++ b/.github/workflows/update-controller-db.yaml
@@ -18,10 +18,13 @@ jobs:
         run: |
           wget -O ./game/assets/sdl_controller_db.txt https://raw.githubusercontent.com/gabomdq/SDL_GameControllerDB/master/gamecontrollerdb.txt
 
-      - name: commit version bump
-        uses: EndBug/add-and-commit@v9
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
         with:
-          default_author: github_actor
-          author_name: 'OpenGOALBot'
-          author_email: 'OpenGOALBot@users.noreply.github.com'
-          message: "Updating Controller Database"
+          author: 'OpenGOALBot <OpenGOALBot@users.noreply.github.com>'
+          committer: 'OpenGOALBot <OpenGOALBot@users.noreply.github.com>'
+          branch: 'bot/update-controller-db'
+          base: "master"
+          body: "Updating Controller Database"
+          commit-message: "ci: updated controller database"
+          title: "CI: Periodic Controller Database Update"


### PR DESCRIPTION
The direct commit option doesn't work as there is no way to bypass required status checks -- this makes the merge queue less useful.  Switch to a PR instead.