### PR TITLE
Redundant `(declare-file (debug))`

### DIFF
--- a/goal_src/jak1/engine/camera/cam-layout.gc
+++ b/goal_src/jak1/engine/camera/cam-layout.gc
@@ -5,8 +5,6 @@
 ;; name in dgo: cam-layout
 ;; dgos: GAME, ENGINE
 
-(declare-file (debug))
-
 ;; DECOMP BEGINS
 
 ;; this file is debug only


### PR DESCRIPTION
Just noticed this while looking into #2225 , this line is repeated a few lines later
https://github.com/open-goal/jak-project/blob/b9cd17b20a29a4674d8515e53bf937a92f331b6c/goal_src/jak1/engine/camera/cam-layout.gc#L8-L13