### PR TITLE
[jak2] fix rare civilian flee crash

### DIFF
--- a/goal_src/jak2/levels/city/common/civilian.gc
+++ b/goal_src/jak2/levels/city/common/civilian.gc
@@ -403,7 +403,8 @@
         (dotimes (s0-0 s2-0)
           (+! f30-0 (civilian-method-214 obj (-> s3-0 branch-array s0-0) (+ arg1 -1) arg2 s1-0))
           )
-        (set! arg3 (+ s1-0 (the float (/ (the int f30-0) s2-0))))
+        ;; changed to fix a divide by zero crash
+        (set! arg3 (+ s1-0 (the float (/-0-guard (the int f30-0) s2-0))))
         )
       )
     )


### PR DESCRIPTION
Fixes a rare crash that can sometimes happen when civilians are picking a direction to flee in, where a branch count may be 0, causing a divide by 0 MATH_EXCEPTION.