### PR TITLE
repl: prevent REPL crash when running `(reload)`

### DIFF
--- a/goalc/main.cpp
+++ b/goalc/main.cpp
@@ -162,7 +162,6 @@ int main(int argc, char** argv) {
             game_version, username,
             std::make_unique<REPL::Wrapper>(username, repl_config, startup_file));
         status = ReplStatus::OK;
-        repl_startup_func();
       }
       // process user input
       std::string input_from_stdin = compiler->get_repl_input();


### PR DESCRIPTION
Stops the REPL crashing with `device or resource busy` when running `(reload)`

However I think this is indicative of a bigger problem where either the `Compiler` or prompt is not ready to handle input immediately after creation and setting the status to `OK`.