### PR TITLE
[jak 2] fix boot, increase level heap sizes

### DIFF
--- a/common/type_system/TypeSystem.cpp
+++ b/common/type_system/TypeSystem.cpp
@@ -648,12 +648,12 @@ MethodInfo TypeSystem::define_method(Type* type,
     int bad_arg_idx = -99;
     // make sure we aren't changing anything that isn't the return type.
     if (!existing_info.type.is_compatible_child_method(ts, type->get_name(), &bad_arg_idx) &&
-        bad_arg_idx != ts.arg_count() - 1) {
+        bad_arg_idx != (int)ts.arg_count() - 1) {
       throw_typesystem_error(
           "The method {} of type {} was originally defined as {}, but has been "
           "redefined as {} (see argument index {})\n",
           method_name, type->get_name(), existing_info.type.print(), ts.print(), bad_arg_idx);
-    } else if (bad_arg_idx == ts.arg_count() - 1 &&
+    } else if (bad_arg_idx == (int)ts.arg_count() - 1 &&
                !tc(existing_info.type.last_arg(), ts.last_arg())) {
       throw_typesystem_error(
           "The method {} of type {} was originally defined as returning {}, but has been redefined "

--- a/decompiler/util/data_decompile.cpp
+++ b/decompiler/util/data_decompile.cpp
@@ -1316,7 +1316,6 @@ goos::Object decompile_structure(const TypeSpec& type,
         // try to find the next thing in the file.
         int num_elts =
             guess_array_size_array(array_start_byte, array_data_seg, elt_size, words, labels);
-        int stride = 4;
 
         std::vector<goos::Object> array_def = {pretty_print::to_symbol(
             fmt::format("new 'static 'array {} {}", field.type().print(), num_elts))};

--- a/game/graphics/opengl_renderer/foreground/Merc2.cpp
+++ b/game/graphics/opengl_renderer/foreground/Merc2.cpp
@@ -489,8 +489,10 @@ void Merc2::handle_pc_model(const DmaTransfer& setup,
         if (should_envmap) {
           auto e = try_alloc_envmap_draw(mdraw, effect.envmap_mode, effect.envmap_texture,
                                          lev_bucket, fade_buffer + 4 * ei, first_bone, lights);
-          e->flags |= MOD_VTX;
-          e->mod_vtx_buffer = mod_opengl_buffers[ei];
+          if (e) {
+            e->flags |= MOD_VTX;
+            e->mod_vtx_buffer = mod_opengl_buffers[ei];
+          }
         }
       }
     } else {

--- a/game/kernel/jak2/kmachine.cpp
+++ b/game/kernel/jak2/kmachine.cpp
@@ -777,7 +777,7 @@ void InitMachineScheme() {
         new_pair(s7.offset + FIX_SYM_GLOBAL_HEAP, *((s7 + FIX_SYM_PAIR_TYPE - 1).cast<u32>()),
                  make_string_from_c("art"), kernel_packages->value());
     kernel_packages->value() =
-        new_pair(s7.offset + FIX_SYM_GLOBAL_HEAP, *((s7 + FIX_SYM_PAIR_TYPE).cast<u32>()),
+        new_pair(s7.offset + FIX_SYM_GLOBAL_HEAP, *((s7 + FIX_SYM_PAIR_TYPE - 1).cast<u32>()),
                  make_string_from_c("common"), kernel_packages->value());
     printf("calling play-boot!\n");
     call_goal_function_by_name("play-boot");  // new function for jak2!

--- a/goal_src/jak2/engine/level/level.gc
+++ b/goal_src/jak2/engine/level/level.gc
@@ -10,6 +10,17 @@
 (define-extern level-update-after-load (function level login-state level))
 (define-extern *level-type-list* type)
 
+(defglobalconstant NUM_LEVEL_PAGES 146)
+;(defglobalconstant DEBUG_LEVEL_PAGE_SIZE #x2f400) ;; original value
+(defglobalconstant DEBUG_LEVEL_PAGE_SIZE  #x40000)
+(defglobalconstant DEBUG_LEVEL_HEAP_SIZE (* NUM_LEVEL_PAGES DEBUG_LEVEL_PAGE_SIZE))
+
+;; multiplier for borrow heap size. It is a bit of a hack required to load the slightly larger PC port levels.
+;; in the original game, borrow levels never got extra room, even with big level heaps
+;; Setting this means that borrow won't work with normal-size level heaps, but this is probably okay
+;; because normal-size level heaps don't work at all.
+(defglobalconstant BONUS_BORROW 1)
+
 (defun give-all-stuff ()
   (send-event *target* 'get-pickup 18 #x447a0000)
   (send-event *target* 'get-pickup 17 #x447a0000)
@@ -502,6 +513,8 @@
      )
     (((load-buffer-mode medium))
      (set! (-> arg0 load-buffer-size) (+ (-> arg1 length) 2048))
+     (format 0 "believed unused load-buffer-resize case hit.")
+     ; (break!)
      )
     )
 
@@ -693,6 +706,11 @@
    This assigns memory to a level and is somewhat confusing."
   (local-vars (bits-to-use int) (borrow-from-lev level) (found-borrow symbol))
 
+  (when (!= (&- (-> *level* heap top) (the-as uint (-> *level* heap base))) DEBUG_LEVEL_HEAP_SIZE)
+    (format 0 "------------- load-begin called without large level heaps. This is not supported on PC~%")
+    (break!)
+    )
+
   ;; a "borrow" level will borrow the heap of an existing level
   (dotimes (v1-0 2)
     (set! (-> obj borrow-level v1-0) #f) ;; levels that borrow our heap
@@ -749,6 +767,8 @@
                (the-as pointer (-> borrow-from-lev borrow-heap slot-in-borrow-from-lev))
                16
                )
+             (start-debug "borrowing from ~A. heap:~%" borrow-from-lev)
+             (inspect (-> obj heap))
              )
            (else
              ;; couldn't find it, die.
@@ -936,12 +956,15 @@
               (set! (-> obj memory-mask) (the-as uint bits-to-use))
               (cond
                 ;; are we using debug sized large level?
-                ((= (&- (-> *level* heap top) (the-as uint (-> *level* heap base))) #x1af2800)
+                ((= (&- (-> *level* heap top) (the-as uint (-> *level* heap base))) DEBUG_LEVEL_HEAP_SIZE)
                  ;; if so, everything is 1.5x bigger!
                  (let ((v1-44 (-> obj heap)))
-                   (set! (-> v1-44 base) (&+ (-> *level* heap base) (* #x2f400 offset-in-level-heap)))
+                   (set! (-> v1-44 base) (&+ (-> *level* heap base) (* DEBUG_LEVEL_PAGE_SIZE offset-in-level-heap)))
                    (set! (-> v1-44 current) (-> v1-44 base))
-                   (set! (-> v1-44 top-base) (&+ (-> v1-44 base) (+ heap-size (/ heap-size 2))))
+                   ;(set! (-> v1-44 top-base) (&+ (-> v1-44 base) (+ heap-size (/ heap-size 2))))
+                   ;; NOTE: changed in PC version to get 2x size levels heaps. This is only safe with the increased
+                   ;; DEBUG_LEVEL_PAGE_SIZE.
+                   (set! (-> v1-44 top-base) (&+ (-> v1-44 base) (* heap-size 2)))
                    (set! (-> v1-44 top) (-> v1-44 top-base))
                    )
                  )
@@ -1392,13 +1415,16 @@
   ;; if somebody will borrow from us, set aside some memory for them on the top of our heap
   (dotimes (v1-211 2)
     (set! (-> lev heap top-base)
-          (the pointer (&- (-> lev heap top-base) (the-as uint (shl (-> lev info borrow-size v1-211) 10))))
+          (the pointer (&- (-> lev heap top-base) (the-as uint (shl (-> lev info borrow-size v1-211) (+ 10 BONUS_BORROW)))))
           )
     (set! (-> lev heap top) (-> lev heap top-base))
     (let ((borrower-heap (-> lev borrow-heap v1-211)))
       (set! (-> borrower-heap base) (-> lev heap top))
       (set! (-> borrower-heap current) (-> borrower-heap base))
-      (set! (-> borrower-heap top-base) (&+ (-> borrower-heap base) (shl (-> lev info borrow-size v1-211) 10)))
+
+      ;; MODIFIED
+      (set! (-> borrower-heap top-base) (&+ (-> borrower-heap base) (shl (-> lev info borrow-size v1-211) (+ 10 BONUS_BORROW))))
+
       (set! (-> borrower-heap top) (-> borrower-heap top-base))
       )
     )
@@ -1850,7 +1876,6 @@
   )
 
 
-
 (defmethod alloc-levels-if-needed level-group ((obj level-group) (arg0 symbol))
   "Setup for playing levels by loading the required base packages (art, common)
    and allocating the level heap."
@@ -1868,7 +1893,7 @@
         )
     (let ((s5-1 (if (and arg0 (not *debug-segment*))
                     #x11f7000
-                    #x1af2800
+                    DEBUG_LEVEL_HEAP_SIZE
                     )
                 )
           (gp-1 (-> obj heap))

--- a/goalc/compiler/Val.cpp
+++ b/goalc/compiler/Val.cpp
@@ -156,7 +156,7 @@ RegVal* LambdaVal::to_reg(const goos::Object& form, Env* fe) {
   return re;
 }
 
-RegVal* InlinedLambdaVal::to_reg(const goos::Object& form, Env* fe) {
+RegVal* InlinedLambdaVal::to_reg(const goos::Object&, Env*) {
   throw std::runtime_error("Cannot put InlinedLambdaVal in a register.");
   return nullptr;
 }

--- a/goalc/compiler/compilation/CompilerControl.cpp
+++ b/goalc/compiler/compilation/CompilerControl.cpp
@@ -651,7 +651,7 @@ Val* Compiler::compile_gen_docs(const goos::Object& form, const goos::Object& re
   int count = 0;
   for (const auto& sym_info : symbols) {
     count++;
-    if (count % 100 == 0 || count == symbols.size()) {
+    if (count % 100 == 0 || count == (int)symbols.size()) {
       lg::info("Processing [{}/{}] symbols...", count, symbols.size());
     }
     std::optional<Docs::DefinitionLocation> def_loc;


### PR DESCRIPTION
Increase level heaps and borrow heaps. The level heap increase was likely not needed, but better safe than sorry. We allocate the 128 MB main heap anyway so there's no harm.

Also fix the crash when using `-boot`. As I thought it was just a one-line typo in the kernel.