### PR TITLE
[jak2] fix highly aggressive guard zoomer ambush

### DIFF
--- a/decompiler/config/jak2/all-types.gc
+++ b/decompiler/config/jak2/all-types.gc
@@ -51541,7 +51541,7 @@
 (define-extern *guard-status-spots* (array int32))
 (define-extern update-guard-status-spots (function vector symbol))
 (define-extern generate-target-spots "Code-gen function to define [[*guard-target-spots*]] using [[*x-vector*]]" (function none))
-(define-extern *alert-level-settings* traffic-alert-state-settings)
+(define-extern *alert-level-settings* (inline-array traffic-alert-state-settings))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; trail-graph                    ;;

--- a/decompiler/config/jak2/label_types.jsonc
+++ b/decompiler/config/jak2/label_types.jsonc
@@ -1030,7 +1030,8 @@
   "traffic-engine": [
     ["L803", "uint64", true],
     ["L733", "uint64", true],
-    ["L734", "uint64", true]
+    ["L734", "uint64", true],
+    ["L697", "(inline-array traffic-alert-state-settings)", 5]
   ],
   "mechtest-obs": [["L79", "attack-info"]],
   "pillar-collapse": [["L193", "attack-info"]],

--- a/goal_src/jak2/levels/city/common/traffic-engine.gc
+++ b/goal_src/jak2/levels/city/common/traffic-engine.gc
@@ -2330,54 +2330,256 @@ Process is recycled and moved to reserved, if it deactivates."
   (none)
   )
 
-(define *alert-level-settings* (new 'static 'traffic-alert-state-settings
-                                 :ped-tazer (new 'static 'traffic-guard-type-settings
-                                   :target-count 5
-                                   :inaccuracy 0.5
-                                   :acquire-delay #x12c
-                                   :shot-delay #x4b
-                                   :burst-delay #x258
-                                   :shot-count 1
+(define *alert-level-settings* (new 'static 'inline-array traffic-alert-state-settings 5
+                                 (new 'static 'traffic-alert-state-settings
+                                   :ped-tazer (new 'static 'traffic-guard-type-settings
+                                     :target-count 5
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-rifle (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :ped-grenade (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-roboguard (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :bike-turret (new 'static 'traffic-guard-type-settings
+                                     :target-count 1
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x5dc
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :hellcat-turret (new 'static 'traffic-guard-type-settings
+                                     :target-count 1
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x5dc
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
                                    )
-                                 :ped-rifle (new 'static 'traffic-guard-type-settings
-                                   :inaccuracy 0.5
-                                   :acquire-delay #x12c
-                                   :shot-delay #x4b
-                                   :burst-delay #x258
-                                   :shot-count 2
-                                   :rand-shot-count 1
+                                 (new 'static 'traffic-alert-state-settings
+                                   :ped-tazer (new 'static 'traffic-guard-type-settings
+                                     :target-count 5
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-rifle (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :ped-grenade (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-roboguard (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :bike-turret (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x5dc
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :hellcat-turret (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x5dc
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
                                    )
-                                 :ped-grenade (new 'static 'traffic-guard-type-settings
-                                   :inaccuracy 0.5
-                                   :acquire-delay #x12c
-                                   :shot-delay #x4b
-                                   :burst-delay #x258
-                                   :shot-count 1
+                                 (new 'static 'traffic-alert-state-settings
+                                   :ped-tazer (new 'static 'traffic-guard-type-settings
+                                     :target-count 3
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-rifle (new 'static 'traffic-guard-type-settings
+                                     :target-count 4
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :ped-grenade (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-roboguard (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :bike-turret (new 'static 'traffic-guard-type-settings
+                                     :target-count 2
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x5dc
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :hellcat-turret (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x5dc
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
                                    )
-                                 :ped-roboguard (new 'static 'traffic-guard-type-settings
-                                   :inaccuracy 0.5
-                                   :acquire-delay #x12c
-                                   :shot-delay #x4b
-                                   :burst-delay #x258
-                                   :shot-count 1
+                                 (new 'static 'traffic-alert-state-settings
+                                   :ped-tazer (new 'static 'traffic-guard-type-settings
+                                     :target-count 2
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-rifle (new 'static 'traffic-guard-type-settings
+                                     :target-count #x7
+                                     :inaccuracy 0.25
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :ped-grenade (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-roboguard (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :bike-turret (new 'static 'traffic-guard-type-settings
+                                     :target-count 3
+                                     :inaccuracy 0.25
+                                     :acquire-delay #xe1
+                                     :shot-delay #x4b
+                                     :burst-delay #x4b0
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :hellcat-turret (new 'static 'traffic-guard-type-settings
+                                     :target-count 2
+                                     :inaccuracy 0.25
+                                     :acquire-delay #xe1
+                                     :shot-delay #x4b
+                                     :burst-delay #x4b0
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
                                    )
-                                 :bike-turret (new 'static 'traffic-guard-type-settings
-                                   :target-count 1
-                                   :inaccuracy 0.5
-                                   :acquire-delay #x12c
-                                   :shot-delay #x4b
-                                   :burst-delay #x5dc
-                                   :shot-count 2
-                                   :rand-shot-count 1
-                                   )
-                                 :hellcat-turret (new 'static 'traffic-guard-type-settings
-                                   :target-count 1
-                                   :inaccuracy 0.5
-                                   :acquire-delay #x12c
-                                   :shot-delay #x4b
-                                   :burst-delay #x5dc
-                                   :shot-count 2
-                                   :rand-shot-count 1
+                                 (new 'static 'traffic-alert-state-settings
+                                   :ped-tazer (new 'static 'traffic-guard-type-settings
+                                     :target-count 2
+                                     :inaccuracy 0.125
+                                     :acquire-delay #x96
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-rifle (new 'static 'traffic-guard-type-settings
+                                     :target-count #x7
+                                     :inaccuracy 0.125
+                                     :acquire-delay #x96
+                                     :shot-delay #x2d
+                                     :burst-delay #x258
+                                     :shot-count 2
+                                     :rand-shot-count 2
+                                     )
+                                   :ped-grenade (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.125
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x384
+                                     :shot-count 1
+                                     )
+                                   :ped-roboguard (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :bike-turret (new 'static 'traffic-guard-type-settings
+                                     :target-count 3
+                                     :inaccuracy 0.125
+                                     :acquire-delay #x96
+                                     :shot-delay #x4b
+                                     :burst-delay #x384
+                                     :shot-count 2
+                                     :rand-shot-count 2
+                                     )
+                                   :hellcat-turret (new 'static 'traffic-guard-type-settings
+                                     :target-count 2
+                                     :inaccuracy 0.125
+                                     :acquire-delay #x96
+                                     :shot-delay #x4b
+                                     :burst-delay #x384
+                                     :shot-count 2
+                                     :rand-shot-count 2
+                                     )
                                    )
                                  )
         )
@@ -2536,7 +2738,7 @@ Process is recycled and moved to reserved, if it deactivates."
     (when #t
       (mem-copy!
         (the-as pointer (-> obj alert-state settings))
-        (the-as pointer (+ (the-as uint *alert-level-settings*) (* (the-as uint 96) (-> obj alert-state level))))
+        (the-as pointer (-> *alert-level-settings* (-> obj alert-state level)))
         96
         )
       (dotimes (v1-10 6)

--- a/test/decompiler/reference/jak2/levels/city/common/traffic-engine_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/common/traffic-engine_REF.gc
@@ -2490,55 +2490,257 @@ Process is recycled and moved to reserved, if it deactivates."
   (none)
   )
 
-;; definition for symbol *alert-level-settings*, type traffic-alert-state-settings
-(define *alert-level-settings* (new 'static 'traffic-alert-state-settings
-                                 :ped-tazer (new 'static 'traffic-guard-type-settings
-                                   :target-count 5
-                                   :inaccuracy 0.5
-                                   :acquire-delay #x12c
-                                   :shot-delay #x4b
-                                   :burst-delay #x258
-                                   :shot-count 1
+;; definition for symbol *alert-level-settings*, type (inline-array traffic-alert-state-settings)
+(define *alert-level-settings* (new 'static 'inline-array traffic-alert-state-settings 5
+                                 (new 'static 'traffic-alert-state-settings
+                                   :ped-tazer (new 'static 'traffic-guard-type-settings
+                                     :target-count 5
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-rifle (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :ped-grenade (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-roboguard (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :bike-turret (new 'static 'traffic-guard-type-settings
+                                     :target-count 1
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x5dc
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :hellcat-turret (new 'static 'traffic-guard-type-settings
+                                     :target-count 1
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x5dc
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
                                    )
-                                 :ped-rifle (new 'static 'traffic-guard-type-settings
-                                   :inaccuracy 0.5
-                                   :acquire-delay #x12c
-                                   :shot-delay #x4b
-                                   :burst-delay #x258
-                                   :shot-count 2
-                                   :rand-shot-count 1
+                                 (new 'static 'traffic-alert-state-settings
+                                   :ped-tazer (new 'static 'traffic-guard-type-settings
+                                     :target-count 5
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-rifle (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :ped-grenade (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-roboguard (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :bike-turret (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x5dc
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :hellcat-turret (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x5dc
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
                                    )
-                                 :ped-grenade (new 'static 'traffic-guard-type-settings
-                                   :inaccuracy 0.5
-                                   :acquire-delay #x12c
-                                   :shot-delay #x4b
-                                   :burst-delay #x258
-                                   :shot-count 1
+                                 (new 'static 'traffic-alert-state-settings
+                                   :ped-tazer (new 'static 'traffic-guard-type-settings
+                                     :target-count 3
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-rifle (new 'static 'traffic-guard-type-settings
+                                     :target-count 4
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :ped-grenade (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-roboguard (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :bike-turret (new 'static 'traffic-guard-type-settings
+                                     :target-count 2
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x5dc
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :hellcat-turret (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x5dc
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
                                    )
-                                 :ped-roboguard (new 'static 'traffic-guard-type-settings
-                                   :inaccuracy 0.5
-                                   :acquire-delay #x12c
-                                   :shot-delay #x4b
-                                   :burst-delay #x258
-                                   :shot-count 1
+                                 (new 'static 'traffic-alert-state-settings
+                                   :ped-tazer (new 'static 'traffic-guard-type-settings
+                                     :target-count 2
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-rifle (new 'static 'traffic-guard-type-settings
+                                     :target-count #x7
+                                     :inaccuracy 0.25
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :ped-grenade (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-roboguard (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :bike-turret (new 'static 'traffic-guard-type-settings
+                                     :target-count 3
+                                     :inaccuracy 0.25
+                                     :acquire-delay #xe1
+                                     :shot-delay #x4b
+                                     :burst-delay #x4b0
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
+                                   :hellcat-turret (new 'static 'traffic-guard-type-settings
+                                     :target-count 2
+                                     :inaccuracy 0.25
+                                     :acquire-delay #xe1
+                                     :shot-delay #x4b
+                                     :burst-delay #x4b0
+                                     :shot-count 2
+                                     :rand-shot-count 1
+                                     )
                                    )
-                                 :bike-turret (new 'static 'traffic-guard-type-settings
-                                   :target-count 1
-                                   :inaccuracy 0.5
-                                   :acquire-delay #x12c
-                                   :shot-delay #x4b
-                                   :burst-delay #x5dc
-                                   :shot-count 2
-                                   :rand-shot-count 1
-                                   )
-                                 :hellcat-turret (new 'static 'traffic-guard-type-settings
-                                   :target-count 1
-                                   :inaccuracy 0.5
-                                   :acquire-delay #x12c
-                                   :shot-delay #x4b
-                                   :burst-delay #x5dc
-                                   :shot-count 2
-                                   :rand-shot-count 1
+                                 (new 'static 'traffic-alert-state-settings
+                                   :ped-tazer (new 'static 'traffic-guard-type-settings
+                                     :target-count 2
+                                     :inaccuracy 0.125
+                                     :acquire-delay #x96
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :ped-rifle (new 'static 'traffic-guard-type-settings
+                                     :target-count #x7
+                                     :inaccuracy 0.125
+                                     :acquire-delay #x96
+                                     :shot-delay #x2d
+                                     :burst-delay #x258
+                                     :shot-count 2
+                                     :rand-shot-count 2
+                                     )
+                                   :ped-grenade (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.125
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x384
+                                     :shot-count 1
+                                     )
+                                   :ped-roboguard (new 'static 'traffic-guard-type-settings
+                                     :inaccuracy 0.5
+                                     :acquire-delay #x12c
+                                     :shot-delay #x4b
+                                     :burst-delay #x258
+                                     :shot-count 1
+                                     )
+                                   :bike-turret (new 'static 'traffic-guard-type-settings
+                                     :target-count 3
+                                     :inaccuracy 0.125
+                                     :acquire-delay #x96
+                                     :shot-delay #x4b
+                                     :burst-delay #x384
+                                     :shot-count 2
+                                     :rand-shot-count 2
+                                     )
+                                   :hellcat-turret (new 'static 'traffic-guard-type-settings
+                                     :target-count 2
+                                     :inaccuracy 0.125
+                                     :acquire-delay #x96
+                                     :shot-delay #x4b
+                                     :burst-delay #x384
+                                     :shot-count 2
+                                     :rand-shot-count 2
+                                     )
                                    )
                                  )
         )
@@ -2705,7 +2907,7 @@ Process is recycled and moved to reserved, if it deactivates."
     (when #t
       (mem-copy!
         (the-as pointer (-> obj alert-state settings))
-        (the-as pointer (+ (the-as uint *alert-level-settings*) (* (the-as uint 96) (-> obj alert-state level))))
+        (the-as pointer (-> *alert-level-settings* (-> obj alert-state level)))
         96
         )
       (dotimes (v1-10 6)


### PR DESCRIPTION
`*alert-level-settings*` was actually an inline array and we were indexing past the end of it. 
I think this will fix some of the strange on-foot guard behavior too.