### PR TITLE
[windows] make the games start up in the user's preferred system UI language

### DIFF
--- a/decompiler/config/jak2/all-types.gc
+++ b/decompiler/config/jak2/all-types.gc
@@ -29638,7 +29638,7 @@
    (sel-length    int32                   :offset-assert 8)
    (sel-menu      debug-menu            8 :offset-assert 12) ;; guessed by decompiler
    (root-menu     debug-menu              :offset-assert 44) ;; guessed by decompiler
-   (joypad-func   (function basic none)   :offset-assert 48) ;; guessed by decompiler
+   (joypad-func   (function basic int none)   :offset-assert 48) ;; guessed by decompiler
    (joypad-item   basic                   :offset-assert 52)
    (font          font-context            :offset-assert 56) ;; guessed by decompiler
    (is-hidden     symbol                  :offset-assert 60) ;; guessed by decompiler
@@ -29774,7 +29774,7 @@
 (define-extern debug-menu-item-var-update-display-str (function debug-menu-item-var debug-menu-item-var)) ;;
 (define-extern debug-menu-item-var-make-int (function debug-menu-item-var (function int debug-menu-msg int int int) int symbol int int symbol debug-menu-item-var))
 (define-extern debug-menu-item-var-make-float (function debug-menu-item-var (function int debug-menu-msg float float float) float symbol float float int debug-menu-item-var))
-(define-extern debug-menu-context-grab-joypad (function debug-menu-context basic (function basic none) symbol)) ;;
+(define-extern debug-menu-context-grab-joypad (function debug-menu-context basic (function basic int none) symbol)) ;;
 (define-extern debug-menu-context-release-joypad (function debug-menu-context symbol)) ;;
 (define-extern debug-menu-item-get-max-width (function debug-menu-item debug-menu int)) ;;
 (define-extern debug-menu-context-default-selection (function debug-menu-context symbol debug-menu-context)) ;;
@@ -29799,7 +29799,7 @@
 (define-extern debug-menu-item-submenu-msg (function debug-menu-item-submenu debug-menu-msg debug-menu-item-submenu)) ;;
 (define-extern debug-menu-item-function-msg (function debug-menu-item-function debug-menu-msg debug-menu-item-function)) ;;
 (define-extern debug-menu-item-flag-msg (function debug-menu-item-flag debug-menu-msg debug-menu-item-flag)) ;;
-(define-extern debug-menu-item-var-joypad-handler (function debug-menu-item-var debug-menu-msg debug-menu-item-var)) ;;
+(define-extern debug-menu-item-var-joypad-handler (function debug-menu-item-var int debug-menu-item-var)) ;;
 (define-extern debug-menu-item-var-msg (function debug-menu-item-var debug-menu-msg debug-menu-item-var)) ;;
 (define-extern debug-menu-item-send-msg (function debug-menu-item debug-menu-msg debug-menu-item)) ;;
 (define-extern debug-menu-send-msg (function debug-menu debug-menu-msg symbol debug-menu)) ;;

--- a/game/kernel/jak2/kboot.cpp
+++ b/game/kernel/jak2/kboot.cpp
@@ -56,6 +56,7 @@ s32 goal_main(int argc, const char* const* argv) {
       break;
     case SCE_ITALIAN_LANGUAGE:
       masterConfig.language = (u16)Language::Italian;
+      break;
     default:
       masterConfig.language = (u16)Language::English;
       break;

--- a/game/sce/libscf.cpp
+++ b/game/sce/libscf.cpp
@@ -2,12 +2,46 @@
 
 #include <ctime>
 
+#ifdef _WIN32
+#include <Windows.h>
+#include <WinNls.h>
+#endif
+
 namespace ee {
 int sceScfGetAspect() {
   return SCE_ASPECT_43;
 }
 
 int sceScfGetLanguage() {
+#ifdef _WIN32
+  // method 1: GetUserDefaultUILanguage
+  LANGID curLang = GetUserDefaultUILanguage();
+  auto curLangMain = curLang & 0x3ff;        // "base" language
+  auto curLangSub = (curLang >> 10) & 0x3f;  // "sub"-language
+  if (curLangMain == LANG_JAPANESE) {
+    return SCE_JAPANESE_LANGUAGE;
+  } else if (curLangMain == LANG_ENGLISH) {
+    return SCE_ENGLISH_LANGUAGE;
+  } else if (curLangMain == LANG_FRENCH) {
+    return SCE_FRENCH_LANGUAGE;
+  } else if (curLangMain == LANG_SPANISH) {
+    // would non-European Spanish speakers prefer this over English?
+    // I'll wait for someone to complain first
+    return SCE_SPANISH_LANGUAGE;
+  } else if (curLangMain == LANG_GERMAN) {
+    return SCE_GERMAN_LANGUAGE;
+  } else if (curLangMain == LANG_ITALIAN) {
+    return SCE_ITALIAN_LANGUAGE;
+  } else if (curLangMain == LANG_PORTUGUESE) {
+    if (curLangSub == SUBLANG_PORTUGUESE) {
+      return SCE_ENGLISH_LANGUAGE;  // SCE_PORTUGUESE_LANGUAGE;
+    } else {
+      return SCE_ENGLISH_LANGUAGE;
+    }
+  } else if (curLangMain == LANG_DUTCH) {
+    return SCE_DUTCH_LANGUAGE;
+  }
+#endif
   return SCE_ENGLISH_LANGUAGE;
 }
 

--- a/game/sce/libscf.cpp
+++ b/game/sce/libscf.cpp
@@ -3,8 +3,10 @@
 #include <ctime>
 
 #ifdef _WIN32
+// clang-format off
 #include <Windows.h>
 #include <WinNls.h>
+// clang-format on
 #endif
 
 namespace ee {

--- a/goal_src/jak1/pc/debug/pc-debug-common.gc
+++ b/goal_src/jak1/pc/debug/pc-debug-common.gc
@@ -14,12 +14,13 @@
 
 (defconstant MEM_BAR_WIDTH 152) ;; total width of the bar
 (defconstant MEM_BAR_HEIGHT 8) ;; total height of the bar
+(defconstant MEM_BAR_HORZ_PAD 8) ;; horizontal padding for the bar text
 (defconstant MEM_BAR_NUM 7) ;; amount of bars (override later if wanted)
 (defconstant MEM_BAR_BG_COL (static-rgba 64 64 64 64)) ;; color for the empty part of the bar
 (defconstant MEM_BAR_RIGHT 480) ;; x coord for the right side of the bar list
 (defconstant MEM_BAR_BOTTOM 224) ;; x coord for the bottom side of the bar list
 
-(defconstant MEM_BAR_X (- MEM_BAR_RIGHT MEM_BAR_WIDTH)) ;; x coord for left side of the bar list
+(defconstant MEM_BAR_X (- MEM_BAR_RIGHT MEM_BAR_WIDTH MEM_BAR_HORZ_PAD)) ;; x coord for left side of the bar list
 (defconstant MEM_BAR_Y (- MEM_BAR_BOTTOM 4 (* MEM_BAR_HEIGHT MEM_BAR_NUM))) ;; y coord for top side of the bar list
 
 (defmacro draw-memory-bar-generic (buf &key remain &key total &key name &key idx &key color)
@@ -33,9 +34,9 @@
         )
       (draw-sprite2d-xy ,buf    MEM_BAR_X         used-y used-x MEM_BAR_HEIGHT ,color)
       (draw-sprite2d-xy ,buf (+ MEM_BAR_X used-x) used-y (- MEM_BAR_WIDTH used-x) MEM_BAR_HEIGHT MEM_BAR_BG_COL)
-      (draw-string-xy ,name ,buf MEM_BAR_X used-y (font-color red) (font-flags shadow kerning right))
+      (draw-string-xy ,name ,buf (- MEM_BAR_X MEM_BAR_HORZ_PAD) used-y (font-color red) (font-flags shadow kerning right))
       (draw-string-xy (string-format "~,,2f%" (* used-p 100)) ,buf (+ MEM_BAR_X used-x) used-y (font-color default) (font-flags shadow kerning middle))
-      (draw-string-xy (string-format "~,,1fM" (/ total (* 1024 1024))) ,buf (+ MEM_BAR_X MEM_BAR_WIDTH) used-y (font-color red) (font-flags shadow kerning left))
+      (draw-string-xy (string-format "~,,1fM" (/ total (* 1024 1024))) ,buf (+ MEM_BAR_X MEM_BAR_WIDTH MEM_BAR_HORZ_PAD) used-y (font-color red) (font-flags shadow kerning left))
       )
   )
 (defmacro draw-memory-bar-kheap (buf heap &key (name #f) &key idx &key color)

--- a/goal_src/jak1/pc/pckernel-h.gc
+++ b/goal_src/jak1/pc/pckernel-h.gc
@@ -474,7 +474,7 @@
   "Set the default misc settings"
 
   (set! (-> obj force-actors?) #f)
-  (set! (-> obj text-language) (pc-subtitle-lang english))
+  (set! (-> obj text-language) (the pc-subtitle-lang (scf-get-language)))
   (set! (-> obj hinttitles?) #t)
   (set! (-> obj subtitle-speaker?) 'auto)
   (reset-original-camera obj)

--- a/goal_src/jak1/pc/pckernel-impl.gc
+++ b/goal_src/jak1/pc/pckernel-impl.gc
@@ -59,14 +59,21 @@
   "Set the default misc settings"
 
   ((method-of-type pc-settings reset-misc) obj)
-  (set! (-> obj text-language) (case *jak1-territory*
-                                    ((GAME_TERRITORY_SCEE) (pc-subtitle-lang uk-english))
-                                    (else (pc-subtitle-lang english))))
+  (set! (-> obj text-language) (the pc-subtitle-lang (scf-get-language)))
+  (set! (-> obj subtitle-language) (the pc-subtitle-lang (scf-get-language)))
   (set! (-> obj skip-movies?) #t)
   (set! (-> obj subtitles?) *debug-segment*)
-  (set! (-> obj subtitle-language) (case *jak1-territory*
-                                        ((GAME_TERRITORY_SCEE) (pc-subtitle-lang uk-english))
-                                        (else (pc-subtitle-lang english))))
+  (cond
+    ((and (= *jak1-territory* GAME_TERRITORY_SCEE) (= (-> obj text-language) (pc-subtitle-lang english)))
+      (set! (-> obj text-language) (pc-subtitle-lang uk-english))
+      ;(set! (-> obj subtitle-language) (pc-subtitle-lang uk-english))
+      )
+    ((= *jak1-territory* GAME_TERRITORY_SCEI)
+      (set! (-> obj text-language) (pc-subtitle-lang japanese))
+      ;(set! (-> obj subtitle-language) (pc-subtitle-lang japanese))
+      )
+    (else
+      ))
   (set! (-> obj money-starburst?) #f)
   (set! (-> obj extra-hud?) #f)
   (none))

--- a/goal_src/jak2/engine/debug/menu.gc
+++ b/goal_src/jak2/engine/debug/menu.gc
@@ -11,15 +11,15 @@
 (declare-file (debug))
 
 (deftype debug-menu-context (basic)
-  ((is-active     symbol                  :offset-assert   4)
-   (sel-length    int32                   :offset-assert   8)
-   (sel-menu      debug-menu            8 :offset-assert  12)
-   (root-menu     debug-menu              :offset-assert  44)
-   (joypad-func   (function basic none)   :offset-assert  48)
-   (joypad-item   basic                   :offset-assert  52)
-   (font          font-context            :offset-assert  56)
-   (is-hidden     symbol                  :offset-assert  60)
-   (joypad-number int32                   :offset-assert  64)
+  ((is-active     symbol                      :offset-assert   4)
+   (sel-length    int32                       :offset-assert   8)
+   (sel-menu      debug-menu                8 :offset-assert  12)
+   (root-menu     debug-menu                  :offset-assert  44)
+   (joypad-func   (function basic int none)   :offset-assert  48)
+   (joypad-item   basic                       :offset-assert  52)
+   (font          font-context                :offset-assert  56)
+   (is-hidden     symbol                      :offset-assert  60)
+   (joypad-number int32                       :offset-assert  64)
    )
   :method-count-assert 9
   :size-assert         #x44
@@ -29,24 +29,6 @@
     )
   )
 
-(defmethod inspect debug-menu-context ((obj debug-menu-context))
-  (when (not obj)
-    (set! obj obj)
-    (goto cfg-4)
-    )
-  (format #t "[~8x] ~A~%" obj (-> obj type))
-  (format #t "~1Tis-active: ~A~%" (-> obj is-active))
-  (format #t "~1Tsel-length: ~D~%" (-> obj sel-length))
-  (format #t "~1Tsel-menu[8] @ #x~X~%" (-> obj sel-menu))
-  (format #t "~1Troot-menu: ~A~%" (-> obj root-menu))
-  (format #t "~1Tjoypad-func: ~A~%" (-> obj joypad-func))
-  (format #t "~1Tjoypad-item: ~A~%" (-> obj joypad-item))
-  (format #t "~1Tfont: ~A~%" (-> obj font))
-  (format #t "~1Tis-hidden: ~A~%" (-> obj is-hidden))
-  (format #t "~1Tjoypad-number: ~D~%" (-> obj joypad-number))
-  (label cfg-4)
-  obj
-  )
 
 (defmethod new debug-menu-context ((allocation symbol) (type-to-make type))
   (let ((gp-0 (object-new allocation type-to-make (the-as int (-> type-to-make size)))))
@@ -56,16 +38,8 @@
     (set! (-> gp-0 root-menu) #f)
     (set! (-> gp-0 joypad-func) #f)
     (set! (-> gp-0 joypad-item) #f)
-    (set! (-> gp-0 font) (new
-                           'debug
-                           'font-context
-                           *font-default-matrix*
-                           0
-                           0
-                           0.0
-                           (font-color default)
-                           (font-flags shadow kerning)
-                           )
+    (set! (-> gp-0 font)
+          (new 'debug 'font-context *font-default-matrix* 0 0 0.0 (font-color default) (font-flags shadow kerning))
           )
     (set! (-> gp-0 joypad-number) 0)
     gp-0
@@ -83,19 +57,6 @@
   :flag-assert         #x900000014
   )
 
-(defmethod inspect debug-menu-node ((obj debug-menu-node))
-  (when (not obj)
-    (set! obj obj)
-    (goto cfg-4)
-    )
-  (format #t "[~8x] ~A~%" obj (-> obj type))
-  (format #t "~1Tname: ~A~%" (-> obj name))
-  (format #t "~1Tparent: ~A~%" (-> obj parent))
-  (format #t "~1Trefresh-delay: ~D~%" (-> obj refresh-delay))
-  (format #t "~1Trefresh-ctr: ~D~%" (-> obj refresh-ctr))
-  (label cfg-4)
-  obj
-  )
 
 (defmethod print debug-menu-node ((obj debug-menu-node))
   (format #t "#<~A ~A @ #x~X>" (-> obj type) (-> obj name) obj)
@@ -117,24 +78,6 @@
     )
   )
 
-(defmethod inspect debug-menu ((obj debug-menu))
-  (when (not obj)
-    (set! obj obj)
-    (goto cfg-4)
-    )
-  (format #t "[~8x] ~A~%" obj (-> obj type))
-  (format #t "~1Tname: ~A~%" (-> obj name))
-  (format #t "~1Tparent: ~A~%" (-> obj parent))
-  (format #t "~1Trefresh-delay: ~D~%" (-> obj refresh-delay))
-  (format #t "~1Trefresh-ctr: ~D~%" (-> obj refresh-ctr))
-  (format #t "~1Tcontext: ~A~%" (-> obj context))
-  (format #t "~1Tselected-item: ~A~%" (-> obj selected-item))
-  (format #t "~1Tpix-width: ~D~%" (-> obj pix-width))
-  (format #t "~1Tpix-height: ~D~%" (-> obj pix-height))
-  (format #t "~1Titems: ~A~%" (-> obj items))
-  (label cfg-4)
-  obj
-  )
 
 (defmethod new debug-menu ((allocation symbol) (type-to-make type) (arg0 debug-menu-context) (arg1 string))
   (let ((v0-0 (object-new allocation type-to-make (the-as int (-> type-to-make size)))))
@@ -155,20 +98,6 @@
   :flag-assert         #x900000018
   )
 
-(defmethod inspect debug-menu-item ((obj debug-menu-item))
-  (when (not obj)
-    (set! obj obj)
-    (goto cfg-4)
-    )
-  (format #t "[~8x] ~A~%" obj (-> obj type))
-  (format #t "~1Tname: ~A~%" (-> obj name))
-  (format #t "~1Tparent: ~A~%" (-> obj parent))
-  (format #t "~1Trefresh-delay: ~D~%" (-> obj refresh-delay))
-  (format #t "~1Trefresh-ctr: ~D~%" (-> obj refresh-ctr))
-  (format #t "~1Tid: #x~X~%" (-> obj id))
-  (label cfg-4)
-  obj
-  )
 
 (deftype debug-menu-item-submenu (debug-menu-item)
   ((submenu debug-menu  :offset-assert  24)
@@ -181,21 +110,6 @@
     )
   )
 
-(defmethod inspect debug-menu-item-submenu ((obj debug-menu-item-submenu))
-  (when (not obj)
-    (set! obj obj)
-    (goto cfg-4)
-    )
-  (format #t "[~8x] ~A~%" obj (-> obj type))
-  (format #t "~1Tname: ~A~%" (-> obj name))
-  (format #t "~1Tparent: ~A~%" (-> obj parent))
-  (format #t "~1Trefresh-delay: ~D~%" (-> obj refresh-delay))
-  (format #t "~1Trefresh-ctr: ~D~%" (-> obj refresh-ctr))
-  (format #t "~1Tid: #x~X~%" (-> obj id))
-  (format #t "~1Tsubmenu: ~A~%" (-> obj submenu))
-  (label cfg-4)
-  obj
-  )
 
 (defmethod new debug-menu-item-submenu ((allocation symbol) (type-to-make type) (arg0 string) (arg1 debug-menu))
   (let ((v0-0 (object-new allocation type-to-make (the-as int (-> type-to-make size)))))
@@ -221,22 +135,6 @@
     )
   )
 
-(defmethod inspect debug-menu-item-function ((obj debug-menu-item-function))
-  (when (not obj)
-    (set! obj obj)
-    (goto cfg-4)
-    )
-  (format #t "[~8x] ~A~%" obj (-> obj type))
-  (format #t "~1Tname: ~A~%" (-> obj name))
-  (format #t "~1Tparent: ~A~%" (-> obj parent))
-  (format #t "~1Trefresh-delay: ~D~%" (-> obj refresh-delay))
-  (format #t "~1Trefresh-ctr: ~D~%" (-> obj refresh-ctr))
-  (format #t "~1Tid: #x~X~%" (-> obj id))
-  (format #t "~1Tactivate-func: ~A~%" (-> obj activate-func))
-  (format #t "~1Thilite-timer: ~D~%" (-> obj hilite-timer))
-  (label cfg-4)
-  obj
-  )
 
 (defmethod new debug-menu-item-function ((allocation symbol) (type-to-make type) (arg0 string) (arg1 object) (arg2 (function object object)))
   (let ((v0-0 (object-new allocation type-to-make (the-as int (-> type-to-make size)))))
@@ -263,22 +161,6 @@
     )
   )
 
-(defmethod inspect debug-menu-item-flag ((obj debug-menu-item-flag))
-  (when (not obj)
-    (set! obj obj)
-    (goto cfg-4)
-    )
-  (format #t "[~8x] ~A~%" obj (-> obj type))
-  (format #t "~1Tname: ~A~%" (-> obj name))
-  (format #t "~1Tparent: ~A~%" (-> obj parent))
-  (format #t "~1Trefresh-delay: ~D~%" (-> obj refresh-delay))
-  (format #t "~1Trefresh-ctr: ~D~%" (-> obj refresh-ctr))
-  (format #t "~1Tid: #x~X~%" (-> obj id))
-  (format #t "~1Tactivate-func: ~A~%" (-> obj activate-func))
-  (format #t "~1Tis-on: ~A~%" (-> obj is-on))
-  (label cfg-4)
-  obj
-  )
 
 (defmethod new debug-menu-item-flag ((allocation symbol)
                                    (type-to-make type)
@@ -334,46 +216,6 @@
     )
   )
 
-(defmethod inspect debug-menu-item-var ((obj debug-menu-item-var))
-  (when (not obj)
-    (set! obj obj)
-    (goto cfg-4)
-    )
-  (format #t "[~8x] ~A~%" obj (-> obj type))
-  (format #t "~1Tname: ~A~%" (-> obj name))
-  (format #t "~1Tparent: ~A~%" (-> obj parent))
-  (format #t "~1Trefresh-delay: ~D~%" (-> obj refresh-delay))
-  (format #t "~1Trefresh-ctr: ~D~%" (-> obj refresh-ctr))
-  (format #t "~1Tid: #x~X~%" (-> obj id))
-  (format #t "~1Tdisplay-str: ~A~%" (-> obj display-str))
-  (format #t "~1Tgrabbed-joypad-p: ~A~%" (-> obj grabbed-joypad-p))
-  (format #t "~1Tfloat-p: ~A~%" (-> obj float-p))
-  (format #t "~1Trange-p: ~A~%" (-> obj range-p))
-  (format #t "~1Tshow-len: ~D~%" (-> obj show-len))
-  (format #t "~1Tinc-delay: ~D~%" (-> obj inc-delay))
-  (format #t "~1Tinc-delay-ctr: ~D~%" (-> obj inc-delay-ctr))
-  (format #t "~1Tstep-delay-ctr: ~D~%" (-> obj step-delay-ctr))
-  (format #t "~1Tinc-dir: ~D~%" (-> obj inc-dir))
-  (format #t "~1Tfval: ~f~%" (-> obj fval))
-  (format #t "~1Tfundo-val: ~f~%" (-> obj fundo-val))
-  (format #t "~1Tfrange-min: ~f~%" (-> obj frange-min))
-  (format #t "~1Tfrange-max: ~f~%" (-> obj frange-max))
-  (format #t "~1Tfstart-inc: ~f~%" (-> obj fstart-inc))
-  (format #t "~1Tfstep: ~f~%" (-> obj fstep))
-  (format #t "~1Tfprecision: ~D~%" (-> obj fprecision))
-  (format #t "~1Tfactivate-func: ~A~%" (-> obj factivate-func))
-  (format #t "~1Tival: ~D~%" (-> obj fval))
-  (format #t "~1Tiundo-val: ~D~%" (-> obj fundo-val))
-  (format #t "~1Tirange-min: ~D~%" (-> obj frange-min))
-  (format #t "~1Tirange-max: ~D~%" (-> obj frange-max))
-  (format #t "~1Tistart-inc: ~D~%" (-> obj fstart-inc))
-  (format #t "~1Tistep: ~D~%" (-> obj fstep))
-  (format #t "~1Tihex-p: ~A~%" (-> obj ihex-p))
-  (format #t "~1Tiactivate-func: ~A~%" (-> obj factivate-func))
-  (format #t "~1Tifloat-p: ~A~%" (-> obj ifloat-p))
-  (label cfg-4)
-  obj
-  )
 
 (defun debug-menu-item-var-update-display-str ((arg0 debug-menu-item-var))
   (cond
@@ -507,7 +349,7 @@
     )
   )
 
-(defun debug-menu-context-grab-joypad ((arg0 debug-menu-context) (arg1 basic) (arg2 (function basic none)))
+(defun debug-menu-context-grab-joypad ((arg0 debug-menu-context) (arg1 basic) (arg2 (function basic int none)))
   (cond
     ((-> arg0 joypad-func)
      #f
@@ -529,7 +371,6 @@
 (defun debug-menu-item-get-max-width ((arg0 debug-menu-item) (arg1 debug-menu))
   (local-vars (v0-1 int))
   0
-
   (cond
     ((= (-> arg0 type) debug-menu-item-submenu)
      (set! v0-1 (+ (the int (-> (get-string-length (-> arg0 name) (-> arg1 context font)) length)) 16))
@@ -656,6 +497,8 @@
   arg0
   )
 
+;; WARN: Return type mismatch object vs function.
+;; WARN: Using new Jak 2 rtype-of
 (defun debug-menu-func-decode ((arg0 object))
   (let ((v1-2 (rtype-of arg0)))
     (the-as function (cond
@@ -886,6 +729,7 @@
     )
   )
 
+;; ERROR: Failed store: (s.w! (+ v1-9 8) 0) at op 42
 (defun debug-menu-item-submenu-render ((arg0 debug-menu-item-submenu) (arg1 int) (arg2 int) (arg3 int) (arg4 symbol))
   (let ((s5-0 (-> arg0 parent context font)))
     (let ((v1-2 s5-0)
@@ -906,30 +750,17 @@
                               )
                             )
           )
-    (let* ((s3-0 (-> *display* frames (-> *display* on-screen) debug-buf))
-           (s4-0 (-> s3-0 base))
-           )
+    (with-dma-buffer-add-bucket ((s3-0 (-> *display* frames (-> *display* on-screen) debug-buf))
+                                 (bucket-id debug3)
+                                 )
       (draw-string-adv (-> arg0 name) s3-0 s5-0)
       (draw-string-adv "..." s3-0 s5-0)
-      (let ((a3-1 (-> s3-0 base)))
-        (let ((v1-9 (the-as object (-> s3-0 base))))
-          (set! (-> (the-as dma-packet v1-9) dma) (new 'static 'dma-tag :id (dma-tag-id next)))
-          (set! (-> (the-as dma-packet v1-9) vif0) (new 'static 'vif-tag))
-          (set! (-> (the-as dma-packet v1-9) vif1) (new 'static 'vif-tag))
-          (set! (-> s3-0 base) (&+ (the-as pointer v1-9) 16))
-          )
-        (dma-bucket-insert-tag
-          (-> *display* frames (-> *display* on-screen) bucket-group)
-          (bucket-id debug3)
-          s4-0
-          (the-as (pointer dma-tag) a3-1)
-          )
-        )
       )
     )
   arg0
   )
 
+;; ERROR: Failed store: (s.w! (+ v1-3 8) 0) at op 49
 (defun debug-menu-item-function-render ((arg0 debug-menu-item-function) (arg1 int) (arg2 int) (arg3 int) (arg4 symbol))
   (let ((v1-2 (-> arg0 parent context font)))
     (let ((a0-1 v1-2)
@@ -956,29 +787,16 @@
                                                )
                                   )
           )
-    (let* ((s4-0 (-> *display* frames (-> *display* on-screen) debug-buf))
-           (s5-0 (-> s4-0 base))
-           )
+    (with-dma-buffer-add-bucket ((s4-0 (-> *display* frames (-> *display* on-screen) debug-buf))
+                                 (bucket-id debug3)
+                                 )
       (draw-string (-> arg0 name) s4-0 v1-2)
-      (let ((a3-1 (-> s4-0 base)))
-        (let ((v1-3 (the-as object (-> s4-0 base))))
-          (set! (-> (the-as dma-packet v1-3) dma) (new 'static 'dma-tag :id (dma-tag-id next)))
-          (set! (-> (the-as dma-packet v1-3) vif0) (new 'static 'vif-tag))
-          (set! (-> (the-as dma-packet v1-3) vif1) (new 'static 'vif-tag))
-          (set! (-> s4-0 base) (&+ (the-as pointer v1-3) 16))
-          )
-        (dma-bucket-insert-tag
-          (-> *display* frames (-> *display* on-screen) bucket-group)
-          (bucket-id debug3)
-          s5-0
-          (the-as (pointer dma-tag) a3-1)
-          )
-        )
       )
     )
   arg0
   )
 
+;; ERROR: Failed store: (s.w! (+ v1-3 8) 0) at op 47
 (defun debug-menu-item-flag-render ((arg0 debug-menu-item-flag) (arg1 int) (arg2 int) (arg3 int) (arg4 symbol))
   (let ((v1-2 (-> arg0 parent context font)))
     (let ((a0-1 v1-2)
@@ -1005,29 +823,16 @@
                               )
                             )
           )
-    (let* ((s4-0 (-> *display* frames (-> *display* on-screen) debug-buf))
-           (s5-0 (-> s4-0 base))
-           )
+    (with-dma-buffer-add-bucket ((s4-0 (-> *display* frames (-> *display* on-screen) debug-buf))
+                                 (bucket-id debug3)
+                                 )
       (draw-string (-> arg0 name) s4-0 v1-2)
-      (let ((a3-1 (-> s4-0 base)))
-        (let ((v1-3 (the-as object (-> s4-0 base))))
-          (set! (-> (the-as dma-packet v1-3) dma) (new 'static 'dma-tag :id (dma-tag-id next)))
-          (set! (-> (the-as dma-packet v1-3) vif0) (new 'static 'vif-tag))
-          (set! (-> (the-as dma-packet v1-3) vif1) (new 'static 'vif-tag))
-          (set! (-> s4-0 base) (&+ (the-as pointer v1-3) 16))
-          )
-        (dma-bucket-insert-tag
-          (-> *display* frames (-> *display* on-screen) bucket-group)
-          (bucket-id debug3)
-          s5-0
-          (the-as (pointer dma-tag) a3-1)
-          )
-        )
       )
     )
   arg0
   )
 
+;; ERROR: Failed store: (s.w! (+ v1-16 8) 0) at op 95
 (defun debug-menu-item-var-render ((arg0 debug-menu-item-var) (arg1 int) (arg2 int) (arg3 int) (arg4 symbol))
   (let ((s5-0 (-> arg0 parent context font)))
     (let ((v1-2 s5-0)
@@ -1051,9 +856,9 @@
                               )
                             )
           )
-    (let* ((s1-0 (-> *display* frames (-> *display* on-screen) debug-buf))
-           (s4-0 (-> s1-0 base))
-           )
+    (with-dma-buffer-add-bucket ((s1-0 (-> *display* frames (-> *display* on-screen) debug-buf))
+                                 (bucket-id debug3)
+                                 )
       (draw-string-adv (-> arg0 name) s1-0 s5-0)
       (draw-string-adv ":" s1-0 s5-0)
       (cond
@@ -1075,20 +880,6 @@
             (draw-string-adv ":" s1-0 s5-0)
             (draw-string (-> arg0 display-str) s1-0 s5-0)
             )
-          )
-        )
-      (let ((a3-1 (-> s1-0 base)))
-        (let ((v1-16 (the-as object (-> s1-0 base))))
-          (set! (-> (the-as dma-packet v1-16) dma) (new 'static 'dma-tag :id (dma-tag-id next)))
-          (set! (-> (the-as dma-packet v1-16) vif0) (new 'static 'vif-tag))
-          (set! (-> (the-as dma-packet v1-16) vif1) (new 'static 'vif-tag))
-          (set! (-> s1-0 base) (the-as pointer (&+ (the-as dma-packet v1-16) 16)))
-          )
-        (dma-bucket-insert-tag
-          (-> *display* frames (-> *display* on-screen) bucket-group)
-          (bucket-id debug3)
-          s4-0
-          (the-as (pointer dma-tag) a3-1)
           )
         )
       )
@@ -1124,6 +915,7 @@
   arg0
   )
 
+;; ERROR: Failed store: (s.w! (+ v1-9 8) 0) at op 47
 (defun debug-menu-render ((arg0 debug-menu) (arg1 int) (arg2 int) (arg3 debug-menu-node) (arg4 int))
   (local-vars (sv-16 dma-buffer) (sv-32 pointer))
   (let ((v1-0 0))
@@ -1144,24 +936,10 @@
         (set! arg2 (- arg2 (* 15 (+ v1-0 -16))))
         )
     )
-  (let* ((s0-0 (-> *display* frames (-> *display* on-screen) debug-buf))
-         (s1-0 (-> s0-0 base))
-         )
+  (with-dma-buffer-add-bucket ((s0-0 (-> *display* frames (-> *display* on-screen) debug-buf))
+                               (bucket-id debug3)
+                               )
     (draw-sprite2d-xy s0-0 arg1 arg2 (-> arg0 pix-width) (-> arg0 pix-height) (new 'static 'rgba :a #x40))
-    (let ((a3-2 (-> s0-0 base)))
-      (let ((v1-9 (the-as object (-> s0-0 base))))
-        (set! (-> (the-as dma-packet v1-9) dma) (new 'static 'dma-tag :id (dma-tag-id next)))
-        (set! (-> (the-as dma-packet v1-9) vif0) (new 'static 'vif-tag))
-        (set! (-> (the-as dma-packet v1-9) vif1) (new 'static 'vif-tag))
-        (set! (-> s0-0 base) (&+ (the-as pointer v1-9) 16))
-        )
-      (dma-bucket-insert-tag
-        (-> *display* frames (-> *display* on-screen) bucket-group)
-        (bucket-id debug3)
-        s1-0
-        (the-as (pointer dma-tag) a3-2)
-        )
-      )
     )
   (let* ((s3-1 (+ arg1 3))
          (s2-1 (+ arg2 5))
@@ -1399,9 +1177,9 @@
   arg0
   )
 
-(defun debug-menu-item-var-joypad-handler ((arg0 debug-menu-item-var) (arg1 debug-menu-msg))
+(defun debug-menu-item-var-joypad-handler ((arg0 debug-menu-item-var) (arg1 int))
   (cond
-    ((zero? (logand (-> *cpad-list* cpads arg1 button0-abs 0) (pad-buttons x)))
+    ((not (cpad-hold? arg1 x))
      (let ((a0-2 (-> arg0 parent context)))
        (debug-menu-context-release-joypad a0-2)
        )
@@ -1538,7 +1316,11 @@
     ((= arg1 (debug-menu-msg press))
      (when (not (-> arg0 grabbed-joypad-p))
        (let ((a0-2 (-> arg0 parent context)))
-         (when (debug-menu-context-grab-joypad a0-2 arg0 (the-as (function basic none) debug-menu-item-var-joypad-handler))
+         (when (debug-menu-context-grab-joypad
+                 a0-2
+                 arg0
+                 (the-as (function basic int none) debug-menu-item-var-joypad-handler)
+                 )
            (set! (-> arg0 grabbed-joypad-p) #t)
            (set! (-> arg0 fundo-val) (-> arg0 fval))
            (set! (-> arg0 fundo-val) (-> arg0 fval))
@@ -1689,19 +1471,10 @@
 
 (defun debug-menus-active ((arg0 debug-menu-context))
   (when (not (-> arg0 is-hidden))
-    (cond
-      ((-> arg0 joypad-func)
-       (let ((t9-0 (-> arg0 joypad-func))
-             (a0-1 (-> arg0 joypad-item))
-             )
-         (-> arg0 joypad-number)
-         (t9-0 a0-1)
-         )
-       )
-      (else
+    (if (-> arg0 joypad-func)
+        ((-> arg0 joypad-func) (-> arg0 joypad-item) (-> arg0 joypad-number))
         (debug-menus-default-joypad-func arg0)
         )
-      )
     (debug-menu-context-render arg0)
     )
   arg0
@@ -1713,8 +1486,3 @@
       )
   arg0
   )
-
-0
-
-
-

--- a/goal_src/jak2/pc/debug/pc-debug-methods.gc
+++ b/goal_src/jak2/pc/debug/pc-debug-methods.gc
@@ -33,7 +33,11 @@
 			(draw-memory-bar-kheap buf global :idx idx :color (static-rgba 32 32 255 64))
 			(draw-memory-bar-kheap buf debug :idx (1+! idx) :color (static-rgba 255 32 32 64))
 			(dotimes (i (-> *level* length))
-				(draw-memory-bar-kheap buf (-> *level* level i heap) :name (string-format "l~D" i) :idx (1+! idx) :color (-> level-heap-colors i))
+				(draw-memory-bar-kheap buf (-> *level* level i heap)
+								:name (aif (-> *level* level i borrow-from-level)
+													(string-format "(~A)l~D<-l~D" (-> *level* level i name) i (-> it index))
+													(string-format "(~A)l~D" (-> *level* level i name) i))
+								:idx (1+! idx) :color (-> level-heap-colors i))
 				)
 			(draw-memory-bar-dead-pool-heap buf *nk-dead-pool* :name "actor" :idx (1+! idx) :color (static-rgba 32 255 32 64))
 			(draw-memory-bar-generic buf

--- a/test/decompiler/reference/jak2/engine/debug/menu_REF.gc
+++ b/test/decompiler/reference/jak2/engine/debug/menu_REF.gc
@@ -6,15 +6,15 @@
 
 ;; definition of type debug-menu-context
 (deftype debug-menu-context (basic)
-  ((is-active     symbol                  :offset-assert   4)
-   (sel-length    int32                   :offset-assert   8)
-   (sel-menu      debug-menu            8 :offset-assert  12)
-   (root-menu     debug-menu              :offset-assert  44)
-   (joypad-func   (function basic none)   :offset-assert  48)
-   (joypad-item   basic                   :offset-assert  52)
-   (font          font-context            :offset-assert  56)
-   (is-hidden     symbol                  :offset-assert  60)
-   (joypad-number int32                   :offset-assert  64)
+  ((is-active     symbol                      :offset-assert   4)
+   (sel-length    int32                       :offset-assert   8)
+   (sel-menu      debug-menu                8 :offset-assert  12)
+   (root-menu     debug-menu                  :offset-assert  44)
+   (joypad-func   (function basic int none)   :offset-assert  48)
+   (joypad-item   basic                       :offset-assert  52)
+   (font          font-context                :offset-assert  56)
+   (is-hidden     symbol                      :offset-assert  60)
+   (joypad-number int32                       :offset-assert  64)
    )
   :method-count-assert 9
   :size-assert         #x44
@@ -520,7 +520,7 @@
   )
 
 ;; definition for function debug-menu-context-grab-joypad
-(defun debug-menu-context-grab-joypad ((arg0 debug-menu-context) (arg1 basic) (arg2 (function basic none)))
+(defun debug-menu-context-grab-joypad ((arg0 debug-menu-context) (arg1 basic) (arg2 (function basic int none)))
   (cond
     ((-> arg0 joypad-func)
      #f
@@ -1375,7 +1375,7 @@
   )
 
 ;; definition for function debug-menu-item-var-joypad-handler
-(defun debug-menu-item-var-joypad-handler ((arg0 debug-menu-item-var) (arg1 debug-menu-msg))
+(defun debug-menu-item-var-joypad-handler ((arg0 debug-menu-item-var) (arg1 int))
   (cond
     ((not (cpad-hold? arg1 x))
      (let ((a0-2 (-> arg0 parent context)))
@@ -1515,7 +1515,11 @@
     ((= arg1 (debug-menu-msg press))
      (when (not (-> arg0 grabbed-joypad-p))
        (let ((a0-2 (-> arg0 parent context)))
-         (when (debug-menu-context-grab-joypad a0-2 arg0 (the-as (function basic none) debug-menu-item-var-joypad-handler))
+         (when (debug-menu-context-grab-joypad
+                 a0-2
+                 arg0
+                 (the-as (function basic int none) debug-menu-item-var-joypad-handler)
+                 )
            (set! (-> arg0 grabbed-joypad-p) #t)
            (set! (-> arg0 fundo-val) (-> arg0 fval))
            (set! (-> arg0 fundo-val) (-> arg0 fval))
@@ -1672,19 +1676,10 @@
 ;; definition for function debug-menus-active
 (defun debug-menus-active ((arg0 debug-menu-context))
   (when (not (-> arg0 is-hidden))
-    (cond
-      ((-> arg0 joypad-func)
-       (let ((t9-0 (-> arg0 joypad-func))
-             (a0-1 (-> arg0 joypad-item))
-             )
-         (-> arg0 joypad-number)
-         (t9-0 a0-1)
-         )
-       )
-      (else
+    (if (-> arg0 joypad-func)
+        ((-> arg0 joypad-func) (-> arg0 joypad-item) (-> arg0 joypad-number))
         (debug-menus-default-joypad-func arg0)
         )
-      )
     (debug-menu-context-render arg0)
     )
   arg0
@@ -1700,3 +1695,7 @@
 
 ;; failed to figure out what this is:
 0
+
+
+
+


### PR DESCRIPTION
Where applicable, of course.

My system language is set to English so I actually can't test this. If anyone has their Windows language (NOT LOCALE) set to Spanish, German, French, Italian or Japanese please test this.

Fixes #1734 

Also fixes the opengoal debugger on Windows and fixes the decomp for `menu` which was causing some crashes related to input handling.