### PR TITLE
jak2: fix `jellyfish` crash and temporarily disable underwater warp

### DIFF
--- a/goal_src/jak2/levels/underport/underb-master.gc
+++ b/goal_src/jak2/levels/underport/underb-master.gc
@@ -188,7 +188,8 @@
         (not (-> *setting-control* user-current pilot-exit))
         )
        (('bubbler)
-        (and (handle->process (-> self warp-handle))
+        ;; TODO warp effect
+        (and ;; (handle->process (-> self warp-handle))
              (or (and (-> self next-state) (= (-> self next-state name) 'idle)) (not (under-warp-check self)))
              )
         )
@@ -229,18 +230,19 @@
           ((-> arg3 param 1)
            (set-under-fog-interp! 1.0)
            (when (not (handle->process (-> self warp-handle)))
-             (let ((s2-0 (camera-matrix))
-                   (s3-0 (new 'stack-no-clear 'vector))
-                   (gp-0 (new 'stack-no-clear 'vector))
-                   (s5-0 (new 'stack-no-clear 'quaternion))
-                   )
-               (set! (-> gp-0 quad) (-> (camera-pos) quad))
-               (vector-normalize-copy! s3-0 (-> s2-0 vector 2) 1.0)
-               (matrix->quaternion s5-0 s2-0)
-               (set! (-> self warp-handle)
-                     (ppointer->handle (process-spawn under-warp gp-0 s5-0 (-> self level) :to *display-pool*))
-                     )
-               )
+             ;; TODO warp effect
+             ;; (let ((s2-0 (camera-matrix))
+             ;;       (s3-0 (new 'stack-no-clear 'vector))
+             ;;       (gp-0 (new 'stack-no-clear 'vector))
+             ;;       (s5-0 (new 'stack-no-clear 'quaternion))
+             ;;       )
+             ;;   (set! (-> gp-0 quad) (-> (camera-pos) quad))
+             ;;   (vector-normalize-copy! s3-0 (-> s2-0 vector 2) 1.0)
+             ;;   (matrix->quaternion s5-0 s2-0)
+             ;;   (set! (-> self warp-handle)
+             ;;         (ppointer->handle (process-spawn under-warp gp-0 s5-0 (-> self level) :to *display-pool*))
+             ;;         )
+             ;;   )
              (set! v0-0 (sound-play "mech-under-amb"))
              (set! (-> self ambient-sound-id) (the-as sound-id v0-0))
              v0-0
@@ -608,22 +610,21 @@
   (none)
   )
 
-;; TODO uncomment once hover-formation is in
 (defun underb-login ((arg0 level))
-  ;; (set! *nav-network* (new 'loading-level 'nav-network))
-  ;; (nav-network-method-9 *nav-network*)
+  (set! *nav-network* (new 'loading-level 'nav-network))
+  (nav-network-method-9 *nav-network*)
   0
   (none)
   )
 
 (defun underb-deactivate ((arg0 level))
-  ;; (set! *nav-network* (the-as nav-network 0))
+  (set! *nav-network* (the-as nav-network 0))
   0
   (none)
   )
 
 (defun underb-activate ((arg0 level))
-  ;; (nav-network-method-10 *nav-network* arg0 *under-adjacency*)
+  (nav-network-method-10 *nav-network* arg0 *under-adjacency*)
   (let ((v1-3 (process-spawn underb-master arg0 :to *entity-pool*)))
     (if v1-3
         (set! (-> v1-3 0 level) arg0)


### PR DESCRIPTION
Fix crash when the game tries to spawn `jellyfish` in Underport and temporarily disable the rendering of the warp effect until it's properly implemented.