### PR TITLE
[jak2] fix crash with `*print-column*` loading the wrong memory

### DIFF
--- a/game/kernel/jak2/klisten.cpp
+++ b/game/kernel/jak2/klisten.cpp
@@ -49,7 +49,7 @@ void InitListener() {
   kernel_dispatcher = intern_from_c("kernel-dispatcher");
   sync_dispatcher = intern_from_c("sync-dispatcher");
   kernel_packages = intern_from_c("*kernel-packages*");
-  print_column = intern_from_c("*print-column*").cast<u32>();
+  print_column = intern_from_c("*print-column*").cast<u32>();  // this is wrong
   ListenerLinkBlock->value() = s7.offset;
   ListenerFunction->value() = s7.offset;
   KernelFunction->value() = s7.offset;

--- a/game/kernel/jak2/kprint.cpp
+++ b/game/kernel/jak2/kprint.cpp
@@ -93,7 +93,7 @@ s32 format_impl_jak2(uint64_t* args) {
   // read goal binteger
   if (print_column.offset) {
     // added the if check so we can format even if the kernel didn't load right.
-    indentation = (*print_column) >> 3;
+    indentation = (*(print_column - 1)) >> 3;
   }
 
   // which arg we're on

--- a/game/overlord/fake_iso.cpp
+++ b/game/overlord/fake_iso.cpp
@@ -244,7 +244,7 @@ LoadStackEntry* FS_OpenWad(FileRecord* fr, int32_t offset) {
  * This is an ISO FS API Function
  */
 void FS_Close(LoadStackEntry* fd) {
-  lg::debug("[OVERLORD] FS_Close {}", fd->fr->name);
+  lg::debug("[OVERLORD] FS_Close {} @ {}/{}", fd->fr->name, fd->fr->location, fd->location);
 
   // close the FD
   fd->fr = nullptr;

--- a/goal_src/jak1/pc/debug/entity-debug.gc
+++ b/goal_src/jak1/pc/debug/entity-debug.gc
@@ -7,6 +7,8 @@
 
 |#
 
+(declare-file (debug))
+
 (define *debug-temp-string* (new 'debug 'string 4096 (the string #f)))
 
 (defmethod set-entity! entity-debug-inspect ((obj entity-debug-inspect) (e entity))


### PR DESCRIPTION
`inspect` also prints with the correct indent now as a result.