### PR TITLE
dbgr: allow dumping the backtrace to a file

### DIFF
--- a/goalc/compiler/compilation/Debug.cpp
+++ b/goalc/compiler/compilation/Debug.cpp
@@ -340,8 +340,14 @@ Val* Compiler::compile_di(const goos::Object& form, const goos::Object& rest, En
         form,
         "Cannot get debug info, the debugger must be connected and the target must be halted.");
   }
+  auto args = get_va(form, rest);
 
-  m_debugger.update_break_info();
+  std::optional<std::string> dump_path;
+  if (args.unnamed.size() > 0 && args.unnamed.at(0).is_string()) {
+    dump_path = args.unnamed.at(0).as_string()->data;
+  }
+
+  m_debugger.update_break_info(dump_path);
   return get_none();
 }
 

--- a/goalc/debugger/Debugger.h
+++ b/goalc/debugger/Debugger.h
@@ -96,7 +96,7 @@ class Debugger {
   const char* get_symbol_name_from_offset(s32 ofs) const;
   void add_addr_breakpoint(u32 addr);
   void remove_addr_breakpoint(u32 addr);
-  void update_break_info();
+  void update_break_info(std::optional<std::string> dump_path);
 
   InstructionPointerInfo get_rip_info(u64 x86_rip);
   DebugInfo& get_debug_info_for_object(const std::string& object_name);
@@ -105,7 +105,7 @@ class Debugger {
   std::string get_info_about_addr(u32 addr);
   Disassembly disassemble_at_rip(const InstructionPointerInfo& info);
 
-  std::vector<BacktraceFrame> get_backtrace(u64 rip, u64 rsp);
+  std::vector<BacktraceFrame> get_backtrace(u64 rip, u64 rsp, std::optional<std::string> dump_path);
 
   std::string disassemble_x86_with_symbols(int len, u64 base_addr) const;
 

--- a/test/goalc/test_debugger.cpp
+++ b/test/goalc/test_debugger.cpp
@@ -182,7 +182,7 @@ TEST(Jak1Debugger, SimpleBreakpoint) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
-    compiler.get_debugger().update_break_info();
+    compiler.get_debugger().update_break_info({});
     auto expected_instr_before_rip = compiler.get_debugger().get_x86_base_addr() + func_addr;
     auto rip = compiler.get_debugger().get_regs().rip;
     // instructions can be at most 15 bytes long.


### PR DESCRIPTION
Some backtraces are quite large, an option is to increase your terminal buffer -- but dumping to a file is also useful if you want to share the crash.

I'm not crazy about the way I hacked this in, but it felt like the least invasive way for now and I don't want to cause a regression with the debugger.  It's also nice that it dumps with ansi colors as then you can view the backtrace with the original coloring:

![image](https://user-images.githubusercontent.com/13153231/221460358-991916ad-90f0-445d-ba81-7bc3dbc42eb4.png)

Usage:
```clj
(:di "./stacktrace.log")
```