### PR TITLE
Fix Bombbot crash

### DIFF
--- a/goal_src/jak2/levels/common/enemy/bombots/bombbot.gc
+++ b/goal_src/jak2/levels/common/enemy/bombots/bombbot.gc
@@ -1308,7 +1308,9 @@
        (cond
          ((zero? (-> obj hit-points))
           (if (not (and (-> obj next-state) (= (-> obj next-state name) 'die)))
-              ((method-of-object obj kill-prefer-falling))
+              ;; Manual patch here.
+              ;;((method-of-object obj kill-prefer-falling))
+              (go (method-of-object obj die))
               )
           )
          (else


### PR DESCRIPTION

https://github.com/Zedb0T/jak-project/blob/c3cd8150cdfb897e22eb1f134b733c97bf53812e/goal_src/jak2/levels/common/enemy/bombots/bombbot.gc#L1311-L1315

It would crash on this dereference - 

https://github.com/open-goal/jak-project/blob/d6bd437ea1b6ee16bb2a4d03b479fadc5af412f9/goal_src/jak2/engine/ai/enemy.gc#L570-L575

Based on the info here it looks like it should always return `(go (method-of-object obj die))`

https://github.com/open-goal/jak-project/blob/d6bd437ea1b6ee16bb2a4d03b479fadc5af412f9/goal_src/jak2/levels/common/enemy/bombots/bombbot.gc#LL594C5-L594C24


https://cdn.discordapp.com/attachments/995787558816595968/1080179182555889754/2023-02-28_12-24-02.mp4



