### PR TITLE
[jak2] fix blerc profile bar issue

### DIFF
--- a/goal_src/jak2/engine/gfx/merc/merc-blend-shape.gc
+++ b/goal_src/jak2/engine/gfx/merc/merc-blend-shape.gc
@@ -170,7 +170,8 @@
            (setup-blerc-chains a0-13 a1-2 (-> *display* frames (-> *display* on-screen) global-buf))
            )
          (logior! (-> arg0 skel status) (joint-control-status blend-shape-valid))
-         (return (the-as object #f))
+         ;;(return (the-as object #f))
+         (goto end) ;; modified so we don't skip the profiler bar end
          )
         (else
           (let ((t2-0 (-> a3-0 blend-shape-anim)))
@@ -206,7 +207,8 @@
                 (setup-blerc-chains a0-15 a1-2 (-> *display* frames (-> *display* on-screen) global-buf))
                 )
               (logior! (-> arg0 skel status) (joint-control-status blend-shape-valid))
-              (return (the-as object #f))
+              ;; (return (the-as object #f))
+              (goto end) ;; modified so we don't skip the profiler bar end
               )
             )
           )
@@ -221,6 +223,7 @@
       (-> *display* frames (-> *display* on-screen) global-buf)
       )
     )
+  (label end)
   (when *debug-segment*
     (let ((gp-1 (-> *display* frames (-> *display* on-screen) profile-array data 0)))
       (when (and *dproc* *debug-segment*)


### PR DESCRIPTION
Fix so the profile bar doesn't do something silly when `merc-blend-shape` returns early, skipping the part where `end-time` is set.