### PR TITLE
[jak1] disable `auto-save-check`

### DIFF
--- a/goal_src/jak1/engine/game/game-save.gc
+++ b/goal_src/jak1/engine/game/game-save.gc
@@ -1533,7 +1533,7 @@
       ;; this means that the original game only cleared the first 64K of that buffer when allocating
       ;; a new save file which would leave the last parts to be filled with garbage, which may or may not cause issues.
       ;; for the port we clear the entire spool buffer instead, entirely bypassing this potential issue.
-      (set! (-> self save) (new 'loading-level 'game-save SPOOL_HEAP_SIZE))
+      (set! (-> self save) (new 'loading-level 'game-save (- SPOOL_HEAP_SIZE (psize-of game-save))))
       (save-game! *game-info* (-> self save) "save")
       (set! loading-level (the-as kheap gp-0))
       0

--- a/goal_src/jak1/engine/game/main.gc
+++ b/goal_src/jak1/engine/game/main.gc
@@ -855,15 +855,24 @@
                      (str-play-kick)
                      )
 
-      (with-profiler "level-and-save"
-         (level-update *level*) ;; also updates settings.
-         (mc-run)
-         (auto-save-check)
+      (with-profiler "level-update"
+        (level-update *level*) ;; also updates settings.
+        )
+      (with-profiler "mc-run"
+        (mc-run)
+        )
+      ;; PC port note : this function checks to see if the memory card has been removed or swapped
+      ;; and disabled auto-save if it has. the pc port can only disable auto-save manually through the menu option.
+      ;; the port doesn't use memory cards so those checks will never pass.
+      ;; it runs some C kernel functions which in the port also do some I/O which gets very slow very quickly.
+      ;; we're just not gonna run it.
+      ; (auto-save-check)
 
-         (#when PC_PORT
-           (update *pc-settings*)
-           )
-         )
+      (with-profiler "update-pc"
+        (#when PC_PORT
+          (update *pc-settings*)
+          )
+        )
 
 
       ;; suspend


### PR DESCRIPTION
Fixes unnecessary performance degradation when auto-save is enabled.