### PR TITLE
ci: stop emitting event to the launcher repo

### DIFF
--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -79,10 +79,3 @@ jobs:
         run: |
           TAG_VAL=$(echo ${{ github.REF }} | awk -F'refs/tags/' '{print $2}')
           gh release edit ${TAG_VAL} --draft=false --repo open-goal/jak-project
-
-      - name: Consume Release in the Launcher
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.BOT_PAT }}
-          repository: 'open-goal/launcher'
-          event-type: releaseLauncher


### PR DESCRIPTION
The launcher and the main repo are now loosely coupled, there is no reason to emit a consumption event when we cut a release anymore.