### PR TITLE
[jak2] fix atest flag in tfrag

### DIFF
--- a/common/custom_data/Tfrag3Data.h
+++ b/common/custom_data/Tfrag3Data.h
@@ -73,7 +73,7 @@ struct MemoryUsageTracker {
   void add(MemoryUsageCategory category, u32 size_bytes) { data[category] += size_bytes; }
 };
 
-constexpr int TFRAG3_VERSION = 29;
+constexpr int TFRAG3_VERSION = 30;
 
 // These vertices should be uploaded to the GPU at load time and don't change
 struct PreloadedVertex {

--- a/decompiler/level_extractor/BspHeader.cpp
+++ b/decompiler/level_extractor/BspHeader.cpp
@@ -1942,6 +1942,11 @@ void BspHeader::read_from_file(const decompiler::LinkedObjectFile& file,
       texture_remap_table.push_back(remap);
     }
   }
+
+  if (version > GameVersion::Jak1) {
+    auto ff = get_field_ref(ref, "texture-flags", dts);
+    memcpy_plain_data((u8*)texture_flags, ff, sizeof(u16) * kNumTextureFlags);
+  }
 }
 
 std::string BspHeader::print(const PrintSettings& settings) const {

--- a/decompiler/level_extractor/BspHeader.h
+++ b/decompiler/level_extractor/BspHeader.h
@@ -827,6 +827,9 @@ struct BspHeader {
   //      (texture-remap-table (pointer uint64) :offset-assert 52)
   //  (texture-remap-table-len int32 :offset-assert 56)
   std::vector<TextureRemap> texture_remap_table;
+
+  static constexpr int kNumTextureFlags = 10;
+  u16 texture_flags[kNumTextureFlags];  // jak 2 only
   //
   //  (texture-ids (pointer texture-id) :offset-assert 60)
   //  (texture-page-count int32 :offset-assert 64)

--- a/decompiler/level_extractor/extract_level.cpp
+++ b/decompiler/level_extractor/extract_level.cpp
@@ -178,9 +178,15 @@ std::vector<level_tools::TextureRemap> extract_bsp_from_level(const ObjectFileDB
       if (it != hacks.missing_textures_by_level.end()) {
         expected_missing_textures = it->second;
       }
+      bool atest_disable_flag = false;
+      if (db.version() == GameVersion::Jak2) {
+        if (bsp_header.texture_flags[0] & 1) {
+          atest_disable_flag = true;
+        }
+      }
       extract_tfrag(as_tfrag_tree, fmt::format("{}-{}", dgo_name, i++),
                     bsp_header.texture_remap_table, tex_db, expected_missing_textures, level_data,
-                    false, level_name);
+                    false, level_name, atest_disable_flag);
     } else if (draw_tree->my_type() == "drawable-tree-instance-tie") {
       auto as_tie_tree = dynamic_cast<level_tools::DrawableTreeInstanceTie*>(draw_tree.get());
       ASSERT(as_tie_tree);

--- a/decompiler/level_extractor/extract_tfrag.h
+++ b/decompiler/level_extractor/extract_tfrag.h
@@ -29,6 +29,7 @@ void extract_tfrag(const level_tools::DrawableTreeTfrag* tree,
                    const std::vector<std::pair<int, int>>& expected_missing_textures,
                    tfrag3::Level& out,
                    bool dump_level,
-                   const std::string& level_name);
+                   const std::string& level_name,
+                   bool disable_atest_in_normal);
 
 }  // namespace decompiler


### PR DESCRIPTION
Support the weird `tfrag-gs-test` and `texture-page-flag` stuff added in jak 2. Solves some issues with partially invisible tfrags.