### PR TITLE
[jak2] increase size of DMA buffers + potentially fix print buffer bug

### DIFF
--- a/game/kernel/jak2/kprint.cpp
+++ b/game/kernel/jak2/kprint.cpp
@@ -123,7 +123,7 @@ s32 format_impl_jak2(uint64_t* args) {
       }
 
       // read arguments
-      while ((u8)(format_ptr[1] - '0') < 10 ||  // number 0 to 10
+      while ((u8)(format_ptr[1] - '0') < 10 ||  // number 0 to 9
              format_ptr[1] == ',' ||            // comma
              format_ptr[1] == '\'' ||           // quote
              format_ptr[1] == '`' ||            // backtick
@@ -538,10 +538,12 @@ s32 format_impl_jak2(uint64_t* args) {
     // change for Jak 2: if we are disk-booting and do a (format #t, immediately flush to stdout.
     // we'd get these eventually in ClearPending, but for some reason they flush these here.
     // This is nicer because we may crash in between here and flushing the print buffer.
-    // It's actually really annoying though so we disable it when in debug mode
-    if (DiskBoot && !MasterDebug) {
-      printf("%s", PrintPendingLocal3);
-      fflush(stdout);
+    if (DiskBoot) {
+      // It's actually really annoying when debugging though so we disable it then
+      if (!MasterDebug) {
+        printf("%s", PrintPendingLocal3);
+        fflush(stdout);
+      }
       PrintPending = make_ptr(PrintPendingLocal2).cast<u8>();
     }
 

--- a/goal_src/jak2/engine/gfx/hw/display.gc
+++ b/goal_src/jak2/engine/gfx/hw/display.gc
@@ -5,6 +5,11 @@
 ;; name in dgo: display
 ;; dgos: ENGINE, GAME
 
+;(defconstant DMA_BUFFER_GLOBAL_SIZE (* 1280 1024)) ;; 1280K
+(defconstant DMA_BUFFER_GLOBAL_SIZE (* 1280 1024 PROCESS_HEAP_MULT)) ;; expand based on actor heap expansion
+;(defconstant DMA_BUFFER_DEBUG_SIZE (* 8 1024 1024)) ;; 8M
+(defconstant DMA_BUFFER_DEBUG_SIZE (* 12 1024 1024)) ;; expand to 12M because we can
+
 ;; DECOMP BEGINS
 
 (defun get-current-time ()
@@ -69,11 +74,11 @@
   (when (zero? (-> arg0 frames 0 calc-buf))
     (set! (-> arg0 frames 0 calc-buf) (new 'global 'dma-buffer 10000))
     (set! (-> arg0 frames 1 calc-buf) (new 'global 'dma-buffer 10000))
-    (set! (-> arg0 frames 0 global-buf) (new 'global 'dma-buffer #x140000))
-    (set! (-> arg0 frames 1 global-buf) (new 'global 'dma-buffer #x140000))
+    (set! (-> arg0 frames 0 global-buf) (new 'global 'dma-buffer DMA_BUFFER_GLOBAL_SIZE))
+    (set! (-> arg0 frames 1 global-buf) (new 'global 'dma-buffer DMA_BUFFER_GLOBAL_SIZE))
     (when *debug-segment*
-      (set! (-> arg0 frames 0 debug-buf) (new 'debug 'dma-buffer #x800000))
-      (set! (-> arg0 frames 1 debug-buf) (new 'debug 'dma-buffer #x800000))
+      (set! (-> arg0 frames 0 debug-buf) (new 'debug 'dma-buffer DMA_BUFFER_DEBUG_SIZE))
+      (set! (-> arg0 frames 1 debug-buf) (new 'debug 'dma-buffer DMA_BUFFER_DEBUG_SIZE))
       )
     )
   arg0


### PR DESCRIPTION
The actor heap size was increased but not the DMA buffer because I forgot.