### PR TITLE
[jak2] update sprite to check matrix == -1

### DIFF
--- a/game/graphics/opengl_renderer/sprite/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/sprite/Sprite3.cpp
@@ -503,6 +503,7 @@ void Sprite3::draw_debug_window() {
               m_debug_stats.count_2d_grp1);
   ImGui::Checkbox("Culling", &m_enable_culling);
   ImGui::Checkbox("2d", &m_2d_enable);
+  ImGui::Checkbox("Glow", &m_enable_glow);
   ImGui::SameLine();
   ImGui::Checkbox("3d", &m_3d_enable);
   ImGui::Checkbox("Distort", &m_distort_enable);
@@ -726,6 +727,16 @@ void Sprite3::do_block_common(SpriteMode mode,
       auto bsphere = m_vec_data_2d[sprite_idx].xyz_sx;
       bsphere.w() = std::max(bsphere.w(), m_vec_data_2d[sprite_idx].sy());
       if (bsphere.w() == 0 || !sphere_in_view_ref(bsphere, render_state->camera_planes)) {
+        continue;
+      }
+    }
+
+    if (render_state->version > GameVersion::Jak1) {
+      // glow code sets the matrix to -1,
+      // jak 2 adds:
+      // ibltz vi08, L4
+      // which is set from ilw.y vi08, 1(vi02)
+      if (m_vec_data_2d[sprite_idx].matrix() == -1) {
         continue;
       }
     }

--- a/game/graphics/opengl_renderer/sprite/Sprite3.h
+++ b/game/graphics/opengl_renderer/sprite/Sprite3.h
@@ -163,6 +163,7 @@ class Sprite3 : public BucketRenderer {
 
   bool m_enable_distort_instancing = true;
   bool m_enable_culling = true;
+  bool m_enable_glow = true;
 
   bool m_2d_enable = true;
   bool m_3d_enable = true;

--- a/game/graphics/opengl_renderer/sprite/Sprite3_Glow.cpp
+++ b/game/graphics/opengl_renderer/sprite/Sprite3_Glow.cpp
@@ -213,10 +213,13 @@ void Sprite3::glow_dma_and_draw(DmaFollower& dma,
     ASSERT(vecdata_xfer.size_bytes == 4 * 16);
     ASSERT(shader_xfer.size_bytes == 5 * 16);
 
-    auto* out = m_glow_renderer.alloc_sprite();
-    if (!glow_math(&consts, vecdata_xfer.data, shader_xfer.data, out)) {
-      m_glow_renderer.cancel_sprite();
+    if (m_enable_glow) {
+      auto* out = m_glow_renderer.alloc_sprite();
+      if (!glow_math(&consts, vecdata_xfer.data, shader_xfer.data, out)) {
+        m_glow_renderer.cancel_sprite();
+      }
     }
+
     control_xfer = dma.read_and_advance();
     while (control_xfer.size_bytes == 0 && control_xfer.vifcode0().kind == VifCode::Kind::NOP &&
            control_xfer.vifcode1().kind == VifCode::Kind::NOP) {


### PR DESCRIPTION
Fixes an issue where glow sprites are drawn twice, sometimes causing the weird black outlines