### PR TITLE
Dont overwrite profile data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ cmake-build-debug--o0/*
 build/*
 /decompiler_out*
 logs/*
+profile_data/*
 
 # for vscode/clangd
 .cache/*

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -9,7 +9,7 @@
 #include <memory>
 #include <mutex>
 #include <sstream>
-
+#include <fstream>
 
 #include "common/dma/dma_copy.h"
 #include "common/global_profiler/GlobalProfiler.h"
@@ -754,7 +754,7 @@ void update_global_profiler() {
       while (true) {
         std::stringstream ss;
         ss << "profile_data/prof" << file_index << ".json";
-        std::string new_file_path = (file_util::get_jak_project_dir() /  ss.str()).string();
+        std::string new_file_path = (file_util::get_jak_project_dir() / ss.str()).string();
         std::ifstream new_file(new_file_path);
         if (!new_file.good()) {
           file_path = new_file_path;

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <mutex>
 #include <sstream>
-#include <fstream>
 
 #include "common/dma/dma_copy.h"
 #include "common/global_profiler/GlobalProfiler.h"

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -8,6 +8,8 @@
 #include <condition_variable>
 #include <memory>
 #include <mutex>
+#include <sstream>
+
 
 #include "common/dma/dma_copy.h"
 #include "common/global_profiler/GlobalProfiler.h"
@@ -739,11 +741,35 @@ void update_global_profiler() {
   if (g_gfx_data->debug_gui.dump_events) {
     prof().set_enable(false);
     g_gfx_data->debug_gui.dump_events = false;
-    prof().dump_to_json((file_util::get_jak_project_dir() / "prof.json").string());
+
+    std::string dir_path = (file_util::get_jak_project_dir() / "profile_data").string();
+    fs::create_directories(dir_path);
+
+    std::string file_path = (file_util::get_jak_project_dir() / "profile_data/prof.json").string();
+    std::ifstream file(file_path);
+    if (file.good()) {
+      file.close();
+
+      int file_index = 1;
+      while (true) {
+        std::stringstream ss;
+        ss << "profile_data/prof" << file_index << ".json";
+        std::string new_file_path = (file_util::get_jak_project_dir() /  ss.str()).string();
+        std::ifstream new_file(new_file_path);
+        if (!new_file.good()) {
+          file_path = new_file_path;
+          break;
+        }
+        new_file.close();
+        file_index++;
+      }
+    } else {
+      file.close();
+    }
+    prof().dump_to_json(file_path);
   }
   prof().set_enable(g_gfx_data->debug_gui.record_events);
 }
-
 void GLDisplay::VMode::set(const GLFWvidmode* vmode) {
   width = vmode->width;
   height = vmode->height;


### PR DESCRIPTION
This way a user can take multiple data samples from one/multiple play sessions quickly. Creates a directory called profile_data that is added to gitignore to place the data in, and checks to see if a file is there and if so it creates prof1.json prof2.json prof3.json and so on...