### PR TITLE
jak2: add some temporary `gui-control` hacks to make missions completable

### DIFF
--- a/goal_src/jak2/levels/atoll/sig0-course.gc
+++ b/goal_src/jak2/levels/atoll/sig0-course.gc
@@ -2582,7 +2582,8 @@
         :on-update (lambda ((arg0 sig-atoll))
           (with-pp
             (cond
-              ((not (speech-playing? arg0 27))
+              ;; TODO remove when VAG streams work
+              (#f ;; ((not (speech-playing? arg0 27))
                (if (>= (- (-> pp clock frame-counter) (-> arg0 waypoint-time0)) (seconds 0.5))
                    (play-speech arg0 27)
                    )

--- a/goal_src/jak2/levels/castle/boss/castle-baron.gc
+++ b/goal_src/jak2/levels/castle/boss/castle-baron.gc
@@ -3313,9 +3313,10 @@ For example for an elevator pre-compute the distance between the first and last 
       (ja-eval)
       (suspend)
       )
-    (while (nonzero? (get-status *gui-control* (the-as sound-id (-> self id))))
-      (suspend)
-      )
+    ;; TODO uncomment when VAG streams work
+    ;; (while (nonzero? (get-status *gui-control* (the-as sound-id (-> self id))))
+    ;;   (suspend)
+    ;;   )
     (set! (-> self movie-handle) (ppointer->handle (process-spawn
                                                      scene-player
                                                      :init scene-player-init

--- a/goal_src/jak2/levels/dig/dig-obs.gc
+++ b/goal_src/jak2/levels/dig/dig-obs.gc
@@ -562,9 +562,10 @@
           (suspend)
           (set! v1-12 (and *target* (not (focus-test? *target* in-air)) (process-grab? *target* #f)))
           )
-        (while (!= (get-status *gui-control* s5-0) (gui-status ready))
-          (suspend)
-          )
+        ;; TODO uncomment when VAG streams work
+        ;; (while (!= (get-status *gui-control* s5-0) (gui-status ready))
+        ;;   (suspend)
+        ;;   )
         (set! (-> self state-time) (-> self clock frame-counter))
         (until (>= (- (-> self clock frame-counter) (-> self state-time)) (seconds 0.2))
           (suspend)


### PR DESCRIPTION
Add some hacks to make the Sig escort, Dig 2 and Krew boss missions completable without streamed audio for now.