### PR TITLE
cli: ensure an overridden project path is absolute

### DIFF
--- a/common/util/FileUtil.cpp
+++ b/common/util/FileUtil.cpp
@@ -144,9 +144,9 @@ bool setup_project_path(std::optional<fs::path> project_path_override) {
   }
 
   if (project_path_override) {
-    gFilePathInfo.path_to_data = *project_path_override;
+    gFilePathInfo.path_to_data = fs::absolute(project_path_override.value());
     gFilePathInfo.initialized = true;
-    lg::info("Using explicitly set project path: {}", project_path_override->string());
+    lg::info("Using explicitly set project path: {}", gFilePathInfo.path_to_data.string());
     return true;
   }
 


### PR DESCRIPTION
Fixes #1771

Probably want to do some testing with the launcher to ensure no breaking changes

before/after:
![image](https://user-images.githubusercontent.com/13153231/230793111-f3217ef7-5932-4dcd-83ee-d5f2c8d245fd.png)
