### PR TITLE
[jak2] fix disappearing guard

### DIFF
--- a/goal_src/jak2/engine/nav/nav-enemy.gc
+++ b/goal_src/jak2/engine/nav/nav-enemy.gc
@@ -560,6 +560,20 @@
     (set! (-> s5-0 y) 0.0)
     (vector-normalize! s5-0 1.0)
     (quaternion-set! (-> obj root-override2 quat) 0.0 (-> s5-0 x) 0.0 (+ 1.0 (-> s5-0 z)))
+
+    ;; modified for PC:
+    ;; this code is doing a clever way to go from heading vector to quaternion, but it doesn't handle the case where
+    ;; the heading is exactly pointing along -z. So we do this manually
+    ;; There's two possible theories for how this worked on ps2:
+    ;; - it was just wrong, but instead of giving nans, it just points the guard in the wrong direction
+    ;; - the code that generates the heading on PS2 can't generate (0, 0, -1) exactly.
+    ;;    (this was the case for punch glitch - the trig function acos couldn't reach 1.0 exactly with PS2
+    ;;     float rounding rules).
+    (when (and (= (-> s5-0 x) 0.0)
+               (= (+ 1.0 (-> s5-0 z)) 0.0) ;; actually the condition that causes problems
+               )
+      (quaternion-set! (-> obj root-override2 quat) 0.0 1.0 0.0 0.0)
+      )
     )
   (quaternion-normalize! (-> obj root-override2 quat))
   0


### PR DESCRIPTION
This bug feels very similar to punch glitch, where code worked on PS2 only because some value didn't reach exactly 1.0 or 0.0 with ps2-style floating rounding. It might be better to track down the source of the "only 1.0 on PC" value, rather than patching downstream code to handle it, but I can't easily find it in this case - there's a lot of code that touches this heading value. (it's also possible this bug happens on ps2, but the result is the guard appears to face the wrong direction, rather than disappearing).

Detailed debug notes:
Ran a process that just calls this function:
```
(defun print-guard-info ()
  (let ((proc (process-by-name "crimson-guard-level-42" *active-pool*)))
    (when proc
      (format *stdcon* "PROC: ~A~%" (-> proc state))
      (let* ((pd (the process-drawable proc))
             (css (-> pd node-list))
             (cs (-> css data 15))
             )
        (format *stdcon* "joint: ~A~%" (-> cs joint))
        (format *stdcon* "pos: ~`vector`P~%" (-> cs bone position))
        )
      )
    )
  )
```
it prints out the state, and the bone position for some bone that happens to be on the upper body. It goes to NaN when the upper half disappears, in the state `tazer-hostile`.

Modified the code in this state to call this function in a bunch of places:
```
(defun guard-nan-debug ((guard process-drawable) (info string))
  (when (string= (-> guard name) "crimson-guard-level-42")
    (format 0 "[guard-nan] ~S : ~`vector`P~%" info (-> guard node-list data 15 bone position))
    )
  )
```
which prints the bone position to stdout.

This shows that the problem happens after `post`, but before `trans`:
```
[guard-nan] post-end : #<vector 2723306.0000  269921.0312  388825.2187       1.0000 @ #x1f1350>
[guard-nan] trans-start : #<vector          NaN          NaN          NaN          NaN @ #x1f1350>
```
this is probably as part of the bone math.

To check, I added some prints to `execute-math-engine`, before and after the call to `do-joint-math`:
```
[guard-nan-math] pre-math : #<vector 2722236.5000  268609.5312  385339.9062       1.0000 @ #x1f1350>
[guard-nan-math] post-math : #<vector          NaN          NaN          NaN          NaN @ #x1f1350>
```

The first part of `do-joint-math` is calling the `generate-frame-function`, which does animation blending to compute a bunch of joint transforms. I dumped these:
```
              (let ((jaf (the-as joint-anim-frame (+ 2400 (scratchpad-object int)))))
                (format 0 "generate frame:~%")
                (format 0 "~`matrix`I~%" (-> jaf matrices 0))
                (format 0 "~`matrix`I~%" (-> jaf matrices 1))
                (dotimes (i (-> obj mgeo num-joints))
                  (format 0 "~`transformq`P~%" (-> jaf data i))
                  )
                )
```
and confirmed that they always look good.

The next part is "prebind", which allows something to modify the `joint-anim-frame`. Nothing does this on the guard.

The next part is what I've named the "root bind", which computes the transform of the root bone based on the process-drawable root's position.

```
                (when (the-as (function cspace transformq none) t9-3)
                    (when *djm-debug* (format 0 "djm: first bind func ptrs #x~X #x~X~%" cspace<-transformq! t9-3))
                    (when *djm-debug* (format 0 "djm: first bind func input: ~`transformq`P~%" (-> v1-20 param1)))

                    ((the-as (function object object object none) t9-3) v1-20 (-> v1-20 param1) (-> v1-20 param2))
                    (when *djm-debug* (format 0 "djm: first bind func result:~%~`matrix`I~%" (-> v1-20 bone transform)))

                    )
```
in this case, the first print confirms that we're using `cspace<-transformq!` as the root binding function. 

When the guard entirely disappears, it is caused by the root of the process drawable having NaNs as its `quat`:
```
djm: first bind func input: #<transformq @ #x1f04f0
		trans:2724817.7500  262144.0000  388891.1875       1.0000 
		quat:           NaN          NaN          NaN          NaN 
		scale:      1.0000       1.0000       1.0000       1.0000>
djm: first bind func result:
[001f0e70] matrix
	[         NaN] [         NaN] [         NaN] [         NaN]
	[         NaN] [         NaN] [         NaN] [         NaN]
	[         NaN] [         NaN] [         NaN] [         NaN]
	[2724817.7500] [ 262144.0000] [ 388891.1875] [      1.0000]
```

After this, it's possible to get the lower half of the guard to return, but I believe the real problem is this first `quat` being NaN. Then the nans probably spread everywhere.

So now we now to look for the `(-> guard root quat)` becoming NaN:
```
(defun guard-nan-debug ((guard process-drawable) (info string))
  (when (string= (-> guard name) "crimson-guard-level-42")
    (format 0 "[guard-nan] ~S : ~`vector`P~%" info (-> guard root quat))
    )
  )
```

and we see this happens in post somewhere
```
[guard-nan] post-start : #<vector       0.0000      -1.0000       0.0000       0.0000 @ #x1f0500>
[guard-nan] post-end : #<vector          NaN          NaN          NaN          NaN @ #x1f0500>
```

Looking at individual methods
```
[guard-nan] before-142 : #<vector       0.0000      -1.0000       0.0000       0.0000 @ #x1f0500>
            heading: #<vector       0.0000       0.0000      -1.0000       0.0000 @ #x3432670>
[guard-nan] before-143 : #<vector          NaN          NaN          NaN          NaN @ #x1f0500>
            heading: #<vector       0.0000       0.0000      -1.0000       0.0000 @ #x3432670>
```
It looks like the problem is converting this heading to a quaternion.