### PR TITLE
Making some room for custom level

### DIFF
--- a/game/assets/jak1/text/game_text_en.gs
+++ b/game/assets/jak1/text/game_text_en.gs
@@ -437,6 +437,8 @@
 (#x1524 "ALL CUTSCENES"
         "ALL CUTSCENES")
 
+;; Custom Level Text: 1600-1800
+
 ;; -----------------
 ;; test (DO NOT TRANSLATE)
 

--- a/goal_src/jak1/engine/game/task/game-task-h.gc
+++ b/goal_src/jak1/engine/game/task/game-task-h.gc
@@ -127,5 +127,10 @@
   (plunger-lurker-hit 113)
   (leaving-misty 114)
   (assistant-village3 115)
-  (max 116)
+  ;;Do not remove dummy
+  (dummy 116)
+
+  ;; Custom Missions: 150-224
+
+  (max 225)
   )

--- a/goal_src/jak1/engine/game/task/task-control.gc
+++ b/goal_src/jak1/engine/game/task/task-control.gc
@@ -4090,7 +4090,7 @@
 (defun get-task-control ((arg0 game-task))
   "Get the task control for a given game-task"
   (cond
-    ((or (>= (the-as uint 1) (the-as uint arg0)) (>= (the-as uint arg0) (the-as uint 116)))
+    ((or (>= (the-as uint 1) (the-as uint arg0)) (>= (the-as uint arg0) (the-as uint (game-task max))))
      ;; invalid game task
      (format 0 "ERROR<GMJ>: get-task-control received invalid task ~D/~S~%" arg0 (game-task->string arg0))
      *null-task-control*


### PR DESCRIPTION
OpenMaya will soon export new progress screens, load boundaries, and missions to custom levels. I figured having somewhere standardized to export these things to would be good.