### PR TITLE
d/jak2: fix `dig-sinking-plat`s in dig3

### DIFF
--- a/decompiler/config/jak2/all-types.gc
+++ b/decompiler/config/jak2/all-types.gc
@@ -36704,7 +36704,7 @@
     )
   )
 
-(define-extern *dig-sinking-platform-constants* rigid-body-object-constants)
+(define-extern *dig-sinking-platform-constants* rigid-body-platform-constants)
 (define-extern *dig-log-button-infos* (array dig-log-button-info))
 (define-extern *dig-log-heights* (inline-array vector))
 (define-extern dig-log-event-handler (function process int symbol event-message-block object :behavior dig-log))

--- a/goal_src/jak2/levels/dig/dig-obs.gc
+++ b/goal_src/jak2/levels/dig/dig-obs.gc
@@ -65,7 +65,7 @@
   (none)
   )
 
-(define *dig-sinking-platform-constants* (new 'static 'rigid-body-object-constants
+(define *dig-sinking-platform-constants* (new 'static 'rigid-body-platform-constants
                                            :info (new 'static 'rigid-body-info
                                              :mass 4.0
                                              :inv-mass 0.25
@@ -82,6 +82,19 @@
                                              :attack-force-scale 2.0
                                              )
                                            :name '*dig-sinking-platform-constants*
+                                           :drag-factor 2.0
+                                           :buoyancy-factor 1.2
+                                           :max-buoyancy-depth (meters 2)
+                                           :player-weight (meters 80)
+                                           :player-bonk-factor 0.5
+                                           :player-dive-factor 1.0
+                                           :player-force-distance (meters 30)
+                                           :player-force-clamp (meters 1000000)
+                                           :player-force-timeout #x1e
+                                           :explosion-force (meters 1000)
+                                           :control-point-count 5
+                                           :platform #t
+                                           :sound-name "mud-plat"
                                            )
         )
 

--- a/test/decompiler/reference/jak2/levels/dig/dig-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/dig/dig-obs_REF.gc
@@ -85,8 +85,8 @@
   (none)
   )
 
-;; definition for symbol *dig-sinking-platform-constants*, type rigid-body-object-constants
-(define *dig-sinking-platform-constants* (new 'static 'rigid-body-object-constants
+;; definition for symbol *dig-sinking-platform-constants*, type rigid-body-platform-constants
+(define *dig-sinking-platform-constants* (new 'static 'rigid-body-platform-constants
                                            :info (new 'static 'rigid-body-info
                                              :mass 4.0
                                              :inv-mass 0.25
@@ -103,6 +103,19 @@
                                              :attack-force-scale 2.0
                                              )
                                            :name '*dig-sinking-platform-constants*
+                                           :drag-factor 2.0
+                                           :buoyancy-factor 1.2
+                                           :max-buoyancy-depth (meters 2)
+                                           :player-weight (meters 80)
+                                           :player-bonk-factor 0.5
+                                           :player-dive-factor 1.0
+                                           :player-force-distance (meters 30)
+                                           :player-force-clamp (meters 1000000)
+                                           :player-force-timeout #x1e
+                                           :explosion-force (meters 1000)
+                                           :control-point-count 5
+                                           :platform #t
+                                           :sound-name "mud-plat"
                                            )
         )
 


### PR DESCRIPTION
Fixes #2518

They were spawning in, but immediately falling forever