### PR TITLE
d/jak2: decompile missing function in `whack`

### DIFF
--- a/decompiler/config/jak2/all-types.gc
+++ b/decompiler/config/jak2/all-types.gc
@@ -43579,7 +43579,7 @@
     )
   )
 
-(define-extern birth-func-whack-score (function int sparticle-cpuinfo sparticle-launchinfo none))
+(define-extern birth-func-whack-score (function sparticle-system sparticle-cpuinfo sprite-vec-data-3d sparticle-launcher sparticle-launch-state none))
 (define-extern *mole-data* (array (array hip-mole-event)))
 (define-extern hip-mole-init (function handle int none :behavior hip-mole))
 (define-extern whack-a-metal-init (function entity-actor none :behavior whack-a-metal))

--- a/decompiler/config/jak2/ntsc_v1/hacks.jsonc
+++ b/decompiler/config/jak2/ntsc_v1/hacks.jsonc
@@ -741,7 +741,6 @@
     "generic-warp-dest",
     "generic-warp-envmap-dest",
     "generic-no-light-proc"
-
   ],
 
   "mips2c_jump_table_functions": {},

--- a/decompiler/config/jak2/ntsc_v1/type_casts.jsonc
+++ b/decompiler/config/jak2/ntsc_v1/type_casts.jsonc
@@ -9859,7 +9859,6 @@
   ],
   "generic-vu1-init-buf": [[[24, 32], "v1", "dma-packet"]],
   "generic-vu1-init-buf-special": [[[27, 37], "v1", "dma-packet"]],
-
   "(method 11 drill-wall)": [
     [159, "v0", "(pointer actor-group)"],
     ["_stack_", 16, "res-tag"]
@@ -11269,18 +11268,15 @@
     [78, "v1", "generic-work"],
     [80, "v1", "generic-work"],
     [95, "a0", "generic-work"],
-
     [143, "v1", "generic-work"],
     [145, "v1", "generic-work"],
     [147, "v1", "generic-work"]
   ],
-
   "generic-work-init": [
     [4, "a0", "generic-work"],
     [[9, 19], "a0", "generic-work"],
     [23, "a1", "generic-work"]
   ],
-
   "generic-initialize-without-sync": [
     [8, "a0", "generic-work"],
     [21, "a0", "generic-work"]
@@ -11293,9 +11289,6 @@
     [1, "v1", "generic-work"],
     [4, "v1", "generic-work"]
   ],
-  "generic-warp-source": [
-    [2, "at", "generic-work"]
-  ]
-
-
+  "generic-warp-source": [[2, "at", "generic-work"]],
+  "birth-func-whack-score": [[[0, 29], "v1", "(array int32)"]]
 }

--- a/test/decompiler/reference/jak2/levels/hiphog/whack_REF.gc
+++ b/test/decompiler/reference/jak2/levels/hiphog/whack_REF.gc
@@ -1,12 +1,7 @@
 ;;-*-Lisp-*-
 (in-package goal)
 
-;; name: whack.gc
-;; name in dgo: whack
-;; dgos: LWHACK
-
-;; DECOMP BEGINS
-
+;; failed to figure out what this is:
 (defpartgroup group-whack-scoreboard-misses
   :id 765
   :duration (seconds 0.017)
@@ -16,6 +11,7 @@
   :parts ((sp-item 3334 :flags (is-3d launch-asap bit6 bit7) :period 80 :length 9) (sp-item 3335 :flags (bit6)))
   )
 
+;; failed to figure out what this is:
 (defpart 3335
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #xca :page #xc))
     (sp-flt spt-num 1.0)
@@ -34,6 +30,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3334
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #x1b :page #x3d3))
     (sp-flt spt-num 1.0)
@@ -78,6 +75,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3336
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #x63 :page #x3e6))
     (sp-flt spt-num 1.0)
@@ -99,6 +97,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpartgroup group-whack-scoreboard-points
   :id 766
   :duration (seconds 0.017)
@@ -114,6 +113,8 @@
     )
   )
 
+;; definition for function birth-func-whack-score
+;; WARN: Return type mismatch int vs none.
 (defun birth-func-whack-score ((arg0 sparticle-system)
                       (arg1 sparticle-cpuinfo)
                       (arg2 sprite-vec-data-3d)
@@ -158,6 +159,7 @@
   (none)
   )
 
+;; failed to figure out what this is:
 (defpart 3337
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #x49 :page #x3e6))
     (sp-func spt-birth-func 'birth-func-whack-score)
@@ -197,6 +199,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3338
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #x49 :page #x3e6))
     (sp-func spt-birth-func 'birth-func-whack-score)
@@ -236,6 +239,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3339
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #x49 :page #x3e6))
     (sp-func spt-birth-func 'birth-func-whack-score)
@@ -275,6 +279,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3340
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #x49 :page #x3e6))
     (sp-func spt-birth-func 'birth-func-whack-score)
@@ -314,6 +319,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpartgroup group-whack-miss
   :id 767
   :duration (seconds 0.067)
@@ -323,6 +329,7 @@
   :parts ((sp-item 3341 :flags (bit7) :period 150 :length 5))
   )
 
+;; failed to figure out what this is:
 (defpart 3341
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :page #xc))
     (sp-flt spt-num 8.0)
@@ -348,6 +355,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpartgroup group-whack-hit
   :id 768
   :duration (seconds 0.067)
@@ -363,6 +371,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3347
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #xbb :page #xc))
     (sp-flt spt-num 1.0)
@@ -382,6 +391,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3342
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :page #xc))
     (sp-flt spt-num 32.0)
@@ -407,6 +417,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3343
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :page #xc))
     (sp-flt spt-num 8.0)
@@ -432,6 +443,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3344
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #x47 :page #x3e6))
     (sp-func spt-birth-func 'birth-func-texture-group)
@@ -464,6 +476,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3345
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #x9b :page #xb))
     (sp-func spt-birth-func 'birth-func-texture-group)
@@ -490,6 +503,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3349
   :init-specs ((sp-rnd-flt spt-r 32.0 16.0 1.0)
     (sp-copy-from-other spt-g -1)
@@ -500,10 +514,12 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3350
   :init-specs ((sp-rnd-flt spt-r 16.0 8.0 1.0) (sp-copy-from-other spt-g -1) (sp-rnd-flt spt-b 24.0 8.0 1.0))
   )
 
+;; failed to figure out what this is:
 (defpart 3346
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #x48 :page #x3e6))
     (sp-flt spt-num 8.0)
@@ -529,6 +545,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3348
   :init-specs ((sp-rnd-flt spt-r 64.0 32.0 1.0)
     (sp-rnd-flt spt-g 96.0 32.0 1.0)
@@ -539,10 +556,12 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3351
   :init-specs ((sp-flt spt-r 32.0) (sp-rnd-flt spt-g 32.0 16.0 1.0) (sp-rnd-flt spt-b 48.0 16.0 1.0))
   )
 
+;; failed to figure out what this is:
 (defpartgroup group-whack-shock
   :id 769
   :duration (seconds 0.1)
@@ -555,6 +574,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3352
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #xbb :page #xc))
     (sp-flt spt-num 1.0)
@@ -573,6 +593,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3353
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #xbb :page #xc))
     (sp-flt spt-num 1.0)
@@ -594,6 +615,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3354
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #xc9 :page #xc))
     (sp-flt spt-num 32.0)
@@ -618,6 +640,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpartgroup group-mole-dizzy
   :id 770
   :duration (seconds 4)
@@ -666,6 +689,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3356
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #xc9 :page #xc))
     (sp-flt spt-num 32.0)
@@ -679,6 +703,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3355
   :init-specs ((sp-tex spt-texture (new 'static 'texture-id :index #xbc :page #xc))
     (sp-flt spt-num 1.0)
@@ -705,6 +730,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3357
   :init-specs ((sp-flt spt-fade-a 0.0)
     (sp-int-plain-rnd spt-next-time 225 224 1)
@@ -712,10 +738,12 @@
     )
   )
 
+;; failed to figure out what this is:
 (defpart 3358
   :init-specs ((sp-rnd-flt spt-fade-a -0.42666668 -0.42666668 1.0))
   )
 
+;; definition of type hip-mole-event
 (deftype hip-mole-event (structure)
   ((min-time uint16  :offset   0)
    (max-time uint16  :offset   2)
@@ -726,7 +754,21 @@
   :flag-assert         #x900000005
   )
 
+;; definition for method 3 of type hip-mole-event
+(defmethod inspect hip-mole-event ((obj hip-mole-event))
+  (when (not obj)
+    (set! obj obj)
+    (goto cfg-4)
+    )
+  (format #t "[~8x] ~A~%" obj 'hip-mole-event)
+  (format #t "~1Tmin-time: ~D~%" (-> obj min-time))
+  (format #t "~1Tmax-time: ~D~%" (-> obj max-time))
+  (format #t "~1Tmode: ~D~%" (-> obj mode))
+  (label cfg-4)
+  obj
+  )
 
+;; definition for symbol *mole-data*, type (array (array hip-mole-event))
 (define *mole-data* (the-as (array (array hip-mole-event))
                       (new 'static 'boxed-array :type array
                         (new 'static 'boxed-array :type hip-mole-event
@@ -1434,18 +1476,21 @@
                       )
         )
 
+;; failed to figure out what this is:
 (defskelgroup skel-hip-mole hip-mole hip-mole-lod0-jg hip-mole-up-ja
               ((hip-mole-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 1 0 1.5)
               :origin-joint-index 3
               )
 
+;; failed to figure out what this is:
 (defskelgroup skel-big-bopper big-bopper big-bopper-lod0-jg big-bopper-idle-ja
               ((big-bopper-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 2)
               :origin-joint-index 3
               )
 
+;; definition of type hip-mole
 (deftype hip-mole (process-drawable)
   ((cabinet  handle  :offset-assert 200)
    (index    int32   :offset-assert 208)
@@ -1463,7 +1508,25 @@
     )
   )
 
+;; definition for method 3 of type hip-mole
+(defmethod inspect hip-mole ((obj hip-mole))
+  (when (not obj)
+    (set! obj obj)
+    (goto cfg-4)
+    )
+  (let ((t9-0 (method-of-type process-drawable inspect)))
+    (t9-0 obj)
+    )
+  (format #t "~2Tcabinet: ~D~%" (-> obj cabinet))
+  (format #t "~2Tindex: ~D~%" (-> obj index))
+  (format #t "~2Tmode: ~D~%" (-> obj mode))
+  (format #t "~2Tsound-id: ~D~%" (-> obj sound-id))
+  (format #t "~2Tabort?: ~A~%" (-> obj abort?))
+  (label cfg-4)
+  obj
+  )
 
+;; failed to figure out what this is:
 (set! (-> *lightning-spec-id-table* 21) (new 'static 'lightning-spec
                                           :name "lightning-hip-mole-deadly"
                                           :flags (lightning-spec-flags lsf0)
@@ -1483,6 +1546,7 @@
                                           )
       )
 
+;; failed to figure out what this is:
 (defstate idle (hip-mole)
   :virtual #t
   :event (behavior ((proc process) (arg1 int) (event-type symbol) (event event-message-block))
@@ -1547,6 +1611,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defstate active (hip-mole)
   :virtual #t
   :event (behavior ((proc process) (arg1 int) (event-type symbol) (event event-message-block))
@@ -1666,6 +1731,7 @@
   :post (-> (method-of-type hip-mole idle) post)
   )
 
+;; definition for function hip-mole-init
 ;; WARN: Return type mismatch object vs none.
 (defbehavior hip-mole-init hip-mole ((arg0 handle) (arg1 int))
   (set! (-> self index) arg1)
@@ -1683,6 +1749,7 @@
   (none)
   )
 
+;; definition of type whack-a-metal
 (deftype whack-a-metal (process-drawable)
   ((cabinet          handle                     :offset-assert 200)
    (bopper           (pointer process)          :offset-assert 208)
@@ -1722,7 +1789,39 @@
     )
   )
 
+;; definition for method 3 of type whack-a-metal
+(defmethod inspect whack-a-metal ((obj whack-a-metal))
+  (when (not obj)
+    (set! obj obj)
+    (goto cfg-4)
+    )
+  (let ((t9-0 (method-of-type process-drawable inspect)))
+    (t9-0 obj)
+    )
+  (format #t "~2Tcabinet: ~D~%" (-> obj cabinet))
+  (format #t "~2Tbopper: #x~X~%" (-> obj bopper))
+  (format #t "~2Tmole[8] @ #x~X~%" (-> obj mole))
+  (format #t "~2Tscore-part[2] @ #x~X~%" (-> obj score-part))
+  (format #t "~2Twave: ~D~%" (-> obj wave))
+  (format #t "~2Tevent: ~D~%" (-> obj event))
+  (format #t "~2Tevent-time: ~D~%" (-> obj event-time))
+  (format #t "~2Tevent-length: ~D~%" (-> obj event-length))
+  (format #t "~2Thud-score: ~D~%" (-> obj hud-score))
+  (format #t "~2Thud-goal: ~D~%" (-> obj hud-goal))
+  (format #t "~2Tscore: ~f~%" (-> obj score))
+  (format #t "~2Tscore-time: ~D~%" (-> obj score-time))
+  (format #t "~2Tdizzy?: ~A~%" (-> obj dizzy?))
+  (format #t "~2Tmiss-count: ~D~%" (-> obj miss-count))
+  (format #t "~2Tair-attack-count: ~D~%" (-> obj air-attack-count))
+  (format #t "~2Tslot-buffer[4] @ #x~X~%" (-> obj slot-buffer))
+  (format #t "~2Tspeech-time: ~D~%" (-> obj speech-time))
+  (format #t "~2Tspeech-count: ~D~%" (-> obj speech-count))
+  (format #t "~2Tspeech-last[4] @ #x~X~%" (-> obj speech-last))
+  (label cfg-4)
+  obj
+  )
 
+;; definition for method 10 of type whack-a-metal
 (defmethod deactivate whack-a-metal ((obj whack-a-metal))
   (dotimes (s5-0 2)
     (if (nonzero? (-> obj score-part s5-0))
@@ -1733,6 +1832,7 @@
   (none)
   )
 
+;; definition for method 7 of type whack-a-metal
 ;; WARN: Return type mismatch process-drawable vs whack-a-metal.
 (defmethod relocate whack-a-metal ((obj whack-a-metal) (arg0 int))
   (dotimes (v1-0 2)
@@ -1746,6 +1846,7 @@
     )
   )
 
+;; definition for method 29 of type whack-a-metal
 (defmethod whack-a-metal-method-29 whack-a-metal ((obj whack-a-metal) (arg0 int) (arg1 int))
   (let ((v0-1 (mod (+ (-> obj speech-last arg0) (rand-vu-int-range 1 2)) arg1)))
     (set! (-> obj speech-last arg0) v0-1)
@@ -1753,6 +1854,7 @@
     )
   )
 
+;; definition for method 26 of type whack-a-metal
 ;; WARN: Return type mismatch int vs integer.
 (defmethod whack-a-metal-method-26 whack-a-metal ((obj whack-a-metal))
   (if (or (-> obj dizzy?) (>= (-> obj miss-count) 20))
@@ -1838,6 +1940,8 @@
     )
   )
 
+;; definition for method 27 of type whack-a-metal
+;; WARN: Return type mismatch int vs none.
 (defmethod whack-a-metal-method-27 whack-a-metal ((obj whack-a-metal))
   (with-pp
     (let ((s4-0 (-> *mole-data* (-> obj wave) (-> obj event)))
@@ -2034,6 +2138,8 @@
     )
   )
 
+;; definition for method 28 of type whack-a-metal
+;; WARN: Return type mismatch int vs none.
 (defmethod whack-a-metal-method-28 whack-a-metal ((obj whack-a-metal))
   (with-pp
     (cond
@@ -2073,6 +2179,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defstate hide (whack-a-metal)
   :virtual #t
   :code (behavior ()
@@ -2083,6 +2190,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defstate wait-for-start (whack-a-metal)
   :virtual #t
   :code (behavior ()
@@ -2101,6 +2209,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defstate active (whack-a-metal)
   :virtual #t
   :event (behavior ((proc process) (arg1 int) (event-type symbol) (event event-message-block))
@@ -2342,6 +2451,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defstate attack (whack-a-metal)
   :virtual #t
   :event (-> (method-of-type whack-a-metal active) event)
@@ -2642,6 +2752,7 @@
   :post (-> (method-of-type whack-a-metal active) post)
   )
 
+;; failed to figure out what this is:
 (defstate lose (whack-a-metal)
   :virtual #t
   :exit (-> (method-of-type whack-a-metal active) exit)
@@ -2718,6 +2829,7 @@
     )
   )
 
+;; failed to figure out what this is:
 (defstate win (whack-a-metal)
   :virtual #t
   :exit (-> (method-of-type whack-a-metal active) exit)
@@ -2790,9 +2902,9 @@
   :post (-> (method-of-type whack-a-metal lose) post)
   )
 
+;; definition for function whack-a-metal-init
 ;; WARN: Return type mismatch object vs none.
 (defbehavior whack-a-metal-init whack-a-metal ((arg0 entity-actor))
-  (stack-size-set! (-> self main-thread) 512) ;; added
   (set! (-> self entity) arg0)
   (set! (-> self level) (level-get *level* 'hiphog))
   (set! (-> self root) (new 'process 'trsqv))
@@ -2829,6 +2941,7 @@
   (none)
   )
 
+;; failed to figure out what this is:
 (set-subtask-hook!
   *game-info*
   226
@@ -2840,3 +2953,7 @@
                                        )
                                   )
   )
+
+
+
+

--- a/test/offline/config/jak2/config.jsonc
+++ b/test/offline/config/jak2/config.jsonc
@@ -56,6 +56,7 @@
     "DGO/LPROTECT.DGO",
     "DGO/LSACK.DGO",
     "DGO/LSHUTTLE.DGO",
+    "DGO/LWHACK.DGO",
     "DGO/MCN.DGO",
     "DGO/MTN.DGO",
     "DGO/NEB.DGO",


### PR DESCRIPTION
Fixes #2520 

Just was missing the particle birth func for the score counter, took essentially a guess at the arbitrary data on it -- it works!