### PR TITLE
Do not swap between clocks for airlocks speed

### DIFF
--- a/goal_src/jak2/engine/draw/drawable.gc
+++ b/goal_src/jak2/engine/draw/drawable.gc
@@ -1751,11 +1751,6 @@
   (tick! (-> arg0 bg-clock))
   (set! (-> arg0 bg-clock frame-counter) (the-as time-frame (mod (-> arg0 bg-clock frame-counter) #x69780)))
   (tick! (-> arg0 part-clock))
-  (with-pc
-    (if (-> *pc-settings* fast-airlock?)
-        (update-rates! *airlock-clock* (* *airlock-speed* (-> arg0 entity-clock clock-ratio)))
-        (update-rates! *airlock-clock* (-> arg0 entity-clock clock-ratio)))
-    (tick! *airlock-clock*))
 
   ; (when (and (nonzero? *screen-shot-work*) (!= (-> *screen-shot-work* count) -1))
   ;   (let ((v1-43 (-> *screen-shot-work* size)))

--- a/goal_src/jak2/engine/gfx/hw/display.gc
+++ b/goal_src/jak2/engine/gfx/hw/display.gc
@@ -41,11 +41,6 @@
   (-> obj dog-ratio)
   )
 
-(#when PC_PORT
-(define *airlock-clock* (new 'global 'clock 13))
-(define *airlock-speed* 1.5)
-)
-
 (defun set-display ((arg0 display))
   "Allocate and initialize clocks for the display."
   (dotimes (s5-0 13)

--- a/goal_src/jak2/levels/common/airlock.gc
+++ b/goal_src/jak2/levels/common/airlock.gc
@@ -412,7 +412,6 @@
       )
     )
   :enter (behavior ((arg0 symbol))
-    (#when PC_PORT (set! (-> self clock) (-> self parent 0 clock)))
     (set! (-> self visible-move?) #f)
     (none)
     )
@@ -617,7 +616,6 @@
   :virtual #t
   :event (-> (method-of-type com-airlock close) event)
   :enter (behavior ((arg0 symbol))
-    (#when PC_PORT (set! (-> self clock) *airlock-clock*))
     (set! (-> self visible-move?) #f)
     (none)
     )
@@ -660,7 +658,8 @@
             )
         (rotate-gear! self 65536.0)
         (suspend)
-        (ja :num! (seek! (ja-aframe (-> self lock-frame) 0) (-> self pre-open-speed)))
+        ;; pc port note: added speed modifier
+        (ja :num! (seek! (ja-aframe (-> self lock-frame) 0) (* (get-airlock-speed *pc-settings*) (-> self pre-open-speed))))
         (transform-post)
         )
       (when (nonzero? (-> self sound-id))
@@ -690,7 +689,8 @@
             )
         (rotate-gear! self 65536.0)
         (suspend)
-        (ja :num! (seek! (ja-aframe (-> self open-frame) 0) 2.0))
+        ;; pc port note: added speed modifier
+        (ja :num! (seek! (ja-aframe (-> self open-frame) 0) (* (get-airlock-speed *pc-settings*) 2.0)))
         (transform-post)
         )
       (when (nonzero? (-> self sound-id))
@@ -739,7 +739,8 @@
       (while (not (ja-max? 0))
         (rotate-gear! self 65536.0)
         (suspend)
-        (ja :num! (seek!))
+        ;; pc port note: added speed modifier
+        (ja :num! (seek! max (get-airlock-speed *pc-settings*)))
         (transform-post)
         )
       (when (nonzero? (-> self sound-id))

--- a/goal_src/jak2/pc/pckernel-impl.gc
+++ b/goal_src/jak2/pc/pckernel-impl.gc
@@ -31,6 +31,7 @@
   
   (:methods
     (eligible-for-fast-elevator? (_type_ process) symbol)
+    (get-airlock-speed (_type_) float)
     )
   )
 

--- a/goal_src/jak2/pc/pckernel.gc
+++ b/goal_src/jak2/pc/pckernel.gc
@@ -92,6 +92,14 @@
                                         (string= (-> proc name )"drill-lift-2"))))
   )
 
+(define *airlock-speed* 1.5)
+(defmethod get-airlock-speed pc-settings-jak2 ((obj pc-settings-jak2))
+  "return the current speed modifier for airlocks"
+  (if (-> obj fast-airlock?)
+      *airlock-speed*
+      1.0)
+  )
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; file I/O


### PR DESCRIPTION
Fixes crash at the end of various missions.

Fixes #2456