### PR TITLE
Fix bad `lsack` level borrow

### DIFF
--- a/goal_src/jak2/engine/game/task/game-task.gc
+++ b/goal_src/jak2/engine/game/task/game-task.gc
@@ -3514,7 +3514,7 @@
               )
             :on-open #f
             :info #f
-            :borrow '((hiphog 0 ltess special) (ctywide 0 lsack display))
+            :borrow '((hiphog 0 ltess special)) ;; (ctywide 0 lsack display) PC PORT NOTE : removed bad borrow!!
             :open? #f
             :on-close #f
             :description (text-id text-x202)


### PR DESCRIPTION
Fixes crash when completing city side missions with `city-krew-collection-introduction` open.

Fixes #2539 