### PR TITLE
less branches for division + fix divide by zeros

### DIFF
--- a/common/goos/Object.cpp
+++ b/common/goos/Object.cpp
@@ -41,6 +41,7 @@
 #include "Object.h"
 
 #include <cinttypes>
+#include <cstring>
 
 #include "common/util/FileUtil.h"
 #include "common/util/print_float.h"
@@ -205,6 +206,19 @@ Object build_list(std::vector<Object>&& objects) {
   result.type = ObjectType::PAIR;
   result.heap_obj = head;
   return result;
+}
+
+/*!
+ * Is this a float object that's a power of two?
+ * NOTE: assumes 64-bit float.
+ */
+bool Object::is_power_of_2_float() const {
+  FloatType val = as_float();
+  u64 val_i = -1;
+  memcpy(&val_i, &val, sizeof(val));
+  u64 mantissa = val_i & ((1LL << 52) - 1);
+  u64 exponent = (val_i >> 52) & ((1LL << 11) - 1);
+  return mantissa == 0 && exponent != 0 && exponent != ((1LL << 11) - 1);
 }
 
 /*!

--- a/common/goos/Object.h
+++ b/common/goos/Object.h
@@ -309,6 +309,15 @@ class Object {
   bool is_macro() const { return type == ObjectType::MACRO; }
   bool is_string_hash_table() const { return type == ObjectType::STRING_HASH_TABLE; }
 
+  bool is_power_of_2_float() const {
+    FloatType val = as_float();
+    u64 val_i = -1;
+    memcpy(&val_i, &val, sizeof(val));
+    u64 mantissa = val_i & ((1LL << 52) - 1);
+    u64 exponent = (val_i >> 52) & ((1LL << 11) - 1);
+    return mantissa == 0 && exponent != 0 && exponent != ((1LL << 11) - 1);
+  }
+
   bool operator==(const Object& other) const;
   bool operator!=(const Object& other) const { return !((*this) == other); }
 };

--- a/common/goos/Object.h
+++ b/common/goos/Object.h
@@ -309,14 +309,7 @@ class Object {
   bool is_macro() const { return type == ObjectType::MACRO; }
   bool is_string_hash_table() const { return type == ObjectType::STRING_HASH_TABLE; }
 
-  bool is_power_of_2_float() const {
-    FloatType val = as_float();
-    u64 val_i = -1;
-    memcpy(&val_i, &val, sizeof(val));
-    u64 mantissa = val_i & ((1LL << 52) - 1);
-    u64 exponent = (val_i >> 52) & ((1LL << 11) - 1);
-    return mantissa == 0 && exponent != 0 && exponent != ((1LL << 11) - 1);
-  }
+  bool is_power_of_2_float() const;
 
   bool operator==(const Object& other) const;
   bool operator!=(const Object& other) const { return !((*this) == other); }

--- a/goalc/compiler/Compiler.h
+++ b/goalc/compiler/Compiler.h
@@ -339,7 +339,8 @@ class Compiler {
                                        const TypeSpec& result_type,
                                        RegVal* a,
                                        RegVal* b,
-                                       Env* env);
+                                       Env* env,
+                                       bool imm_divisor);
 
   Val* compile_format_string(const goos::Object& form,
                              Env* env,


### PR DESCRIPTION
Slight change to float divide operations (again). Now it only turns into inverse multiplication if the float is a power of 2 (positive or negative). Non-zero immediate divisors will be compiled as regular float divisions but will forgo the extra branches and checks for divide by zero.

Also fixes #2584 