### PR TITLE
[jak2] Fix temp stacks being created outside process stack

### DIFF
--- a/goal_src/jak1/kernel/gkernel.gc
+++ b/goal_src/jak1/kernel/gkernel.gc
@@ -242,10 +242,7 @@
                  ;; we're allocating a temporary thread, the main thread already exists.
                  ;; we can stash the cpu-thread structure at the bottom of the stack.
                  ;; we use the smaller PROCESS_STACK_SIZE, in case we're running on the scratchpad.
-                 (the cpu-thread (&+ stack-top
-                                     (- PROCESS_STACK_SIZE)
-                                     *gtype-basic-offset*
-                                     ))
+                 (the cpu-thread (&+ stack-top (- PROCESS_STACK_SIZE) *gtype-basic-offset*))
                  )
                 (else
                  ;; the main thread. We need the main thread's cpu-thread to stick around, so we put it in the

--- a/goal_src/jak2/kernel/gkernel-h.gc
+++ b/goal_src/jak2/kernel/gkernel-h.gc
@@ -11,7 +11,7 @@
 (defconstant *kernel-minor-version* 0)
 
 (defconstant DPROCESS_STACK_SIZE (#if PC_PORT #x8000 #x3800))
-(defconstant PROCESS_STACK_SIZE (#if PC_PORT #x6000 #x1c00))
+(defconstant PROCESS_STACK_SIZE (#if PC_PORT #x4000 #x1c00))
 
 ;; the size of the shared heap used by dynamically sized processes
 (#if PC_BIG_MEMORY

--- a/goal_src/jak2/kernel/gkernel.gc
+++ b/goal_src/jak2/kernel/gkernel.gc
@@ -200,7 +200,7 @@
   (let ((v0-0 (cond
                 ((-> parent-process top-thread)
                  ;; this is just a temporary thread, throw the thread on the bottom of the stack
-                 (the cpu-thread (&+ stack-top (- PROCESS_STACK_SIZE *gtype-basic-offset*)))
+                 (the cpu-thread (&+ stack-top (- PROCESS_STACK_SIZE) *gtype-basic-offset*))
                  )
                 (else
                   ;; this is the main thread, allocate it from the process heap.
@@ -2434,13 +2434,10 @@
 (kmemopen global "process-buffers")
 
 ;; set up the listener process to run functions sent from the REPL.
-(let ((v0-43 (new 'global 'process "listener" 2048)))
-  (set! *listener-process* v0-43)
-  (let ((gp-0 v0-43))
-    (set! (-> gp-0 status) 'ready)
-    (set! (-> gp-0 pid) 1)
-    (set! (-> gp-0 main-thread) (new 'process 'cpu-thread gp-0 'main 256 (&-> *dram-stack* 14336)))
-    )
+(let ((obj (define *listener-process* (new 'global 'process "listener" 2048))))
+  (set! (-> obj status) 'ready)
+  (set! (-> obj pid) 1)
+  (set! (-> obj main-thread) (new 'process 'cpu-thread obj 'main 256 *kernel-dram-stack*))
   )
 
 ;; an always dead process used as a placeholder


### PR DESCRIPTION
Somehow this was only causing issues (afaik) with `draw-decoration-load-save` getting corrupted, perhaps because other processes either use the shared dram stack or the gigantic spr stack.