### PR TITLE
g/j2: remove temporary hack to allow the avalanche to play

### DIFF
--- a/goal_src/jak2/levels/temple/mountain-obs.gc
+++ b/goal_src/jak2/levels/temple/mountain-obs.gc
@@ -2277,15 +2277,14 @@ This commonly includes things such as:
         (+! gp-0 1)
         )
       )
-    ;; TODO - disabled to let the rocks fall down, not yet solved by overlord branch
-    ;; (let ((gp-1
-    ;;         (add-process *gui-control* self (gui-channel art-load-next) (gui-action queue) (-> self anim name) -1.0 0)
-    ;;         )
-    ;;       )
-    ;;   (while (!= (get-status *gui-control* gp-1) (gui-status ready))
-    ;;     (suspend)
-    ;;     )
-    ;;   )
+    (let ((gp-1
+            (add-process *gui-control* self (gui-channel art-load-next) (gui-action queue) (-> self anim name) -1.0 0)
+            )
+          )
+      (while (!= (get-status *gui-control* gp-1) (gui-status ready))
+        (suspend)
+        )
+      )
     (until #f
       (let ((v1-16
               (lookup-gui-connection


### PR DESCRIPTION
No longer needed after the latest changes in the overlord PR that recently merged.

Fixes #2509