### PR TITLE
[goalc] default to non-immediate lambdas if not requested

### DIFF
--- a/goal_src/goal-lib.gc
+++ b/goal_src/goal-lib.gc
@@ -211,14 +211,14 @@
 
 ;; Bind vars in body
 (defmacro let (bindings &rest body)
-  `((lambda :inline-only #t ,(apply first bindings) ,@body)
+  `((lambda :immediate #t ,(apply first bindings) ,@body)
     ,@(apply second bindings)))
 
 ;; Let, but recursive, allowing you to define variables in terms of others.
 (defmacro let* (bindings &rest body)
   (if (null? bindings)
     `(begin ,@body)
-    `((lambda :inline-only #t (,(caar bindings))
+    `((lambda :immediate #t (,(caar bindings))
         (let* ,(cdr bindings) ,@body))
       ,(car (cdar bindings))
       )
@@ -229,7 +229,7 @@
 (defmacro mlet* (bindings &rest body)
   (if (null? bindings)
     `(begin ,@body)
-    `((lambda :inline-only #t (,(caar bindings))
+    `((lambda :immediate #t (,(caar bindings))
         (mlet* ,(cdr bindings) ,@body))
       ,(car (cdar bindings))
       )
@@ -503,7 +503,7 @@
   `(let ((,(car bindings) ,(cadr bindings)))
       (while (not (null? ,(car bindings)))
         ,@body
-        
+
         (set! ,(car bindings) (cdr ,(car bindings)))
         )
       )

--- a/goalc/compiler/Val.h
+++ b/goalc/compiler/Val.h
@@ -131,10 +131,11 @@ class SymbolValueVal : public Val {
  */
 class LambdaVal : public Val {
  public:
-  explicit LambdaVal(TypeSpec ts) : Val(std::move(ts)) {}
+  explicit LambdaVal(TypeSpec ts, bool immediate) : Val(std::move(ts)), is_immediate(immediate) {}
   std::string print() const override { return "lambda-" + lambda.debug_name; }
   FunctionEnv* func = nullptr;
   Lambda lambda;
+  bool is_immediate = false;
   RegVal* to_reg(const goos::Object& form, Env* fe) override;
 };
 

--- a/goalc/compiler/compilation/Type.cpp
+++ b/goalc/compiler/compilation/Type.cpp
@@ -273,7 +273,7 @@ Val* Compiler::generate_inspector_for_structure_type(const goos::Object& form,
 
   // add this function to the object file
   auto fe = env->function_env();
-  auto method = fe->alloc_val<LambdaVal>(m_ts.make_typespec("function"));
+  auto method = fe->alloc_val<LambdaVal>(m_ts.make_typespec("function"), false);
   method->func = method_env.get();
   auto obj_env_inspect = method_env->file_env();
   obj_env_inspect->add_function(std::move(method_env));
@@ -344,7 +344,7 @@ Val* Compiler::generate_inspector_for_bitfield_type(const goos::Object& form,
 
   // add this function to the object file
   auto fe = env->function_env();
-  auto method = fe->alloc_val<LambdaVal>(m_ts.make_typespec("function"));
+  auto method = fe->alloc_val<LambdaVal>(m_ts.make_typespec("function"), false);
   method->func = method_env.get();
   auto obj_env_inspect = method_env->file_env();
   obj_env_inspect->add_function(std::move(method_env));
@@ -450,7 +450,7 @@ Val* Compiler::compile_defmethod(const goos::Object& form, const goos::Object& _
     throw_compiler_error(form, "Method type must be a symbol, got {}", method_name.print());
   }
 
-  auto place = fe->alloc_val<LambdaVal>(get_none()->type());
+  auto place = fe->alloc_val<LambdaVal>(get_none()->type(), false);
   auto& lambda = place->lambda;
   auto lambda_ts = m_ts.make_typespec("function");
 

--- a/test/goalc/source_templates/control-statements/lambda-1.static.gc
+++ b/test/goalc/source_templates/control-statements/lambda-1.static.gc
@@ -1,1 +1,1 @@
-((lambda :inline-only #t (x y z) y) 1 2 3)
+((lambda :immediate #t (x y z) y) 1 2 3)


### PR DESCRIPTION
This fixes a long time issue with `lambda`. The `lambda` is a bit overloaded in OpenGOAL: it's used in the implementation of `let`, and also to define local anonymous functions. 

```
(defmacro let (bindings &rest body)
  `((lambda :inline #t ,(apply first bindings) ,@body)
    ,@(apply second bindings)))
```

```
(defmacro defun (name bindings &rest body)
  (let ((docstring ""))
    (when (and (> (length body) 1) (string? (first body)))
      (set! docstring (first body))
      (set! body (cdr body)))
    `(define ,name ,docstring (lambda :name ,name ,bindings ,@body))))
```

In the first case of a `let`, a `return` from inside the `let` should return from the functioning containing the `let`, not the scope of the `lambda`. In the second case, we should return from the lambda.  The way we told the different between these cases was if the `lambda` was used "immeidately", in the head of an expression (like it would be for the `let` macro).  But, this falsely triggers when an anonymous function is used immediately: eg
```
((lambda () (return #f)))
```
should generate and call a real x86 function that returns immediately.

This should fix some death/mission failed stuff in jak 2.