### PR TITLE
game: don't exit prematurely when rebooting in debug

### DIFF
--- a/game/main.cpp
+++ b/game/main.cpp
@@ -192,6 +192,7 @@ int main(int argc, char** argv) {
     // run the runtime in a loop so we can reset the game and have it restart cleanly
     lg::info("OpenGOAL Runtime {}.{}", versions::GOAL_VERSION_MAJOR, versions::GOAL_VERSION_MINOR);
     try {
+      MasterExit = RuntimeExitStatus::RUNNING;
       auto exit_status = exec_runtime(game_options, arg_ptrs.size(), arg_ptrs.data());
       switch (exit_status) {
         case RuntimeExitStatus::EXIT:


### PR DESCRIPTION
I'm not sure what has changed here...but rebooting in debug mode now hangs.

- It seems to exit the GFX loop prematurely because `MasterExit` is still set to `RESTART_IN_DEBUG` https://github.com/open-goal/jak-project/blob/master/game/runtime.cpp#L431
- And then it gets stuck waiting for the DECI thread to close

This works, but im not sure if it's the right fix / what has changed to require this.