### PR TITLE
decomp: `ctywide-speech`

### DIFF
--- a/goal_src/jak2/levels/city/common/ctywide-speech.gc
+++ b/goal_src/jak2/levels/city/common/ctywide-speech.gc
@@ -5,9 +5,536 @@
 ;; name in dgo: ctywide-speech
 ;; dgos: CWI
 
-;; hack
-(defun restore-city-speeches ()
-  (none)
-  )
 ;; DECOMP BEGINS
 
+(defun restore-city-speeches ()
+  (speech-control-method-10
+    *speech-control*
+    1
+    (new 'static 'speech-type-info
+      :priority -10
+      :min-delay #x960
+      :max-delay #x1770
+      :list (new 'static 'boxed-array :type string
+        "kg007a"
+        "kg010"
+        "kg015"
+        "kg030"
+        "kg031"
+        "kg032"
+        "kg033"
+        "kg007"
+        "kg035a"
+        "kg033a"
+        "kg121a"
+        "kg034"
+        "kg030a"
+        "kg031a"
+        "kg034a"
+        "kg128a"
+        "kg035"
+        "kg032a"
+        "kg038"
+        "kg129a"
+        "kg041a"
+        "kg042a"
+        "kg043a"
+        "kg121"
+        "kg125"
+        "kg124"
+        "kg128"
+        "kg125a"
+        "kg129"
+        "kg131"
+        "kg124a"
+        "kg131a"
+        )
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    2
+    (new 'static 'speech-type-info
+      :priority 3
+      :request-timeout #x12c
+      :min-delay #x960
+      :max-delay #x1770
+      :list (new 'static 'boxed-array :type string "kg044a" "kg045a" "kg046a" "kg047a" "kg048a" "kg049a" "kg050a")
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    3
+    (new 'static 'speech-type-info
+      :priority 3
+      :request-timeout #x12c
+      :min-delay #x12c
+      :max-delay #x12c
+      :list (new 'static 'boxed-array :type string
+        "kg070"
+        "kg071a"
+        "kg072a"
+        "kg077"
+        "kg073a"
+        "kg074a"
+        "kg070a"
+        "kg075a"
+        "kg076a"
+        "kg077a"
+        )
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    4
+    (new 'static 'speech-type-info
+      :min-delay #x384
+      :max-delay #x960
+      :list (new 'static 'boxed-array :type string
+        "kg029a"
+        "kg036"
+        "kg037"
+        "kg051a"
+        "kg052a"
+        "kg053a"
+        "kg037a"
+        "kg054a"
+        "kg055a"
+        "kg056a"
+        "kg036a"
+        "kg057a"
+        "kg058a"
+        "kg059a"
+        "kg060a"
+        "kg061a"
+        "kg029"
+        "kg062a"
+        "kg063a"
+        "kg064a"
+        "kg113a"
+        )
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    5
+    (new 'static 'speech-type-info
+      :flags (speech-type-flag random-order)
+      :priority 5
+      :request-timeout #x12c
+      :min-delay #x12c
+      :max-delay #x12c
+      :list (new 'static 'boxed-array :type string "kg065a" "kg066a" "kg069" "kg067a" "kg068a" "kg069a")
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    6
+    (new 'static 'speech-type-info
+      :flags (speech-type-flag random-order)
+      :min-delay #x258
+      :max-delay #x4b0
+      :list (new 'static 'boxed-array :type string
+        "kg001"
+        "kg002"
+        "kg004"
+        "kg006"
+        "kg001a"
+        "kg013"
+        "kg016"
+        "kg018"
+        "kg019"
+        "kg020"
+        "kg023"
+        "kg024"
+        "kg002a"
+        "kg004a"
+        "kg078a"
+        "kg079a"
+        "kg080a"
+        "kg081a"
+        "kg004a"
+        "kg082a"
+        "kg083a"
+        "kg084a"
+        "kg085a"
+        "kg086a"
+        "kg087a"
+        "kg088a"
+        "kg091a"
+        "kg023a"
+        "kg006a"
+        "kg092a"
+        "kg020a"
+        "kg093a"
+        "kg094a"
+        "kg005a"
+        "kg095a"
+        "kg103a"
+        "kg104a"
+        "kg112a"
+        "kg024a"
+        "kg134"
+        "kg136"
+        "kg137"
+        "kg138"
+        "kg139"
+        "kg140"
+        "kg141"
+        )
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    7
+    (new 'static 'speech-type-info
+      :flags (speech-type-flag random-order)
+      :min-delay #x258
+      :max-delay #x4b0
+      :list (new 'static 'boxed-array :type string
+        "kg005"
+        "kg008"
+        "kg008a"
+        "kg011"
+        "kg011a"
+        "kg021"
+        "kg022"
+        "kg025"
+        "kg025a"
+        "kg026"
+        "kg026a"
+        "kg027"
+        "kg027a"
+        "kg028"
+        "kg028a"
+        "kg039"
+        "kg039a"
+        "kg040"
+        "kg040a"
+        )
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    8
+    (new 'static 'speech-type-info
+      :min-delay #x258
+      :max-delay #x4b0
+      :list (new 'static 'boxed-array :type string
+        "kg300a"
+        "kg301a"
+        "kg302a"
+        "kg303a"
+        "kg304a"
+        "kg305a"
+        "kg306a"
+        "kg307a"
+        "kg308a"
+        "kg309a"
+        "kg310a"
+        "kg311a"
+        "kg312a"
+        "kg313a"
+        "kg314a"
+        "kg315a"
+        "kg316a"
+        "kg317a"
+        "kg318a"
+        "kg319a"
+        )
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    9
+    (new 'static 'speech-type-info
+      :priority 1
+      :min-delay #x258
+      :max-delay #x4b0
+      :list (new 'static 'boxed-array :type string "kg014" "kg153" "kg135" "kg142" "kg144" "kg145" "kg150")
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    10
+    (new 'static 'speech-type-info
+      :flags (speech-type-flag random-order)
+      :priority #xa
+      :request-timeout #x258
+      :min-delay #x258
+      :max-delay #x4b0
+      :list (new 'static 'boxed-array :type string
+        "kg009"
+        "kg132"
+        "kg132a"
+        "kg133"
+        "kg146"
+        "kg147"
+        "kg148"
+        "kg149"
+        "kg151"
+        "kg152"
+        "kg153"
+        "kg154"
+        "kg159"
+        "kg165"
+        "kg165a"
+        "kg165b"
+        "kg166"
+        "kg166a"
+        "kg166b"
+        "kg167"
+        "kg167a"
+        "kg167b"
+        "kg168"
+        "kg168a"
+        "kg168b"
+        "kg169"
+        "kg169a"
+        "kg169b"
+        "kg170"
+        "kg170a"
+        "kg170b"
+        "kg171"
+        "kg171a"
+        "kg171b"
+        "kg172"
+        "kg172a"
+        "kg172b"
+        "kg173"
+        "kg173a"
+        "kg173b"
+        "kg236a"
+        "kg236b"
+        "kg237a"
+        "kg237b"
+        "kg238a"
+        "kg239a"
+        "kg239b"
+        "kg240a"
+        )
+      )
+    )
+  ;; manually decompiled
+  (speech-control-method-10
+    *speech-control*
+    11
+    (new 'static 'speech-type-info
+      :priority 2
+      :min-delay #x1e
+      :max-delay #x1e
+      :list (new 'static 'boxed-array :type string
+        "kg386a"
+        "kg387a"
+        "kg388a"
+        "kg389a"
+        "kg390a"
+        "kg391a"
+        "kg392a"
+        "kg393a"
+        "kg394a"
+        "kg395a"
+        "kg396a"
+        "kg397a"
+        "kg398a"
+        "kg399a"
+        "kg400a"
+        "kg401a"
+        "kg402a"
+        "kg403a"
+        "kg404a"
+        "kg405a"
+        "kg406a"
+        "kg407a"
+        "kg408a"
+        "kg409a"
+        "kg410a"
+        "kg411a"
+        "kg412a"
+        "kg413a"
+        "kg414a"
+        "kg415a"
+        "kg416a"
+        "kg417a"
+        "kg418a"
+        "kg419a"
+        "kg420a"
+        "kg421a"
+        "kg422a"
+        "kg423a"
+        "kg424a"
+        "kg425a"
+        "kg426a"
+        "kg427a"
+        "kg428a"
+        "kg089a"
+        )
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    12
+    (new 'static 'speech-type-info
+      :priority 5
+      :min-delay #x12c
+      :max-delay #x12c
+      :list (new 'static 'boxed-array :type string)
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    13
+    (new 'static 'speech-type-info
+      :priority #xa
+      :min-delay #x12c
+      :max-delay #x12c
+      :list (new 'static 'boxed-array :type string "kg012" "kg012a" "kg176")
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    14
+    (new 'static 'speech-type-info
+      :priority #xa
+      :min-delay #x12c
+      :max-delay #x12c
+      :list (new 'static 'boxed-array :type string "kg387a" "kg396a" "kg399a")
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    16
+    (new 'static 'speech-type-info
+      :channel #x1
+      :flags (speech-type-flag random-order)
+      :min-delay #x384
+      :max-delay #x834
+      :list (new 'static 'boxed-array :type string
+        "cit099"
+        "cit099a"
+        "cit099b"
+        "cit100"
+        "cit100a"
+        "cit101"
+        "cit101a"
+        "cit101b"
+        )
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    19
+    (new 'static 'speech-type-info
+      :channel #x1
+      :flags (speech-type-flag random-order)
+      :priority 2
+      :min-delay #x12c
+      :max-delay #x258
+      :list (new 'static 'boxed-array :type string "cit097" "cit097a" "cit097b" "cit098" "cit098a" "cit098b")
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    20
+    (new 'static 'speech-type-info
+      :channel #x1
+      :min-delay #x5dc
+      :max-delay #x1194
+      :list (new 'static 'boxed-array :type string
+        "cit099"
+        "cit099a"
+        "cit099b"
+        "cit100"
+        "cit100a"
+        "cit100b"
+        "cit101"
+        "cit101a"
+        "cit101b"
+        )
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    22
+    (new 'static 'speech-type-info
+      :channel #x1
+      :flags (speech-type-flag random-order)
+      :priority 1
+      :min-delay #x12c
+      :max-delay #x258
+      :list (new 'static 'boxed-array :type string
+        "cit001"
+        "cit004"
+        "cit008"
+        "cit010"
+        "cit016"
+        "cit033"
+        "cit034"
+        "cit035"
+        "cit046"
+        "cit047"
+        "cit051"
+        "cit053"
+        "cit055"
+        "cit056"
+        "cit057"
+        "cit058"
+        )
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    24
+    (new 'static 'speech-type-info
+      :channel #x1
+      :flags (speech-type-flag random-order)
+      :min-delay #x384
+      :max-delay #x834
+      :list (new 'static 'boxed-array :type string
+        "cit099c"
+        "cit099d"
+        "cit100c"
+        "cit101c"
+        "cit103"
+        "cit103a"
+        "cit104"
+        "cit104a"
+        "cit105"
+        "cit120"
+        "cit120a"
+        )
+      )
+    )
+  (speech-control-method-10
+    *speech-control*
+    27
+    (new 'static 'speech-type-info
+      :channel #x1
+      :flags (speech-type-flag random-order)
+      :priority 2
+      :min-delay #x12c
+      :max-delay #x258
+      :list (new 'static 'boxed-array :type string "cit097c" "cit097d" "cit098c" "cit098d" "cit099c" "cit098d")
+      )
+    )
+  (speech-control-method-10 *speech-control* 28 (new 'static 'speech-type-info
+                                                  :channel #x1
+                                                  :min-delay #x5dc
+                                                  :max-delay #x1194
+                                                  :list (new 'static 'boxed-array :type string
+                                                    "cit099c"
+                                                    "cit099d"
+                                                    "cit100c"
+                                                    "cit101c"
+                                                    "cit103"
+                                                    "cit103a"
+                                                    "cit104"
+                                                    "cit104a"
+                                                    "cit105"
+                                                    "cit120"
+                                                    "cit120a"
+                                                    )
+                                                  )
+                            )
+  (none)
+  )


### PR DESCRIPTION
Should make guards patrol sector nine again.

Due to #1948, part of this file was decompiled manually.

Partially fixes #2582 