### PR TITLE
pack tfrag normals into 10 bits

### DIFF
--- a/common/custom_data/Tfrag3Data.h
+++ b/common/custom_data/Tfrag3Data.h
@@ -73,22 +73,23 @@ struct MemoryUsageTracker {
   void add(MemoryUsageCategory category, u32 size_bytes) { data[category] += size_bytes; }
 };
 
-constexpr int TFRAG3_VERSION = 34;
+constexpr int TFRAG3_VERSION = 35;
 
 // These vertices should be uploaded to the GPU at load time and don't change
 struct PreloadedVertex {
   // the vertex position
   float x = 0, y = 0, z = 0;
+  // envmap tint color, not used in == or hash.
+  u8 r = 0, g = 0, b = 0, a = 0;
   // texture coordinates
   float s = 0, t = 0;
 
-  u8 r = 0, g = 0, b = 0, a = 0;  // envmap tint color, not used in == or hash.
+  // not used in == or hash!!
+  // note that this is a 10-bit 3-element field packed into 32-bits.
+  u32 nor = 0;
 
   // color table index
   u16 color_index = 0;
-
-  // not used in == or hash!!
-  s16 nx = 0, ny = 0, nz = 0;
 
   struct hash {
     std::size_t operator()(const PreloadedVertex& x) const;

--- a/game/graphics/opengl_renderer/background/Tfrag3.cpp
+++ b/game/graphics/opengl_renderer/background/Tfrag3.cpp
@@ -111,7 +111,7 @@ void Tfrag3::update_load(const std::vector<tfrag3::TFragmentTreeKind>& tree_kind
         );
 
         glVertexAttribIPointer(2,                                // location 2 in the shader
-                               1,                                // 1 values per vert
+                               2,                                // 1 values per vert
                                GL_UNSIGNED_SHORT,                // u16
                                sizeof(tfrag3::PreloadedVertex),  // stride
                                (void*)offsetof(tfrag3::PreloadedVertex, color_index)  // offset (0)

--- a/game/graphics/opengl_renderer/background/Tie3.cpp
+++ b/game/graphics/opengl_renderer/background/Tie3.cpp
@@ -136,18 +136,18 @@ void Tie3::load_from_fr3_data(const LevelData* loader_data) {
       );
 
       glVertexAttribIPointer(2,                                // location 2 in the shader
-                             1,                                // 1 values per vert
+                             2,                                // 1 values per vert
                              GL_UNSIGNED_SHORT,                // u16
                              sizeof(tfrag3::PreloadedVertex),  // stride
                              (void*)offsetof(tfrag3::PreloadedVertex, color_index)  // offset (0)
       );
 
       glVertexAttribPointer(3,                                // location 1 in the shader
-                            3,                                // 3 values per vert
-                            GL_SHORT,                         // floats
+                            4,                                // 3 values per vert
+                            GL_INT_2_10_10_10_REV,            // floats
                             GL_TRUE,                          // normalized
                             sizeof(tfrag3::PreloadedVertex),  // stride
-                            (void*)offsetof(tfrag3::PreloadedVertex, nx)  // offset (0)
+                            (void*)offsetof(tfrag3::PreloadedVertex, nor)  // offset (0)
       );
 
       glVertexAttribPointer(4,                                           // location 1 in the shader

--- a/game/overlord/jak2/stream.cpp
+++ b/game/overlord/jak2/stream.cpp
@@ -251,11 +251,11 @@ void* RPC_PLAY([[maybe_unused]] unsigned int fno, void* _cmd, int size) {
             list_node.prio = iVar5;
             pRVar2 = FindThisVagStream(cmd_iter->names[s].chars, cmd_iter->id[s]);
             if ((pRVar2 == 0x0) || (pRVar2->byte4 == '\0')) {
-              printf(" didn't exist, looks like it needs to be added!\n");
+              // printf(" didn't exist, looks like it needs to be added!\n");
               WaitSema(EEPlayList.sema);
               iVar3 = (VagStrListNode*)FindVagStreamInList(&list_node, &EEPlayList);
               if (iVar3 == (VagStrListNode*)0x0) {
-                printf("node also doesn't exist, adding it!\n");
+                // printf("node also doesn't exist, adding it!\n");
                 iVar4 = (VagStrListNode*)InsertVagStreamInList(&list_node, &EEPlayList);
 
                 iVar4->id = list_node.id;

--- a/game/overlord/jak2/vag.cpp
+++ b/game/overlord/jak2/vag.cpp
@@ -377,7 +377,7 @@ void TerminateVAG(VagCmd* cmd, int param_2) {
     lfo_node.plugin_id = cmd->plugin_id;
     RemoveLfoStreamFromList(&lfo_node, &LfoList);
   }
-  printf("termina removing %s (2)\n", vag_node.name);
+  // printf("termina removing %s (2)\n", vag_node.name);
 
   RemoveVagStreamFromList(&vag_node, &EEPlayList);
   if (param_2 == 1) {


### PR DESCRIPTION
Saves 16 bits and lets us align the `color_index` field properly.

This shouldn't improve or decrease performance by any noticeable amount except maybe in really low end systems.