### PR TITLE
jak1: fix regression with npc NaNs

### DIFF
--- a/goal_src/jak1/engine/common-obs/process-taskable.gc
+++ b/goal_src/jak1/engine/common-obs/process-taskable.gc
@@ -916,7 +916,7 @@
                         )
                    )
               (< (-> (target-pos 0) y) (+ 8192.0 (-> self root-override root-prim prim-core world-sphere y)))
-              (< (vector-vector-distance (target-pos 0) (the-as vector (-> self root-override root-prim prim-core)))
+              (less-than-hack (vector-vector-distance (target-pos 0) (the-as vector (-> self root-override root-prim prim-core)))
                  32768.0
                  )
               (= (-> *level* loading-level) (-> *level* level-default))


### PR DESCRIPTION
In #2457, this use of `less-than-hack` was accidentally removed, reintroducing the "Press O to talk" NaN bug.