### PR TITLE
fix shadow colors in jak 1 and jak 2 shadow crash

### DIFF
--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -242,15 +242,15 @@ void OpenGLRenderer::init_bucket_renderers_jak2() {
                                              BucketId::TEX_ALL_MAP);
   // 320
   init_bucket_renderer<ProgressRenderer>("progress", BucketCategory::OTHER, BucketId::PROGRESS,
-                                         0x8000);
+                                         0x1000);
   init_bucket_renderer<DirectRenderer>("screen-filter", BucketCategory::OTHER,
                                        BucketId::SCREEN_FILTER, 256);
   init_bucket_renderer<DirectRenderer>("subtitle", BucketCategory::OTHER, BucketId::SUBTITLE,
-                                       0x8000);
+                                       0x1000);
   init_bucket_renderer<DirectRenderer>("debug2", BucketCategory::OTHER, BucketId::DEBUG2, 0x8000);
   init_bucket_renderer<DirectRenderer>("debug-no-zbuf2", BucketCategory::OTHER,
                                        BucketId::DEBUG_NO_ZBUF2, 0x8000);
-  init_bucket_renderer<DirectRenderer>("debug3", BucketCategory::OTHER, BucketId::DEBUG3, 0x1000);
+  init_bucket_renderer<DirectRenderer>("debug3", BucketCategory::OTHER, BucketId::DEBUG3, 0x2000);
 
   auto eye_renderer = std::make_unique<EyeRenderer>("eyes", 0);
   m_render_state.eye_renderer = eye_renderer.get();
@@ -259,7 +259,7 @@ void OpenGLRenderer::init_bucket_renderers_jak2() {
   // for now, for any unset renderers, just set them to an EmptyBucketRenderer.
   for (size_t i = 0; i < m_bucket_renderers.size(); i++) {
     if (!m_bucket_renderers[i]) {
-      init_bucket_renderer<EmptyBucketRenderer>(fmt::format("bucket{}", i), BucketCategory::OTHER,
+      init_bucket_renderer<EmptyBucketRenderer>(fmt::format("bucket-{}", i), BucketCategory::OTHER,
                                                 i);
     }
 
@@ -353,6 +353,8 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
   // 22 : SHRUB_BILLBOARD_LEVEL0
   // 23 : SHRUB_TRANS_LEVEL0
   // 24 : SHRUB_GENERIC_LEVEL0
+  init_bucket_renderer<Generic2>("l0-shrub-generic", BucketCategory::GENERIC,
+                                 BucketId::SHRUB_GENERIC_LEVEL0);
 
   //-----------------------
   // LEVEL 1 shrub texture
@@ -366,7 +368,7 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
   // 28 : SHRUB_BILLBOARD_LEVEL1
   // 29 : SHRUB_TRANS_LEVEL1
   // 30 : SHRUB_GENERIC_LEVEL1
-  init_bucket_renderer<Generic2>("mystery-generic", BucketCategory::GENERIC,
+  init_bucket_renderer<Generic2>("l1-shrub-generic", BucketCategory::GENERIC,
                                  BucketId::SHRUB_GENERIC_LEVEL1);
 
   //-----------------------
@@ -484,7 +486,7 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
   // for now, for any unset renderers, just set them to an EmptyBucketRenderer.
   for (size_t i = 0; i < m_bucket_renderers.size(); i++) {
     if (!m_bucket_renderers[i]) {
-      init_bucket_renderer<EmptyBucketRenderer>(fmt::format("bucket{}", i), BucketCategory::OTHER,
+      init_bucket_renderer<EmptyBucketRenderer>(fmt::format("bucket-{}", i), BucketCategory::OTHER,
                                                 (BucketId)i);
     }
 

--- a/game/graphics/opengl_renderer/ShadowRenderer.h
+++ b/game/graphics/opengl_renderer/ShadowRenderer.h
@@ -119,6 +119,8 @@ class ShadowRenderer : public BucketRenderer {
   u32 m_next_front_index = 0;
   u32 m_next_back_index = 0;
 
+  math::Vector4f m_color;
+
   struct {
     // index is front, back
     GLuint vertex_buffer, index_buffer[2], vao;

--- a/game/graphics/opengl_renderer/foreground/Shadow2.cpp
+++ b/game/graphics/opengl_renderer/foreground/Shadow2.cpp
@@ -63,7 +63,6 @@ void Shadow2::reset_buffers() {
 }
 
 void Shadow2::render(DmaFollower& dma, SharedRenderState* render_state, ScopedProfilerNode& prof) {
-  reset_buffers();
   // jump to bucket
   dma.read_and_advance();
 
@@ -78,6 +77,8 @@ void Shadow2::render(DmaFollower& dma, SharedRenderState* render_state, ScopedPr
     // nothing
     return;
   }
+
+  reset_buffers();
 
   // shadow-vu1-constants
   ASSERT(maybe_constants.size_bytes >= sizeof(ShadowVu1Constants));
@@ -550,7 +551,6 @@ void Shadow2::draw_buffers(SharedRenderState* render_state,
 
   if (have_darken) {
     glColorMask(darken_channel[0], darken_channel[1], darken_channel[2], false);
-    glBlendEquation(GL_FUNC_REVERSE_SUBTRACT);
     glUniform4f(m_ogl.uniforms.color, (128 - m_color[0]) / 256.f, (128 - m_color[1]) / 256.f,
                 (128 - m_color[2]) / 256.f, 0);
     glBlendEquation(GL_FUNC_REVERSE_SUBTRACT);

--- a/game/graphics/opengl_renderer/foreground/Shadow2.h
+++ b/game/graphics/opengl_renderer/foreground/Shadow2.h
@@ -6,8 +6,8 @@
 
 class Shadow2 : public BucketRenderer {
  public:
-  static constexpr int kMaxVerts = 8192 * 3;
-  static constexpr int kMaxInds = 8192 * 3;
+  static constexpr int kMaxVerts = 8192 * 3 * 2;
+  static constexpr int kMaxInds = kMaxVerts;
   Shadow2(const std::string& name, int my_id);
   ~Shadow2();
   void render(DmaFollower& dma, SharedRenderState* render_state, ScopedProfilerNode& prof) override;

--- a/game/graphics/opengl_renderer/shaders/shadow.frag
+++ b/game/graphics/opengl_renderer/shaders/shadow.frag
@@ -4,5 +4,5 @@ out vec4 color;
 uniform vec4 color_uniform;
 
 void main() {
-    color = color_uniform;
+  color = color_uniform * 2;
 }


### PR DESCRIPTION
Fixes Jak 1 shadow color. Old behavior is subtractive blend with a hardcoded value, which often times look way too dark, but it looks like the actual game uses some sort of multiplicative blend and a customizable shadow color (for all shadows at once).

Before vs after:
![image](https://github.com/open-goal/jak-project/assets/7569514/a409a403-9ddf-40dd-a74f-a29bd9b98323)
![20230514234953763_gk_HxercNamqn](https://github.com/open-goal/jak-project/assets/7569514/211565ae-405f-4056-96e5-ec188d2c0a30)

![image](https://github.com/open-goal/jak-project/assets/7569514/f84244a6-153c-4f7d-84d0-dae57147e4ae)
![20230514235005037_gk_jGjwKFhnLE](https://github.com/open-goal/jak-project/assets/7569514/4262d136-3130-4791-ae70-14d4369ba8d4)


Also fixes #2646 