### PR TITLE
fix: add unicode tree-sitter include directory

### DIFF
--- a/third-party/tree-sitter/CMakeLists.txt
+++ b/third-party/tree-sitter/CMakeLists.txt
@@ -1,4 +1,4 @@
-
+include_directories(tree-sitter/lib/src/)
 add_library(tree-sitter
         tree-sitter/lib/src/lib.c
         tree-sitter-opengoal/parser.c)


### PR DESCRIPTION
This Commit is used to avoid some errors in the build process using Ubuntu that I stumbled upon : 

Discussed in Discord (https://discord.com/channels/756287461377703987/1110990884876603523)

When I tried in a proper docker container using Ubuntu image 20.04, I hit this error : 

```
/build/source/third-party/tree-sitter/tree-sitter/lib/src/././unicode/utf8.h:37:10: fatal error: unicode/umachine.h: No such file or directory
   37 | #include "unicode/umachine.h"
```

In detail : 
```
xxx@DESKTOP-324T1BE:~/jak-project$ cmake -B build && cmake --build build -j 12
-- Statically Link? OFF
-- GCC detected - Setting Defaults
-- Using c++ standard c++17
-- CMake version: 3.16.3
-- Project version: 3.2.0
-- Using Stack Protection hardening
-- CMAKE_CXX_COMPILER '/usr/bin/c++' 'GNU' '9.4.0'
-- CMAKE_CXX_FLAGS                '         -Wall         -Winit-self         -ggdb
-Wextra         -Wno-cast-align         -Wcast-qual         -Wdisabled-optimization
-Wformat         -Wextra         -Wmissing-include-dirs         -Woverloaded-virtual         -Wredundant-decls         -Wshadow         -Wsign-promo         -fdiagnostics-color=always         -mavx -O3 -w  -Wall -Wextra -Wpedantic -Wswitch-enum -Wshadow -Wno-long-long'
-- CMAKE_CXX_FLAGS_RELEASE        '-O3 -DNDEBUG'
-- Compile sqlite3 from source in subdirectory
-- SQLITECPP_RUN_CPPLINT OFF
-- SQLITECPP_RUN_CPPCHECK OFF
-- SQLITECPP_RUN_DOXYGEN OFF
-- SQLITECPP_BUILD_EXAMPLES OFF
-- SQLITECPP_BUILD_TESTS OFF
-- write_revision_h(): /home/xxx/jak-project
-- Git found, using it to get revision info
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
-- Including X11 support
-- Module support is disabled.
-- Version: 9.1.1
-- Build type: Release
-- dynamically linking zydis
-- zydis: dynamically link? ON
-- Configuring done
-- Generating done
-- Build files have been written to: /home/xxx/jak-project/build
Scanning dependencies of target tree-sitter
[  1%] Built target lzokay
[  3%] Built target sqlite3
[  3%] Building CXX object third-party/replxx/CMakeFiles/replxx.dir/src/ConvertUTF.cpp.o
[  3%] Built target stb_image
[  4%] Built target xdelta3
[  4%] Built target speex
[  6%] Built target Zycore
[  6%] Built target fmt
[  6%] Building C object third-party/tree-sitter/CMakeFiles/tree-sitter.dir/tree-sitter/lib/src/lib.c.o
[ 10%] Built target libzstd_static
[ 10%] Built target libco
[ 10%] Building CXX object third-party/replxx/CMakeFiles/replxx.dir/src/conversion.cxx.o
[ 10%] Building CXX object third-party/replxx/CMakeFiles/replxx.dir/src/escape.cxx.o
[ 10%] Building CXX object third-party/replxx/CMakeFiles/replxx.dir/src/history.cxx.o
[ 13%] Built target glfw
[ 13%] Built target gtest
[ 14%] Built target SQLiteCpp
[ 14%] Built target tiny_gltf
[ 15%] Built target cubeb
[ 15%] Building CXX object third-party/replxx/CMakeFiles/replxx.dir/src/replxx.cxx.o
[ 15%] Building CXX object third-party/replxx/CMakeFiles/replxx.dir/src/prompt.cxx.o
[ 17%] Built target Zydis
[ 17%] Building CXX object third-party/replxx/CMakeFiles/replxx.dir/src/replxx_impl.cxx.o
[ 19%] Building CXX object third-party/replxx/CMakeFiles/replxx.dir/src/terminal.cxx.o
[ 18%] Built target imgui
In file included from /home/xxx/jak-project/third-party/tree-sitter/tree-sitter/lib/src/././unicode.h:13,
                 from /home/xxx/jak-project/third-party/tree-sitter/tree-sitter/lib/src/./lexer.c:5,
                 from /home/xxx/jak-project/third-party/tree-sitter/tree-sitter/lib/src/lib.c:11:
/home/xxx/jak-project/third-party/tree-sitter/tree-sitter/lib/src/././unicode/utf8.h:37:10: fatal error: unicode/umachine.h: No such file or directory
   37 | #include "unicode/umachine.h"
      |          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [third-party/tree-sitter/CMakeFiles/tree-sitter.dir/build.make:63: third-party/tree-sitter/CMakeFiles/tree-sitter.dir/tree-sitter/lib/src/lib.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1689: third-party/tree-sitter/CMakeFiles/tree-sitter.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 19%] Building CXX object third-party/replxx/CMakeFiles/replxx.dir/src/util.cxx.o
[ 19%] Building CXX object third-party/replxx/CMakeFiles/replxx.dir/src/wcwidth.cpp.o
[ 19%] Building CXX object third-party/replxx/CMakeFiles/replxx.dir/src/windows.cxx.o
[ 19%] Built target clangformat
[ 19%] Linking CXX shared library libreplxx.so
[ 19%] Built target replxx
make: *** [Makefile:141: all] Error 2
```

This error can be resolved using by fixing include directories for the tree-sitter library, either by editing the includes, or by adding an include path.

I decided using the CMake fix since it doesn't modify the vendor sources.