### PR TITLE
[jak2] float patch for bogus collide frags

### DIFF
--- a/docs/progress-notes/jak2/shadow-vu1.txt
+++ b/docs/progress-notes/jak2/shadow-vu1.txt
@@ -405,6 +405,8 @@ L20:
   mtir vi07, vf29.z          |  nop
   b L19                      |  nop
   mtir vi02, vf29.x          |  nop
+
+  ;;;;;;;;;; WEIRD TRIANGLES
 L21:
   iaddiu vi03, vi00, 0x158   |  nop
   ilwr.x vi08, vi03          |  nop

--- a/game/mips2c/mips2c_private.h
+++ b/game/mips2c/mips2c_private.h
@@ -1344,6 +1344,15 @@ struct ExecutionContext {
     }
   }
 
+  void vftoi0_sat(DEST mask, int dst, int src) {
+    auto s = vf_src(src);
+    for (int i = 0; i < 4; i++) {
+      if ((u64)mask & (1 << i)) {
+        vfs[dst].ds32[i] = float_to_int_sat(s.f[i]);
+      }
+    }
+  }
+
   void mfc1(int dst, int src) {
     s32 val;
     memcpy(&val, &fprs[src], 4);


### PR DESCRIPTION
Should fix https://github.com/open-goal/jak-project/issues/2679

Here's a test program that will trigger the bug when near these guards:
```lisp
(define *cquery* (new 'global 'collide-query))

(defun test-bad-collide ()
  (let ((lower (new 'static 'vector  :x 1681893.8750  :y 61314.2031 :z 345208.6562 :w 1.))
        (upper (new 'static 'vector :x 1701603.8750 :y  67624.0625 :z 357881.0312 :w 1.))
        ;(cquery (new 'stack-no-clear 'collide-query))
        )
    (set! (-> *cquery* collide-with) (the-as collide-spec 1))
    (set! (-> *cquery* ignore-process0) #f)
    (set! (-> *cquery* ignore-process1) #f)
    (set! (-> *cquery* ignore-pat) (new 'static 'pat-surface :noentity #x1 :nojak #x1 :probe #x1 :noendlessfall #x1))
    (set! (-> *cquery* action-mask) (collide-action solid))
    (set! (-> *cquery* bbox min quad) (-> lower quad))
    (set! (-> *cquery* bbox max quad) (-> upper quad))
    (format 0 "doing collide...~%")
    (fill-using-bounding-box *collide-cache* *cquery*)
    (format 0 "have ~d and ~d~%" (-> *collide-cache* num-tris) (-> *collide-cache* num-prims))
    )
  (none)
  )
```

As far as I can tell, there's a totally invalid collide-hash with an inside `axis-scale.z`. On the PS2, it gets ignore because of how float->int works for floats that are too big. On PC, it ends up using a negative value and loop forever. 