### PR TITLE
ci: bump timeouts on builds, mostly for cache misses

### DIFF
--- a/.github/workflows/linux-build-clang.yaml
+++ b/.github/workflows/linux-build-clang.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: Clang
     runs-on: ubuntu-20.04
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     env: # overrides: https://github.com/mbitsnbites/buildcache/blob/master/doc/configuration.md
       BUILDCACHE_MAX_CACHE_SIZE: 1000000000 # 1gb

--- a/.github/workflows/linux-build-gcc.yaml
+++ b/.github/workflows/linux-build-gcc.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: GCC
     runs-on: ubuntu-20.04
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     env: # overrides: https://github.com/mbitsnbites/buildcache/blob/master/doc/configuration.md
       BUILDCACHE_MAX_CACHE_SIZE: 1000000000 # 1gb

--- a/.github/workflows/windows-build-clang.yaml
+++ b/.github/workflows/windows-build-clang.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Clang
     runs-on: windows-2022
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     env: # overrides: https://github.com/mbitsnbites/buildcache/blob/master/doc/configuration.md
       BUILDCACHE_MAX_CACHE_SIZE: 1000000000 # 1gb

--- a/.github/workflows/windows-build-msvc.yaml
+++ b/.github/workflows/windows-build-msvc.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: MSVC
     runs-on: windows-2022
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     env: # overrides: https://github.com/mbitsnbites/buildcache/blob/master/doc/configuration.md
       BUILDCACHE_MAX_CACHE_SIZE: 1000000000 # 1gb


### PR DESCRIPTION
we had a GCC build timeout on master, try to make this less flaky