### PR TITLE
g/settings: set a default `target-fps`

### DIFF
--- a/goal_src/jak1/pc/pckernel-h.gc
+++ b/goal_src/jak1/pc/pckernel-h.gc
@@ -413,6 +413,7 @@
   (set! (-> obj aspect-custom-x) 4)
   (set! (-> obj aspect-custom-y) 3)
   ;; graphics
+  (set! (-> obj target-fps) 60)
   (set! (-> obj aspect-ratio-auto?) #t)
   (set! (-> obj win-width) PC_BASE_WIDTH)
   (set! (-> obj win-height) PC_BASE_HEIGHT)

--- a/goal_src/jak1/pc/pckernel-h.gc
+++ b/goal_src/jak1/pc/pckernel-h.gc
@@ -410,8 +410,11 @@
   (set! (-> obj user) #f)
   (set! (-> obj debug?) #f)
   (set! (-> obj movie?) #f)
+  (set! (-> obj font-scale) 1.0)
   (set! (-> obj aspect-custom-x) 4)
   (set! (-> obj aspect-custom-y) 3)
+  (set! (-> obj discord-rpc?) #t)
+  (set! (-> obj speedrunner-mode?) #f)
   ;; graphics
   (set! (-> obj target-fps) 60)
   (set! (-> obj aspect-ratio-auto?) #t)


### PR DESCRIPTION
If this wasn't set, it used `0` because the code that still remains in the per-frame pckernel update-to-os function sets the framerate.  This can probably be refactored out eventually like a few other things that were done in the SDL PR but, this was the underlying issue.