### PR TITLE
readme: add `mesa-libGL-devel` dependency for fedora users

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Run tests:
 Install packages and init repository:
 
 ```sh
-sudo dnf install cmake python lld clang nasm libX11-devel libXrandr-devel libXinerama-devel libXcursor-devel libXi-devel pulseaudio-libs-devel
+sudo dnf install cmake python lld clang nasm libX11-devel libXrandr-devel libXinerama-devel libXcursor-devel libXi-devel pulseaudio-libs-devel mesa-libGL-devel
 sudo sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 ```
 


### PR DESCRIPTION
SDL requires this dependency on Fedora in order to be configured with OpenGL support.