### PR TITLE
ci: don't run CI builds on non `master` branch pushes

### DIFF
--- a/.github/workflows/build-matrix.yaml
+++ b/.github/workflows/build-matrix.yaml
@@ -2,8 +2,8 @@ name: Build
 
 on:
   push:
-    branches-ignore:
-      - "l10n_master"
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -3,7 +3,7 @@ name: Lint
 on:
   push:
     branches:
-      - '*'
+      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
We are limited on concurrent builds, when people push branches directly to upstream, we are running duplicate builds for every commit on a PR for no reason.

This should stop that