### PR TITLE
SDL: Hint to Windows that we handle DPI scaling

### DIFF
--- a/game/system/hid/display_manager.cpp
+++ b/game/system/hid/display_manager.cpp
@@ -7,6 +7,8 @@
 
 DisplayManager::DisplayManager(SDL_Window* window)
     : m_window(window), m_selected_fullscreen_display_id(0) {
+  // SDL hint to disable OS level forced scaling and allow native resolution at non 100% scales
+  SDL_SetHint("SDL_WINDOWS_DPI_SCALING", "true");
   update_curr_display_info();
   update_video_modes();
   // Load display settings from a file


### PR DESCRIPTION
Fixes https://github.com/open-goal/jak-project/issues/2699

Setting a Windows specific SDL hint that disables OS forced scaling. With Windows handling scaling we are locked into a progressively smaller resolution buffer the higher the Windows display scaling option is set. Not sure if this is the best place to put it.

The game itself handles scaling already but ImGUI does not which can lead to it getting quite small on high DPI devices with high scaling. OS scaling can still be forced on the gk.exe as shown bellow to revert this behaviour if a blurry but larger ImGUI is preferable:

![image](https://github.com/open-goal/jak-project/assets/11966090/5313e79c-9021-45d3-a357-75c3263f55f7)