### PR TITLE
cmake: properly statically link SDL when applicable

### DIFF
--- a/.github/scripts/releases/extract_build_linux.sh
+++ b/.github/scripts/releases/extract_build_linux.sh
@@ -27,7 +27,6 @@ fi
 mkdir -p $DEST/data
 mkdir -p $DEST/data/launcher/
 mkdir -p $DEST/data/decompiler/
-mkdir -p $DEST/data/assets
 mkdir -p $DEST/data/game
 mkdir -p $DEST/data/log
 mkdir -p $DEST/data/game/graphics/opengl_renderer/

--- a/.github/scripts/releases/extract_build_windows.sh
+++ b/.github/scripts/releases/extract_build_windows.sh
@@ -15,7 +15,6 @@ cp $BIN_SOURCE/extractor.exe $DEST
 mkdir -p $DEST/data
 mkdir -p $DEST/data/launcher/
 mkdir -p $DEST/data/decompiler/
-mkdir -p $DEST/data/assets
 mkdir -p $DEST/data/game
 mkdir -p $DEST/data/log
 mkdir -p $DEST/data/game/graphics/opengl_renderer/

--- a/third-party/cmake/modules/SDLOptions.cmake
+++ b/third-party/cmake/modules/SDLOptions.cmake
@@ -1,5 +1,12 @@
-set(SDL_STATIC OFF CACHE BOOL "" FORCE)
-set(SDL_SHARED ON CACHE BOOL "" FORCE)
+if(STATICALLY_LINK)
+    message(STATUS "Statically Linking SDL")
+    set(SDL_STATIC ON CACHE BOOL "" FORCE)
+    set(SDL_SHARED OFF CACHE BOOL "" FORCE)
+else()
+    message(STATUS "Dynamically Linking SDL")
+    set(SDL_STATIC OFF CACHE BOOL "" FORCE)
+    set(SDL_SHARED ON CACHE BOOL "" FORCE)
+endif()
 
 # why this is disabled, i have no idea but this MUST be on for a windows+clang(llvm) shared compile to work
 set(SDL_LIBC ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
Also removed the empty `assets` folder that is in every release.