### PR TITLE
repl: update replxx and some configuration for bracketed paste

### DIFF
--- a/common/repl/util.cpp
+++ b/common/repl/util.cpp
@@ -150,6 +150,9 @@ void Wrapper::init_settings() {
   // NOTE - a nice popular project that uses replxx
   // - https://github.com/ClickHouse/ClickHouse/blob/master/base/base/ReplxxLineReader.cpp#L366
   repl.set_word_break_characters(" \t");
+  repl.set_complete_on_empty(false);
+  repl.set_indent_multiline(false);
+  repl.enable_bracketed_paste();
   // Setup default keybinds
   for (const auto& bind : repl_config.keybinds) {
     char32_t code;
@@ -167,8 +170,6 @@ void Wrapper::init_settings() {
     repl.bind_key(code, commit_text_action(bind.command));
   }
 }
-
-// TODO - command to print out keybinds
 
 void Wrapper::reload_startup_file() {
   startup_file = load_user_startup_file(username, repl_config.game_version);

--- a/third-party/replxx/.github/workflows/ci.yml
+++ b/third-party/replxx/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Install required software
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install g++ cmake python3-pexpect
+
+      # Runs a single command using the runners shell
+      - name: Build the code
+        run: ./build-all.sh
+
+      - name: Run regression tests
+        run: env SKIP=8bit_encoding ./tests.py
+

--- a/third-party/replxx/.gitignore
+++ b/third-party/replxx/.gitignore
@@ -8,7 +8,8 @@ example
 linenoise_example
 libreplxx.a
 *.dSYM
-history.txt
+replxx_history.txt
+replxx_history_alt.txt
 *.o
 *~
 .vs

--- a/third-party/replxx/CMakeLists.txt
+++ b/third-party/replxx/CMakeLists.txt
@@ -50,7 +50,7 @@ set(REPLXX_CONTACT "amok@codestation.org")
 set(is-clang $<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>)
 set(is-msvc $<CXX_COMPILER_ID:MSVC>)
 set(is-gnu $<CXX_COMPILER_ID:GNU>)
-set(compiler-id-clang-or-gnu $<AND:$<OR:${is-clang},${is-gnu}>,$<NOT:${is-msvc}>>)
+set(compiler-id-clang-or-gnu $<OR:${is-clang},${is-gnu}>)
 
 set(coverage-config $<AND:$<CONFIG:Coverage>,$<OR:${is-gnu},${is-clang}>>)
 
@@ -97,6 +97,7 @@ if (NOT CMAKE_VERSION VERSION_LESS 3.13)
 	target_link_options(
 		replxx
 		PRIVATE
+			$<$<AND:$<CONFIG:Debug>,$<CXX_COMPILER_ID:GNU>>:-g -ggdb -g3 -ggdb3>
 			$<${coverage-config}:--coverage>
 			$<${is-msvc}:/ignore:4099>
 	)
@@ -182,6 +183,8 @@ if (REPLXX_BUILD_EXAMPLES)
 	)
 	target_compile_definitions(replxx-example-cxx-api PRIVATE REPLXX_STATIC $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS=1>)
 	target_compile_definitions(replxx-example-c-api PRIVATE REPLXX_STATIC $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS=1>)
+	target_link_options(replxx-example-cxx-api PRIVATE $<$<AND:$<CONFIG:Debug>,$<CXX_COMPILER_ID:GNU>>:-g -ggdb -g3 -ggdb3>)
+	target_link_options(replxx-example-c-api PRIVATE $<$<AND:$<CONFIG:Debug>,$<CXX_COMPILER_ID:GNU>>:-g -ggdb -g3 -ggdb3>)
 	target_link_libraries(replxx-example-cxx-api PRIVATE replxx::replxx)
 	target_link_libraries(
 		replxx-example-c-api

--- a/third-party/replxx/README.md
+++ b/third-party/replxx/README.md
@@ -1,8 +1,8 @@
 # Read Evaluate Print Loop ++
 
-![demo](https://drive.google.com/uc?export=download&id=0B53g2Y3z7rWNT2dCRGVVNldaRnc)
+![demo](https://codestation.org/download/replxx.gif)
 
-[![Build Status](https://travis-ci.org/AmokHuginnsson/replxx.svg?branch=master)](https://travis-ci.org/AmokHuginnsson/replxx)
+![Build Status](https://github.com/AmokHuginnsson/replxx/actions/workflows/ci.yml/badge.svg)
 
 A small, portable GNU readline replacement for Linux, Windows and
 MacOS which is capable of handling UTF-8 characters. Unlike GNU
@@ -29,13 +29,6 @@ programs.
 * Only uses a subset of VT100 escapes (ANSI.SYS compatible)
 * UTF8 aware
 * support for Linux, MacOS and Windows
-
-It deviates from Salvatore's original goal to have a minimal readline
-replacement for the sake of supporting UTF8 and Windows. It deviates
-from 10gen Inc.'s goal to create a C++ interface to linenoise. This
-library uses C++ internally, but to the user it provides a pure C
-interface that is compatible with the original linenoise API.
-C interface.
 
 ## Requirements
 
@@ -109,11 +102,4 @@ cmake -G "Visual Studio 12 2013 Win64" -DCMAKE_BUILD_TYPE=Release ..
  * Windows
 
 Please test it everywhere you can and report back!
-
-## Let's push this forward!
-
-Patches should be provided in the respect of linenoise sensibility for
-small and easy to understand code that and the license
-restrictions. Extensions must be submitted under a BSD license-style.
-A contributor license is required for contributions.
 

--- a/third-party/replxx/examples/c-api.c
+++ b/third-party/replxx/examples/c-api.c
@@ -143,6 +143,7 @@ int main( int argc, char** argv ) {
 	int installCompletionCallback = 1;
 	int installHighlighterCallback = 1;
 	int installHintsCallback = 1;
+	int indentMultiline = 0;
 	while ( argc > 1 ) {
 		-- argc;
 		++ argv;
@@ -160,11 +161,13 @@ int main( int argc, char** argv ) {
 			case 'h': replxx_set_max_hint_rows( replxx, atoi( (*argv) + 1 ) );             break;
 			case 'H': replxx_set_hint_delay( replxx, atoi( (*argv) + 1 ) );                break;
 			case 's': replxx_set_max_history_size( replxx, atoi( (*argv) + 1 ) );          break;
-			case 'i': replxx_set_preload_buffer( replxx, recode( (*argv) + 1 ) );          break;
+			case 'P': replxx_set_preload_buffer( replxx, recode( (*argv) + 1 ) );          break;
 			case 'I': replxx_set_immediate_completion( replxx, (*argv)[1] - '0' );         break;
 			case 'u': replxx_set_unique_history( replxx, (*argv)[1] - '0' );               break;
 			case 'w': replxx_set_word_break_characters( replxx, (*argv) + 1 );             break;
 			case 'm': replxx_set_no_color( replxx, (*argv)[1] - '0' );                     break;
+			case 'i': replxx_set_ignore_case( replxx, (*argv)[1] - '0' );                  break;
+			case 'n': indentMultiline = (*argv)[1] - '0';                                  break;
 			case 'B': replxx_enable_bracketed_paste( replxx );                             break;
 			case 'p': prompt = recode( (*argv) + 1 );                                      break;
 			case 'q': quiet = atoi( (*argv) + 1 );                                         break;
@@ -177,6 +180,7 @@ int main( int argc, char** argv ) {
 
 	}
 
+	replxx_set_indent_multiline( replxx, indentMultiline );
 	const char* file = "./replxx_history.txt";
 
 	replxx_history_load( replxx, file );

--- a/third-party/replxx/src/conversion.cxx
+++ b/third-party/replxx/src/conversion.cxx
@@ -20,11 +20,6 @@ void to_lower( std::string& s_ ) {
 	transform( s_.begin(), s_.end(), s_.begin(), static_cast<int(*)(int)>( &tolower ) );
 }
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
-#endif
-
 bool is_8bit_encoding( void ) {
 	bool is8BitEncoding( false );
 	string origLC( setlocale( LC_CTYPE, nullptr ) );
@@ -41,10 +36,6 @@ bool is_8bit_encoding( void ) {
 	}
 	return ( is8BitEncoding );
 }
-
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
 
 bool is8BitEncoding( is_8bit_encoding() );
 

--- a/third-party/replxx/src/history.cxx
+++ b/third-party/replxx/src/history.cxx
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include <memory>
 #include <fstream>
+#include <ostream>
+#include <istream>
 #include <cstring>
 
 #ifndef _WIN32
@@ -22,6 +24,7 @@ namespace {
 void delete_ReplxxHistoryScanImpl( Replxx::HistoryScanImpl* impl_ ) {
 	delete impl_;
 }
+static int const ETB = 0x17;
 }
 
 static int const REPLXX_DEFAULT_HISTORY_MAX_LEN( 1000 );
@@ -130,7 +133,12 @@ bool History::save( std::string const& filename, bool sync_ ) {
 		_entries = entries;
 		reset_iters();
 	}
-	do_load( filename );
+	/* scope for ifstream object auto-close */ {
+		ifstream histFile( filename );
+		if ( histFile ) {
+			do_load( histFile );
+		}
+	}
 	sort();
 	remove_duplicates();
 	trim_to_max_size();
@@ -142,19 +150,27 @@ bool History::save( std::string const& filename, bool sync_ ) {
 	umask( old_umask );
 	chmod( filename.c_str(), S_IRUSR | S_IWUSR );
 #endif
-	Utf8String utf8;
-	for ( Entry const& h : _entries ) {
-		if ( ! h.text().is_empty() ) {
-			utf8.assign( h.text() );
-			histFile << "### " << h.timestamp() << "\n" << utf8.get() << endl;
-		}
-	}
+	save( histFile );
 	if ( ! sync_ ) {
 		_entries = std::move( entries );
 		_locations = std::move( locations );
 	}
 	reset_iters();
 	return ( true );
+}
+
+void History::save( std::ostream& histFile ) {
+	Utf8String utf8;
+	UnicodeString us;
+	for ( Entry& h : _entries ) {
+		h.reset_scratch();
+		if ( ! h.text().is_empty() ) {
+			us.assign( h.text() );
+			std::replace( us.begin(), us.end(), char32_t( '\n' ), char32_t( ETB ) );
+			utf8.assign( us );
+			histFile << "### " << h.timestamp() << "\n" << utf8.get() << endl;
+		}
+	}
 }
 
 namespace {
@@ -179,13 +195,10 @@ bool is_timestamp( std::string const& s ) {
 
 }
 
-bool History::do_load( std::string const& filename ) {
-	ifstream histFile( filename );
-	if ( ! histFile ) {
-		return ( false );
-	}
+void History::do_load( std::istream& histFile ) {
 	string line;
 	string when( "0000-00-00 00:00:00.000" );
+	UnicodeString us;
 	while ( getline( histFile, line ).good() ) {
 		string::size_type eol( line.find_first_of( "\r\n" ) );
 		if ( eol != string::npos ) {
@@ -196,21 +209,31 @@ bool History::do_load( std::string const& filename ) {
 			continue;
 		}
 		if ( ! line.empty() ) {
-			_entries.emplace_back( when, UnicodeString( line ) );
+			us.assign( line );
+			std::replace( us.begin(), us.end(), char32_t( ETB ), char32_t( '\n' ) );
+			_entries.emplace_back( when, us );
 		}
 	}
-	return ( true );
 }
 
 bool History::load( std::string const& filename ) {
+	ifstream histFile( filename );
+	if ( ! histFile ) {
+		clear();
+		return false;
+	}
+	load(histFile);
+	return true;
+}
+
+void History::load( std::istream& histFile ) {
 	clear();
-	bool success( do_load( filename ) );
+	do_load( histFile );
 	sort();
 	remove_duplicates();
 	trim_to_max_size();
 	_previous = _current = last();
 	_yankPos = _entries.end();
-	return ( success );
 }
 
 void History::sort( void ) {
@@ -281,11 +304,12 @@ void History::restore_pos( void ) {
 	_current = _previous;
 }
 
-bool History::common_prefix_search( UnicodeString const& prefix_, int prefixSize_, bool back_ ) {
+bool History::common_prefix_search( UnicodeString const& prefix_, int prefixSize_, bool back_, bool ignoreCase ) {
 	int step( back_ ? -1 : 1 );
-	entries_t::const_iterator it( moved( _current, step, true ) );
+	entries_t::iterator it( moved( _current, step, true ) );
+	bool lowerCaseContext( std::none_of( prefix_.begin(), prefix_.end(), []( char32_t x ) { return iswupper( static_cast<wint_t>( x ) ); } ) );
 	while ( it != _current ) {
-		if ( it->text().starts_with( prefix_.begin(), prefix_.begin() + prefixSize_ ) ) {
+		if ( it->text().starts_with( prefix_.begin(), prefix_.begin() + prefixSize_, ignoreCase && lowerCaseContext ? case_insensitive_equal : case_sensitive_equal ) ) {
 			_current = it;
 			commit_index();
 			return ( true );
@@ -295,7 +319,7 @@ bool History::common_prefix_search( UnicodeString const& prefix_, int prefixSize
 	return ( false );
 }
 
-bool History::move( entries_t::const_iterator& it_, int by_, bool wrapped_ ) const {
+bool History::move( entries_t::iterator& it_, int by_, bool wrapped_ ) {
 	if ( by_ > 0 ) {
 		for ( int i( 0 ); i < by_; ++ i ) {
 			++ it_;
@@ -321,12 +345,12 @@ bool History::move( entries_t::const_iterator& it_, int by_, bool wrapped_ ) con
 	return ( true );
 }
 
-History::entries_t::const_iterator History::moved( entries_t::const_iterator it_, int by_, bool wrapped_ ) const {
+History::entries_t::iterator History::moved( entries_t::iterator it_, int by_, bool wrapped_ ) {
 	move( it_, by_, wrapped_ );
 	return ( it_ );
 }
 
-void History::erase( entries_t::const_iterator it_ ) {
+void History::erase( entries_t::iterator it_ ) {
 	bool invalidated( it_ == _current );
 	_locations.erase( it_->text() );
 	it_ = _entries.erase( it_ );
@@ -364,6 +388,7 @@ void History::remove_duplicates( void ) {
 	_locations.clear();
 	typedef std::pair<locations_t::iterator, bool> locations_insertion_result_t;
 	for ( entries_t::iterator it( _entries.begin() ), end( _entries.end() ); it != end; ++ it ) {
+		it->reset_scratch();
 		locations_insertion_result_t locationsInsertionResult( _locations.insert( make_pair( it->text(), it ) ) );
 		if ( ! locationsInsertionResult.second ) {
 			_entries.erase( locationsInsertionResult.first->second );
@@ -382,14 +407,15 @@ void History::update_last( UnicodeString const& line_ ) {
 }
 
 void History::drop_last( void ) {
+	reset_current_scratch();
 	erase( last() );
 }
 
-bool History::is_last( void ) const {
+bool History::is_last( void ) {
 	return ( _current == last() );
 }
 
-History::entries_t::const_iterator History::last( void ) const {
+History::entries_t::iterator History::last( void ) {
 	return ( moved( _entries.end(), -1 ) );
 }
 

--- a/third-party/replxx/src/history.hxx
+++ b/third-party/replxx/src/history.hxx
@@ -33,28 +33,36 @@ public:
 	class Entry {
 		std::string _timestamp;
 		UnicodeString _text;
+		UnicodeString _scratch;
 	public:
 		Entry( std::string const& timestamp_, UnicodeString const& text_ )
 			: _timestamp( timestamp_ )
-			, _text( text_ ) {
+			, _text( text_ )
+			, _scratch( text_ ) {
 		}
 		std::string const& timestamp( void ) const {
 			return ( _timestamp );
 		}
 		UnicodeString const& text( void ) const {
-			return ( _text );
+			return ( _scratch );
+		}
+		void set_scratch( UnicodeString const& s ) {
+			_scratch = s;
+		}
+		void reset_scratch( void ) {
+			_scratch = _text;
 		}
 		bool operator < ( Entry const& other_ ) const {
 			return ( _timestamp < other_._timestamp );
 		}
 	};
 	typedef std::list<Entry> entries_t;
-	typedef std::unordered_map<UnicodeString, entries_t::const_iterator> locations_t;
+	typedef std::unordered_map<UnicodeString, entries_t::iterator> locations_t;
 private:
 	entries_t _entries;
 	locations_t _locations;
 	int _maxSize;
-	entries_t::const_iterator _current;
+	entries_t::iterator _current;
 	entries_t::const_iterator _yankPos;
 	/*
 	 * _previous and _recallMostRecent are used to allow
@@ -64,14 +72,16 @@ private:
 	 * Special meaning is: a down arrow shall jump to the line one
 	 * after previously accepted from history.
 	 */
-	entries_t::const_iterator _previous;
+	entries_t::iterator _previous;
 	bool _recallMostRecent;
 	bool _unique;
 public:
 	History( void );
 	void add( UnicodeString const& line, std::string const& when = now_ms_str() );
 	bool save( std::string const& filename, bool );
+	void save( std::ostream& histFile );
 	bool load( std::string const& filename );
+	void load( std::istream& histFile );
 	void clear( void );
 	void set_max_size( int len );
 	void set_unique( bool unique_ ) {
@@ -92,8 +102,19 @@ public:
 	}
 	void update_last( UnicodeString const& );
 	void drop_last( void );
-	bool is_last( void ) const;
+	bool is_last( void );
 	bool move( bool );
+	void set_current_scratch( UnicodeString const& s ) {
+		_current->set_scratch( s );
+	}
+	void reset_scratches( void ) {
+		for ( Entry& entry : _entries ) {
+			entry.reset_scratch();
+		}
+	}
+	void reset_current_scratch( void ) {
+		_current->reset_scratch();
+	}
 	UnicodeString const& current( void ) const {
 		return ( _current->text() );
 	}
@@ -101,7 +122,7 @@ public:
 		return ( _yankPos->text() );
 	}
 	void jump( bool, bool = true );
-	bool common_prefix_search( UnicodeString const&, int, bool );
+	bool common_prefix_search( UnicodeString const&, int, bool, bool );
 	int size( void ) const {
 		return ( static_cast<int>( _entries.size() ) );
 	}
@@ -111,14 +132,14 @@ public:
 private:
 	History( History const& ) = delete;
 	History& operator = ( History const& ) = delete;
-	bool move( entries_t::const_iterator&, int, bool = false ) const;
-	entries_t::const_iterator moved( entries_t::const_iterator, int, bool = false ) const;
-	void erase( entries_t::const_iterator );
+	bool move( entries_t::iterator&, int, bool = false );
+	entries_t::iterator moved( entries_t::iterator, int, bool = false );
+	void erase( entries_t::iterator );
 	void trim_to_max_size( void );
 	void remove_duplicate( UnicodeString const& );
 	void remove_duplicates( void );
-	bool do_load( std::string const& );
-	entries_t::const_iterator last( void ) const;
+	void do_load( std::istream& );
+	entries_t::iterator last( void );
 	void sort( void );
 	void reset_iters( void );
 };

--- a/third-party/replxx/src/prompt.hxx
+++ b/third-party/replxx/src/prompt.hxx
@@ -8,28 +8,27 @@
 
 namespace replxx {
 
-class Prompt {           // a convenience struct for grouping prompt info
+class Prompt {              // a convenience struct for grouping prompt info
 public:
-	UnicodeString _text;   // our copy of the prompt text, edited
-	int _characterCount;   // chars in _text
-	int _byteCount;        // bytes in _text
-	int _extraLines;       // extra lines (beyond 1) occupied by prompt
-	int _indentation;      // column offset to end of prompt
-	int _lastLinePosition; // index into _text where last line begins
-	int _previousInputLen; // _characterCount of previous input line, for clearing
-	int _cursorRowOffset;  // where the cursor is relative to the start of the prompt
-	int _previousLen;      // help erasing
+	UnicodeString _text;      // our copy of the prompt text, edited
+	int _characterCount{0};   // visible characters in _text
+	int _extraLines{0};       // extra lines (beyond 1) occupied by prompt
+	int _lastLinePosition{0}; // index into _text where last line begins
+	int _cursorRowOffset{0};  // where the cursor is relative to the start of the prompt
+
 private:
-	int _screenColumns;    // width of screen in columns [cache]
+	int _screenColumns{0};    // width of screen in columns [cache]
 	Terminal& _terminal;
 public:
 	Prompt( Terminal& );
 	void set_text( UnicodeString const& textPtr );
+	void update_state();
 	void update_screen_columns( void );
 	int screen_columns() const {
 		return ( _screenColumns );
 	}
 	void write();
+	int indentation() const;
 };
 
 // changing prompt for "(reverse-i-search)`text':" etc.

--- a/third-party/replxx/src/replxx_impl.cxx
+++ b/third-party/replxx/src/replxx_impl.cxx
@@ -3,6 +3,7 @@
 #include <cerrno>
 #include <iostream>
 #include <chrono>
+#include <cassert>
 
 #ifdef _WIN32
 
@@ -35,6 +36,7 @@
 #include "replxx.hxx"
 
 using namespace std;
+using namespace replxx::color;
 
 namespace replxx {
 
@@ -42,45 +44,58 @@ namespace {
 
 namespace action_names {
 
-char const INSERT_CHARACTER[]                = "insert_character";
-char const MOVE_CURSOR_TO_BEGINING_OF_LINE[] = "move_cursor_to_begining_of_line";
-char const MOVE_CURSOR_TO_END_OF_LINE[]      = "move_cursor_to_end_of_line";
-char const MOVE_CURSOR_LEFT[]                = "move_cursor_left";
-char const MOVE_CURSOR_RIGHT[]               = "move_cursor_right";
-char const MOVE_CURSOR_ONE_WORD_LEFT[]       = "move_cursor_one_word_left";
-char const MOVE_CURSOR_ONE_WORD_RIGHT[]      = "move_cursor_one_word_right";
-char const KILL_TO_WHITESPACE_ON_LEFT[]      = "kill_to_whitespace_on_left";
-char const KILL_TO_END_OF_WORD[]             = "kill_to_end_of_word";
-char const KILL_TO_BEGINING_OF_WORD[]        = "kill_to_begining_of_word";
-char const KILL_TO_BEGINING_OF_LINE[]        = "kill_to_begining_of_line";
-char const KILL_TO_END_OF_LINE[]             = "kill_to_end_of_line";
-char const YANK[]                            = "yank";
-char const YANK_CYCLE[]                      = "yank_cycle";
-char const YANK_LAST_ARG[]                   = "yank_last_arg";
-char const CAPITALIZE_WORD[]                 = "capitalize_word";
-char const LOWERCASE_WORD[]                  = "lowercase_word";
-char const UPPERCASE_WORD[]                  = "uppercase_word";
-char const TRANSPOSE_CHARACTERS[]            = "transpose_characters";
-char const ABORT_LINE[]                      = "abort_line";
-char const SEND_EOF[]                        = "send_eof";
-char const TOGGLE_OVERWRITE_MODE[]           = "toggle_overwrite_mode";
-char const DELETE_CHARACTER_UNDER_CURSOR[]   = "delete_character_under_cursor";
-char const DELETE_CHARACTER_LEFT_OF_CURSOR[] = "delete_character_left_of_cursor";
-char const COMMIT_LINE[]                     = "commit_line";
-char const CLEAR_SCREEN[]                    = "clear_screen";
-char const COMPLETE_NEXT[]                   = "complete_next";
-char const COMPLETE_PREVIOUS[]               = "complete_previous";
-char const HISTORY_NEXT[]                    = "history_next";
-char const HISTORY_PREVIOUS[]                = "history_previous";
-char const HISTORY_LAST[]                    = "history_last";
-char const HISTORY_FIRST[]                   = "history_first";
-char const HINT_PREVIOUS[]                   = "hint_previous";
-char const HINT_NEXT[]                       = "hint_next";
-char const VERBATIM_INSERT[]                 = "verbatim_insert";
-char const SUSPEND[]                         = "suspend";
-char const COMPLETE_LINE[]                   = "complete_line";
-char const HISTORY_INCREMENTAL_SEARCH[]      = "history_incremental_search";
-char const HISTORY_COMMON_PREFIX_SEARCH[]    = "history_common_prefix_search";
+char const INSERT_CHARACTER[]                  = "insert_character";
+char const NEW_LINE[]                          = "new_line";
+char const MOVE_CURSOR_TO_BEGINING_OF_LINE[]   = "move_cursor_to_begining_of_line";
+char const MOVE_CURSOR_TO_END_OF_LINE[]        = "move_cursor_to_end_of_line";
+char const MOVE_CURSOR_LEFT[]                  = "move_cursor_left";
+char const MOVE_CURSOR_RIGHT[]                 = "move_cursor_right";
+char const MOVE_CURSOR_ONE_WORD_LEFT[]         = "move_cursor_one_word_left";
+char const MOVE_CURSOR_ONE_WORD_RIGHT[]        = "move_cursor_one_word_right";
+char const MOVE_CURSOR_ONE_SUBWORD_LEFT[]      = "move_cursor_one_subword_left";
+char const MOVE_CURSOR_ONE_SUBWORD_RIGHT[]     = "move_cursor_one_subword_right";
+char const KILL_TO_WHITESPACE_ON_LEFT[]        = "kill_to_whitespace_on_left";
+char const KILL_TO_END_OF_WORD[]               = "kill_to_end_of_word";
+char const KILL_TO_END_OF_SUBWORD[]            = "kill_to_end_of_subword";
+char const KILL_TO_BEGINING_OF_WORD[]          = "kill_to_begining_of_word";
+char const KILL_TO_BEGINING_OF_SUBWORD[]       = "kill_to_begining_of_subword";
+char const KILL_TO_BEGINING_OF_LINE[]          = "kill_to_begining_of_line";
+char const KILL_TO_END_OF_LINE[]               = "kill_to_end_of_line";
+char const YANK[]                              = "yank";
+char const YANK_CYCLE[]                        = "yank_cycle";
+char const YANK_LAST_ARG[]                     = "yank_last_arg";
+char const CAPITALIZE_WORD[]                   = "capitalize_word";
+char const LOWERCASE_WORD[]                    = "lowercase_word";
+char const UPPERCASE_WORD[]                    = "uppercase_word";
+char const CAPITALIZE_SUBWORD[]                = "capitalize_subword";
+char const LOWERCASE_SUBWORD[]                 = "lowercase_subword";
+char const UPPERCASE_SUBWORD[]                 = "uppercase_subword";
+char const TRANSPOSE_CHARACTERS[]              = "transpose_characters";
+char const ABORT_LINE[]                        = "abort_line";
+char const SEND_EOF[]                          = "send_eof";
+char const TOGGLE_OVERWRITE_MODE[]             = "toggle_overwrite_mode";
+char const DELETE_CHARACTER_UNDER_CURSOR[]     = "delete_character_under_cursor";
+char const DELETE_CHARACTER_LEFT_OF_CURSOR[]   = "delete_character_left_of_cursor";
+char const COMMIT_LINE[]                       = "commit_line";
+char const CLEAR_SCREEN[]                      = "clear_screen";
+char const COMPLETE_NEXT[]                     = "complete_next";
+char const COMPLETE_PREVIOUS[]                 = "complete_previous";
+char const HISTORY_NEXT[]                      = "history_next";
+char const HISTORY_PREVIOUS[]                  = "history_previous";
+char const LINE_NEXT[]                         = "line_next";
+char const LINE_PREVIOUS[]                     = "line_previous";
+char const HISTORY_LAST[]                      = "history_last";
+char const HISTORY_FIRST[]                     = "history_first";
+char const HISTORY_RESTORE[]                   = "history_restore";
+char const HISTORY_RESTORE_CURRENT[]           = "history_restore_current";
+char const HINT_PREVIOUS[]                     = "hint_previous";
+char const HINT_NEXT[]                         = "hint_next";
+char const VERBATIM_INSERT[]                   = "verbatim_insert";
+char const SUSPEND[]                           = "suspend";
+char const COMPLETE_LINE[]                     = "complete_line";
+char const HISTORY_INCREMENTAL_SEARCH[]        = "history_incremental_search";
+char const HISTORY_SEEDED_INCREMENTAL_SEARCH[] = "history_seeded_incremental_search";
+char const HISTORY_COMMON_PREFIX_SEARCH[]      = "history_common_prefix_search";
 }
 
 static int const REPLXX_MAX_HINT_ROWS( 4 );
@@ -88,7 +103,11 @@ static int const REPLXX_MAX_HINT_ROWS( 4 );
  * All whitespaces and all non-alphanumerical characters from ASCII range
  * with an exception of an underscore ('_').
  */
-char const defaultBreakChars[] = " \t\v\f\a\b\r\n`~!@#$%^&*()-=+[{]}\\|;:'\",<.>/?";
+char const defaultWordBreakChars[] = " \t\v\f\a\b\r\n`~!@#$%^&*()-=+[{]}\\|;:'\",<.>/?";
+/*
+ * All whitespaces and all non-alphanumerical characters from ASCII range
+ */
+char const defaultSubwordBreakChars[] = " \t\v\f\a\b\r\n`~!@#$%^&*()-=+[{]}\\|;:'\",<.>/?_";
 static const char* unsupported_term[] = {"dumb", "cons25", "emacs", NULL};
 
 static bool isUnsupportedTerm(void) {
@@ -111,16 +130,29 @@ inline int long long now_us( void ) {
 	return ( std::chrono::duration_cast<std::chrono::microseconds>( std::chrono::high_resolution_clock::now().time_since_epoch() ).count() );
 }
 
+class IOModeGuard {
+	Terminal& _terminal;
+public:
+	IOModeGuard( Terminal& terminal_ )
+		: _terminal( terminal_ ) {
+	}
+	~IOModeGuard( void ) {
+		try {
+			_terminal.reset_raw_mode();
+		} catch ( ... ) {
+		}
+	}
+};
+
 }
 
 Replxx::ReplxxImpl::ReplxxImpl( FILE*, FILE*, FILE* )
 	: _utf8Buffer()
 	, _data()
-	, _charWidths()
+	, _pos( 0 )
 	, _display()
 	, _displayInputLength( 0 )
 	, _hint()
-	, _pos( 0 )
 	, _prefix( 0 )
 	, _hintSelection( -1 )
 	, _history()
@@ -130,7 +162,8 @@ Replxx::ReplxxImpl::ReplxxImpl( FILE*, FILE*, FILE* )
 	, _lastYankSize( 0 )
 	, _maxHintRows( REPLXX_MAX_HINT_ROWS )
 	, _hintDelay( 0 )
-	, _breakChars( defaultBreakChars )
+	, _wordBreakChars( defaultWordBreakChars )
+	, _subwordBreakChars( defaultSubwordBreakChars )
 	, _completionCountCutoff( 100 )
 	, _overwrite( false )
 	, _doubleTabCompletion( false )
@@ -139,6 +172,7 @@ Replxx::ReplxxImpl::ReplxxImpl( FILE*, FILE*, FILE* )
 	, _immediateCompletion( true )
 	, _bracketedPaste( false )
 	, _noColor( false )
+	, _indentMultiline( true )
 	, _namedActions()
 	, _keyPressHandlers()
 	, _terminal()
@@ -149,6 +183,8 @@ Replxx::ReplxxImpl::ReplxxImpl( FILE*, FILE*, FILE* )
 	, _hintCallback( nullptr )
 	, _keyPresses()
 	, _messages()
+	, _asyncPrompt()
+	, _updatePrompt( false )
 	, _completions()
 	, _completionContextLength( 0 )
 	, _completionSelection( -1 )
@@ -160,51 +196,68 @@ Replxx::ReplxxImpl::ReplxxImpl( FILE*, FILE*, FILE* )
 	, _hintsCache()
 	, _hintContextLenght( -1 )
 	, _hintSeed()
+	, _hasNewlines( false )
+	, _oldPos( 0 )
+	, _moveCursor( false )
+	, _ignoreCase( false )
 	, _mutex() {
 	using namespace std::placeholders;
-	_namedActions[action_names::INSERT_CHARACTER]                = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::INSERT_CHARACTER,                _1 );
-	_namedActions[action_names::MOVE_CURSOR_TO_BEGINING_OF_LINE] = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::MOVE_CURSOR_TO_BEGINING_OF_LINE, _1 );
-	_namedActions[action_names::MOVE_CURSOR_TO_END_OF_LINE]      = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::MOVE_CURSOR_TO_END_OF_LINE,      _1 );
-	_namedActions[action_names::MOVE_CURSOR_LEFT]                = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::MOVE_CURSOR_LEFT,                _1 );
-	_namedActions[action_names::MOVE_CURSOR_RIGHT]               = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::MOVE_CURSOR_RIGHT,               _1 );
-	_namedActions[action_names::MOVE_CURSOR_ONE_WORD_LEFT]       = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::MOVE_CURSOR_ONE_WORD_LEFT,       _1 );
-	_namedActions[action_names::MOVE_CURSOR_ONE_WORD_RIGHT]      = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::MOVE_CURSOR_ONE_WORD_RIGHT,      _1 );
-	_namedActions[action_names::KILL_TO_WHITESPACE_ON_LEFT]      = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::KILL_TO_WHITESPACE_ON_LEFT,      _1 );
-	_namedActions[action_names::KILL_TO_END_OF_WORD]             = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::KILL_TO_END_OF_WORD,             _1 );
-	_namedActions[action_names::KILL_TO_BEGINING_OF_WORD]        = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::KILL_TO_BEGINING_OF_WORD,        _1 );
-	_namedActions[action_names::KILL_TO_BEGINING_OF_LINE]        = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::KILL_TO_BEGINING_OF_LINE,        _1 );
-	_namedActions[action_names::KILL_TO_END_OF_LINE]             = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::KILL_TO_END_OF_LINE,             _1 );
-	_namedActions[action_names::YANK]                            = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::YANK,                            _1 );
-	_namedActions[action_names::YANK_CYCLE]                      = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::YANK_CYCLE,                      _1 );
-	_namedActions[action_names::YANK_LAST_ARG]                   = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::YANK_LAST_ARG,                   _1 );
-	_namedActions[action_names::CAPITALIZE_WORD]                 = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::CAPITALIZE_WORD,                 _1 );
-	_namedActions[action_names::LOWERCASE_WORD]                  = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::LOWERCASE_WORD,                  _1 );
-	_namedActions[action_names::UPPERCASE_WORD]                  = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::UPPERCASE_WORD,                  _1 );
-	_namedActions[action_names::TRANSPOSE_CHARACTERS]            = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::TRANSPOSE_CHARACTERS,            _1 );
-	_namedActions[action_names::ABORT_LINE]                      = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::ABORT_LINE,                      _1 );
-	_namedActions[action_names::SEND_EOF]                        = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::SEND_EOF,                        _1 );
-	_namedActions[action_names::TOGGLE_OVERWRITE_MODE]           = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::TOGGLE_OVERWRITE_MODE,           _1 );
-	_namedActions[action_names::DELETE_CHARACTER_UNDER_CURSOR]   = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::DELETE_CHARACTER_UNDER_CURSOR,   _1 );
-	_namedActions[action_names::DELETE_CHARACTER_LEFT_OF_CURSOR] = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::DELETE_CHARACTER_LEFT_OF_CURSOR, _1 );
-	_namedActions[action_names::COMMIT_LINE]                     = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::COMMIT_LINE,                     _1 );
-	_namedActions[action_names::CLEAR_SCREEN]                    = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::CLEAR_SCREEN,                    _1 );
-	_namedActions[action_names::COMPLETE_NEXT]                   = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::COMPLETE_NEXT,                   _1 );
-	_namedActions[action_names::COMPLETE_PREVIOUS]               = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::COMPLETE_PREVIOUS,               _1 );
-	_namedActions[action_names::HISTORY_NEXT]                    = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_NEXT,                    _1 );
-	_namedActions[action_names::HISTORY_PREVIOUS]                = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_PREVIOUS,                _1 );
-	_namedActions[action_names::HISTORY_LAST]                    = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_LAST,                    _1 );
-	_namedActions[action_names::HISTORY_FIRST]                   = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_FIRST,                   _1 );
-	_namedActions[action_names::HINT_PREVIOUS]                   = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HINT_PREVIOUS,                   _1 );
-	_namedActions[action_names::HINT_NEXT]                       = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HINT_NEXT,                       _1 );
+	_namedActions[action_names::INSERT_CHARACTER]                  = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::INSERT_CHARACTER,                  _1 );
+	_namedActions[action_names::NEW_LINE]                          = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::NEW_LINE,                          _1 );
+	_namedActions[action_names::MOVE_CURSOR_TO_BEGINING_OF_LINE]   = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::MOVE_CURSOR_TO_BEGINING_OF_LINE,   _1 );
+	_namedActions[action_names::MOVE_CURSOR_TO_END_OF_LINE]        = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::MOVE_CURSOR_TO_END_OF_LINE,        _1 );
+	_namedActions[action_names::MOVE_CURSOR_LEFT]                  = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::MOVE_CURSOR_LEFT,                  _1 );
+	_namedActions[action_names::MOVE_CURSOR_RIGHT]                 = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::MOVE_CURSOR_RIGHT,                 _1 );
+	_namedActions[action_names::MOVE_CURSOR_ONE_WORD_LEFT]         = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::MOVE_CURSOR_ONE_WORD_LEFT,         _1 );
+	_namedActions[action_names::MOVE_CURSOR_ONE_WORD_RIGHT]        = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::MOVE_CURSOR_ONE_WORD_RIGHT,        _1 );
+	_namedActions[action_names::MOVE_CURSOR_ONE_SUBWORD_LEFT]      = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::MOVE_CURSOR_ONE_SUBWORD_LEFT,      _1 );
+	_namedActions[action_names::MOVE_CURSOR_ONE_SUBWORD_RIGHT]     = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::MOVE_CURSOR_ONE_SUBWORD_RIGHT,     _1 );
+	_namedActions[action_names::KILL_TO_WHITESPACE_ON_LEFT]        = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::KILL_TO_WHITESPACE_ON_LEFT,        _1 );
+	_namedActions[action_names::KILL_TO_END_OF_WORD]               = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::KILL_TO_END_OF_WORD,               _1 );
+	_namedActions[action_names::KILL_TO_BEGINING_OF_WORD]          = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::KILL_TO_BEGINING_OF_WORD,          _1 );
+	_namedActions[action_names::KILL_TO_END_OF_SUBWORD]            = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::KILL_TO_END_OF_SUBWORD,            _1 );
+	_namedActions[action_names::KILL_TO_BEGINING_OF_SUBWORD]       = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::KILL_TO_BEGINING_OF_SUBWORD,       _1 );
+	_namedActions[action_names::KILL_TO_BEGINING_OF_LINE]          = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::KILL_TO_BEGINING_OF_LINE,          _1 );
+	_namedActions[action_names::KILL_TO_END_OF_LINE]               = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::KILL_TO_END_OF_LINE,               _1 );
+	_namedActions[action_names::YANK]                              = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::YANK,                              _1 );
+	_namedActions[action_names::YANK_CYCLE]                        = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::YANK_CYCLE,                        _1 );
+	_namedActions[action_names::YANK_LAST_ARG]                     = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::YANK_LAST_ARG,                     _1 );
+	_namedActions[action_names::CAPITALIZE_WORD]                   = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::CAPITALIZE_WORD,                   _1 );
+	_namedActions[action_names::LOWERCASE_WORD]                    = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::LOWERCASE_WORD,                    _1 );
+	_namedActions[action_names::UPPERCASE_WORD]                    = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::UPPERCASE_WORD,                    _1 );
+	_namedActions[action_names::CAPITALIZE_SUBWORD]                = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::CAPITALIZE_SUBWORD,                _1 );
+	_namedActions[action_names::LOWERCASE_SUBWORD]                 = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::LOWERCASE_SUBWORD,                 _1 );
+	_namedActions[action_names::UPPERCASE_SUBWORD]                 = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::UPPERCASE_SUBWORD,                 _1 );
+	_namedActions[action_names::TRANSPOSE_CHARACTERS]              = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::TRANSPOSE_CHARACTERS,              _1 );
+	_namedActions[action_names::ABORT_LINE]                        = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::ABORT_LINE,                        _1 );
+	_namedActions[action_names::SEND_EOF]                          = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::SEND_EOF,                          _1 );
+	_namedActions[action_names::TOGGLE_OVERWRITE_MODE]             = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::TOGGLE_OVERWRITE_MODE,             _1 );
+	_namedActions[action_names::DELETE_CHARACTER_UNDER_CURSOR]     = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::DELETE_CHARACTER_UNDER_CURSOR,     _1 );
+	_namedActions[action_names::DELETE_CHARACTER_LEFT_OF_CURSOR]   = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::DELETE_CHARACTER_LEFT_OF_CURSOR,   _1 );
+	_namedActions[action_names::COMMIT_LINE]                       = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::COMMIT_LINE,                       _1 );
+	_namedActions[action_names::CLEAR_SCREEN]                      = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::CLEAR_SCREEN,                      _1 );
+	_namedActions[action_names::COMPLETE_NEXT]                     = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::COMPLETE_NEXT,                     _1 );
+	_namedActions[action_names::COMPLETE_PREVIOUS]                 = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::COMPLETE_PREVIOUS,                 _1 );
+	_namedActions[action_names::LINE_NEXT]                         = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::LINE_NEXT,                         _1 );
+	_namedActions[action_names::LINE_PREVIOUS]                     = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::LINE_PREVIOUS,                     _1 );
+	_namedActions[action_names::HISTORY_NEXT]                      = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_NEXT,                      _1 );
+	_namedActions[action_names::HISTORY_PREVIOUS]                  = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_PREVIOUS,                  _1 );
+	_namedActions[action_names::HISTORY_LAST]                      = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_LAST,                      _1 );
+	_namedActions[action_names::HISTORY_FIRST]                     = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_FIRST,                     _1 );
+	_namedActions[action_names::HISTORY_RESTORE]                   = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_RESTORE,                   _1 );
+	_namedActions[action_names::HISTORY_RESTORE_CURRENT]           = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_RESTORE_CURRENT,           _1 );
+	_namedActions[action_names::HINT_PREVIOUS]                     = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HINT_PREVIOUS,                     _1 );
+	_namedActions[action_names::HINT_NEXT]                         = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HINT_NEXT,                         _1 );
 #ifndef _WIN32
-	_namedActions[action_names::VERBATIM_INSERT]                 = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::VERBATIM_INSERT,                 _1 );
-	_namedActions[action_names::SUSPEND]                         = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::SUSPEND,                         _1 );
+	_namedActions[action_names::VERBATIM_INSERT]                   = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::VERBATIM_INSERT,                   _1 );
+	_namedActions[action_names::SUSPEND]                           = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::SUSPEND,                           _1 );
 #else
 	_namedActions[action_names::VERBATIM_INSERT] = _namedActions[action_names::SUSPEND] = Replxx::key_press_handler_t();
 #endif
-	_namedActions[action_names::COMPLETE_LINE]                   = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::COMPLETE_LINE,                   _1 );
-	_namedActions[action_names::HISTORY_INCREMENTAL_SEARCH]      = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_INCREMENTAL_SEARCH,      _1 );
-	_namedActions[action_names::HISTORY_COMMON_PREFIX_SEARCH]    = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_COMMON_PREFIX_SEARCH,    _1 );
+	_namedActions[action_names::COMPLETE_LINE]                     = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::COMPLETE_LINE,                     _1 );
+	_namedActions[action_names::HISTORY_INCREMENTAL_SEARCH]        = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_INCREMENTAL_SEARCH,        _1 );
+	_namedActions[action_names::HISTORY_SEEDED_INCREMENTAL_SEARCH] = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_SEEDED_INCREMENTAL_SEARCH, _1 );
+	_namedActions[action_names::HISTORY_COMMON_PREFIX_SEARCH]      = std::bind( &ReplxxImpl::invoke, this, Replxx::ACTION::HISTORY_COMMON_PREFIX_SEARCH,      _1 );
 
 	bind_key( Replxx::KEY::control( 'A' ),                 _namedActions.at( action_names::MOVE_CURSOR_TO_BEGINING_OF_LINE ) );
 	bind_key( Replxx::KEY::HOME + 0,                       _namedActions.at( action_names::MOVE_CURSOR_TO_BEGINING_OF_LINE ) );
@@ -215,17 +268,18 @@ Replxx::ReplxxImpl::ReplxxImpl( FILE*, FILE*, FILE* )
 	bind_key( Replxx::KEY::control( 'F' ),                 _namedActions.at( action_names::MOVE_CURSOR_RIGHT ) );
 	bind_key( Replxx::KEY::RIGHT + 0,                      _namedActions.at( action_names::MOVE_CURSOR_RIGHT ) );
 	bind_key( Replxx::KEY::meta( 'b' ),                    _namedActions.at( action_names::MOVE_CURSOR_ONE_WORD_LEFT ) );
-	bind_key( Replxx::KEY::meta( 'B' ),                    _namedActions.at( action_names::MOVE_CURSOR_ONE_WORD_LEFT ) );
+	bind_key( Replxx::KEY::meta( 'B' ),                    _namedActions.at( action_names::MOVE_CURSOR_ONE_SUBWORD_LEFT ) );
 	bind_key( Replxx::KEY::control( Replxx::KEY::LEFT ),   _namedActions.at( action_names::MOVE_CURSOR_ONE_WORD_LEFT ) );
 	bind_key( Replxx::KEY::meta( Replxx::KEY::LEFT ),      _namedActions.at( action_names::MOVE_CURSOR_ONE_WORD_LEFT ) ); // Emacs allows Meta, readline don't
 	bind_key( Replxx::KEY::meta( 'f' ),                    _namedActions.at( action_names::MOVE_CURSOR_ONE_WORD_RIGHT ) );
-	bind_key( Replxx::KEY::meta( 'F' ),                    _namedActions.at( action_names::MOVE_CURSOR_ONE_WORD_RIGHT ) );
+	bind_key( Replxx::KEY::meta( 'F' ),                    _namedActions.at( action_names::MOVE_CURSOR_ONE_SUBWORD_RIGHT ) );
 	bind_key( Replxx::KEY::control( Replxx::KEY::RIGHT ),  _namedActions.at( action_names::MOVE_CURSOR_ONE_WORD_RIGHT ) );
 	bind_key( Replxx::KEY::meta( Replxx::KEY::RIGHT ),     _namedActions.at( action_names::MOVE_CURSOR_ONE_WORD_RIGHT ) ); // Emacs allows Meta, readline don't
 	bind_key( Replxx::KEY::meta( Replxx::KEY::BACKSPACE ), _namedActions.at( action_names::KILL_TO_WHITESPACE_ON_LEFT ) );
 	bind_key( Replxx::KEY::meta( 'd' ),                    _namedActions.at( action_names::KILL_TO_END_OF_WORD ) );
-	bind_key( Replxx::KEY::meta( 'D' ),                    _namedActions.at( action_names::KILL_TO_END_OF_WORD ) );
+	bind_key( Replxx::KEY::meta( 'D' ),                    _namedActions.at( action_names::KILL_TO_END_OF_SUBWORD ) );
 	bind_key( Replxx::KEY::control( 'W' ),                 _namedActions.at( action_names::KILL_TO_BEGINING_OF_WORD ) );
+	bind_key( Replxx::KEY::meta( 'W' ),                    _namedActions.at( action_names::KILL_TO_BEGINING_OF_SUBWORD ) );
 	bind_key( Replxx::KEY::control( 'U' ),                 _namedActions.at( action_names::KILL_TO_BEGINING_OF_LINE ) );
 	bind_key( Replxx::KEY::control( 'K' ),                 _namedActions.at( action_names::KILL_TO_END_OF_LINE ) );
 	bind_key( Replxx::KEY::control( 'Y' ),                 _namedActions.at( action_names::YANK ) );
@@ -233,29 +287,35 @@ Replxx::ReplxxImpl::ReplxxImpl( FILE*, FILE*, FILE* )
 	bind_key( Replxx::KEY::meta( 'Y' ),                    _namedActions.at( action_names::YANK_CYCLE ) );
 	bind_key( Replxx::KEY::meta( '.' ),                    _namedActions.at( action_names::YANK_LAST_ARG ) );
 	bind_key( Replxx::KEY::meta( 'c' ),                    _namedActions.at( action_names::CAPITALIZE_WORD ) );
-	bind_key( Replxx::KEY::meta( 'C' ),                    _namedActions.at( action_names::CAPITALIZE_WORD ) );
+	bind_key( Replxx::KEY::meta( 'C' ),                    _namedActions.at( action_names::CAPITALIZE_SUBWORD ) );
 	bind_key( Replxx::KEY::meta( 'l' ),                    _namedActions.at( action_names::LOWERCASE_WORD ) );
-	bind_key( Replxx::KEY::meta( 'L' ),                    _namedActions.at( action_names::LOWERCASE_WORD ) );
+	bind_key( Replxx::KEY::meta( 'L' ),                    _namedActions.at( action_names::LOWERCASE_SUBWORD ) );
 	bind_key( Replxx::KEY::meta( 'u' ),                    _namedActions.at( action_names::UPPERCASE_WORD ) );
-	bind_key( Replxx::KEY::meta( 'U' ),                    _namedActions.at( action_names::UPPERCASE_WORD ) );
+	bind_key( Replxx::KEY::meta( 'U' ),                    _namedActions.at( action_names::UPPERCASE_SUBWORD ) );
 	bind_key( Replxx::KEY::control( 'T' ),                 _namedActions.at( action_names::TRANSPOSE_CHARACTERS ) );
 	bind_key( Replxx::KEY::control( 'C' ),                 _namedActions.at( action_names::ABORT_LINE ) );
+	bind_key( Replxx::KEY::ABORT,                          _namedActions.at( action_names::ABORT_LINE ) );
 	bind_key( Replxx::KEY::control( 'D' ),                 _namedActions.at( action_names::SEND_EOF ) );
 	bind_key( Replxx::KEY::INSERT + 0,                     _namedActions.at( action_names::TOGGLE_OVERWRITE_MODE ) );
 	bind_key( 127,                                         _namedActions.at( action_names::DELETE_CHARACTER_UNDER_CURSOR ) );
 	bind_key( Replxx::KEY::DELETE + 0,                     _namedActions.at( action_names::DELETE_CHARACTER_UNDER_CURSOR ) );
 	bind_key( Replxx::KEY::BACKSPACE + 0,                  _namedActions.at( action_names::DELETE_CHARACTER_LEFT_OF_CURSOR ) );
-	bind_key( Replxx::KEY::control( 'J' ),                 _namedActions.at( action_names::COMMIT_LINE ) );
+	bind_key( Replxx::KEY::control( 'J' ),                 _namedActions.at( action_names::NEW_LINE ) );
+	bind_key( Replxx::KEY::meta( '\r' ),                   _namedActions.at( action_names::NEW_LINE ) );
 	bind_key( Replxx::KEY::ENTER + 0,                      _namedActions.at( action_names::COMMIT_LINE ) );
 	bind_key( Replxx::KEY::control( 'L' ),                 _namedActions.at( action_names::CLEAR_SCREEN ) );
 	bind_key( Replxx::KEY::control( 'N' ),                 _namedActions.at( action_names::COMPLETE_NEXT ) );
 	bind_key( Replxx::KEY::control( 'P' ),                 _namedActions.at( action_names::COMPLETE_PREVIOUS ) );
-	bind_key( Replxx::KEY::DOWN + 0,                       _namedActions.at( action_names::HISTORY_NEXT ) );
-	bind_key( Replxx::KEY::UP + 0,                         _namedActions.at( action_names::HISTORY_PREVIOUS ) );
+	bind_key( Replxx::KEY::DOWN + 0,                       _namedActions.at( action_names::LINE_NEXT ) );
+	bind_key( Replxx::KEY::UP + 0,                         _namedActions.at( action_names::LINE_PREVIOUS ) );
+	bind_key( Replxx::KEY::meta( Replxx::KEY::DOWN ),      _namedActions.at( action_names::HISTORY_NEXT ) );
+	bind_key( Replxx::KEY::meta( Replxx::KEY::UP ),        _namedActions.at( action_names::HISTORY_PREVIOUS ) );
 	bind_key( Replxx::KEY::meta( '<' ),                    _namedActions.at( action_names::HISTORY_FIRST ) );
 	bind_key( Replxx::KEY::PAGE_UP + 0,                    _namedActions.at( action_names::HISTORY_FIRST ) );
 	bind_key( Replxx::KEY::meta( '>' ),                    _namedActions.at( action_names::HISTORY_LAST ) );
 	bind_key( Replxx::KEY::PAGE_DOWN + 0,                  _namedActions.at( action_names::HISTORY_LAST ) );
+	bind_key( Replxx::KEY::control( 'G' ),                 _namedActions.at( action_names::HISTORY_RESTORE_CURRENT ) );
+	bind_key( Replxx::KEY::meta( 'g' ),                    _namedActions.at( action_names::HISTORY_RESTORE ) );
 	bind_key( Replxx::KEY::control( Replxx::KEY::UP ),     _namedActions.at( action_names::HINT_PREVIOUS ) );
 	bind_key( Replxx::KEY::control( Replxx::KEY::DOWN ),   _namedActions.at( action_names::HINT_NEXT ) );
 #ifndef _WIN32
@@ -265,6 +325,7 @@ Replxx::ReplxxImpl::ReplxxImpl( FILE*, FILE*, FILE* )
 	bind_key( Replxx::KEY::TAB + 0,                        _namedActions.at( action_names::COMPLETE_LINE ) );
 	bind_key( Replxx::KEY::control( 'R' ),                 _namedActions.at( action_names::HISTORY_INCREMENTAL_SEARCH ) );
 	bind_key( Replxx::KEY::control( 'S' ),                 _namedActions.at( action_names::HISTORY_INCREMENTAL_SEARCH ) );
+	bind_key( Replxx::KEY::meta( 'r' ),                    _namedActions.at( action_names::HISTORY_SEEDED_INCREMENTAL_SEARCH ) );
 	bind_key( Replxx::KEY::meta( 'p' ),                    _namedActions.at( action_names::HISTORY_COMMON_PREFIX_SEARCH ) );
 	bind_key( Replxx::KEY::meta( 'P' ),                    _namedActions.at( action_names::HISTORY_COMMON_PREFIX_SEARCH ) );
 	bind_key( Replxx::KEY::meta( 'n' ),                    _namedActions.at( action_names::HISTORY_COMMON_PREFIX_SEARCH ) );
@@ -278,50 +339,63 @@ Replxx::ReplxxImpl::~ReplxxImpl( void ) {
 
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::invoke( Replxx::ACTION action_, char32_t code ) {
 	switch ( action_ ) {
-		case ( Replxx::ACTION::INSERT_CHARACTER ):                return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::insert_character, code ) );
-		case ( Replxx::ACTION::DELETE_CHARACTER_UNDER_CURSOR ):   return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::delete_character, code ) );
-		case ( Replxx::ACTION::DELETE_CHARACTER_LEFT_OF_CURSOR ): return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::backspace_character, code ) );
-		case ( Replxx::ACTION::KILL_TO_END_OF_LINE ):             return ( action( WANT_REFRESH | SET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::kill_to_end_of_line, code ) );
-		case ( Replxx::ACTION::KILL_TO_BEGINING_OF_LINE ):        return ( action( SET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::kill_to_begining_of_line, code ) );
-		case ( Replxx::ACTION::KILL_TO_END_OF_WORD ):             return ( action( SET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::kill_word_to_right, code ) );
-		case ( Replxx::ACTION::KILL_TO_BEGINING_OF_WORD ):        return ( action( SET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::kill_word_to_left, code ) );
-		case ( Replxx::ACTION::KILL_TO_WHITESPACE_ON_LEFT ):      return ( action( SET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::kill_to_whitespace_to_left, code ) );
-		case ( Replxx::ACTION::YANK ):                            return ( action( HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::yank, code ) );
-		case ( Replxx::ACTION::YANK_CYCLE ):                      return ( action( HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::yank_cycle, code ) );
-		case ( Replxx::ACTION::YANK_LAST_ARG ):                   return ( action( HISTORY_RECALL_MOST_RECENT | DONT_RESET_HIST_YANK_INDEX, &Replxx::ReplxxImpl::yank_last_arg, code ) );
-		case ( Replxx::ACTION::MOVE_CURSOR_TO_BEGINING_OF_LINE ): return ( action( WANT_REFRESH, &Replxx::ReplxxImpl::go_to_begining_of_line, code ) );
-		case ( Replxx::ACTION::MOVE_CURSOR_TO_END_OF_LINE ):      return ( action( WANT_REFRESH, &Replxx::ReplxxImpl::go_to_end_of_line, code ) );
-		case ( Replxx::ACTION::MOVE_CURSOR_ONE_WORD_LEFT ):       return ( action( RESET_KILL_ACTION, &Replxx::ReplxxImpl::move_one_word_left, code ) );
-		case ( Replxx::ACTION::MOVE_CURSOR_ONE_WORD_RIGHT ):      return ( action( RESET_KILL_ACTION, &Replxx::ReplxxImpl::move_one_word_right, code ) );
-		case ( Replxx::ACTION::MOVE_CURSOR_LEFT ):                return ( action( RESET_KILL_ACTION, &Replxx::ReplxxImpl::move_one_char_left, code ) );
-		case ( Replxx::ACTION::MOVE_CURSOR_RIGHT ):               return ( action( RESET_KILL_ACTION, &Replxx::ReplxxImpl::move_one_char_right, code ) );
-		case ( Replxx::ACTION::HISTORY_NEXT ):                    return ( action( RESET_KILL_ACTION, &Replxx::ReplxxImpl::history_next, code ) );
-		case ( Replxx::ACTION::HISTORY_PREVIOUS ):                return ( action( RESET_KILL_ACTION, &Replxx::ReplxxImpl::history_previous, code ) );
-		case ( Replxx::ACTION::HISTORY_FIRST ):                   return ( action( RESET_KILL_ACTION, &Replxx::ReplxxImpl::history_first, code ) );
-		case ( Replxx::ACTION::HISTORY_LAST ):                    return ( action( RESET_KILL_ACTION, &Replxx::ReplxxImpl::history_last, code ) );
-		case ( Replxx::ACTION::HISTORY_INCREMENTAL_SEARCH ):      return ( action( NOOP, &Replxx::ReplxxImpl::incremental_history_search, code ) );
-		case ( Replxx::ACTION::HISTORY_COMMON_PREFIX_SEARCH ):    return ( action( RESET_KILL_ACTION | DONT_RESET_PREFIX, &Replxx::ReplxxImpl::common_prefix_search, code ) );
-		case ( Replxx::ACTION::HINT_NEXT ):                       return ( action( NOOP, &Replxx::ReplxxImpl::hint_next, code ) );
-		case ( Replxx::ACTION::HINT_PREVIOUS ):                   return ( action( NOOP, &Replxx::ReplxxImpl::hint_previous, code ) );
-		case ( Replxx::ACTION::CAPITALIZE_WORD ):                 return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::capitalize_word, code ) );
-		case ( Replxx::ACTION::LOWERCASE_WORD ):                  return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::lowercase_word, code ) );
-		case ( Replxx::ACTION::UPPERCASE_WORD ):                  return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::uppercase_word, code ) );
-		case ( Replxx::ACTION::TRANSPOSE_CHARACTERS ):            return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::transpose_characters, code ) );
-		case ( Replxx::ACTION::TOGGLE_OVERWRITE_MODE ):           return ( action( NOOP, &Replxx::ReplxxImpl::toggle_overwrite_mode, code ) );
+		case ( Replxx::ACTION::INSERT_CHARACTER ):                  return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::insert_character, code ) );
+		case ( Replxx::ACTION::NEW_LINE ):                          return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::new_line, code ) );
+		case ( Replxx::ACTION::DELETE_CHARACTER_UNDER_CURSOR ):     return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::delete_character, code ) );
+		case ( Replxx::ACTION::DELETE_CHARACTER_LEFT_OF_CURSOR ):   return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::backspace_character, code ) );
+		case ( Replxx::ACTION::KILL_TO_END_OF_LINE ):               return ( action( WANT_REFRESH | SET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::kill_to_end_of_line, code ) );
+		case ( Replxx::ACTION::KILL_TO_BEGINING_OF_LINE ):          return ( action( SET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::kill_to_begining_of_line, code ) );
+		case ( Replxx::ACTION::KILL_TO_END_OF_WORD ):               return ( action( SET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::kill_word_to_right<false>, code ) );
+		case ( Replxx::ACTION::KILL_TO_BEGINING_OF_WORD ):          return ( action( SET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::kill_word_to_left<false>, code ) );
+		case ( Replxx::ACTION::KILL_TO_END_OF_SUBWORD ):            return ( action( SET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::kill_word_to_right<true>, code ) );
+		case ( Replxx::ACTION::KILL_TO_BEGINING_OF_SUBWORD ):       return ( action( SET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::kill_word_to_left<true>, code ) );
+		case ( Replxx::ACTION::KILL_TO_WHITESPACE_ON_LEFT ):        return ( action( SET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::kill_to_whitespace_to_left, code ) );
+		case ( Replxx::ACTION::YANK ):                              return ( action( HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::yank, code ) );
+		case ( Replxx::ACTION::YANK_CYCLE ):                        return ( action( HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::yank_cycle, code ) );
+		case ( Replxx::ACTION::YANK_LAST_ARG ):                     return ( action( HISTORY_RECALL_MOST_RECENT | DONT_RESET_HIST_YANK_INDEX, &Replxx::ReplxxImpl::yank_last_arg, code ) );
+		case ( Replxx::ACTION::MOVE_CURSOR_TO_BEGINING_OF_LINE ):   return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::go_to_begining_of_line, code ) );
+		case ( Replxx::ACTION::MOVE_CURSOR_TO_END_OF_LINE ):        return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::go_to_end_of_line, code ) );
+		case ( Replxx::ACTION::MOVE_CURSOR_ONE_WORD_LEFT ):         return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::move_one_word_left<false>, code ) );
+		case ( Replxx::ACTION::MOVE_CURSOR_ONE_WORD_RIGHT ):        return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::move_one_word_right<false>, code ) );
+		case ( Replxx::ACTION::MOVE_CURSOR_ONE_SUBWORD_LEFT ):      return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::move_one_word_left<true>, code ) );
+		case ( Replxx::ACTION::MOVE_CURSOR_ONE_SUBWORD_RIGHT ):     return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::move_one_word_right<true>, code ) );
+		case ( Replxx::ACTION::MOVE_CURSOR_LEFT ):                  return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::move_one_char_left, code ) );
+		case ( Replxx::ACTION::MOVE_CURSOR_RIGHT ):                 return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::move_one_char_right, code ) );
+		case ( Replxx::ACTION::LINE_NEXT ):                         return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::line_next, code ) );
+		case ( Replxx::ACTION::LINE_PREVIOUS ):                     return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::line_previous, code ) );
+		case ( Replxx::ACTION::HISTORY_NEXT ):                      return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::history_next, code ) );
+		case ( Replxx::ACTION::HISTORY_PREVIOUS ):                  return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::history_previous, code ) );
+		case ( Replxx::ACTION::HISTORY_FIRST ):                     return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::history_first, code ) );
+		case ( Replxx::ACTION::HISTORY_LAST ):                      return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::history_last, code ) );
+		case ( Replxx::ACTION::HISTORY_RESTORE_CURRENT ):           return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::history_restore_current, code ) );
+		case ( Replxx::ACTION::HISTORY_RESTORE ):                   return ( action( MOVE_CURSOR | RESET_KILL_ACTION, &Replxx::ReplxxImpl::history_restore, code ) );
+		case ( Replxx::ACTION::HISTORY_INCREMENTAL_SEARCH ):        return ( action( NOOP, &Replxx::ReplxxImpl::incremental_history_search, code ) );
+		case ( Replxx::ACTION::HISTORY_SEEDED_INCREMENTAL_SEARCH ): return ( action( NOOP, &Replxx::ReplxxImpl::incremental_history_search, code ) );
+		case ( Replxx::ACTION::HISTORY_COMMON_PREFIX_SEARCH ):      return ( action( RESET_KILL_ACTION | DONT_RESET_PREFIX, &Replxx::ReplxxImpl::common_prefix_search, code ) );
+		case ( Replxx::ACTION::HINT_NEXT ):                         return ( action( NOOP, &Replxx::ReplxxImpl::hint_next, code ) );
+		case ( Replxx::ACTION::HINT_PREVIOUS ):                     return ( action( NOOP, &Replxx::ReplxxImpl::hint_previous, code ) );
+		case ( Replxx::ACTION::CAPITALIZE_WORD ):                   return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::capitalize_word<false>, code ) );
+		case ( Replxx::ACTION::LOWERCASE_WORD ):                    return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::lowercase_word<false>, code ) );
+		case ( Replxx::ACTION::UPPERCASE_WORD ):                    return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::uppercase_word<false>, code ) );
+		case ( Replxx::ACTION::CAPITALIZE_SUBWORD ):                return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::capitalize_word<true>, code ) );
+		case ( Replxx::ACTION::LOWERCASE_SUBWORD ):                 return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::lowercase_word<true>, code ) );
+		case ( Replxx::ACTION::UPPERCASE_SUBWORD ):                 return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::uppercase_word<true>, code ) );
+		case ( Replxx::ACTION::TRANSPOSE_CHARACTERS ):              return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::transpose_characters, code ) );
+		case ( Replxx::ACTION::TOGGLE_OVERWRITE_MODE ):             return ( action( NOOP, &Replxx::ReplxxImpl::toggle_overwrite_mode, code ) );
 #ifndef _WIN32
-		case ( Replxx::ACTION::VERBATIM_INSERT ):                 return ( action( WANT_REFRESH | RESET_KILL_ACTION, &Replxx::ReplxxImpl::verbatim_insert, code ) );
-		case ( Replxx::ACTION::SUSPEND ):                         return ( action( WANT_REFRESH, &Replxx::ReplxxImpl::suspend, code ) );
+		case ( Replxx::ACTION::VERBATIM_INSERT ):                   return ( action( WANT_REFRESH | RESET_KILL_ACTION, &Replxx::ReplxxImpl::verbatim_insert, code ) );
+		case ( Replxx::ACTION::SUSPEND ):                           return ( action( WANT_REFRESH, &Replxx::ReplxxImpl::suspend, code ) );
 #endif
-		case ( Replxx::ACTION::CLEAR_SCREEN ):                    return ( action( NOOP, &Replxx::ReplxxImpl::clear_screen, code ) );
+		case ( Replxx::ACTION::CLEAR_SCREEN ):                      return ( action( NOOP, &Replxx::ReplxxImpl::clear_screen, code ) );
 		case ( Replxx::ACTION::CLEAR_SELF ): clear_self_to_end_of_screen(); return ( Replxx::ACTION_RESULT::CONTINUE );
-		case ( Replxx::ACTION::REPAINT ):    repaint();           return ( Replxx::ACTION_RESULT::CONTINUE );
-		case ( Replxx::ACTION::COMPLETE_LINE ):                   return ( action( HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::complete_line, code ) );
-		case ( Replxx::ACTION::COMPLETE_NEXT ):                   return ( action( RESET_KILL_ACTION | DONT_RESET_COMPLETIONS | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::complete_next, code ) );
-		case ( Replxx::ACTION::COMPLETE_PREVIOUS ):               return ( action( RESET_KILL_ACTION | DONT_RESET_COMPLETIONS | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::complete_previous, code ) );
-		case ( Replxx::ACTION::COMMIT_LINE ):                     return ( action( RESET_KILL_ACTION, &Replxx::ReplxxImpl::commit_line, code ) );
-		case ( Replxx::ACTION::ABORT_LINE ):                      return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::abort_line, code ) );
-		case ( Replxx::ACTION::SEND_EOF ):                        return ( action( HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::send_eof, code ) );
-		case ( Replxx::ACTION::BRACKETED_PASTE ):                 return ( action( WANT_REFRESH | RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::bracketed_paste, code ) );
+		case ( Replxx::ACTION::REPAINT ):    repaint();             return ( Replxx::ACTION_RESULT::CONTINUE );
+		case ( Replxx::ACTION::COMPLETE_LINE ):                     return ( action( HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::complete_line, code ) );
+		case ( Replxx::ACTION::COMPLETE_NEXT ):                     return ( action( RESET_KILL_ACTION | DONT_RESET_COMPLETIONS | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::complete_next, code ) );
+		case ( Replxx::ACTION::COMPLETE_PREVIOUS ):                 return ( action( RESET_KILL_ACTION | DONT_RESET_COMPLETIONS | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::complete_previous, code ) );
+		case ( Replxx::ACTION::COMMIT_LINE ):                       return ( action( RESET_KILL_ACTION, &Replxx::ReplxxImpl::commit_line, code ) );
+		case ( Replxx::ACTION::ABORT_LINE ):                        return ( action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::abort_line, code ) );
+		case ( Replxx::ACTION::SEND_EOF ):                          return ( action( HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::send_eof, code ) );
+		case ( Replxx::ACTION::BRACKETED_PASTE ):                   return ( action( WANT_REFRESH | RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::bracketed_paste, code ) );
 	}
 	return ( Replxx::ACTION_RESULT::BAIL );
 }
@@ -351,6 +425,10 @@ void Replxx::ReplxxImpl::set_state( Replxx::State const& state_ ) {
 		_pos = min( state_.cursor_position(), _data.length() );
 	}
 	_modifiedState = true;
+}
+
+void Replxx::ReplxxImpl::set_ignore_case( bool val ) {
+	_ignoreCase = val;
 }
 
 char32_t Replxx::ReplxxImpl::read_char( HINT_ACTION hintAction_ ) {
@@ -386,13 +464,24 @@ char32_t Replxx::ReplxxImpl::read_char( HINT_ACTION hintAction_ ) {
 			refresh_line( HINT_ACTION::REPAINT );
 			continue;
 		}
+
 		std::lock_guard<std::mutex> l( _mutex );
+		_terminal.set_cursor_visible( false );
 		clear_self_to_end_of_screen();
+
+		if ( _updatePrompt ) {
+			// Update the prompt after the screen has been cleared and before it is redrawn
+			_updatePrompt = false;
+			std::string const updated = std::move( _asyncPrompt );
+			_prompt.set_text( UnicodeString( updated ) );
+		}
+
 		while ( ! _messages.empty() ) {
 			string const& message( _messages.front() );
 			_terminal.write8( message.data(), static_cast<int>( message.length() ) );
 			_messages.pop_front();
 		}
+		_lastRefreshTime = 0;
 		repaint();
 	}
 	/* try scheduled key presses */ {
@@ -427,7 +516,10 @@ void Replxx::ReplxxImpl::call_modify_callback( void ) {
 	std::string origLine( _utf8Buffer.get() );
 	int pos( _pos );
 	std::string line( origLine );
-	_modifyCallback( line, pos );
+	/* IOModeGuard scope */ {
+		IOModeGuard ioModeGuard( _terminal );
+		_modifyCallback( line, pos );
+	}
 	if ( ( pos != _pos ) || ( line != origLine ) ) {
 		_data.assign( line.c_str() );
 		_pos = min( pos, _data.length() );
@@ -538,24 +630,29 @@ char const* Replxx::ReplxxImpl::input( std::string const& prompt ) {
 		if ( ! tty::in ) { // input not from a terminal, we should work with piped input, i.e. redirected stdin
 			return ( read_from_stdin() );
 		}
-		if (!_errorMessage.empty()) {
-			printf("%s", _errorMessage.c_str());
-			fflush(stdout);
+		if ( ! _errorMessage.empty() ) {
+			printf( "%s", _errorMessage.c_str() );
+			fflush( stdout );
 			_errorMessage.clear();
 		}
 		if ( isUnsupportedTerm() ) {
-			cout << prompt << flush;
-			fflush(stdout);
+			fprintf( stdout, "%s", prompt.c_str() );
+			fflush( stdout );
 			return ( read_from_stdin() );
 		}
-		if (_terminal.enable_raw_mode() == -1) {
+		std::unique_lock<std::mutex> l( _mutex );
+		if ( _terminal.enable_raw_mode() == -1 ) {
 			return nullptr;
 		}
+
+		_asyncPrompt.clear();
+		_updatePrompt = false;
 		_prompt.set_text( UnicodeString( prompt ) );
 		_currentThread = std::this_thread::get_id();
+		l.unlock();
 		clear();
-		if (!_preloadedBuffer.empty()) {
-			preload_puffer(_preloadedBuffer.c_str());
+		if ( !_preloadedBuffer.empty() ) {
+			preload_puffer( _preloadedBuffer.c_str() );
 			_preloadedBuffer.clear();
 		}
 		if ( get_input_line() == -1 ) {
@@ -570,6 +667,14 @@ char const* Replxx::ReplxxImpl::input( std::string const& prompt ) {
 }
 
 char const* Replxx::ReplxxImpl::finalize_input( char const* retVal_ ) {
+	std::unique_lock<std::mutex> l( _mutex );
+	while ( ! _messages.empty() ) {
+		string const& message( _messages.front() );
+		l.unlock();
+		_terminal.write8( message.data(), static_cast<int>( message.length() ) );
+		l.lock();
+		_messages.pop_front();
+	}
 	_currentThread = std::thread::id();
 	_terminal.disable_raw_mode();
 	return ( retVal_ );
@@ -600,20 +705,35 @@ void Replxx::ReplxxImpl::disable_bracketed_paste( void ) {
 }
 
 void Replxx::ReplxxImpl::print( char const* str_, int size_ ) {
+	std::unique_lock<std::mutex> l( _mutex );
 	if ( ( _currentThread == std::thread::id() ) || ( _currentThread == std::this_thread::get_id() ) ) {
+#ifndef _WIN32
+		l.unlock();
+#endif
 		_terminal.write8( str_, size_ );
 	} else {
-		std::lock_guard<std::mutex> l( _mutex );
 		_messages.emplace_back( str_, size_ );
 		_terminal.notify_event( Terminal::EVENT_TYPE::MESSAGE );
 	}
 	return;
 }
 
+void Replxx::ReplxxImpl::set_prompt( std::string prompt ) {
+	std::unique_lock<std::mutex> l( _mutex );
+	if ( _currentThread == std::this_thread::get_id() ) {
+		_prompt.set_text( UnicodeString( prompt ) );
+		l.unlock();
+		clear_self_to_end_of_screen();
+		repaint();
+	} else if ( _currentThread != std::thread::id() ) {
+		_asyncPrompt = std::move( prompt );
+		_updatePrompt = true;
+		_terminal.notify_event( Terminal::EVENT_TYPE::MESSAGE );
+	}
+}
+
 void Replxx::ReplxxImpl::preload_puffer(const char* preloadText) {
 	_data.assign( preloadText );
-	_charWidths.resize( _data.length() );
-	recompute_character_widths( _data.get(), _charWidths.data(), _data.length() );
 	_prefix = _pos = _data.length();
 }
 
@@ -625,15 +745,28 @@ void Replxx::ReplxxImpl::set_color( Replxx::Color color_ ) {
 	}
 }
 
+void Replxx::ReplxxImpl::indent( void ) {
+	if ( ! _indentMultiline ) {
+		return;
+	}
+	for ( int i( 0 ); i < _prompt.indentation(); ++ i ) {
+		_display.push_back( ' ' );
+	}
+}
+
 void Replxx::ReplxxImpl::render( char32_t ch ) {
 	if ( ch == Replxx::KEY::ESCAPE ) {
 		_display.push_back( '^' );
 		_display.push_back( '[' );
-	} else if ( is_control_code( ch ) ) {
+	} else if ( is_control_code( ch ) && ( ch != '\n' ) ) {
 		_display.push_back( '^' );
 		_display.push_back( control_to_human( ch ) );
 	} else {
 		_display.push_back( ch );
+	}
+	if ( ch == '\n' ) {
+		_hasNewlines = true;
+		indent();
 	}
 	return;
 }
@@ -647,6 +780,7 @@ void Replxx::ReplxxImpl::render( HINT_ACTION hintAction_ ) {
 	if ( hintAction_ == HINT_ACTION::SKIP ) {
 		return;
 	}
+	_hasNewlines = false;
 	_display.clear();
 	if ( _noColor ) {
 		for ( char32_t ch : _data ) {
@@ -659,11 +793,13 @@ void Replxx::ReplxxImpl::render( HINT_ACTION hintAction_ ) {
 	Replxx::colors_t colors( _data.length(), Replxx::Color::DEFAULT );
 	_utf8Buffer.assign( _data );
 	if ( !! _highlighterCallback ) {
+		IOModeGuard ioModeGuard( _terminal );
 		_highlighterCallback( _utf8Buffer.get(), colors );
 	}
 	paren_info_t pi( matching_paren() );
+	Replxx::Color ERROR( Replxx::Color::RED | color::bg( Replxx::Color::BRIGHTRED ) );
 	if ( pi.index != -1 ) {
-		colors[pi.index] = pi.error ? Replxx::Color::ERROR : Replxx::Color::BRIGHTRED;
+		colors[pi.index] = pi.error ? ERROR : Replxx::Color::BRIGHTRED;
 	}
 	Replxx::Color c( Replxx::Color::DEFAULT );
 	for ( int i( 0 ); i < _data.length(); ++ i ) {
@@ -679,25 +815,24 @@ void Replxx::ReplxxImpl::render( HINT_ACTION hintAction_ ) {
 	return;
 }
 
-int Replxx::ReplxxImpl::handle_hints( HINT_ACTION hintAction_ ) {
+void Replxx::ReplxxImpl::handle_hints( HINT_ACTION hintAction_ ) {
 	if ( _noColor ) {
-		return ( 0 );
+		return;
 	}
 	if ( ! _hintCallback ) {
-		return ( 0 );
+		return;
 	}
 	if ( ( _hintDelay > 0 ) && ( hintAction_ != HINT_ACTION::REPAINT ) ) {
 		_hintSelection = -1;
-		return ( 0 );
+		return;
 	}
 	if ( ( hintAction_ == HINT_ACTION::SKIP ) || ( hintAction_ == HINT_ACTION::TRIM ) ) {
-		return ( 0 );
+		return;
 	}
 	if ( _pos != _data.length() ) {
-		return ( 0 );
+		return;
 	}
 	_hint = UnicodeString();
-	int len( 0 );
 	if ( hintAction_ == HINT_ACTION::REGENERATE ) {
 		_hintSelection = -1;
 	}
@@ -706,12 +841,13 @@ int Replxx::ReplxxImpl::handle_hints( HINT_ACTION hintAction_ ) {
 		_hintSeed.assign( _utf8Buffer );
 		_hintContextLenght = context_length();
 		_hintColor = Replxx::Color::GRAY;
+		IOModeGuard ioModeGuard( _terminal );
 		_hintsCache = call_hinter( _utf8Buffer.get(), _hintContextLenght, _hintColor );
 	}
 	int hintCount( static_cast<int>( _hintsCache.size() ) );
 	if ( hintCount == 1 ) {
 		_hint = _hintsCache.front();
-		len = _hint.length() - _hintContextLenght;
+		int len( _hint.length() - _hintContextLenght );
 		if ( len > 0 ) {
 			set_color( _hintColor );
 			for ( int i( 0 ); i < len; ++ i ) {
@@ -720,7 +856,8 @@ int Replxx::ReplxxImpl::handle_hints( HINT_ACTION hintAction_ ) {
 			set_color( Replxx::Color::DEFAULT );
 		}
 	} else if ( ( _maxHintRows > 0 ) && ( hintCount > 0 ) ) {
-		int startCol( _prompt._indentation + _pos );
+		int posInLine( pos_in_line() );
+		int startCol( ( _indentMultiline || ( posInLine == _pos ) ? _prompt.indentation() : 0 ) + posInLine );
 		int maxCol( _prompt.screen_columns() );
 #ifdef _WIN32
 		-- maxCol;
@@ -732,7 +869,7 @@ int Replxx::ReplxxImpl::handle_hints( HINT_ACTION hintAction_ ) {
 		}
 		if ( _hintSelection != -1 ) {
 			_hint = _hintsCache[_hintSelection];
-			len = min<int>( _hint.length(), maxCol - startCol );
+			int len( min<int>( _hint.length(), maxCol - ( startCol - _hintContextLenght ) ) );
 			if ( _hintContextLenght < len ) {
 				set_color( _hintColor );
 				for ( int i( _hintContextLenght ); i < len; ++ i ) {
@@ -752,25 +889,26 @@ int Replxx::ReplxxImpl::handle_hints( HINT_ACTION hintAction_ ) {
 				_display.push_back( ' ' );
 			}
 			set_color( _hintColor );
-			for ( int i( _pos - _hintContextLenght ); ( i < _pos ) && ( col < maxCol ); ++ i, ++ col ) {
-				_display.push_back( _data[i] );
-			}
 			int hintNo( hintRow + _hintSelection + 1 );
 			if ( hintNo == hintCount ) {
+				for ( int i( _pos - _hintContextLenght ); ( i < _pos ) && ( col < maxCol ); ++ i, ++ col ) {
+					_display.push_back( _data[i] );
+				}
 				continue;
 			} else if ( hintNo > hintCount ) {
 				-- hintNo;
 			}
 			UnicodeString const& h( _hintsCache[hintNo % hintCount] );
-			for ( int i( _hintContextLenght ); ( i < h.length() ) && ( col < maxCol ); ++ i, ++ col ) {
+			for ( int i( 0 ); ( i < h.length() ) && ( col < maxCol ); ++ i, ++ col ) {
 				_display.push_back( h[i] );
 			}
 			set_color( Replxx::Color::DEFAULT );
 		}
 	}
-	return ( len );
+	return;
 }
 
+// check for a matching brace/bracket/paren, remember its position if found
 Replxx::ReplxxImpl::paren_info_t Replxx::ReplxxImpl::matching_paren( void ) {
 	if (_pos >= _data.length()) {
 		return ( paren_info_t{ -1, false } );
@@ -778,7 +916,7 @@ Replxx::ReplxxImpl::paren_info_t Replxx::ReplxxImpl::matching_paren( void ) {
 	/* this scans for a brace matching _data[_pos] to highlight */
 	unsigned char part1, part2;
 	int scanDirection = 0;
-	if ( strchr("}])", _data[_pos]) ) {
+	if ( strchr( "}])", _data[_pos] ) ) {
 		scanDirection = -1; /* backwards */
 		if (_data[_pos] == '}') {
 			part1 = '}'; part2 = '{';
@@ -787,7 +925,7 @@ Replxx::ReplxxImpl::paren_info_t Replxx::ReplxxImpl::matching_paren( void ) {
 		} else {
 			part1 = ')'; part2 = '(';
 		}
-	} else if ( strchr("{[(", _data[_pos]) ) {
+	} else if ( strchr( "{[(", _data[_pos] ) ) {
 		scanDirection = 1; /* forwards */
 		if (_data[_pos] == '{') {
 			//part1 = '{'; part2 = '}';
@@ -831,6 +969,11 @@ Replxx::ReplxxImpl::paren_info_t Replxx::ReplxxImpl::matching_paren( void ) {
 	return ( paren_info_t{ highlightIdx, indicateError } );
 }
 
+int Replxx::ReplxxImpl::virtual_render( char32_t const* buffer_, int len_, int& xPos_, int& yPos_, Prompt const* prompt_ ) {
+	Prompt const& prompt( prompt_ ? *prompt_ : _prompt );
+	return ( replxx::virtual_render( buffer_, len_, xPos_, yPos_, prompt.screen_columns(), _indentMultiline ? prompt.indentation() : 0 ) );
+}
+
 /**
  * Refresh the user's input line: the prompt is already onscreen and is not
  * redrawn here screen position
@@ -844,40 +987,40 @@ void Replxx::ReplxxImpl::refresh_line( HINT_ACTION hintAction_ ) {
 		return;
 	}
 	_refreshSkipped = false;
-	// check for a matching brace/bracket/paren, remember its position if found
 	render( hintAction_ );
-	int hintLen( handle_hints( hintAction_ ) );
-	// calculate the position of the end of the input line
-	int xEndOfInput( 0 ), yEndOfInput( 0 );
-	calculate_screen_position(
-		_prompt._indentation, 0, _prompt.screen_columns(),
-		calculate_displayed_length( _data.get(), _data.length() ) + hintLen,
-		xEndOfInput, yEndOfInput
-	);
-	yEndOfInput += static_cast<int>( count( _display.begin(), _display.end(), '\n' ) );
-
+	handle_hints( hintAction_ );
 	// calculate the desired position of the cursor
-	int xCursorPos( 0 ), yCursorPos( 0 );
-	calculate_screen_position(
-		_prompt._indentation, 0, _prompt.screen_columns(),
-		calculate_displayed_length( _data.get(), _pos ),
-		xCursorPos, yCursorPos
-	);
+	int xCursorPos( _prompt.indentation() );
+	int yCursorPos( 0 );
+	virtual_render( _data.get(), _pos, xCursorPos, yCursorPos );
+
+	// calculate the position of the end of the input line
+	int xEndOfInput( _prompt.indentation() );
+	int yEndOfInput( 0 );
+	// _data part of _display already contains the indent,
+	// also newlines belonging to hints part of display shall be ignored
+	// with respect to extra indent for multiline inputs
+	// in other words _display should not be re-indented
+	replxx::virtual_render( _display.data(), static_cast<int>( _display.size() ), xEndOfInput, yEndOfInput, _prompt.screen_columns(), 0 );
 
 	// position at the end of the prompt, clear to end of previous input
 	_terminal.set_cursor_visible( false );
 	_terminal.jump_cursor(
-		_prompt._indentation, // 0-based on Win32
+		_prompt.indentation(), // 0-based on Win32
 		-( _prompt._cursorRowOffset - _prompt._extraLines )
 	);
-	_prompt._previousInputLen = _data.length();
 	// display the input line
-	_terminal.write32( _display.data(), _displayInputLength );
-	_terminal.clear_screen( Terminal::CLEAR_SCREEN::TO_END );
-	_terminal.write32( _display.data() + _displayInputLength, static_cast<int>( _display.size() ) - _displayInputLength );
+	if ( _hasNewlines ) {
+		_terminal.clear_screen( Terminal::CLEAR_SCREEN::TO_END );
+		_terminal.write32( _display.data(), static_cast<int>( _display.size() ) );
+	} else {
+		_terminal.write32( _display.data(), _displayInputLength );
+		_terminal.clear_screen( Terminal::CLEAR_SCREEN::TO_END );
+		_terminal.write32( _display.data() + _displayInputLength, static_cast<int>( _display.size() ) - _displayInputLength );
+	}
 #ifndef _WIN32
 	// we have to generate our own newline on line wrap
-	if ( ( xEndOfInput == 0 ) && ( yEndOfInput > 0 ) ) {
+	if ( ( xEndOfInput == 0 ) && ( yEndOfInput > 0 ) && ! _data.is_empty() && ( _data.back() != '\n' ) ) {
 		_terminal.write8( "\n", 1 );
 	}
 #endif
@@ -886,12 +1029,26 @@ void Replxx::ReplxxImpl::refresh_line( HINT_ACTION hintAction_ ) {
 	_terminal.set_cursor_visible( true );
 	_prompt._cursorRowOffset = _prompt._extraLines + yCursorPos; // remember row for next pass
 	_lastRefreshTime = now_us();
+	_oldPos = _pos;
+	_moveCursor = false;
+}
+
+void Replxx::ReplxxImpl::move_cursor( void ) {
+	// calculate the desired position of the cursor
+	int xCursorPos( _prompt.indentation() );
+	int yCursorPos( 0 );
+	virtual_render( _data.get(), _pos, xCursorPos, yCursorPos );
+	// position the cursor
+	_terminal.jump_cursor( xCursorPos, -( _prompt._cursorRowOffset - _prompt._extraLines - yCursorPos ) );
+	_prompt._cursorRowOffset = _prompt._extraLines + yCursorPos;
+	_oldPos = _pos;
+	_moveCursor = false;
 }
 
 int Replxx::ReplxxImpl::context_length() {
 	int prefixLength = _pos;
 	while ( prefixLength > 0 ) {
-		if ( is_word_break_character( _data[prefixLength - 1] ) ) {
+		if ( is_word_break_character<false>( _data[prefixLength - 1] ) ) {
 			break;
 		}
 		-- prefixLength;
@@ -915,7 +1072,8 @@ void Replxx::ReplxxImpl::clear_self_to_end_of_screen( Prompt const* prompt_ ) {
 }
 
 namespace {
-int longest_common_prefix( Replxx::ReplxxImpl::completions_t const& completions ) {
+
+int longest_common_prefix( Replxx::ReplxxImpl::completions_t const& completions, bool ignoreCase ) {
 	int completionsCount( static_cast<int>( completions.size() ) );
 	if ( completionsCount < 1 ) {
 		return ( 0 );
@@ -933,19 +1091,19 @@ int longest_common_prefix( Replxx::ReplxxImpl::completions_t const& completions 
 				return ( longestCommonPrefix );
 			}
 			char32_t cc( candidate[longestCommonPrefix] );
-			if ( cc != sc ) {
-				return ( longestCommonPrefix );
+			if ( ignoreCase ) {
+				if ( !case_insensitive_equal( cc, sc ) ) {
+					return longestCommonPrefix;
+				}
+			} else if ( cc != sc ) {
+				return longestCommonPrefix;
 			}
 		}
 		++ longestCommonPrefix;
 	}
 }
-}
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
-#endif
+}
 
 /**
  * Handle command completion, using a completionCallback() routine to provide
@@ -968,7 +1126,10 @@ char32_t Replxx::ReplxxImpl::do_complete_line( bool showCompletions_ ) {
 	// get a list of completions
 	_completionSelection = -1;
 	_completionContextLength = context_length();
-	_completions = call_completer( _utf8Buffer.get(), _completionContextLength );
+	/* IOModeGuard scope */ {
+		IOModeGuard ioModeGuard( _terminal );
+		_completions = call_completer( _utf8Buffer.get(), _completionContextLength );
+	}
 
 	// if no completions, we are done
 	if ( _completions.empty() ) {
@@ -980,14 +1141,15 @@ char32_t Replxx::ReplxxImpl::do_complete_line( bool showCompletions_ ) {
 	int longestCommonPrefix = 0;
 	int completionsCount( static_cast<int>( _completions.size() ) );
 	int selectedCompletion( 0 );
-	if ( _hintSelection != -1 ) {
+	if ( ( completionsCount > 1 ) && ( _hintSelection != -1 ) ) {
 		selectedCompletion = _hintSelection;
 		completionsCount = 1;
 	}
 	if ( completionsCount == 1 ) {
 		longestCommonPrefix = static_cast<int>( _completions[selectedCompletion].text().length() );
 	} else {
-		longestCommonPrefix = longest_common_prefix( _completions );
+		bool ignoreCase( _ignoreCase && std::none_of( _data.end() - _completionContextLength, _data.end(), []( char32_t x ) { return iswupper( static_cast<wint_t>( x ) ); } ) );
+		longestCommonPrefix = longest_common_prefix( _completions, ignoreCase );
 	}
 	if ( _beepOnAmbiguousCompletion && ( completionsCount != 1 ) ) { // beep if ambiguous
 		beep();
@@ -995,11 +1157,24 @@ char32_t Replxx::ReplxxImpl::do_complete_line( bool showCompletions_ ) {
 
 	// if we can extend the item, extend it and return to main loop
 	if ( ( longestCommonPrefix > _completionContextLength ) || ( completionsCount == 1 ) ) {
+		UnicodeString const* cand( &_completions[selectedCompletion].text() );
+		if ( _ignoreCase && ( _hintSelection == -1 ) ) {
+			for ( int i( 0 ); i < completionsCount; ++ i ) {
+				if ( _completions[i].text() < *cand ) {
+					cand = &_completions[i].text();
+				}
+			}
+		}
 		_pos -= _completionContextLength;
 		_data.erase( _pos, _completionContextLength );
-		_data.insert( _pos, _completions[selectedCompletion].text(), 0, longestCommonPrefix );
-		_pos = _pos + longestCommonPrefix;
+		_data.insert( _pos, *cand, 0, longestCommonPrefix );
 		_completionContextLength = longestCommonPrefix;
+		if ( _ignoreCase && ( completionsCount > 1 ) ) {
+			for ( int i( 0 ); i < longestCommonPrefix; ++ i ) {
+				_data[_pos + i] = static_cast<char32_t>( towlower( static_cast<wint_t>( _data[_pos + i] ) ) );
+			}
+		}
+		_pos += _completionContextLength;
 		refresh_line();
 		return 0;
 	}
@@ -1135,7 +1310,7 @@ char32_t Replxx::ReplxxImpl::do_complete_line( bool showCompletions_ ) {
 						if (!_noColor) {
 							_terminal.write32(col.get(), col.length());
 						}
-						_terminal.write32(&_data[_pos - _completionContextLength], longestCommonPrefix);
+						_terminal.write32(c.text().get(), longestCommonPrefix);
 						if (!_noColor) {
 							_terminal.write32(res.get(), res.length());
 						}
@@ -1170,10 +1345,6 @@ char32_t Replxx::ReplxxImpl::do_complete_line( bool showCompletions_ ) {
 	refresh_line();
 	return 0;
 }
-
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
 
 int Replxx::ReplxxImpl::get_input_line( void ) {
 	// The latest history entry is always our current buffer
@@ -1223,6 +1394,8 @@ int Replxx::ReplxxImpl::get_input_line( void ) {
 			next = it->second( c );
 			if ( _modifiedState ) {
 				refresh_line();
+			} else if ( _moveCursor ) {
+				move_cursor();
 			}
 		} else {
 			next = action( RESET_KILL_ACTION | HISTORY_RECALL_MOST_RECENT, &Replxx::ReplxxImpl::insert_character, c );
@@ -1257,6 +1430,15 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::action( action_trait_t actionTrait_, k
 	if ( actionTrait_ & WANT_REFRESH ) {
 		_modifiedState = true;
 	}
+	if ( actionTrait_ & MOVE_CURSOR ) {
+		_modifiedState = ( _pos != _oldPos ) && (
+			( _pos == _data.length() )
+			|| ( _oldPos == _data.length() )
+			|| ( ( _pos < _data.length() ) && strchr( "{}[]()", _data[_pos] ) )
+			|| ( ( _oldPos < _data.length() ) && strchr( "{}[]()", _data[_oldPos] ) )
+		);
+		_moveCursor = _pos != _oldPos;
+	}
 	return ( res );
 }
 
@@ -1265,7 +1447,7 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::insert_character( char32_t c ) {
 	 * beep on unknown Ctrl and/or Meta keys
 	 * don't insert control characters
 	 */
-	if ( ( c >= static_cast<int>( Replxx::KEY::BASE ) ) || is_control_code( c ) ) {
+	if ( ( c >= static_cast<int>( Replxx::KEY::BASE ) ) || ( is_control_code( c ) && ( c != '\n' ) ) ) {
 		beep();
 		return ( Replxx::ACTION_RESULT::CONTINUE );
 	}
@@ -1274,6 +1456,7 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::insert_character( char32_t c ) {
 	} else {
 		_data[_pos] = c;
 	}
+	_oldPos = _pos;
 	++ _pos;
 	call_modify_callback();
 	int long long now( now_us() );
@@ -1283,18 +1466,17 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::insert_character( char32_t c ) {
 		_refreshSkipped = true;
 		return ( Replxx::ACTION_RESULT::CONTINUE );
 	}
-	int inputLen = calculate_displayed_length( _data.get(), _data.length() );
+	int xCursorPos( _prompt.indentation() );
+	int yCursorPos( 0 );
+	virtual_render( _data.get(), _data.length(), xCursorPos, yCursorPos );
 	if (
 		( _pos == _data.length() )
 		&& ! _modifiedState
 		&& ( _noColor || ! ( !! _highlighterCallback || !! _hintCallback ) )
-		&& ( _prompt._indentation + inputLen < _prompt.screen_columns() )
+		&& ( yCursorPos == 0 )
 	) {
 		/* Avoid a full assign of the line in the
 		 * trivial case. */
-		if (inputLen > _prompt._previousInputLen) {
-			_prompt._previousInputLen = inputLen;
-		}
 		render( c );
 		_displayInputLength = static_cast<int>( _display.size() );
 		_terminal.write32( reinterpret_cast<char32_t*>( &c ), 1 );
@@ -1305,14 +1487,31 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::insert_character( char32_t c ) {
 	return ( Replxx::ACTION_RESULT::CONTINUE );
 }
 
+// ctrl-J/linefeed/newline
+Replxx::ACTION_RESULT Replxx::ReplxxImpl::new_line( char32_t ) {
+	return ( insert_character( '\n' ) );
+}
+
 // ctrl-A, HOME: move cursor to start of line
-Replxx::ACTION_RESULT Replxx::ReplxxImpl::go_to_begining_of_line( char32_t ) {
-	_pos = 0;
+Replxx::ACTION_RESULT Replxx::ReplxxImpl::go_to_begining_of_line( char32_t char_ ) {
+	if ( _hasNewlines ) {
+		bool onNewline( ( _pos > 0 ) && ( _pos < _data.length() ) && ( _data[_pos] == '\n' ) );
+		int startPos( onNewline ? _pos - 1 : _pos );
+		int newPos( prev_newline_position( startPos ) + 1 );
+		_pos = ( newPos == _pos ) && ( char_ == Replxx::KEY::control( 'A' ) ) ? 0 : newPos;
+	} else {
+		_pos = 0;
+	}
 	return ( Replxx::ACTION_RESULT::CONTINUE );
 }
 
-Replxx::ACTION_RESULT Replxx::ReplxxImpl::go_to_end_of_line( char32_t ) {
-	_pos = _data.length();
+Replxx::ACTION_RESULT Replxx::ReplxxImpl::go_to_end_of_line( char32_t char_ ) {
+	if ( _hasNewlines ) {
+		int newPos( next_newline_position( _pos ) );
+		_pos = ( newPos < 0 ) || ( ( newPos == _pos ) && ( char_ == Replxx::KEY::control( 'E' ) ) ) ? _data.length() : newPos;
+	} else {
+		_pos = _data.length();
+	}
 	return ( Replxx::ACTION_RESULT::CONTINUE );
 }
 
@@ -1320,7 +1519,6 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::go_to_end_of_line( char32_t ) {
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::move_one_char_left( char32_t ) {
 	if (_pos > 0) {
 		--_pos;
-		refresh_line();
 	}
 	return ( Replxx::ACTION_RESULT::CONTINUE );
 }
@@ -1329,47 +1527,47 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::move_one_char_left( char32_t ) {
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::move_one_char_right( char32_t ) {
 	if ( _pos < _data.length() ) {
 		++_pos;
-		refresh_line();
 	}
 	return ( Replxx::ACTION_RESULT::CONTINUE );
 }
 
 // meta-B, move cursor left by one word
+template <bool subword>
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::move_one_word_left( char32_t ) {
 	if (_pos > 0) {
-		while (_pos > 0 && is_word_break_character( _data[_pos - 1] ) ) {
+		while (_pos > 0 && is_word_break_character<subword>( _data[_pos - 1] ) ) {
 			--_pos;
 		}
-		while (_pos > 0 && !is_word_break_character( _data[_pos - 1] ) ) {
+		while (_pos > 0 && !is_word_break_character<subword>( _data[_pos - 1] ) ) {
 			--_pos;
 		}
-		refresh_line();
 	}
 	return ( Replxx::ACTION_RESULT::CONTINUE );
 }
 
-// meta-F, move cursor right by one word
+// meta-f, move cursor right by one word
+template <bool subword>
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::move_one_word_right( char32_t ) {
 	if ( _pos < _data.length() ) {
-		while ( _pos < _data.length() && is_word_break_character( _data[_pos] ) ) {
+		while ( _pos < _data.length() && is_word_break_character<subword>( _data[_pos] ) ) {
 			++_pos;
 		}
-		while ( _pos < _data.length() && !is_word_break_character( _data[_pos] ) ) {
+		while ( _pos < _data.length() && !is_word_break_character<subword>( _data[_pos] ) ) {
 			++_pos;
 		}
-		refresh_line();
 	}
 	return ( Replxx::ACTION_RESULT::CONTINUE );
 }
 
 // meta-Backspace, kill word to left of cursor
+template <bool subword>
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::kill_word_to_left( char32_t ) {
 	if ( _pos > 0 ) {
 		int startingPos = _pos;
-		while ( _pos > 0 && is_word_break_character( _data[_pos - 1] ) ) {
+		while ( _pos > 0 && is_word_break_character<subword>( _data[_pos - 1] ) ) {
 			-- _pos;
 		}
-		while ( _pos > 0 && !is_word_break_character( _data[_pos - 1] ) ) {
+		while ( _pos > 0 && !is_word_break_character<subword>( _data[_pos - 1] ) ) {
 			-- _pos;
 		}
 		_killRing.kill( _data.get() + _pos, startingPos - _pos, false);
@@ -1380,13 +1578,14 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::kill_word_to_left( char32_t ) {
 }
 
 // meta-D, kill word to right of cursor
+template <bool subword>
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::kill_word_to_right( char32_t ) {
 	if ( _pos < _data.length() ) {
 		int endingPos = _pos;
-		while ( endingPos < _data.length() && is_word_break_character( _data[endingPos] ) ) {
+		while ( endingPos < _data.length() && is_word_break_character<subword>( _data[endingPos] ) ) {
 			++ endingPos;
 		}
-		while ( endingPos < _data.length() && !is_word_break_character( _data[endingPos] ) ) {
+		while ( endingPos < _data.length() && !is_word_break_character<subword>( _data[endingPos] ) ) {
 			++ endingPos;
 		}
 		_killRing.kill( _data.get() + _pos, endingPos - _pos, true );
@@ -1415,19 +1614,37 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::kill_to_whitespace_to_left( char32_t )
 
 // ctrl-K, kill from cursor to end of line
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::kill_to_end_of_line( char32_t ) {
-	_killRing.kill( _data.get() + _pos, _data.length() - _pos, true );
-	_data.erase( _pos, _data.length() - _pos );
+	int to( _data.length() );
+	if ( _hasNewlines ) {
+		to = next_newline_position( _pos );
+		if ( ( to < 0 ) || ( to == _pos ) ) {
+			to = _data.length();
+		}
+	}
+
+	_killRing.kill( _data.get() + _pos, to - _pos, true );
+	_data.erase( _pos, to - _pos );
 	return ( Replxx::ACTION_RESULT::CONTINUE );
 }
 
 // ctrl-U, kill all characters to the left of the cursor
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::kill_to_begining_of_line( char32_t ) {
-	if (_pos > 0) {
-		_killRing.kill( _data.get(), _pos, false );
-		_data.erase( 0, _pos );
-		_pos = 0;
-		refresh_line();
+	if (_pos <= 0) {
+		return ( Replxx::ACTION_RESULT::CONTINUE );
 	}
+	int newPos( 0 );
+	if ( _hasNewlines ) {
+		bool onNewline( ( _pos > 0 ) && ( _pos < _data.length() ) && ( _data[_pos] == '\n' ) );
+		int startPos( onNewline ? _pos - 1 : _pos );
+		newPos = prev_newline_position( startPos ) + 1;
+		if ( newPos == _pos ) {
+			newPos = 0;
+		}
+	}
+	_killRing.kill( _data.get() + newPos, _pos - newPos, false );
+	_data.erase( newPos, _pos - newPos );
+	_pos = newPos;
+	refresh_line();
 	return ( Replxx::ACTION_RESULT::CONTINUE );
 }
 
@@ -1493,20 +1710,21 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::yank_last_arg( char32_t ) {
 }
 
 // meta-C, give word initial Cap
+template <bool subword>
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::capitalize_word( char32_t ) {
 	if (_pos < _data.length()) {
-		while ( _pos < _data.length() && is_word_break_character( _data[_pos] ) ) {
+		while ( _pos < _data.length() && is_word_break_character<subword>( _data[_pos] ) ) {
 			++_pos;
 		}
-		if (_pos < _data.length() && !is_word_break_character( _data[_pos] ) ) {
-			if ( _data[_pos] >= 'a' && _data[_pos] <= 'z' ) {
-				_data[_pos] += 'A' - 'a';
+		if (_pos < _data.length() && !is_word_break_character<subword>( _data[_pos] ) ) {
+			if ( iswlower( static_cast<wint_t>( _data[_pos] ) ) ) {
+				_data[_pos] = static_cast<char32_t>( towupper( static_cast<wint_t>( _data[_pos] ) ) );
 			}
 			++_pos;
 		}
-		while (_pos < _data.length() && !is_word_break_character( _data[_pos] ) ) {
-			if ( _data[_pos] >= 'A' && _data[_pos] <= 'Z' ) {
-				_data[_pos] += 'a' - 'A';
+		while (_pos < _data.length() && !is_word_break_character<subword>( _data[_pos] ) ) {
+			if ( iswupper( static_cast<wint_t>( _data[_pos] ) ) ) {
+				_data[_pos] = static_cast<char32_t>( towlower( static_cast<wint_t>( _data[_pos] ) ) );
 			}
 			++_pos;
 		}
@@ -1516,14 +1734,15 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::capitalize_word( char32_t ) {
 }
 
 // meta-L, lowercase word
+template <bool subword>
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::lowercase_word( char32_t ) {
 	if (_pos < _data.length()) {
-		while ( _pos < _data.length() && is_word_break_character( _data[_pos] ) ) {
+		while ( _pos < _data.length() && is_word_break_character<subword>( _data[_pos] ) ) {
 			++ _pos;
 		}
-		while (_pos < _data.length() && !is_word_break_character( _data[_pos] ) ) {
-			if ( _data[_pos] >= 'A' && _data[_pos] <= 'Z' ) {
-				_data[_pos] += 'a' - 'A';
+		while (_pos < _data.length() && !is_word_break_character<subword>( _data[_pos] ) ) {
+			if ( iswupper( static_cast<wint_t>( _data[_pos] ) ) ) {
+				_data[_pos] = static_cast<char32_t>( towlower( static_cast<wint_t>( _data[_pos] ) ) );
 			}
 			++ _pos;
 		}
@@ -1533,14 +1752,15 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::lowercase_word( char32_t ) {
 }
 
 // meta-U, uppercase word
+template <bool subword>
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::uppercase_word( char32_t ) {
 	if (_pos < _data.length()) {
-		while ( _pos < _data.length() && is_word_break_character( _data[_pos] ) ) {
+		while ( _pos < _data.length() && is_word_break_character<subword>( _data[_pos] ) ) {
 			++ _pos;
 		}
-		while ( _pos < _data.length() && !is_word_break_character( _data[_pos] ) ) {
-			if ( _data[_pos] >= 'a' && _data[_pos] <= 'z') {
-				_data[_pos] += 'A' - 'a';
+		while ( _pos < _data.length() && !is_word_break_character<subword>( _data[_pos] ) ) {
+			if ( iswlower( static_cast<wint_t>( _data[_pos] ) ) ) {
+				_data[_pos] = static_cast<char32_t>( towupper( static_cast<wint_t>( _data[_pos] ) ) );
 			}
 			++ _pos;
 		}
@@ -1565,7 +1785,7 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::transpose_characters( char32_t ) {
 }
 
 // ctrl-C, abort this line
-Replxx::ACTION_RESULT Replxx::ReplxxImpl::abort_line( char32_t ) {
+Replxx::ACTION_RESULT Replxx::ReplxxImpl::abort_line( char32_t keyCode_ ) {
 	errno = EAGAIN;
 	_history.drop_last();
 	// we need one last refresh with the cursor at the end of the line
@@ -1573,7 +1793,9 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::abort_line( char32_t ) {
 	_pos = _data.length(); // pass _data.length() as _pos for EOL
 	_lastRefreshTime = 0;
 	refresh_line( _refreshSkipped ? HINT_ACTION::REGENERATE : HINT_ACTION::TRIM );
-	_terminal.write8( "^C\r\n", 4 );
+	if ( keyCode_ == Replxx::KEY::control( 'C' ) ) {
+		_terminal.write8( "^C\r\n", 4 );
+	}
 	return ( Replxx::ACTION_RESULT::BAIL );
 }
 
@@ -1606,8 +1828,7 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::backspace_character( char32_t ) {
 	return ( Replxx::ACTION_RESULT::CONTINUE );
 }
 
-// ctrl-J/linefeed/newline, accept line
-// ctrl-M/return/enter
+// ctrl-M/return/enter, accept line
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::commit_line( char32_t ) {
 	// we need one last refresh with the cursor at the end of the line
 	// so we don't display the next prompt over the previous input line
@@ -1619,26 +1840,116 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::commit_line( char32_t ) {
 	return ( Replxx::ACTION_RESULT::RETURN );
 }
 
+int Replxx::ReplxxImpl::prev_newline_position( int pos_ ) const {
+	assert( ( pos_ >= 0 ) && ( pos_ <= _data.length() ) );
+	if ( pos_ == _data.length() ) {
+		-- pos_;
+	}
+	while ( pos_ >= 0 ) {
+		if ( _data[pos_] == '\n' ) {
+			break;
+		}
+		-- pos_;
+	}
+	return ( pos_ );
+}
+
+int Replxx::ReplxxImpl::next_newline_position( int pos_ ) const {
+	assert( ( pos_ >= 0 ) && ( pos_ <= _data.length() ) );
+	int len( _data.length() );
+	while ( pos_ < len ) {
+		if ( _data[pos_] == '\n' ) {
+			break;
+		}
+		++ pos_;
+	}
+	return ( pos_ < len ? pos_ : -1 );
+}
+
+int Replxx::ReplxxImpl::pos_in_line( void ) const {
+	if ( ! _hasNewlines ) {
+		return ( _pos );
+	}
+	int lineStart( prev_newline_position( _pos ) + 1 );
+	return ( _pos - lineStart );
+}
+
+// Up, recall previous line in history
+Replxx::ACTION_RESULT Replxx::ReplxxImpl::line_previous( char32_t ) {
+	assert( ( _pos >= 0 ) && ( _pos <= _data.length() ) );
+	do {
+		if ( ! _hasNewlines ) {
+			break;
+		}
+		int prevNewlinePosition( prev_newline_position( _pos ) );
+		if ( prevNewlinePosition == _pos ) {
+			prevNewlinePosition = prev_newline_position( _pos - 1 );
+		}
+		if ( prevNewlinePosition < 0 ) {
+			break;
+		}
+		int posInLine( _pos - prevNewlinePosition - 1 );
+		int prevLineStart( prevNewlinePosition > 0 ? prev_newline_position( prevNewlinePosition - 1 ) + 1 : 0 );
+		int prevLineLength( max( prevNewlinePosition - prevLineStart, 0 ) );
+		int shift( ! _indentMultiline && ( prevLineStart == 0 ) ? _prompt.indentation() : 0 );
+		posInLine = max( min( posInLine, prevLineLength + shift ) - shift, 0 );
+		_pos = prevLineStart + posInLine;
+		assert( ( _pos >= 0 ) && ( _pos <= _data.length() ) );
+		return ( Replxx::ACTION_RESULT::CONTINUE );
+	} while ( false );
+	return ( history_move( true ) );
+}
+
 // Down, recall next line in history
+Replxx::ACTION_RESULT Replxx::ReplxxImpl::line_next( char32_t ) {
+	assert( ( _pos >= 0 ) && ( _pos <= _data.length() ) );
+	do {
+		if ( ! _hasNewlines ) {
+			break;
+		}
+		int nextNewlinePosition( next_newline_position( _pos ) );
+		if ( nextNewlinePosition < 0 ) {
+			break;
+		}
+		int nextLineStart( nextNewlinePosition + 1 );
+		int nextLineEnd( next_newline_position( nextLineStart ) );
+		if ( nextLineEnd < 0 ) {
+			nextLineEnd = _data.length();
+		}
+		int nextLineLength( nextLineEnd - nextLineStart );
+		int prevNewlinePosition( prev_newline_position( _pos ) );
+		if ( prevNewlinePosition == _pos ) {
+			prevNewlinePosition = _pos > 0 ? prev_newline_position( _pos - 1 ) : -1;
+		}
+		int lineStartPosition( prevNewlinePosition + 1 );
+		int posInLine( _pos - lineStartPosition );
+		int shift( ! _indentMultiline && ( lineStartPosition == 0 ) ? _prompt.indentation() : 0 );
+		posInLine = max( min( posInLine + shift, nextLineLength ), 0 );
+		_pos = nextLineStart + posInLine;
+		assert( ( _pos >= 0 ) && ( _pos <= _data.length() ) );
+		return ( Replxx::ACTION_RESULT::CONTINUE );
+	} while ( false );
+	return ( history_move( false ) );
+}
+
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::history_next( char32_t ) {
 	return ( history_move( false ) );
 }
 
-// Up, recall previous line in history
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::history_previous( char32_t ) {
 	return ( history_move( true ) );
 }
 
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::history_move( bool previous_ ) {
 	// if not already recalling, add the current line to the history list so
-	// we don't
-	// have to special case it
+	// we don't have to special case it
 	if ( _history.is_last() ) {
 		_history.update_last( _data );
 	}
 	if ( _history.is_empty() ) {
 		return ( Replxx::ACTION_RESULT::CONTINUE );
 	}
+	_history.set_current_scratch( _data );
 	if ( ! _history.move( previous_ ) ) {
 		return ( Replxx::ACTION_RESULT::CONTINUE );
 	}
@@ -1651,13 +1962,57 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::history_move( bool previous_ ) {
 // meta-<, beginning of history
 // Page Up, beginning of history
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::history_first( char32_t ) {
+	do {
+		if ( ! _hasNewlines ) {
+			break;
+		}
+		if ( _pos == 0 ) {
+			break;
+		}
+		_pos = 0;
+		return ( Replxx::ACTION_RESULT::CONTINUE );
+	} while ( false );
 	return ( history_jump( true ) );
 }
 
 // meta->, end of history
 // Page Down, end of history
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::history_last( char32_t ) {
+	do {
+		if ( ! _hasNewlines ) {
+			break;
+		}
+		if ( _pos == _data.length() ) {
+			break;
+		}
+		_pos = _data.length();
+		return ( Replxx::ACTION_RESULT::CONTINUE );
+	} while ( false );
 	return ( history_jump( false ) );
+}
+
+// CTRL-g, restore current history entry
+Replxx::ACTION_RESULT Replxx::ReplxxImpl::history_restore_current( char32_t ) {
+	// if not already recalling, there is nothing to restore.
+	if ( ! _history.is_last() ) {
+		_history.reset_current_scratch();
+		_data.assign( _history.current() );
+		_pos = _data.length();
+		refresh_line();
+	}
+	return ( Replxx::ACTION_RESULT::CONTINUE );
+}
+
+// meta-g restore all history entries
+Replxx::ACTION_RESULT Replxx::ReplxxImpl::history_restore( char32_t ) {
+	_history.reset_scratches();
+	// if not already recalling, there is nothing to restore.
+	if ( ! _history.is_last() ) {
+		_data.assign( _history.current() );
+		_pos = _data.length();
+		refresh_line();
+	}
+	return ( Replxx::ACTION_RESULT::CONTINUE );
 }
 
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::history_jump( bool back_ ) {
@@ -1668,6 +2023,7 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::history_jump( bool back_ ) {
 		_history.update_last( _data );
 	}
 	if ( ! _history.is_empty() ) {
+		_history.set_current_scratch( _data );
 		_history.jump( back_ );
 		_data.assign( _history.current() );
 		_pos = _data.length();
@@ -1714,9 +2070,10 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::verbatim_insert( char32_t ) {
 
 // ctrl-Z, job control
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::suspend( char32_t ) {
-	_terminal.disable_raw_mode(); // Returning to Linux (whatever) shell, leave raw mode
-	raise(SIGSTOP);   // Break out in mid-line
-	_terminal.enable_raw_mode();  // Back from Linux shell, re-enter raw mode
+	/* IOModeGuard scope */ {
+		IOModeGuard ioModeGuard( _terminal );
+		raise( SIGSTOP );   // Break out in mid-line
+	}
 	// Redraw prompt
 	_prompt.write();
 	return ( Replxx::ACTION_RESULT::CONTINUE );
@@ -1783,10 +2140,9 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::complete_previous( char32_t ) {
 // Alt-N, forward history search for prefix
 // Alt-N, forward history search for prefix
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::common_prefix_search( char32_t startChar ) {
-	int prefixSize( calculate_displayed_length( _data.get(), _prefix ) );
 	if (
 		_history.common_prefix_search(
-			_data, prefixSize, ( startChar == ( Replxx::KEY::meta( 'p' ) ) ) || ( startChar == ( Replxx::KEY::meta( 'P' ) ) )
+			_data, _prefix, ( startChar == ( Replxx::KEY::meta( 'p' ) ) ) || ( startChar == ( Replxx::KEY::meta( 'P' ) ) ), _ignoreCase
 		)
 	) {
 		_data.assign( _history.current() );
@@ -1814,13 +2170,15 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::incremental_history_search( char32_t s
 	_history.save_pos();
 	int historyLinePosition( _pos );
 	clear_self_to_end_of_screen();
+	bool seeded( startChar == Replxx::KEY::meta( 'r' ) );
+	DynamicPrompt dp( _terminal, ( startChar == Replxx::KEY::control( 'R' ) ) || seeded ? -1 : 1 );
+	if ( seeded ) {
+		dp._searchText.assign( _data );
+		dp.updateSearchPrompt();
+	}
 
-	DynamicPrompt dp( _terminal, (startChar == Replxx::KEY::control('R')) ? -1 : 1 );
-
-	dp._previousLen = _prompt._previousLen;
-	dp._previousInputLen = _prompt._previousInputLen;
 	// draw user's text with our prompt
-	dynamicRefresh(dp, _data.get(), _data.length(), historyLinePosition);
+	dynamic_refresh( _prompt, dp, _data.get(), _data.length(), historyLinePosition );
 
 	// loop until we get an exit character
 	char32_t c( 0 );
@@ -1829,9 +2187,12 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::incremental_history_search( char32_t s
 	bool searchAgain = false;
 	UnicodeString activeHistoryLine;
 	while ( keepLooping ) {
-		c = read_char();
+		if ( ! seeded ) {
+			c = read_char();
+		}
 
-		switch (c) {
+		switch ( c ) {
+			case 0: break;
 			// these characters keep the selected text but do not execute it
 			case Replxx::KEY::control('A'): // ctrl-A, move cursor to start of line
 			case Replxx::KEY::HOME:
@@ -1886,15 +2247,15 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::incremental_history_search( char32_t s
 			} break;
 
 			// these characters stay in search mode and assign the display
-			case Replxx::KEY::control('S'):
-			case Replxx::KEY::control('R'): {
-				if ( dp._searchText.length() == 0 ) { // if no current search text, recall previous text
-					if ( _previousSearchText.length() > 0 ) {
-						dp._searchText = _previousSearchText;
-					}
+			case Replxx::KEY::control( 'S' ):
+			case Replxx::KEY::control( 'R' ):
+			case Replxx::KEY::meta( 'r' ): {
+				if ( ( dp._searchText.length() == 0 ) && ( _previousSearchText.length() > 0 ) ) {
+					// if no current search text, recall previous text
+					dp._searchText = _previousSearchText;
 				}
 				if (
-					( ( dp._direction == 1 ) && ( c == Replxx::KEY::control( 'R' ) ) )
+					( ( dp._direction == 1 ) && ( ( c == Replxx::KEY::control( 'R' ) ) || ( c == Replxx::KEY::meta( 'r' ) ) ) )
 					|| ( ( dp._direction == -1 ) && ( c == Replxx::KEY::control( 'S' ) ) )
 				) {
 					dp._direction = 0 - dp._direction; // reverse direction
@@ -1907,10 +2268,14 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::incremental_history_search( char32_t s
 // job control is its own thing
 #ifndef _WIN32
 			case Replxx::KEY::control('Z'): { // ctrl-Z, job control
-				_terminal.disable_raw_mode();   // Returning to Linux (whatever) shell, leave raw mode
-				raise( SIGSTOP );               // Break out in mid-line
-				_terminal.enable_raw_mode();    // Back from Linux shell, re-enter raw mode
-				dynamicRefresh( dp, activeHistoryLine.get(), activeHistoryLine.length(), historyLinePosition );
+				/* IOModeGuard scope */ {
+					IOModeGuard ioModeGuard( _terminal );
+					// Returning to Linux (whatever) shell, leave raw mode
+					// Break out in mid-line
+					// Back from Linux shell, re-enter raw mode
+					raise( SIGSTOP );
+				}
+				dynamic_refresh( dp, dp, activeHistoryLine.get(), activeHistoryLine.length(), historyLinePosition );
 				continue;
 			} break;
 #endif
@@ -1952,6 +2317,7 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::incremental_history_search( char32_t s
 				lineSearchPos += dp._direction;
 			}
 			searchAgain = false;
+			bool ignoreCase( _ignoreCase && std::none_of( dp._searchText.begin(), dp._searchText.end(), []( char32_t x ) { return iswupper( static_cast<wint_t>( x ) ); } ) );
 			while ( true ) {
 				while (
 					dp._direction < 0
@@ -1961,10 +2327,17 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::incremental_history_search( char32_t s
 					if (
 						( lineSearchPos >= 0 )
 						&& ( ( lineSearchPos + dp._searchText.length() ) <= activeHistoryLine.length() )
-						&& std::equal( dp._searchText.begin(), dp._searchText.end(), activeHistoryLine.begin() + lineSearchPos )
+						&& std::equal(
+							dp._searchText.begin(), dp._searchText.end(), activeHistoryLine.begin() + lineSearchPos,
+							ignoreCase ? case_insensitive_equal : case_sensitive_equal
+						)
 					) {
-						found = true;
-						break;
+						if ( ! seeded ) {
+							found = true;
+							break;
+						} else {
+							seeded = false;
+						}
 					}
 					lineSearchPos += dp._direction;
 				}
@@ -1975,6 +2348,7 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::incremental_history_search( char32_t s
 					activeHistoryLine.assign( _history.current() );
 					lineSearchPos = ( dp._direction > 0 ) ? 0 : ( activeHistoryLine.length() - dp._searchText.length() );
 				} else {
+					historyLinePosition = _pos;
 					beep();
 					break;
 				}
@@ -1987,33 +2361,25 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::incremental_history_search( char32_t s
 			historyLinePosition = _pos;
 		}
 		activeHistoryLine.assign( _history.current() );
-		dynamicRefresh( dp, activeHistoryLine.get(), activeHistoryLine.length(), historyLinePosition ); // draw user's text with our prompt
+		dynamic_refresh( dp, dp, activeHistoryLine.get(), activeHistoryLine.length(), historyLinePosition ); // draw user's text with our prompt
+		seeded = false;
 	} // while
 
 	// leaving history search, restore previous prompt, maybe make searched line
 	// current
 	Prompt pb( _terminal );
-	pb._characterCount = _prompt._indentation;
-	pb._byteCount = _prompt._byteCount;
-	UnicodeString tempUnicode( &_prompt._text[_prompt._lastLinePosition], pb._byteCount - _prompt._lastLinePosition );
-	pb._text = tempUnicode;
-	pb._extraLines = 0;
-	pb._indentation = _prompt._indentation;
-	pb._lastLinePosition = 0;
-	pb._previousInputLen = activeHistoryLine.length();
-	pb._cursorRowOffset = dp._cursorRowOffset;
+	UnicodeString tempUnicode( &_prompt._text[_prompt._lastLinePosition], _prompt._text.length() - _prompt._lastLinePosition );
+	pb.set_text( tempUnicode );
 	pb.update_screen_columns();
-	pb._previousLen = dp._characterCount;
 	if ( useSearchedLine && ( activeHistoryLine.length() > 0 ) ) {
 		_history.commit_index();
 		_data.assign( activeHistoryLine );
 		_pos = historyLinePosition;
+		_modifiedState = true;
 	} else if ( ! useSearchedLine ) {
 		_history.restore_pos();
 	}
-	dynamicRefresh(pb, _data.get(), _data.length(), _pos); // redraw the original prompt with current input
-	_prompt._previousInputLen = _data.length();
-	_prompt._cursorRowOffset = _prompt._extraLines + pb._cursorRowOffset;
+	dynamic_refresh(pb, _prompt, _data.get(), _data.length(), _pos); // redraw the original prompt with current input
 	_previousSearchText = dp._searchText; // save search text for possible reuse on ctrl-R ctrl-R
 	emulate_key_press( c ); // pass a character or -1 back to main loop
 	return ( Replxx::ACTION_RESULT::CONTINUE );
@@ -2038,6 +2404,8 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::bracketed_paste( char32_t ) {
 		}
 		if ( ( c == '\r' ) || ( c == KEY::control( 'M' ) ) ) {
 			c = '\n';
+		} else if ( c == KEY::control( 'I' ) ) {
+			c = '\t';
 		}
 		buf.push_back( c );
 	}
@@ -2046,10 +2414,11 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::bracketed_paste( char32_t ) {
 	return ( Replxx::ACTION_RESULT::CONTINUE );
 }
 
+template <bool subword>
 bool Replxx::ReplxxImpl::is_word_break_character( char32_t char_ ) const {
 	bool wbc( false );
 	if ( char_ < 128 ) {
-		wbc = strchr( _breakChars.c_str(), static_cast<char>( char_ ) ) != nullptr;
+		wbc = strchr( subword ? _subwordBreakChars.c_str() : _wordBreakChars.c_str(), static_cast<char>( char_ ) ) != nullptr;
 	}
 	return ( wbc );
 }
@@ -2062,12 +2431,20 @@ bool Replxx::ReplxxImpl::history_save( std::string const& filename ) {
 	return ( _history.save( filename, false ) );
 }
 
+void Replxx::ReplxxImpl::history_save( std::ostream& out ) {
+	_history.save( out );
+}
+
 bool Replxx::ReplxxImpl::history_sync( std::string const& filename ) {
 	return ( _history.save( filename, true ) );
 }
 
 bool Replxx::ReplxxImpl::history_load( std::string const& filename ) {
 	return ( _history.load( filename ) );
+}
+
+void Replxx::ReplxxImpl::history_load( std::istream& in ) {
+	_history.load( in );
 }
 
 void Replxx::ReplxxImpl::history_clear( void ) {
@@ -2115,7 +2492,11 @@ void Replxx::ReplxxImpl::set_hint_delay( int hintDelay_ ) {
 }
 
 void Replxx::ReplxxImpl::set_word_break_characters( char const* wordBreakers ) {
-	_breakChars = wordBreakers;
+	_wordBreakChars = wordBreakers;
+}
+
+void Replxx::ReplxxImpl::set_subword_break_characters( char const* subwordBreakers ) {
+	_subwordBreakChars = subwordBreakers;
 }
 
 void Replxx::ReplxxImpl::set_double_tab_completion( bool val ) {
@@ -2142,6 +2523,10 @@ void Replxx::ReplxxImpl::set_no_color( bool val ) {
 	_noColor = val;
 }
 
+void Replxx::ReplxxImpl::set_indent_multiline( bool val ) {
+	_indentMultiline = val;
+}
+
 /**
  * Display the dynamic incremental search prompt and the current user input
  * line.
@@ -2151,44 +2536,32 @@ void Replxx::ReplxxImpl::set_no_color( bool val ) {
  * @param len   count of characters in the buffer
  * @param pos   current cursor position within the buffer (0 <= pos <= len)
  */
-void Replxx::ReplxxImpl::dynamicRefresh(Prompt& pi, char32_t* buf32, int len, int pos) {
-	clear_self_to_end_of_screen( &pi );
+void Replxx::ReplxxImpl::dynamic_refresh(Prompt& oldPrompt, Prompt& newPrompt, char32_t* buf32, int len, int pos) {
+	clear_self_to_end_of_screen( &oldPrompt );
 	// calculate the position of the end of the prompt
-	int xEndOfPrompt, yEndOfPrompt;
-	calculate_screen_position(
-		0, 0, pi.screen_columns(), pi._characterCount,
-		xEndOfPrompt, yEndOfPrompt
-	);
-	pi._indentation = xEndOfPrompt;
-
-	// calculate the position of the end of the input line
-	int xEndOfInput, yEndOfInput;
-	calculate_screen_position(
-		xEndOfPrompt, yEndOfPrompt, pi.screen_columns(),
-		calculate_displayed_length(buf32, len), xEndOfInput,
-		yEndOfInput
-	);
+	int xEndOfPrompt( 0 );
+	int yEndOfPrompt( 0 );
+	replxx::virtual_render( newPrompt._text.get(), newPrompt._text.length(), xEndOfPrompt, yEndOfPrompt, newPrompt.screen_columns(), 0 );
 
 	// calculate the desired position of the cursor
-	int xCursorPos, yCursorPos;
-	calculate_screen_position(
-		xEndOfPrompt, yEndOfPrompt, pi.screen_columns(),
-		calculate_displayed_length(buf32, pos), xCursorPos,
-		yCursorPos
-	);
+	int xCursorPos( xEndOfPrompt );
+	int yCursorPos( yEndOfPrompt );
+	virtual_render( buf32, pos, xCursorPos, yCursorPos, &newPrompt );
 
-	pi._previousLen = pi._indentation;
-	pi._previousInputLen = len;
+	// calculate the position of the end of the input line
+	int xEndOfInput( xCursorPos );
+	int yEndOfInput( yCursorPos );
+	virtual_render( buf32 + pos, len - pos, xEndOfInput, yEndOfInput, &newPrompt );
 
 	// display the prompt
-	pi.write();
+	newPrompt.write();
 
 	// display the input line
 	_terminal.write32( buf32, len );
 
 #ifndef _WIN32
 	// we have to generate our own newline on line wrap
-	if (xEndOfInput == 0 && yEndOfInput > 0) {
+	if ( ( xEndOfInput == 0 ) && ( yEndOfInput > 0 ) && ( len > 0 ) && ( buf32[len - 1] != '\n' ) ) {
 		_terminal.write8( "\n", 1 );
 	}
 #endif
@@ -2197,7 +2570,7 @@ void Replxx::ReplxxImpl::dynamicRefresh(Prompt& pi, char32_t* buf32, int len, in
 		xCursorPos, // 0-based on Win32
 		-( yEndOfInput - yCursorPos )
 	);
-	pi._cursorRowOffset = pi._extraLines + yCursorPos; // remember row for next pass
+	newPrompt._cursorRowOffset = newPrompt._extraLines + yCursorPos; // remember row for next pass
 }
 
 }

--- a/third-party/replxx/src/terminal.hxx
+++ b/third-party/replxx/src/terminal.hxx
@@ -38,6 +38,7 @@ private:
 	std::vector<char> _empty;
 #else
 	struct termios _origTermios; /* in order to restore at exit */
+	struct termios _rawModeTermios; /* in order to reset raw mode after callbacks */
 	int _interrupt[2];
 #endif
 	bool _rawMode; /* for destructor to check if restore is needed */
@@ -57,6 +58,7 @@ public:
 	void enable_bracketed_paste( void );
 	void disable_bracketed_paste( void );
 	int enable_raw_mode(void);
+	int reset_raw_mode(void);
 	void disable_raw_mode(void);
 	char32_t read_char(void);
 	void clear_screen( CLEAR_SCREEN );

--- a/third-party/replxx/src/utf8string.hxx
+++ b/third-party/replxx/src/utf8string.hxx
@@ -68,7 +68,13 @@ public:
 	}
 
 	bool operator != ( Utf8String const& other_ ) {
-		return ( ( other_._len != _len ) || ( memcmp( other_._data.get(), _data.get(), _len ) != 0 ) );
+		return (
+			( other_._len != _len )
+			|| (
+				(  _len != 0 )
+				&& ( memcmp( other_._data.get(), _data.get(), _len ) != 0 )
+			)
+		);
 	}
 
 private:

--- a/third-party/replxx/src/util.cxx
+++ b/third-party/replxx/src/util.cxx
@@ -5,149 +5,158 @@
 #include <wctype.h>
 
 #include "util.hxx"
+#include "terminal.hxx"
+
+#undef min
 
 namespace replxx {
 
 int mk_wcwidth( char32_t );
 
-/**
- * Recompute widths of all characters in a char32_t buffer
- * @param text      - input buffer of Unicode characters
- * @param widths    - output buffer of character widths
- * @param charCount - number of characters in buffer
- */
-void recompute_character_widths( char32_t const* text, char* widths, int charCount ) {
-	for (int i = 0; i < charCount; ++i) {
-		widths[i] = mk_wcwidth(text[i]);
-	}
-}
-
-/**
- * Calculate a new screen position given a starting position, screen width and
- * character count
- * @param x             - initial x position (zero-based)
- * @param y             - initial y position (zero-based)
- * @param screenColumns - screen column count
- * @param charCount     - character positions to advance
- * @param xOut          - returned x position (zero-based)
- * @param yOut          - returned y position (zero-based)
- */
-void calculate_screen_position(
-	int x, int y, int screenColumns,
-	int charCount, int& xOut, int& yOut
-) {
-	xOut = x;
-	yOut = y;
-	int charsRemaining = charCount;
-	while ( charsRemaining > 0 ) {
-		int charsThisRow = ( ( x + charsRemaining ) < screenColumns )
-			? charsRemaining
-			: screenColumns - x;
-		xOut = x + charsThisRow;
-		yOut = y;
-		charsRemaining -= charsThisRow;
-		x = 0;
-		++ y;
-	}
-	if ( xOut == screenColumns ) {	// we have to special-case line wrap
-		xOut = 0;
-		++ yOut;
-	}
-}
-
-/**
- * Calculate a column width using mk_wcswidth()
- * @param buf32 - text to calculate
- * @param len   - length of text to calculate
- */
-int calculate_displayed_length( char32_t const* buf32_, int size_ ) {
-	int len( 0 );
-	for ( int i( 0 ); i < size_; ++ i ) {
-		char32_t c( buf32_[i] );
+int virtual_render( char32_t const* display_, int size_, int& x_, int& y_, int screenColumns_, int promptLen_, char32_t* rendered_, int* renderedSize_ ) {
+	char32_t* out( rendered_ );
+	int visibleCount( 0 );
+	auto render = [&rendered_, &renderedSize_, &out, &visibleCount]( char32_t c_, bool visible_, bool renderAttributes_ = true ) {
+		if ( rendered_ && renderedSize_ && renderAttributes_ ) {
+			*out = c_;
+			++ out;
+			if ( visible_ ) {
+				++ visibleCount;
+			}
+		}
+	};
+	bool wrapped( false );
+	auto advance_cursor = [&x_, &y_, &screenColumns_, &wrapped]( int by_ = 1 ) {
+		wrapped = false;
+		x_ += by_;
+		if ( x_ >= screenColumns_ ) {
+			x_ = 0;
+			++ y_;
+			wrapped = true;
+		}
+	};
+	bool const renderAttributes( !!tty::out );
+	int pos( 0 );
+	while ( pos < size_ ) {
+		char32_t c( display_[pos] );
+		if ( ( c == '\n' ) || ( c == '\r' ) ) {
+			render( c, true );
+			if ( ( c == '\n' ) && ! wrapped ) {
+				++ y_;
+			}
+			x_ = promptLen_;
+			++ pos;
+			continue;
+		}
+		if ( c == '\b' ) {
+			render( c, true );
+			-- x_;
+			if ( x_ < 0 ) {
+				x_ = screenColumns_ - 1;
+				-- y_;
+			}
+			++ pos;
+			continue;
+		}
 		if ( c == '\033' ) {
-			int escStart( i );
-			++ i;
-			if ( ( i < size_ ) && ( buf32_[i] != '[' ) ) {
-				i = escStart;
-				++ len;
+			render( c, false, renderAttributes );
+			++ pos;
+			if ( pos >= size_ ) {
+				advance_cursor( 2 );
 				continue;
 			}
-			++ i;
-			for ( ; i < size_; ++ i ) {
-				c = buf32_[i];
+			c = display_[pos];
+			if ( c != '[' ) {
+				advance_cursor( 2 );
+				continue;
+			}
+			render( c, false, renderAttributes );
+			++ pos;
+			if ( pos >= size_ ) {
+				advance_cursor( 3 );
+				continue;
+			}
+			int codeLen( 0 );
+			while ( pos < size_ ) {
+				c = display_[pos];
 				if ( ( c != ';' ) && ( ( c < '0' ) || ( c > '9' ) ) ) {
 					break;
 				}
+				render( c, false, renderAttributes );
+				++ codeLen;
+				++ pos;
 			}
-			if ( ( i < size_ ) && ( buf32_[i] == 'm' ) ) {
+			if ( pos >= size_ ) {
 				continue;
 			}
-			i = escStart;
-			len += 2;
-		} else if ( is_control_code( c ) ) {
-			len += 2;
-		} else {
-			int wcw( mk_wcwidth( c ) );
-			if ( wcw < 0 ) {
-				len = -1;
-				break;
+			c = display_[pos];
+			if ( c != 'm' ) {
+				advance_cursor( 3 + codeLen );
+				continue;
 			}
-			len += wcw;
+			render( c, false, renderAttributes );
+			++ pos;
+			continue;
 		}
+		if ( is_control_code( c ) ) {
+			render( c, true );
+			advance_cursor( 2 );
+			++ pos;
+			continue;
+		}
+		int wcw( mk_wcwidth( c ) );
+		if ( wcw < 0 ) {
+			break;
+		}
+		render( c, true );
+		advance_cursor( wcw );
+		++ pos;
 	}
-	return ( len );
+	if ( rendered_ && renderedSize_ ) {
+		*renderedSize_ = out - rendered_;
+	}
+	return ( visibleCount );
 }
 
 char const* ansi_color( Replxx::Color color_ ) {
-	static char const reset[] = "\033[0m";
-	static char const black[] = "\033[0;22;30m";
-	static char const red[] = "\033[0;22;31m";
-	static char const green[] = "\033[0;22;32m";
-	static char const brown[] = "\033[0;22;33m";
-	static char const blue[] = "\033[0;22;34m";
-	static char const magenta[] = "\033[0;22;35m";
-	static char const cyan[] = "\033[0;22;36m";
-	static char const lightgray[] = "\033[0;22;37m";
-
+	int unsigned code( static_cast<int unsigned>( color_ ) );
+	int unsigned fg( code & 0xFFu );
+	int unsigned bg( ( code >> 8 ) & 0xFFu );
+	char const* bold( ( code & color::BOLD ) != 0 ? ";1" : "" );
+	char const* underline = ( ( code & color::UNDERLINE ) != 0 ? ";4" : "" );
+	static int const MAX_COLOR_CODE_SIZE( 32 );
+	static char colorBuffer[MAX_COLOR_CODE_SIZE];
+	int pos( 0 );
+	if ( ( code & static_cast<int unsigned>( Replxx::Color::DEFAULT ) ) != 0 ) {
+		pos = snprintf( colorBuffer, MAX_COLOR_CODE_SIZE, "\033[0%s%sm", underline, bold );
+	} else if ( fg <= static_cast<int unsigned>( Replxx::Color::LIGHTGRAY ) ) {
+		pos = snprintf( colorBuffer, MAX_COLOR_CODE_SIZE, "\033[0;22;3%d%s%sm", fg, underline, bold );
+	} else if ( fg <= static_cast<int unsigned>( Replxx::Color::WHITE ) ) {
 #ifdef _WIN32
-	static bool const has256colorDefault( true );
+		static bool const has256colorDefault( true );
 #else
-	static bool const has256colorDefault( false );
+		static bool const has256colorDefault( false );
 #endif
-	static char const* TERM( getenv( "TERM" ) );
-	static bool const has256color( TERM ? ( strstr( TERM, "256" ) != nullptr ) : has256colorDefault );
-	static char const* gray = has256color ? "\033[0;1;90m" : "\033[0;1;30m";
-	static char const* brightred = has256color ? "\033[0;1;91m" : "\033[0;1;31m";
-	static char const* brightgreen = has256color ? "\033[0;1;92m" : "\033[0;1;32m";
-	static char const* yellow = has256color ? "\033[0;1;93m" : "\033[0;1;33m";
-	static char const* brightblue = has256color ? "\033[0;1;94m" : "\033[0;1;34m";
-	static char const* brightmagenta = has256color ? "\033[0;1;95m" : "\033[0;1;35m";
-	static char const* brightcyan = has256color ? "\033[0;1;96m" : "\033[0;1;36m";
-	static char const* white = has256color ? "\033[0;1;97m" : "\033[0;1;37m";
-	static char const error[] = "\033[101;1;33m";
-
-	char const* code( reset );
-	switch ( color_ ) {
-		case Replxx::Color::BLACK:         code = black;         break;
-		case Replxx::Color::RED:           code = red;           break;
-		case Replxx::Color::GREEN:         code = green;         break;
-		case Replxx::Color::BROWN:         code = brown;         break;
-		case Replxx::Color::BLUE:          code = blue;          break;
-		case Replxx::Color::MAGENTA:       code = magenta;       break;
-		case Replxx::Color::CYAN:          code = cyan;          break;
-		case Replxx::Color::LIGHTGRAY:     code = lightgray;     break;
-		case Replxx::Color::GRAY:          code = gray;          break;
-		case Replxx::Color::BRIGHTRED:     code = brightred;     break;
-		case Replxx::Color::BRIGHTGREEN:   code = brightgreen;   break;
-		case Replxx::Color::YELLOW:        code = yellow;        break;
-		case Replxx::Color::BRIGHTBLUE:    code = brightblue;    break;
-		case Replxx::Color::BRIGHTMAGENTA: code = brightmagenta; break;
-		case Replxx::Color::BRIGHTCYAN:    code = brightcyan;    break;
-		case Replxx::Color::WHITE:         code = white;         break;
-		case Replxx::Color::ERROR:         code = error;         break;
-		case Replxx::Color::DEFAULT:       code = reset;         break;
+		static char const* TERM( getenv( "TERM" ) );
+		static bool const has256color( TERM ? ( strstr( TERM, "256" ) != nullptr ) : has256colorDefault );
+		static char const* ansiEscapeCodeTemplate = has256color ? "\033[0;9%d%s%sm" : "\033[0;1;3%d%s%sm";
+		pos = snprintf( colorBuffer, MAX_COLOR_CODE_SIZE, ansiEscapeCodeTemplate, fg - static_cast<int>( Replxx::Color::GRAY ), underline, bold );
+	} else {
+		pos = snprintf( colorBuffer, MAX_COLOR_CODE_SIZE, "\033[0;38;5;%d%s%sm", fg, underline, bold );
 	}
-	return ( code );
+	if ( ( code & color::BACKGROUND_COLOR_SET ) == 0 ) {
+		return colorBuffer;
+	}
+	if ( bg <= static_cast<int unsigned>( Replxx::Color::WHITE ) ) {
+		if ( bg <= static_cast<int unsigned>( Replxx::Color::LIGHTGRAY ) ) {
+			snprintf( colorBuffer + pos, MAX_COLOR_CODE_SIZE - pos, "\033[4%dm", bg );
+		} else {
+			snprintf( colorBuffer + pos, MAX_COLOR_CODE_SIZE - pos, "\033[10%dm", bg - static_cast<int>( Replxx::Color::GRAY ) );
+		}
+	} else {
+		snprintf( colorBuffer + pos, MAX_COLOR_CODE_SIZE - pos, "\033[48;5;%dm", bg );
+	}
+	return colorBuffer;
 }
 
 std::string now_ms_str( void ) {

--- a/third-party/replxx/src/util.hxx
+++ b/third-party/replxx/src/util.hxx
@@ -5,6 +5,14 @@
 
 namespace replxx {
 
+namespace color {
+static int unsigned const RGB666 = 16u;
+static int unsigned const GRAYSCALE = 232u;
+static int unsigned const BOLD = 1u << 17u;
+static int unsigned const UNDERLINE = 1u << 18u;
+static int unsigned const BACKGROUND_COLOR_SET = 1u << 19u;
+}
+
 inline bool is_control_code(char32_t testChar) {
 	return (testChar < ' ') ||											// C0 controls
 				 (testChar >= 0x7F && testChar <= 0x9F);	// DEL and C1 controls
@@ -14,9 +22,7 @@ inline char32_t control_to_human( char32_t key ) {
 	return ( key < 27 ? ( key + 0x40 ) : ( key + 0x18 ) );
 }
 
-void recompute_character_widths( char32_t const* text, char* widths, int charCount );
-void calculate_screen_position( int x, int y, int screenColumns, int charCount, int& xOut, int& yOut );
-int calculate_displayed_length( char32_t const* buf32, int size );
+int virtual_render( char32_t const*, int, int&, int&, int, int, char32_t* = nullptr, int* = nullptr );
 char const* ansi_color( Replxx::Color );
 std::string now_ms_str( void );
 

--- a/third-party/replxx/src/windows.cxx
+++ b/third-party/replxx/src/windows.cxx
@@ -113,7 +113,7 @@ int win_write( HANDLE out_, bool autoEscape_, char const* str_, int size_ ) {
 						int toWrite( static_cast<int>( str_ - s ) );
 						WriteConsoleA( out_, s, static_cast<DWORD>( toWrite ), &nWritten, nullptr );
 						count += nWritten;
-						if ( nWritten != toWrite ) {
+						if ( static_cast<int>( nWritten ) != toWrite ) {
 							s = str_ = nullptr;
 							break;
 						}

--- a/third-party/replxx/tests.py
+++ b/third-party/replxx/tests.py
@@ -28,6 +28,7 @@ keytab = {
 	"<backspace>": "",
 	"<tab>": "\t",
 	"<cr>": "\r",
+	"<s-cr>": chr( 10 ),
 	"<lf>": "\n",
 	"<left>": "\033[D",
 	"<s-left>": "\033[1;2D",
@@ -55,6 +56,7 @@ keytab = {
 	"<c-d>": "",
 	"<c-e>": "",
 	"<c-f>": "",
+	"<c-g>": "",
 	"<c-k>": "",
 	"<c-l>": "",
 	"<c-n>": "",
@@ -68,13 +70,22 @@ keytab = {
 	"<c-y>": "",
 	"<c-z>": "",
 	"<m-b>": "\033b",
+	"<m-B>": "\033B",
 	"<m-c>": "\033c",
+	"<m-C>": "\033C",
 	"<m-d>": "\033d",
+	"<m-D>": "\033D",
 	"<m-f>": "\033f",
+	"<m-F>": "\033F",
+	"<m-g>": "\033g",
 	"<m-l>": "\033l",
+	"<m-L>": "\033L",
 	"<m-n>": "\033n",
 	"<m-p>": "\033p",
+	"<m-r>": "\033r",
 	"<m-u>": "\033u",
+	"<m-U>": "\033U",
+	"<m-w>": "\033w",
 	"<m-y>": "\033y",
 	"<m-.>": "\033.",
 	"<m-backspace>": "\033\177",
@@ -141,8 +152,30 @@ termseq = {
 	"\x1b[0;1;35m": "<brightmagenta>",
 	"\x1b[0;1;36m": "<brightcyan>",
 	"\x1b[0;1;37m": "<white>",
+	"\x1b[0;1m": "<bold>",
+	"\x1b[0;4m": "<underline>",
+	"\x1b[0;4;1m": "<bold_underline>",
+	"\x1b[0;22;31;1m": "<bold_red>",
+	"\x1b[0;22;31;4m": "<underline_red>",
+	"\x1b[0;1;31;1m": "<bold_brightred>",
+	"\x1b[0;22;31;4;1m": "<bold_underline_red>",
+	"\x1b[40m": "<bgblack>",
+	"\x1b[41m": "<bgred>",
+	"\x1b[42m": "<bggreen>",
+	"\x1b[43m": "<bgbrown>",
+	"\x1b[44m": "<bgblue>",
+	"\x1b[45m": "<bgmagenta>",
+	"\x1b[46m": "<bgcyan>",
+	"\x1b[47m": "<bglightgray>",
+	"\x1b[100m": "<bggray>",
+	"\x1b[101m": "<bgbrightred>",
+	"\x1b[102m": "<bgbrightgreen>",
+	"\x1b[103m": "<bgyellow>",
+	"\x1b[104m": "<bgbrightblue>",
+	"\x1b[105m": "<bgbrightmagenta>",
+	"\x1b[106m": "<bgbrightcyan>",
+	"\x1b[107m": "<bgwhite>",
 	"\x1b[1;32m": "<brightgreen>",
-	"\x1b[101;1;33m": "<err>",
 	"\x07": "<bell>",
 	"\x1b[2~": "<ins-key>",
 	"\x1b[?2004h": "<paste-on>",
@@ -151,6 +184,8 @@ termseq = {
 colRe = re.compile( "\\x1b\\[(\\d+)G" )
 upRe = re.compile( "\\x1b\\[(\\d+)A" )
 downRe = re.compile( "\\x1b\\[(\\d+)B" )
+colorRe = re.compile( "\\x1b\\[0;38;5;(\\d+)m" )
+bgcolorRe = re.compile( "\\x1b\\[48;5;(\\d+)m" )
 
 def sym_to_raw( str_ ):
 	for sym, seq in keytab.items():
@@ -166,6 +201,8 @@ def seq_to_sym( str_ ):
 	str_ = colRe.sub( "<c\\1>", str_ )
 	str_ = upRe.sub( "<u\\1>", str_ )
 	str_ = downRe.sub( "<d\\1>", str_ )
+	str_ = colorRe.sub( "<color\\1>", str_ )
+	str_ = bgcolorRe.sub( "<bgcolor\\1>", str_ )
 	return str_
 
 _words_ = [
@@ -221,11 +258,13 @@ class ReplxxTests( unittest.TestCase ):
 		command = _cxxSample_,
 		dimensions = ( 25, 80 ),
 		prompt = _prompt_,
-		end = _prompt_ + _end_,
+		end = None,
 		encoding = "utf-8",
 		pause = 0.25,
 		intraKeyDelay = 0.002
 	):
+		if end is None:
+			end = prompt + ReplxxTests._end_
 		with open( "replxx_history.txt", "wb" ) as f:
 			f.write( history.encode( encoding ) )
 			f.close()
@@ -331,7 +370,7 @@ class ReplxxTests( unittest.TestCase ):
 			"<c23><c1><ceos>(reverse-i-search)`w': "
 			"two<c25><c1><ceos>(reverse-i-search)`w': "
 			"two<c25><c1><ceos><brightgreen>replxx<rst>> "
-			"two<c10><c9><ceos><c12>\r\n"
+			"two<c10><c9>two<rst><ceos><c10><c9>two<rst><ceos><c12>\r\n"
 			"two\r\n"
 		)
 	def test_ctrl_l( self_ ):
@@ -358,8 +397,7 @@ class ReplxxTests( unittest.TestCase ):
 		self_.check_scenario(
 			"<up><c-a><m-f><c-right><backspace><backspace><backspace><backspace><cr><c-d>",
 			"<c9>one two three<rst><ceos><c22><c9>one two "
-			"three<rst><ceos><c9><c9>one two three<rst><ceos><c12><c9>one two "
-			"three<rst><ceos><c16><c9>one tw three<rst><ceos><c15><c9>one t "
+			"three<rst><ceos><c9><c12><c16><c9>one tw three<rst><ceos><c15><c9>one t "
 			"three<rst><ceos><c14><c9>one  three<rst><ceos><c13><c9>one "
 			"three<rst><ceos><c12><c9>one three<rst><ceos><c18>\r\n"
 			"one three\r\n",
@@ -369,7 +407,7 @@ class ReplxxTests( unittest.TestCase ):
 		self_.check_scenario(
 			"<up><m-b><c-left><del><c-d><del><c-d><cr><c-d>",
 			"<c9>one two three<rst><ceos><c22><c9>one two "
-			"three<rst><ceos><c17><c9>one two three<rst><ceos><c13><c9>one wo "
+			"three<rst><ceos><c17><c13><c9>one wo "
 			"three<rst><ceos><c13><c9>one o three<rst><ceos><c13><c9>one  "
 			"three<rst><ceos><c13><c9>one three<rst><ceos><c13><c9>one three<rst><ceos><c18>\r\n"
 			"one three\r\n",
@@ -390,40 +428,62 @@ class ReplxxTests( unittest.TestCase ):
 	def test_left_key( self_ ):
 		self_.check_scenario(
 			"abc<left>x<aleft><left>y<cr><c-d>",
-			"<c9>a<rst><ceos><c10><c9>ab<rst><ceos><c11><c9>abc<rst><ceos><c12><c9>abc<rst><ceos><c11><c9>abxc<rst><ceos><c12><c9>abxc<rst><ceos><c11><c9>abxc<rst><ceos><c10><c9>aybxc<rst><ceos><c11><c9>aybxc<rst><ceos><c14>\r\n"
+			"<c9>a<rst><ceos><c10><c9>ab<rst><ceos><c11><c9>abc<rst><ceos><c12><c9>abc<rst><ceos><c11><c9>abxc<rst><ceos><c12><c11><c10><c9>aybxc<rst><ceos><c11><c9>aybxc<rst><ceos><c14>\r\n"
 			"aybxc\r\n"
 		)
 	def test_right_key( self_ ):
 		self_.check_scenario(
 			"abc<home><right>x<aright>y<cr><c-d>",
-			"<c9>a<rst><ceos><c10><c9>ab<rst><ceos><c11><c9>abc<rst><ceos><c12><c9>abc<rst><ceos><c9><c9>abc<rst><ceos><c10><c9>axbc<rst><ceos><c11><c9>axbc<rst><ceos><c12><c9>axbyc<rst><ceos><c13><c9>axbyc<rst><ceos><c14>\r\n"
+			"<c9>a<rst><ceos><c10><c9>ab<rst><ceos><c11><c9>abc<rst><ceos><c12><c9>abc<rst><ceos><c9><c10><c9>axbc<rst><ceos><c11><c12><c9>axbyc<rst><ceos><c13><c9>axbyc<rst><ceos><c14>\r\n"
 			"axbyc\r\n"
 		)
 	def test_prev_word_key( self_ ):
 		self_.check_scenario(
-			"abc def ghi<c-left><m-left>x<cr><c-d>",
-			"<c9>a<rst><ceos><c10><c9>ab<rst><ceos><c11><c9>abc<rst><ceos><c12><c9>abc "
-			"<rst><ceos><c13><c9>abc d<rst><ceos><c14><c9>abc "
-			"de<rst><ceos><c15><c9>abc def<rst><ceos><c16><c9>abc "
-			"def <rst><ceos><c17><c9>abc def "
-			"g<rst><ceos><c18><c9>abc def gh<rst><ceos><c19><c9>abc "
-			"def ghi<rst><ceos><c20><c9>abc def ghi<rst><ceos><c17><c9>abc def "
-			"ghi<rst><ceos><c13><c9>abc xdef ghi<rst><ceos><c14><c9>abc xdef "
-			"ghi<rst><ceos><c21>\r\n"
-			"abc xdef ghi\r\n"
+			"<up><c-left><m-left>x<cr><c-d>",
+			"<c9>abc def ghi<rst><ceos><c20><c9>abc def ghi<rst><ceos><c17><c13><c9>abc "
+			"xdef ghi<rst><ceos><c14><c9>abc xdef ghi<rst><ceos><c21>\r\n"
+			"abc xdef ghi\r\n",
+			"abc def ghi\n"
+		)
+		self_.check_scenario(
+			"<up><m-B>x<left><m-B>x<left><m-b>x<left><m-B>x<cr><c-d>",
+			"<c9>abc_def ghi_jkl mnl_opq rst_uvw<rst><ceos><c40><c9>abc_def ghi_jkl "
+			"mnl_opq rst_uvw<rst><ceos><c37><c9>abc_def ghi_jkl mnl_opq "
+			"rst_xuvw<rst><ceos><c38><c37>"
+			"<c33><c9>abc_def ghi_jkl mnl_opq "
+			"xrst_xuvw<rst><ceos><c34><c33>"
+			"<c25><c9>abc_def ghi_jkl xmnl_opq "
+			"xrst_xuvw<rst><ceos><c26><c25>"
+			"<c21><c9>abc_def ghi_xjkl xmnl_opq "
+			"xrst_xuvw<rst><ceos><c22><c9>abc_def ghi_xjkl xmnl_opq "
+			"xrst_xuvw<rst><ceos><c44>\r\n"
+			"abc_def ghi_xjkl xmnl_opq xrst_xuvw\r\n",
+			"abc_def ghi_jkl mnl_opq rst_uvw\r\n"
 		)
 	def test_next_word_key( self_ ):
 		self_.check_scenario(
-			"abc def ghi<home><c-right><m-right>x<cr><c-d>",
-			"<c9>a<rst><ceos><c10><c9>ab<rst><ceos><c11><c9>abc<rst><ceos><c12><c9>abc "
-			"<rst><ceos><c13><c9>abc d<rst><ceos><c14><c9>abc "
-			"de<rst><ceos><c15><c9>abc def<rst><ceos><c16><c9>abc "
-			"def <rst><ceos><c17><c9>abc def "
-			"g<rst><ceos><c18><c9>abc def gh<rst><ceos><c19><c9>abc "
-			"def ghi<rst><ceos><c20><c9>abc def ghi<rst><ceos><c9><c9>abc def "
-			"ghi<rst><ceos><c12><c9>abc def ghi<rst><ceos><c16><c9>abc defx "
-			"ghi<rst><ceos><c17><c9>abc defx ghi<rst><ceos><c21>\r\n"
-			"abc defx ghi\r\n"
+			"<up><home><c-right><m-right>x<cr><c-d>",
+			"<c9>abc def ghi<rst><ceos><c20><c9>abc def "
+			"ghi<rst><ceos><c9><c12><c16><c9>abc defx ghi<rst><ceos><c17><c9>abc defx "
+			"ghi<rst><ceos><c21>\r\n"
+			"abc defx ghi\r\n",
+			"abc def ghi\n"
+		)
+		self_.check_scenario(
+			"<up><home><m-F>x<m-F>x<m-f>x<m-F>x<cr><c-d>",
+			"<c9>abc_def ghi_jkl mno_pqr stu_vwx<rst><ceos><c40><c9>abc_def ghi_jkl "
+			"mno_pqr stu_vwx<rst><ceos><c9>"
+			"<c12><c9>abcx_def ghi_jkl mno_pqr "
+			"stu_vwx<rst><ceos><c13>"
+			"<c17><c9>abcx_defx ghi_jkl mno_pqr "
+			"stu_vwx<rst><ceos><c18>"
+			"<c26><c9>abcx_defx ghi_jklx mno_pqr "
+			"stu_vwx<rst><ceos><c27>"
+			"<c31><c9>abcx_defx ghi_jklx mnox_pqr "
+			"stu_vwx<rst><ceos><c32><c9>abcx_defx ghi_jklx mnox_pqr "
+			"stu_vwx<rst><ceos><c44>\r\n"
+			"abcx_defx ghi_jklx mnox_pqr stu_vwx\r\n",
+			"abc_def ghi_jkl mno_pqr stu_vwx\r\n"
 		)
 	def test_hint_show( self_ ):
 		self_.check_scenario(
@@ -437,11 +497,11 @@ class ReplxxTests( unittest.TestCase ):
 		self_.check_scenario(
 			"<up><cr><c-d>",
 			"<c9>zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz "
-			"<brightgreen>color_brightgreen<rst><ceos><c15><u3><c9>zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz "
-			"<brightgreen>color_brightgreen<rst><ceos><c15>\r\n"
+			"<brightgreen>color_brightgreen<rst><ceos><c63><c9>zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz "
+			"<brightgreen>color_brightgreen<rst><ceos><c63>\r\n"
 			"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz color_brightgreen\r\n",
 			"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz color_brightgreen\n",
-			dimensions = ( 64, 16 )
+			dimensions = ( 16, 64 )
 		)
 	def test_hint_scroll_down( self_ ):
 		self_.check_scenario(
@@ -468,16 +528,40 @@ class ReplxxTests( unittest.TestCase ):
 			"        <gray>color_black<rst>\r\n"
 			"        <gray>color_red<rst>\r\n"
 			"        "
-			"<gray>color_green<rst><u3><c11><c9>co<rst><ceos><gray>lor_normal<rst>\r\n"
+			"<gray>color_green<rst><u3><c11><c9>co<rst><ceos><gray>lor_white<rst>\r\n"
 			"        <gray>co\r\n"
 			"        <gray>color_black<rst>\r\n"
 			"        "
-			"<gray>color_red<rst><u3><c11><c9>co<rst><ceos><gray>lor_white<rst>\r\n"
-			"        <gray>color_normal<rst>\r\n"
+			"<gray>color_red<rst><u3><c11><c9>co<rst><ceos><gray>lor_brightcyan<rst>\r\n"
+			"        <gray>color_white<rst>\r\n"
 			"        <gray>co\r\n"
 			"        "
-			"<gray>color_black<rst><u3><c11><c9><white>color_white<rst><ceos><c20><c9><white>color_white<rst><ceos><c20>\r\n"
-			"color_white\r\n"
+			"<gray>color_black<rst><u3><c11><c9><brightcyan>color_brightcyan<rst><ceos><c25><c9><brightcyan>color_brightcyan<rst><ceos><c25>\r\n"
+			"color_brightcyan\r\n"
+		)
+	def test_overlong_hint( self_ ):
+		self_.check_scenario(
+			"<up><c-down><c-down><tab><cr><c-d>",
+			"<c9>zzzzzzzzzzzzzzzzzzzzzzzzz color_br<rst><ceos>\r\n"
+			"                                  <gray>color_brown<rst>\r\n"
+			"                                  <gray>color_brightre<rst>\r\n"
+			"                                  <gray>color_brightgr<rst>\r\n"
+			"<u4><c43><c9>zzzzzzzzzzzzzzzzzzzzzzzzz color_br<rst><ceos><gray>own<rst>\r\n"
+			"                                  <gray>color_brightre<rst>\r\n"
+			"                                  <gray>color_brightgr<rst>\r\n"
+			"                                  <gray>color_brightbl<rst>\r\n"
+			"<u4><c43><c9>zzzzzzzzzzzzzzzzzzzzzzzzz "
+			"color_br<rst><ceos><gray>ightre<rst>\r\n"
+			"                                  <gray>color_brightgr<rst>\r\n"
+			"                                  <gray>color_brightbl<rst>\r\n"
+			"                                  <gray>color_brightma<rst>\r\n"
+			"<u4><c43><c9>zzzzzzzzzzzzzzzzzzzzzzzzz "
+			"<brightred>color_brightred<rst><ceos><c2><u1><c9>zzzzzzzzzzzzzzzzzzzzzzzzz "
+			"<brightred>color_brightred<rst><ceos><c2>\r\n"
+			"zzzzzzzzzzzzzzzzzzzzzzzzz color_brightred\r\n",
+			#replxx> #
+			        "zzzzzzzzzzzzzzzzzzzzzzzzz color_br\n",###################
+			dimensions = ( 16, 48 )
 		)
 	def test_history( self_ ):
 		self_.check_scenario(
@@ -492,13 +576,13 @@ class ReplxxTests( unittest.TestCase ):
 	def test_paren_matching( self_ ):
 		self_.check_scenario(
 			"ab(cd)ef<left><left><left><left><left><left><left><cr><c-d>",
-			"<c9>a<rst><ceos><c10><c9>ab<rst><ceos><c11><c9>ab<brightmagenta>(<rst><ceos><c12><c9>ab<brightmagenta>(<rst>c<rst><ceos><c13><c9>ab<brightmagenta>(<rst>cd<rst><ceos><c14><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst><ceos><c15><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst>e<rst><ceos><c16><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst>ef<rst><ceos><c17><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst>ef<rst><ceos><c16><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst>ef<rst><ceos><c15><c9>ab<brightred>(<rst>cd<brightmagenta>)<rst>ef<rst><ceos><c14><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst>ef<rst><ceos><c13><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst>ef<rst><ceos><c12><c9>ab<brightmagenta>(<rst>cd<brightred>)<rst>ef<rst><ceos><c11><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst>ef<rst><ceos><c10><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst>ef<rst><ceos><c17>\r\n"
+			"<c9>a<rst><ceos><c10><c9>ab<rst><ceos><c11><c9>ab<brightmagenta>(<rst><ceos><c12><c9>ab<brightmagenta>(<rst>c<rst><ceos><c13><c9>ab<brightmagenta>(<rst>cd<rst><ceos><c14><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst><ceos><c15><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst>e<rst><ceos><c16><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst>ef<rst><ceos><c17><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst>ef<rst><ceos><c16><c15><c9>ab<brightred>(<rst>cd<brightmagenta>)<rst>ef<rst><ceos><c14><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst>ef<rst><ceos><c13><c12><c9>ab<brightmagenta>(<rst>cd<brightred>)<rst>ef<rst><ceos><c11><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst>ef<rst><ceos><c10><c9>ab<brightmagenta>(<rst>cd<brightmagenta>)<rst>ef<rst><ceos><c17>\r\n"
 			"ab(cd)ef\r\n"
 		)
 	def test_paren_not_matched( self_ ):
 		self_.check_scenario(
 			"a(b[c)d<left><left><left><left><left><left><left><cr><c-d>",
-			"<c9>a<rst><ceos><c10><c9>a<brightmagenta>(<rst><ceos><c11><c9>a<brightmagenta>(<rst>b<rst><ceos><c12><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst><ceos><c13><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<rst><ceos><c14><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst><ceos><c15><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c16><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c15><c9>a<err>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c14><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c13><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c12><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c11><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<err>)<rst>d<rst><ceos><c10><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c9><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c16>\r\n"
+			"<c9>a<rst><ceos><c10><c9>a<brightmagenta>(<rst><ceos><c11><c9>a<brightmagenta>(<rst>b<rst><ceos><c12><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst><ceos><c13><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<rst><ceos><c14><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst><ceos><c15><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c16><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c15><c9>a<red><bgbrightred>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c14><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c13><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c12><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c11><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<red><bgbrightred>)<rst>d<rst><ceos><c10><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c9><c9>a<brightmagenta>(<rst>b<brightmagenta>[<rst>c<brightmagenta>)<rst>d<rst><ceos><c16>\r\n"
 			"a(b[c)d\r\n"
 		)
 	def test_tab_completion( self_ ):
@@ -523,7 +607,7 @@ class ReplxxTests( unittest.TestCase ):
 			"<brightmagenta>color_<rst>brown          "
 			"<brightmagenta>color_<rst><brightred>brightred<rst>      <brightmagenta>color_<rst>white\r\n"
 			"<brightmagenta>color_<rst>blue           "
-			"<brightmagenta>color_<rst>brightgreen    <brightmagenta>color_<rst>normal\r\n"
+			"<brightmagenta>color_<rst>brightgreen\r\n"
 			"<brightmagenta>color_<rst>magenta        <brightmagenta>color_<rst>yellow\r\n"
 			"<brightgreen>replxx<rst>> <c9>color_<rst><ceos>\r\n"
 			"        <gray>color_black<rst>\r\n"
@@ -708,7 +792,8 @@ class ReplxxTests( unittest.TestCase ):
 			"golf<c31><c1><ceos>(reverse-i-search)`repl': echo repl "
 			"golf<c32><c1><ceos>(reverse-i-search)`repl': charlie repl "
 			"delta<c35><c1><ceos><brightgreen>replxx<rst>> charlie repl "
-			"delta<c17><c9><ceos><c27>\r\n"
+			"delta<c17><c9>charlie repl delta<rst><ceos><c17><c9>charlie repl "
+			"delta<rst><ceos><c27>\r\n"
 			"charlie repl delta\r\n",
 			"some command\n"
 			"alfa repl bravo\n"
@@ -728,7 +813,7 @@ class ReplxxTests( unittest.TestCase ):
 			"fortran<c25><c1><ceos>(reverse-i-search)`f': "
 			"swift<c27><c1><ceos>(reverse-i-search)`fs': "
 			"fsharp<c25><c1><ceos><brightgreen>replxx<rst>> "
-			"fsharp<c9><c9><ceos><c15>\r\n"
+			"fsharp<c9><c9>fsharp<rst><ceos><c9><c9>fsharp<rst><ceos><c15>\r\n"
 			"fsharp\r\n",
 			"\n".join( _words_ ) + "\n"
 		)
@@ -768,8 +853,8 @@ class ReplxxTests( unittest.TestCase ):
 			"golf<c22><c1><ceos>(i-search)`rep': echo repl "
 			"golf<c23><c1><ceos>(i-search)`repl': echo repl "
 			"golf<c24><c1><ceos>(i-search)`repl': alfa repl "
-			"bravo<c24><c1><ceos><brightgreen>replxx<rst>> alfa repl bravo<c14><c9>final "
-			"thoughts<rst><ceos><c24>\r\n"
+			"bravo<c24><c1><ceos><brightgreen>replxx<rst>> alfa repl bravo<c14><c9>alfa "
+			"repl bravo<rst><ceos><c14><c9>alfa repl bravo<rst><ceos><c24>\r\n"
 			"alfa repl bravo\r\n",
 			"final thoughts\n"
 			"echo repl golf\n"
@@ -796,7 +881,7 @@ class ReplxxTests( unittest.TestCase ):
 			"fortran<c17><c1><ceos>(i-search)`for': fortran<c18><c1><ceos>(i-search)`fo': "
 			"fortran<c17><c1><ceos>(i-search)`f': swift<c19><c1><ceos>(i-search)`fs': "
 			"fsharp<c17><c1><ceos><brightgreen>replxx<rst>> "
-			"fsharp<c9><c9>typescript<rst><ceos><c15>\r\n"
+			"fsharp<c9><c9>fsharp<rst><ceos><c9><c9>fsharp<rst><ceos><c15>\r\n"
 			"fsharp\r\n",
 			"\n".join( _words_[::-1] ) + "\n"
 		)
@@ -827,8 +912,9 @@ class ReplxxTests( unittest.TestCase ):
 			"<c23><c1><ceos>(reverse-i-search)`r': echo repl "
 			"golf<c29><c1><ceos>(reverse-i-search)`re': echo repl "
 			"golf<c30><c1><ceos>(reverse-i-search)`req': other "
-			"request<c32><c1><ceos><brightgreen>replxx<rst>> other request<c15><c9>alfa "
-			"repl bravo<rst><ceos><c24><c9>alfa repl bravo<rst><ceos><c24>\r\n"
+			"request<c32><c1><ceos><brightgreen>replxx<rst>> other request<c15><c9>other "
+			"request<rst><ceos><c15><c9>alfa repl bravo<rst><ceos><c24><c9>alfa repl "
+			"bravo<rst><ceos><c24>\r\n"
 			"alfa repl bravo\r\n",
 			"some command\n"
 			"alfa repl bravo\n"
@@ -847,8 +933,10 @@ class ReplxxTests( unittest.TestCase ):
 			"seriously<c37><u1><c1><ceos>(reverse-i-search)`lo': some very long line of "
 			"text, much longer then a witdth of a terminal, "
 			"seriously<u1><c59><c1><ceos><brightgreen>replxx<rst>> some very long line of "
-			"text, much longer then a witdth of a terminal, "
-			"seriously<u1><c43><c9><ceos><c24>\r\n"
+			"text, much longer then a witdth of a terminal, seriously<u1><c43><c9>some "
+			"very long line of text, much longer then a witdth of a terminal, "
+			"seriously<rst><ceos><u1><c43><c9>some very long line of text, much longer "
+			"then a witdth of a terminal, seriously<rst><ceos><c24>\r\n"
 			"some very long line of text, much longer then a witdth of a terminal, "
 			"seriously\r\n",
 			"fake\nsome very long line of text, much longer then a witdth of a terminal, seriously\nanother fake",
@@ -1000,7 +1088,7 @@ class ReplxxTests( unittest.TestCase ):
 			command = ReplxxTests._cSample_ + " u0 q1"
 		)
 		self_.check_scenario(
-			rapid( "/history\n/unique\n/history\n<c-d>" ),
+			rapid( "/history<cr>/unique<cr>/history<cr><c-d>" ),
 			"<c9>/<rst><ceos><c10><c9>/history<rst><ceos><c17>\r\n"
 			"   0: a\r\n"
 			"   1: b\r\n"
@@ -1051,52 +1139,92 @@ class ReplxxTests( unittest.TestCase ):
 		self_.check_scenario(
 			"<up><home><right><m-c><m-c><right><right><m-c><m-c><m-c><cr><c-d>",
 			"<c9>abc defg ijklmn zzxq<rst><ceos><c29><c9>abc defg ijklmn "
-			"zzxq<rst><ceos><c9><c9>abc defg ijklmn zzxq<rst><ceos><c10><c9>aBc defg "
-			"ijklmn zzxq<rst><ceos><c12><c9>aBc Defg ijklmn zzxq<rst><ceos><c17><c9>aBc "
-			"Defg ijklmn zzxq<rst><ceos><c18><c9>aBc Defg ijklmn "
-			"zzxq<rst><ceos><c19><c9>aBc Defg iJklmn zzxq<rst><ceos><c24><c9>aBc Defg "
+			"zzxq<rst><ceos><c9><c10><c9>aBc defg "
+			"ijklmn zzxq<rst><ceos><c12><c9>aBc Defg ijklmn zzxq<rst><ceos><c17><c18>"
+			"<c19><c9>aBc Defg iJklmn zzxq<rst><ceos><c24><c9>aBc Defg "
 			"iJklmn Zzxq<rst><ceos><c29><c9>aBc Defg iJklmn Zzxq<rst><ceos><c29>\r\n"
 			"aBc Defg iJklmn Zzxq\r\n",
 			"abc defg ijklmn zzxq\n"
+		)
+		self_.check_scenario(
+			"<up><home><right><m-C><m-C><m-c><m-C><right><right><m-C><m-C> <cr><c-d>",
+			"<c9>abc_def ghj_jkl mno_pqr stu_vwx<rst><ceos><c40><c9>abc_def ghj_jkl "
+			"mno_pqr stu_vwx<rst><ceos><c9>"
+			"<c10><c9>aBc_def ghj_jkl mno_pqr "
+			"stu_vwx<rst><ceos><c12><c9>aBc_Def ghj_jkl mno_pqr "
+			"stu_vwx<rst><ceos><c16><c9>aBc_Def Ghj_jkl mno_pqr "
+			"stu_vwx<rst><ceos><c24><c9>aBc_Def Ghj_jkl Mno_pqr "
+			"stu_vwx<rst><ceos><c28><c29>"
+			"<c30><c9>aBc_Def Ghj_jkl Mno_pQr "
+			"stu_vwx<rst><ceos><c32><c9>aBc_Def Ghj_jkl Mno_pQr "
+			"Stu_vwx<rst><ceos><c36><c9>aBc_Def Ghj_jkl Mno_pQr Stu "
+			"_vwx<rst><ceos><c37><c9>aBc_Def Ghj_jkl Mno_pQr Stu _vwx<rst><ceos><c41>\r\n"
+			"aBc_Def Ghj_jkl Mno_pQr Stu _vwx\r\n",
+			"abc_def ghj_jkl mno_pqr stu_vwx\n"
 		)
 	def test_make_upper_case( self_ ):
 		self_.check_scenario(
 			"<up><home><right><right><right><m-u><m-u><right><m-u><cr><c-d>",
 			"<c9>abcdefg hijklmno pqrstuvw<rst><ceos><c34><c9>abcdefg "
-			"hijklmno pqrstuvw<rst><ceos><c9><c9>abcdefg hijklmno "
-			"pqrstuvw<rst><ceos><c10><c9>abcdefg hijklmno "
-			"pqrstuvw<rst><ceos><c11><c9>abcdefg hijklmno "
-			"pqrstuvw<rst><ceos><c12><c9>abcDEFG hijklmno "
+			"hijklmno pqrstuvw<rst><ceos><c9><c10><c11>"
+			"<c12><c9>abcDEFG hijklmno "
 			"pqrstuvw<rst><ceos><c16><c9>abcDEFG HIJKLMNO "
-			"pqrstuvw<rst><ceos><c25><c9>abcDEFG HIJKLMNO "
-			"pqrstuvw<rst><ceos><c26><c9>abcDEFG HIJKLMNO "
+			"pqrstuvw<rst><ceos><c25>"
+			"<c26><c9>abcDEFG HIJKLMNO "
 			"PQRSTUVW<rst><ceos><c34><c9>abcDEFG HIJKLMNO "
 			"PQRSTUVW<rst><ceos><c34>\r\n"
 			"abcDEFG HIJKLMNO PQRSTUVW\r\n",
 			"abcdefg hijklmno pqrstuvw\n"
 		)
+		self_.check_scenario(
+			"<up><home><right><m-U><m-U><right><m-u><right><right><m-U><cr><c-d>",
+			"<c9>abc_def ghi_jkl mno_pqr stu_vwx<rst><ceos><c40><c9>abc_def ghi_jkl "
+			"mno_pqr stu_vwx<rst><ceos><c9>"
+			"<c10><c9>aBC_def ghi_jkl mno_pqr "
+			"stu_vwx<rst><ceos><c12><c9>aBC_DEF ghi_jkl mno_pqr "
+			"stu_vwx<rst><ceos><c16>"
+			"<c17><c9>aBC_DEF GHI_JKL mno_pqr "
+			"stu_vwx<rst><ceos><c24><c25>"
+			"<c26><c9>aBC_DEF GHI_JKL mNO_pqr "
+			"stu_vwx<rst><ceos><c28><c9>aBC_DEF GHI_JKL mNO_pqr "
+			"stu_vwx<rst><ceos><c40>\r\n"
+			"aBC_DEF GHI_JKL mNO_pqr stu_vwx\r\n",
+			"abc_def ghi_jkl mno_pqr stu_vwx\n"
+		)
 	def test_make_lower_case( self_ ):
 		self_.check_scenario(
 			"<up><home><right><right><right><m-l><m-l><right><m-l><cr><c-d>",
 			"<c9>ABCDEFG HIJKLMNO PQRSTUVW<rst><ceos><c34><c9>ABCDEFG "
-			"HIJKLMNO PQRSTUVW<rst><ceos><c9><c9>ABCDEFG HIJKLMNO "
-			"PQRSTUVW<rst><ceos><c10><c9>ABCDEFG HIJKLMNO "
-			"PQRSTUVW<rst><ceos><c11><c9>ABCDEFG HIJKLMNO "
-			"PQRSTUVW<rst><ceos><c12><c9>ABCdefg HIJKLMNO "
+			"HIJKLMNO PQRSTUVW<rst><ceos><c9><c10><c11>"
+			"<c12><c9>ABCdefg HIJKLMNO "
 			"PQRSTUVW<rst><ceos><c16><c9>ABCdefg hijklmno "
-			"PQRSTUVW<rst><ceos><c25><c9>ABCdefg hijklmno "
-			"PQRSTUVW<rst><ceos><c26><c9>ABCdefg hijklmno "
+			"PQRSTUVW<rst><ceos><c25>"
+			"<c26><c9>ABCdefg hijklmno "
 			"pqrstuvw<rst><ceos><c34><c9>ABCdefg hijklmno "
 			"pqrstuvw<rst><ceos><c34>\r\n"
 			"ABCdefg hijklmno pqrstuvw\r\n",
 			"ABCDEFG HIJKLMNO PQRSTUVW\n"
 		)
+		self_.check_scenario(
+			"<up><home><right><m-L><m-L><right><m-l><right><right><m-L><cr><c-d>",
+			"<c9>ABC_DEF GHI_JKL MNO_PQR STU_VWX<rst><ceos><c40><c9>ABC_DEF GHI_JKL "
+			"MNO_PQR STU_VWX<rst><ceos><c9>"
+			"<c10><c9>Abc_DEF GHI_JKL MNO_PQR "
+			"STU_VWX<rst><ceos><c12><c9>Abc_def GHI_JKL MNO_PQR "
+			"STU_VWX<rst><ceos><c16>"
+			"<c17><c9>Abc_def ghi_jkl MNO_PQR "
+			"STU_VWX<rst><ceos><c24><c25>"
+			"<c26><c9>Abc_def ghi_jkl Mno_PQR "
+			"STU_VWX<rst><ceos><c28><c9>Abc_def ghi_jkl Mno_PQR "
+			"STU_VWX<rst><ceos><c40>\r\n"
+			"Abc_def ghi_jkl Mno_PQR STU_VWX\r\n",
+			"ABC_DEF GHI_JKL MNO_PQR STU_VWX\n"
+		)
 	def test_transpose( self_ ):
 		self_.check_scenario(
 			"<up><home><c-t><right><c-t><c-t><c-t><c-t><c-t><cr><c-d>",
 			"<c9>abcd<rst><ceos><c13>"
-			"<c9>abcd<rst><ceos><c9>"
-			"<c9>abcd<rst><ceos><c10>"
+			"<c9>abcd<rst><ceos><c9><c10>"
 			"<c9>bacd<rst><ceos><c11>"
 			"<c9>bcad<rst><ceos><c12>"
 			"<c9>bcda<rst><ceos><c13>"
@@ -1112,13 +1240,8 @@ class ReplxxTests( unittest.TestCase ):
 			"<c9><brightblue>+<rst>abc defg<brightblue>--<rst>ijklmn "
 			"zzxq<brightblue>+<rst><ceos><c32><c9><brightblue>+<rst>abc "
 			"defg<brightblue>--<rst>ijklmn "
-			"zzxq<brightblue>+<rst><ceos><c9><c9><brightblue>+<rst>abc "
-			"defg<brightblue>--<rst>ijklmn "
-			"zzxq<brightblue>+<rst><ceos><c13><c9><brightblue>+<rst>abc "
-			"defg<brightblue>--<rst>ijklmn "
-			"zzxq<brightblue>+<rst><ceos><c18><c9><brightblue>+<rst>abc "
-			"defg<brightblue>--<rst>ijklmn "
-			"zzxq<brightblue>+<rst><ceos><c19><c9><brightblue>-<rst>ijklmn "
+			"zzxq<brightblue>+<rst><ceos><c9><c13><c18>"
+			"<c19><c9><brightblue>-<rst>ijklmn "
 			"zzxq<brightblue>+<rst><ceos><c9><c9><brightblue>-<rst>ijklmn "
 			"zzxq<brightblue>+<rst><ceos><c22><c9><brightblue>-<rst>ijklmn "
 			"zzxq<brightblue>++<rst>abc "
@@ -1133,13 +1256,8 @@ class ReplxxTests( unittest.TestCase ):
 			"<c9><brightblue>+<rst>abc defg<brightblue>--<rst>ijklmn "
 			"zzxq<brightblue>+<rst><ceos><c32><c9><brightblue>+<rst>abc "
 			"defg<brightblue>--<rst>ijklmn "
-			"zzxq<brightblue>+<rst><ceos><c9><c9><brightblue>+<rst>abc "
-			"defg<brightblue>--<rst>ijklmn "
-			"zzxq<brightblue>+<rst><ceos><c13><c9><brightblue>+<rst>abc "
-			"defg<brightblue>--<rst>ijklmn "
-			"zzxq<brightblue>+<rst><ceos><c18><c9><brightblue>+<rst>abc "
-			"defg<brightblue>--<rst>ijklmn "
-			"zzxq<brightblue>+<rst><ceos><c19><c9><brightblue>+<rst>abc "
+			"zzxq<brightblue>+<rst><ceos><c9><c13><c18>"
+			"<c19><c9><brightblue>+<rst>abc "
 			"defg<brightblue>-<rst><ceos><c19><c9><brightblue>+<rst>abc "
 			"defg<brightblue>-<rst><ceos><c9><c9><brightblue>-<rst>ijklmn "
 			"zzxq<brightblue>++<rst>abc "
@@ -1152,19 +1270,32 @@ class ReplxxTests( unittest.TestCase ):
 		self_.check_scenario(
 			"<up><home><c-right><m-d><c-right><c-y><cr><c-d>",
 			"<c9>alpha charlie bravo delta<rst><ceos><c34><c9>alpha "
-			"charlie bravo delta<rst><ceos><c9><c9>alpha charlie bravo "
-			"delta<rst><ceos><c14><c9>alpha bravo delta<rst><ceos><c14><c9>alpha bravo "
-			"delta<rst><ceos><c20><c9>alpha bravo charlie delta<rst><ceos><c28><c9>alpha "
+			"charlie bravo delta<rst><ceos><c9>"
+			"<c14><c9>alpha bravo delta<rst><ceos><c14>"
+			"<c20><c9>alpha bravo charlie delta<rst><ceos><c28><c9>alpha "
 			"bravo charlie delta<rst><ceos><c34>\r\n"
 			"alpha bravo charlie delta\r\n",
 			"alpha charlie bravo delta\n"
+		)
+		self_.check_scenario(
+			"<up><home><c-right><m-D><m-D><m-d><m-D><c-right><c-y><cr><c-d>",
+			"<c9>abc_ABC def_DEF ghi_GHI jkl_JKL XXX<rst><ceos><c44><c9>abc_ABC def_DEF "
+			"ghi_GHI jkl_JKL XXX<rst><ceos><c9>"
+			"<c16><c9>abc_ABC_DEF ghi_GHI jkl_JKL "
+			"XXX<rst><ceos><c16><c9>abc_ABC ghi_GHI jkl_JKL "
+			"XXX<rst><ceos><c16><c9>abc_ABC jkl_JKL XXX<rst><ceos><c16><c9>abc_ABC_JKL "
+			"XXX<rst><ceos><c16><c20><c9>abc_ABC_JKL "
+			"def_DEF ghi_GHI jkl XXX<rst><ceos><c40><c9>abc_ABC_JKL def_DEF ghi_GHI jkl "
+			"XXX<rst><ceos><c44>\r\n"
+			"abc_ABC_JKL def_DEF ghi_GHI jkl XXX\r\n",
+			"abc_ABC def_DEF ghi_GHI jkl_JKL XXX\n"
 		)
 	def test_kill_prev_word_to_white_space( self_ ):
 		self_.check_scenario(
 			"<up><c-left><c-w><c-left><c-y><cr><c-d>",
 			"<c9>alpha charlie bravo delta<rst><ceos><c34><c9>alpha "
 			"charlie bravo delta<rst><ceos><c29><c9>alpha charlie "
-			"delta<rst><ceos><c23><c9>alpha charlie delta<rst><ceos><c15><c9>alpha bravo "
+			"delta<rst><ceos><c23><c15><c9>alpha bravo "
 			"charlie delta<rst><ceos><c21><c9>alpha bravo charlie delta<rst><ceos><c34>\r\n"
 			"alpha bravo charlie delta\r\n",
 			"alpha charlie bravo delta\n"
@@ -1175,8 +1306,8 @@ class ReplxxTests( unittest.TestCase ):
 			"<c9>alpha<brightmagenta>.<rst>charlie "
 			"bravo<brightmagenta>.<rst>delta<rst><ceos><c34><c9>alpha<brightmagenta>.<rst>charlie "
 			"bravo<brightmagenta>.<rst>delta<rst><ceos><c29><c9>alpha<brightmagenta>.<rst>charlie "
-			"delta<rst><ceos><c23><c9>alpha<brightmagenta>.<rst>charlie "
-			"delta<rst><ceos><c15><c9>alpha<brightmagenta>.<rst>bravo<brightmagenta>.<rst>charlie "
+			"delta<rst><ceos><c23>"
+			"<c15><c9>alpha<brightmagenta>.<rst>bravo<brightmagenta>.<rst>charlie "
 			"delta<rst><ceos><c21><c9>alpha<brightmagenta>.<rst>bravo<brightmagenta>.<rst>charlie "
 			"delta<rst><ceos><c34>\r\n"
 			"alpha.bravo.charlie delta\r\n",
@@ -1281,8 +1412,7 @@ class ReplxxTests( unittest.TestCase ):
 			"<c9><yellow>01<rst><ceos><c11>"
 			"<c9><yellow>012<rst><ceos><c12>"
 			"<c9><yellow>0123<rst><ceos><c13>"
-			"<c9><yellow>0123<rst><ceos><c12>"
-			"<c9><yellow>0123<rst><ceos><c11>"
+			"<c9><yellow>0123<rst><ceos><c12><c11>"
 			"<c9><yellow>01<rst>cat<yellow>23<rst><ceos><c14>"
 			"<c9><yellow>01<rst>trillion<yellow>23<rst><ceos><c19>"
 			"<c9><yellow>01<rst>twelve<yellow>23<rst><ceos><c17>"
@@ -1343,7 +1473,7 @@ class ReplxxTests( unittest.TestCase ):
 			"<c9>Alice has a cat.<rst><ceos><c25>"
 			"<c9>Alice has a cat.<rst><ceos><c25>\r\n"
 			"Alice has a cat.\r\n",
-			command = ReplxxTests._cSample_ + " q1 'iAlice has a cat.'"
+			command = ReplxxTests._cSample_ + " q1 'PAlice has a cat.'"
 		)
 		self_.check_scenario(
 			"<cr><c-d>",
@@ -1352,7 +1482,7 @@ class ReplxxTests( unittest.TestCase ):
 			"<rst><ceos><c26>\r\n"
 			"Cat  eats  mice. "
 			"\r\n",
-			command = ReplxxTests._cSample_ + " q1 'iCat\teats\tmice.\r\n'"
+			command = ReplxxTests._cSample_ + " q1 'PCat\teats\tmice.\r\n'"
 		)
 		self_.check_scenario(
 			"<cr><c-d>",
@@ -1361,21 +1491,21 @@ class ReplxxTests( unittest.TestCase ):
 			"<rst><ceos><c26>\r\n"
 			"Cat  eats  mice. "
 			"\r\n",
-			command = ReplxxTests._cSample_ + " q1 'iCat\teats\tmice.\r\n\r\n\n\n'"
+			command = ReplxxTests._cSample_ + " q1 'PCat\teats\tmice.\r\n\r\n\n\n'"
 		)
 		self_.check_scenario(
 			"<cr><c-d>",
 			"<c9>M Alice has a cat.<rst><ceos><c27>"
 			"<c9>M Alice has a cat.<rst><ceos><c27>\r\n"
 			"M Alice has a cat.\r\n",
-			command = ReplxxTests._cSample_ + " q1 'iMAlice has a cat.'"
+			command = ReplxxTests._cSample_ + " q1 'PMAlice has a cat.'"
 		)
 		self_.check_scenario(
 			"<cr><c-d>",
 			"<c9>M  Alice has a cat.<rst><ceos><c28>"
 			"<c9>M  Alice has a cat.<rst><ceos><c28>\r\n"
 			"M  Alice has a cat.\r\n",
-			command = ReplxxTests._cSample_ + " q1 'iM\t\t\t\tAlice has a cat.'"
+			command = ReplxxTests._cSample_ + " q1 'PM\t\t\t\tAlice has a cat.'"
 		)
 	def test_prompt( self_ ):
 		prompt = "date: now\nrepl> "
@@ -1406,41 +1536,29 @@ class ReplxxTests( unittest.TestCase ):
 			"rust sql<rst><ceos><c2><u2><c9>ada clojure eiffel fortran groovy "
 			"java kotlin modula perl python rust sql<rst><ceos><u1><c39><u1><c9>ada "
 			"clojure eiffel fortran groovy java kotlin modula perl python rust "
-			"~sql<rst><ceos><u1><c40><u1><c9>ada clojure eiffel fortran groovy java "
-			"kotlin modula perl python rust ~sql<rst><ceos><u1><c34><u1><c9>ada clojure "
+			"~sql<rst><ceos><u1><c40><c34><u1><c9>ada clojure "
 			"eiffel fortran groovy java kotlin modula perl python ~rust "
-			"~sql<rst><ceos><u1><c35><u1><c9>ada clojure eiffel fortran groovy java "
-			"kotlin modula perl python ~rust ~sql<rst><ceos><u1><c27><u1><c9>ada clojure "
+			"~sql<rst><ceos><u1><c35><c27><u1><c9>ada clojure "
 			"eiffel fortran groovy java kotlin modula perl ~python ~rust "
-			"~sql<rst><ceos><u1><c28><u1><c9>ada clojure eiffel fortran groovy java "
-			"kotlin modula perl ~python ~rust ~sql<rst><ceos><u1><c22><u1><c9>ada clojure "
+			"~sql<rst><ceos><u1><c28><c22><u1><c9>ada clojure "
 			"eiffel fortran groovy java kotlin modula ~perl ~python ~rust "
-			"~sql<rst><ceos><u1><c23><u1><c9>ada clojure eiffel fortran groovy java "
-			"kotlin modula ~perl ~python ~rust ~sql<rst><ceos><u1><c15><u1><c9>ada "
+			"~sql<rst><ceos><u1><c23><c15><u1><c9>ada "
 			"clojure eiffel fortran groovy java kotlin ~modula ~perl ~python ~rust "
-			"~sql<rst><ceos><u1><c16><u1><c9>ada clojure eiffel fortran groovy java "
-			"kotlin ~modula ~perl ~python ~rust ~sql<rst><ceos><u1><c8><u1><c9>ada "
+			"~sql<rst><ceos><u1><c16><c8><u1><c9>ada "
 			"clojure eiffel fortran groovy java ~kotlin ~modula ~perl ~python ~rust "
-			"~sql<rst><ceos><u1><c9><u1><c9>ada clojure eiffel fortran groovy java "
-			"~kotlin ~modula ~perl ~python ~rust ~sql<rst><ceos><u1><c3><u1><c9>ada "
+			"~sql<rst><ceos><u1><c9><c3><u1><c9>ada "
 			"clojure eiffel fortran groovy ~java ~kotlin ~modula ~perl ~python ~rust "
-			"~sql<rst><ceos><u1><c4><u1><c9>ada clojure eiffel fortran groovy ~java "
-			"~kotlin ~modula ~perl ~python ~rust ~sql<rst><ceos><u2><c36><c9>ada clojure "
+			"~sql<rst><ceos><u1><c4><u1><c36><c9>ada clojure "
 			"eiffel fortran ~groovy ~java ~kotlin ~modula ~perl ~python ~rust "
-			"~sql<rst><ceos><u2><c37><c9>ada clojure eiffel fortran ~groovy ~java ~kotlin "
-			"~modula ~perl ~python ~rust ~sql<rst><ceos><u2><c28><c9>ada clojure eiffel "
+			"~sql<rst><ceos><u2><c37><c28><c9>ada clojure eiffel "
 			"~fortran ~groovy ~java ~kotlin ~modula ~perl ~python ~rust "
-			"~sql<rst><ceos><u2><c29><c9>ada clojure eiffel ~fortran ~groovy ~java "
-			"~kotlin ~modula ~perl ~python ~rust ~sql<rst><ceos><u2><c21><c9>ada clojure "
+			"~sql<rst><ceos><u2><c29><c21><c9>ada clojure "
 			"~eiffel ~fortran ~groovy ~java ~kotlin ~modula ~perl ~python ~rust "
-			"~sql<rst><ceos><u2><c22><c9>ada clojure ~eiffel ~fortran ~groovy ~java "
-			"~kotlin ~modula ~perl ~python ~rust ~sql<rst><ceos><u2><c13><c9>ada ~clojure "
+			"~sql<rst><ceos><u2><c22><c13><c9>ada ~clojure "
 			"~eiffel ~fortran ~groovy ~java ~kotlin ~modula ~perl ~python ~rust "
-			"~sql<rst><ceos><u2><c14><c9>ada ~clojure ~eiffel ~fortran ~groovy ~java "
-			"~kotlin ~modula ~perl ~python ~rust ~sql<rst><ceos><u2><c9><c9>~ada ~clojure "
+			"~sql<rst><ceos><u2><c14><c9><c9>~ada ~clojure "
 			"~eiffel ~fortran ~groovy ~java ~kotlin ~modula ~perl ~python ~rust "
-			"~sql<rst><ceos><u2><c10><c9>~ada ~clojure ~eiffel ~fortran ~groovy ~java "
-			"~kotlin ~modula ~perl ~python ~rust ~sql<rst><ceos><u2><c9><c9>~ada ~clojure "
+			"~sql<rst><ceos><u2><c10><c9><c9>~ada ~clojure "
 			"~eiffel ~fortran ~groovy ~java ~kotlin ~modula ~perl ~python ~rust "
 			"~sql<rst><ceos><c14>\r\n"
 			"~ada ~clojure ~eiffel ~fortran ~groovy ~java ~kotlin ~modula ~perl ~python "
@@ -1479,21 +1597,11 @@ class ReplxxTests( unittest.TestCase ):
 			"<c9>one_two three-four five_six "
 			"seven-eight<rst><ceos><c48><c9>one_two three-four five_six "
 			"seven-eight<rst><ceos><c43><c9>one_two three-four five_six "
-			"seven-xeight<rst><ceos><c44><c9>one_two three-four five_six "
-			"seven-xeight<rst><ceos><c43><c9>one_two three-four five_six "
-			"seven-xeight<rst><ceos><c37><c9>one_two three-four five_six "
-			"xseven-xeight<rst><ceos><c38><c9>one_two three-four five_six "
-			"xseven-xeight<rst><ceos><c37><c9>one_two three-four five_six "
-			"xseven-xeight<rst><ceos><c28><c9>one_two three-four xfive_six "
-			"xseven-xeight<rst><ceos><c29><c9>one_two three-four xfive_six "
-			"xseven-xeight<rst><ceos><c28><c9>one_two three-four xfive_six "
-			"xseven-xeight<rst><ceos><c23><c9>one_two three-xfour xfive_six "
-			"xseven-xeight<rst><ceos><c24><c9>one_two three-xfour xfive_six "
-			"xseven-xeight<rst><ceos><c23><c9>one_two three-xfour xfive_six "
-			"xseven-xeight<rst><ceos><c17><c9>one_two xthree-xfour xfive_six "
-			"xseven-xeight<rst><ceos><c18><c9>one_two xthree-xfour xfive_six "
-			"xseven-xeight<rst><ceos><c17><c9>one_two xthree-xfour xfive_six "
-			"xseven-xeight<rst><ceos><c9><c9>xone_two xthree-xfour xfive_six "
+			"seven-xeight<rst><ceos><c44><c43><c37><c9>one_two three-four five_six "
+			"xseven-xeight<rst><ceos><c38><c37><c28><c9>one_two three-four xfive_six "
+			"xseven-xeight<rst><ceos><c29><c28><c23><c9>one_two three-xfour xfive_six "
+			"xseven-xeight<rst><ceos><c24><c23><c17><c9>one_two xthree-xfour xfive_six "
+			"xseven-xeight<rst><ceos><c18><c17><c9><c9>xone_two xthree-xfour xfive_six "
 			"xseven-xeight<rst><ceos><c10><c9>xone_two xthree-xfour xfive_six "
 			"xseven-xeight<rst><ceos><c54>\r\n"
 			"xone_two xthree-xfour xfive_six xseven-xeight\r\n",
@@ -1505,21 +1613,11 @@ class ReplxxTests( unittest.TestCase ):
 			"<c9>one_two three-four five_six "
 			"seven-eight<rst><ceos><c48><c9>one_two three-four five_six "
 			"seven-eight<rst><ceos><c37><c9>one_two three-four five_six "
-			"xseven-eight<rst><ceos><c38><c9>one_two three-four five_six "
-			"xseven-eight<rst><ceos><c37><c9>one_two three-four five_six "
-			"xseven-eight<rst><ceos><c33><c9>one_two three-four five_xsix "
-			"xseven-eight<rst><ceos><c34><c9>one_two three-four five_xsix "
-			"xseven-eight<rst><ceos><c33><c9>one_two three-four five_xsix "
-			"xseven-eight<rst><ceos><c28><c9>one_two three-four xfive_xsix "
-			"xseven-eight<rst><ceos><c29><c9>one_two three-four xfive_xsix "
-			"xseven-eight<rst><ceos><c28><c9>one_two three-four xfive_xsix "
-			"xseven-eight<rst><ceos><c17><c9>one_two xthree-four xfive_xsix "
-			"xseven-eight<rst><ceos><c18><c9>one_two xthree-four xfive_xsix "
-			"xseven-eight<rst><ceos><c17><c9>one_two xthree-four xfive_xsix "
-			"xseven-eight<rst><ceos><c13><c9>one_xtwo xthree-four xfive_xsix "
-			"xseven-eight<rst><ceos><c14><c9>one_xtwo xthree-four xfive_xsix "
-			"xseven-eight<rst><ceos><c13><c9>one_xtwo xthree-four xfive_xsix "
-			"xseven-eight<rst><ceos><c9><c9>xone_xtwo xthree-four xfive_xsix "
+			"xseven-eight<rst><ceos><c38><c37><c33><c9>one_two three-four five_xsix "
+			"xseven-eight<rst><ceos><c34><c33><c28><c9>one_two three-four xfive_xsix "
+			"xseven-eight<rst><ceos><c29><c28><c17><c9>one_two xthree-four xfive_xsix "
+			"xseven-eight<rst><ceos><c18><c17><c13><c9>one_xtwo xthree-four xfive_xsix "
+			"xseven-eight<rst><ceos><c14><c13><c9><c9>xone_xtwo xthree-four xfive_xsix "
 			"xseven-eight<rst><ceos><c10><c9>xone_xtwo xthree-four xfive_xsix "
 			"xseven-eight<rst><ceos><c54>\r\n"
 			"xone_xtwo xthree-four xfive_xsix xseven-eight\r\n",
@@ -1616,7 +1714,7 @@ class ReplxxTests( unittest.TestCase ):
 				"<c9>abcd<rst><ceos><c13><c9>abcde<rst><ceos><c14><c9>abcdef<rst><ceos><c15><c9>abcdef<rst><ceos><c15>\r\n"
 				"abcdef\r\n",
 			],
-			command = [ ReplxxTests._cxxSample_, "" ],
+			command = [ ReplxxTests._cxxSample_, "m" ],
 			pause = 0.5
 		)
 		self_.check_scenario(
@@ -1709,7 +1807,7 @@ class ReplxxTests( unittest.TestCase ):
 				"wrapped: abcdef\r\n"
 			],
 			"a very long line of user input, wider then current terminal, the line is wrapped: \n",
-			command = [ ReplxxTests._cxxSample_, "" ],
+			command = [ ReplxxTests._cxxSample_, "m" ],
 			dimensions = ( 10, 40 ),
 			pause = 0.5
 		)
@@ -1733,7 +1831,7 @@ class ReplxxTests( unittest.TestCase ):
 				"<yellow>3<rst>ef<rst><ceos><c18><c9><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c18>\r\n"
 				"1ab2cd3ef\r\n"
 			],
-			command = [ ReplxxTests._cxxSample_, "123456" ],
+			command = [ ReplxxTests._cxxSample_, "k123456" ],
 			pause = 0.5
 		)
 	def test_special_keys( self_ ):
@@ -1797,7 +1895,7 @@ class ReplxxTests( unittest.TestCase ):
 		self_.check_scenario(
 			"<up><home><right><right>XYZ<ins>012<ins>345<cr><c-d>",
 			"<c9>abcdefgh<rst><ceos><c17><c9>abcdefgh<rst><ceos><c9>"
-			"<c9>abcdefgh<rst><ceos><c10><c9>abcdefgh<rst><ceos><c11>"
+			"<c10><c11>"
 			"<c9>abXcdefgh<rst><ceos><c12><c9>abXYcdefgh<rst><ceos><c13>"
 			"<c9>abXYZcdefgh<rst><ceos><c14><c9>abXYZ<yellow>0<rst>defgh<rst><ceos><c15>"
 			"<c9>abXYZ<yellow>01<rst>efgh<rst><ceos><c16><c9>abXYZ<yellow>012<rst>fgh<rst><ceos><c17>"
@@ -1834,8 +1932,8 @@ class ReplxxTests( unittest.TestCase ):
 			"        <gray>color_black<rst>\r\n"
 			"        <gray>color_red<rst>\r\n"
 			"        "
-			"<gray>color_green<rst><u3><c15><c9><lightgray>color_normal<rst><ceos><c21><c9><lightgray>color_normal<rst><ceos><c21>\r\n"
-			"color_normal\r\n",
+			"<gray>color_green<rst><u3><c15><c9><white>color_white<rst><ceos><c20><c9><white>color_white<rst><ceos><c20>\r\n"
+			"color_white\r\n",
 			"color_\n"
 		)
 		self_.check_scenario(
@@ -1894,7 +1992,7 @@ class ReplxxTests( unittest.TestCase ):
 		self_.check_scenario(
 			"<up><home><right><right>*<cr><c-d>",
 			"<c9>abcd<brightmagenta>12<rst><ceos><c15><c9>abcd<brightmagenta>12<rst><ceos><c9>"
-			"<c9>abcd<brightmagenta>12<rst><ceos><c10><c9>abcd<brightmagenta>12<rst><ceos><c11>"
+			"<c10><c11>"
 			"<c9>ababcd<brightmagenta>12<rst>cd<brightmagenta>12<rst><ceos><c15>"
 			"<c9>ababcd<brightmagenta>12<rst>cd<brightmagenta>12<rst><ceos><c21>\r\n"
 			"ababcd12cd12\r\n",
@@ -2014,6 +2112,1169 @@ class ReplxxTests( unittest.TestCase ):
 			"<brightgreen>replxx<rst>> <c9>x<rst><ceos><c10><c9>x<rst><ceos><c10>\r\n"
 			"x\r\n",
 			command = [ ReplxxTests._cSample_, "q1" ]
+		)
+		self_.check_scenario(
+			"<paste-pfx>aaa\n\tbbb<paste-sfx><backspace><backspace><backspace><backspace><backspace><backspace><backspace><backspace><cr><c-d>",
+			"<c9><ceos><c18><paste-off>\r\n",
+			command = [ ReplxxTests._cxxSample_, "B" ]
+		)
+	def test_embedded_newline( self_ ):
+		self_.check_scenario(
+			"<up><c-left><s-cr><cr><c-d>",
+			"<c9><blue>color_blue<rst> "
+			"<red>color_red<rst><ceos><c29><c9><blue>color_blue<rst> "
+			"<red>color_red<rst><ceos><c20><c9><ceos><blue>color_blue<rst> \r\n"
+			"<red>color_red<rst><c1><u1><c9><ceos><blue>color_blue<rst> \r\n"
+			"<red>color_red<rst><c10>\r\n"
+			"color_blue \r\n"
+			"color_red\r\n",
+			"color_blue color_red\n"
+		)
+	def test_move_up_in_multiline( self_ ):
+		self_.check_scenario(
+			"<up><up> <cr><c-d>",
+			"<c9><ceos><blue>color_blue<rst>\r\n"
+			"<red>color_red<rst><c10><u1><c9><ceos><blue>color_blue<rst>\r\n"
+			"<red>color_red<rst><u1><c10><c9><ceos>c olor_blue\r\n"
+			"<red>color_red<rst><u1><c11><c9><ceos>c olor_blue\r\n"
+			"<red>color_red<rst><c10>\r\n"
+			"c olor_blue\r\n"
+			"color_red\r\n",
+			"some other\ncolor_bluecolor_red\n"
+		)
+		self_.check_scenario(
+			"<up><up> <cr><c-d>",
+			"<c9><ceos><brightblue>color_brightblue<rst>\r\n"
+			"        "
+			"<red>color_red<rst><c18><u1><c9><ceos><brightblue>color_brightblue<rst>\r\n"
+			"        <red>color_red<rst><u1><c18><c9><ceos>color_bri ghtblue\r\n"
+			"        <red>color_red<rst><u1><c19><c9><ceos>color_bri ghtblue\r\n"
+			"        <red>color_red<rst><c18>\r\n"
+			"color_bri ghtblue\r\n"
+			"color_red\r\n",
+			"some other\ncolor_brightbluecolor_red\n",
+			command = [ ReplxxTests._cxxSample_, "I" ]
+		)
+		self_.check_scenario(
+			"<up><up><up><up>x<up><cr><c-d>",
+			"<c9><ceos>bbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbbbbb<rst><c24><u3><c9><ceos>bbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbbbbb<rst><u1><c21><u1><c21><u1><c21><c9><ceos>bbbbbbbbbbbbxbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbbbbb<rst><u3><c22><c9>aaaaaaaaaaaaaaaaaaaa<rst><ceos><c29><c9>aaaaaaaaaaaaaaaaaaaa<rst><ceos><c29>\r\n"
+			"aaaaaaaaaaaaaaaaaaaa\r\n",
+			"aaaaaaaaaaaaaaaaaaaa\nbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+		)
+		self_.check_scenario(
+			"<up><up><up><up>x<up><cr><c-d>",
+			"<c9><ceos>bbbbbbbbbbbbbbbb\r\n"
+			"        bbbbbbbbbbbbb\r\n"
+			"        bbbbbbbbbbbbb\r\n"
+			"        bbbbbbbbbbbbbbbb<rst><c25><u3><c9><ceos>bbbbbbbbbbbbbbbb\r\n"
+			"        bbbbbbbbbbbbb\r\n"
+			"        bbbbbbbbbbbbb\r\n"
+			"        "
+			"bbbbbbbbbbbbbbbb<rst><u1><c22><u1><c22><u1><c22><c9><ceos>bbbbbbbbbbbbbxbbb\r\n"
+			"        bbbbbbbbbbbbb\r\n"
+			"        bbbbbbbbbbbbb\r\n"
+			"        "
+			"bbbbbbbbbbbbbbbb<rst><u3><c23><c9>aaaaaaaaaaaaaaaaaaaa<rst><ceos><c29><c9>aaaaaaaaaaaaaaaaaaaa<rst><ceos><c29>\r\n"
+			"aaaaaaaaaaaaaaaaaaaa\r\n",
+			"aaaaaaaaaaaaaaaaaaaa\nbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+			command = [ ReplxxTests._cxxSample_, "I" ]
+		)
+	def test_move_down_in_multiline( self_ ):
+		self_.check_scenario(
+			"<pgup><down><pgup><down> <cr><c-d>",
+			"<c9>some other<rst><ceos><c19><c9><ceos><red>color_red<rst>\r\n"
+			"<blue>color_blue<rst><c11><u1><c9><ceos><red>color_red<rst>\r\n"
+			"<blue>color_blue<rst><u1><c9><d1><c9><u1><c9><ceos><red>color_red<rst>\r\n"
+			"color_bl ue<rst><c10><u1><c9><ceos><red>color_red<rst>\r\n"
+			"color_bl ue<rst><c12>\r\n"
+			"color_red\r\n"
+			"color_bl ue\r\n",
+			"some other\ncolor_redcolor_blue\n"
+		)
+		self_.check_scenario(
+			"<pgup><down><pgup><down> <cr><c-d>",
+			"<c9>some other<rst><ceos><c19><c9><ceos><red>color_red<rst>\r\n"
+			"        <blue>color_blue<rst><c19><u1><c9><ceos><red>color_red<rst>\r\n"
+			"        "
+			"<blue>color_blue<rst><u1><c9><d1><c9><u1><c9><ceos><red>color_red<rst>\r\n"
+			"         <blue>color_blue<rst><c10><u1><c9><ceos><red>color_red<rst>\r\n"
+			"         <blue>color_blue<rst><c20>\r\n"
+			"color_red\r\n"
+			" color_blue\r\n",
+			"some other\ncolor_redcolor_blue\n",
+			command = [ ReplxxTests._cxxSample_, "I" ]
+		)
+		self_.check_scenario(
+			"<pgup><pgup><down><down><down>x<down><cr><c-d>",
+			"<c9><ceos>bbbbbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbb<rst><c17><u3><c9><ceos>bbbbbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbb<rst><u3><c9><d1><c9><d1><c9><d1><c9><u3><c9><ceos>bbbbbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbxbbbbbbbb<rst><c10><u3><c9>aaaaaaaaaaaaaaaaaaaa<rst><ceos><c29><c9>aaaaaaaaaaaaaaaaaaaa<rst><ceos><c29>\r\n"
+			"aaaaaaaaaaaaaaaaaaaa\r\n",
+			"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\naaaaaaaaaaaaaaaaaaaa\n"
+		)
+		self_.check_scenario(
+			"<pgup><pgup><down><down><down>x<down><cr><c-d>",
+			"<c9><ceos>bbbbbbbbbbbbbbbbbbbbbbb\r\n"
+			"        bbbbbbbbbbbbbbbbbbbb\r\n"
+			"        bbbbbbbbbbbbbbbbbbbb\r\n"
+			"        bbbbbbbbbbbbbbbb<rst><c25><u3><c9><ceos>bbbbbbbbbbbbbbbbbbbbbbb\r\n"
+			"        bbbbbbbbbbbbbbbbbbbb\r\n"
+			"        bbbbbbbbbbbbbbbbbbbb\r\n"
+			"        "
+			"bbbbbbbbbbbbbbbb<rst><u3><c9><d1><c9><d1><c9><d1><c9><u3><c9><ceos>bbbbbbbbbbbbbbbbbbbbbbb\r\n"
+			"        bbbbbbbbbbbbbbbbbbbb\r\n"
+			"        bbbbbbbbbbbbbbbbbbbb\r\n"
+			"        "
+			"xbbbbbbbbbbbbbbbb<rst><c10><u3><c9>aaaaaaaaaaaaaaaaaaaa<rst><ceos><c29><c9>aaaaaaaaaaaaaaaaaaaa<rst><ceos><c29>\r\n"
+			"aaaaaaaaaaaaaaaaaaaa\r\n",
+			"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\naaaaaaaaaaaaaaaaaaaa\n",
+			command = [ ReplxxTests._cxxSample_, "I" ]
+		)
+	def test_go_to_beginning_of_multiline_entry( self_ ):
+		self_.check_scenario(
+			"<up><pgup>x <pgup><pgup><cr><c-d>",
+			"<c9><ceos><red>color_red<rst>\r\n"
+			"<blue>color_blue<rst>\r\n"
+			"zzzzzz<rst><c7><u2><c9><ceos><red>color_red<rst>\r\n"
+			"<blue>color_blue<rst>\r\n"
+			"zzzzzz<rst><u2><c9><c9><ceos>xcolor_red\r\n"
+			"<blue>color_blue<rst>\r\n"
+			"zzzzzz<rst><u2><c10><c9><ceos>x <red>color_red<rst>\r\n"
+			"<blue>color_blue<rst>\r\n"
+			"zzzzzz<rst><u2><c11><c9><c9>some other<rst><ceos><c19><c9>some "
+			"other<rst><ceos><c19>\r\n"
+			"some other\r\n",
+			"some other\ncolor_redcolor_bluezzzzzz\n"
+		)
+	def test_go_to_end_of_multiline_entry( self_ ):
+		self_.check_scenario(
+			"<up><up><pgup>x <pgdown><pgdown><cr><c-d>",
+			"<c9><yellow>123<rst><ceos><c12><c9><ceos><red>color_red<rst> "
+			"<green>color_green<rst>\r\n"
+			"<blue>color_blue<rst> <yellow>color_yellow<rst>\r\n"
+			"zzzzzz<rst><c7><u2><c9><ceos><red>color_red<rst> <green>color_green<rst>\r\n"
+			"<blue>color_blue<rst> <yellow>color_yellow<rst>\r\n"
+			"zzzzzz<rst><u2><c9><c9><ceos>xcolor_red <green>color_green<rst>\r\n"
+			"<blue>color_blue<rst> <yellow>color_yellow<rst>\r\n"
+			"zzzzzz<rst><u2><c10><c9><ceos>x <red>color_red<rst> "
+			"<green>color_green<rst>\r\n"
+			"<blue>color_blue<rst> <yellow>color_yellow<rst>\r\n"
+			"zzzzzz<rst><u2><c11><c9><ceos>x <red>color_red<rst> "
+			"<green>color_green<rst>\r\n"
+			"<blue>color_blue<rst> <yellow>color_yellow<rst>\r\n"
+			"zzzzzz<rst><c7><u2><c9><rst><ceos><c9><c9><rst><ceos><c9>\r\n",
+			"some other\ncolor_red color_greencolor_blue color_yellowzzzzzz\n123\n"
+		)
+	def test_move_to_beginning_of_line_in_multiline( self_ ):
+		self_.check_scenario(
+			"<up><home>x <c-right><up><home>x <c-right><up><home>x <cr><c-d>",
+			"<c9><ceos><red>color_red<rst> more text\r\n"
+			"<blue>color_blue<rst> <yellow>123<rst>\r\n"
+			"<green>color_green<rst> zzz<rst><c16><u2><c9><ceos><red>color_red<rst> more "
+			"text\r\n"
+			"<blue>color_blue<rst> <yellow>123<rst>\r\n"
+			"<green>color_green<rst> zzz<rst><c1><u2><c9><ceos><red>color_red<rst> more "
+			"text\r\n"
+			"<blue>color_blue<rst> <yellow>123<rst>\r\n"
+			"xcolor_green zzz<rst><c2><u2><c9><ceos><red>color_red<rst> more text\r\n"
+			"<blue>color_blue<rst> <yellow>123<rst>\r\n"
+			"x <green>color_green<rst> "
+			"zzz<rst><c3><c14><u1><c14><c1><u1><c9><ceos><red>color_red<rst> more text\r\n"
+			"xcolor_blue <yellow>123<rst>\r\n"
+			"x <green>color_green<rst> zzz<rst><u1><c2><u1><c9><ceos><red>color_red<rst> "
+			"more text\r\n"
+			"x <blue>color_blue<rst> <yellow>123<rst>\r\n"
+			"x <green>color_green<rst> "
+			"zzz<rst><u1><c3><c13><u1><c13><c9><c9><ceos>xcolor_red more text\r\n"
+			"x <blue>color_blue<rst> <yellow>123<rst>\r\n"
+			"x <green>color_green<rst> zzz<rst><u2><c10><c9><ceos>x <red>color_red<rst> "
+			"more text\r\n"
+			"x <blue>color_blue<rst> <yellow>123<rst>\r\n"
+			"x <green>color_green<rst> zzz<rst><u2><c11><c9><ceos>x <red>color_red<rst> "
+			"more text\r\n"
+			"x <blue>color_blue<rst> <yellow>123<rst>\r\n"
+			"x <green>color_green<rst> zzz<rst><c18>\r\n"
+			"x color_red more text\r\n"
+			"x color_blue 123\r\n"
+			"x color_green zzz\r\n",
+			"color_red more textcolor_blue 123color_green zzz\n"
+		)
+		self_.check_scenario(
+			"<up><up><c-a><c-a><cr><c-d>",
+			"<c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><c20><u3><c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><u1><c20><c1><u2><c9><c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><c20>\r\n"
+			"first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code\r\n",
+			"first line of textsecond verse of a poemnext passage of a scripturelast line of a code\n"
+		)
+	def test_move_to_end_of_line_in_multiline( self_ ):
+		self_.check_scenario(
+			"<up><pgup>x <end>x<right><end>x<right><end>x<cr><c-d>",
+			"<c9><ceos><red>color_red<rst> more text\r\n"
+			"<blue>color_blue<rst> <yellow>123<rst>\r\n"
+			"<green>color_green<rst> zzz<rst><c16><u2><c9><ceos><red>color_red<rst> more "
+			"text\r\n"
+			"<blue>color_blue<rst> <yellow>123<rst>\r\n"
+			"<green>color_green<rst> zzz<rst><u2><c9><c9><ceos>xcolor_red more text\r\n"
+			"<blue>color_blue<rst> <yellow>123<rst>\r\n"
+			"<green>color_green<rst> zzz<rst><u2><c10><c9><ceos>x <red>color_red<rst> "
+			"more text\r\n"
+			"<blue>color_blue<rst> <yellow>123<rst>\r\n"
+			"<green>color_green<rst> zzz<rst><u2><c11><c30><c9><ceos>x "
+			"<red>color_red<rst> more textx\r\n"
+			"<blue>color_blue<rst> <yellow>123<rst>\r\n"
+			"<green>color_green<rst> zzz<rst><u2><c31><d1><c1><c15><u1><c9><ceos>x "
+			"<red>color_red<rst> more textx\r\n"
+			"<blue>color_blue<rst> <yellow>123<rst>x\r\n"
+			"<green>color_green<rst> zzz<rst><u1><c16><d1><c1><u2><c9><ceos>x "
+			"<red>color_red<rst> more textx\r\n"
+			"<blue>color_blue<rst> <yellow>123<rst>x\r\n"
+			"<green>color_green<rst> zzz<rst><c16><u2><c9><ceos>x <red>color_red<rst> "
+			"more textx\r\n"
+			"<blue>color_blue<rst> <yellow>123<rst>x\r\n"
+			"<green>color_green<rst> zzzx<rst><c17><u2><c9><ceos>x <red>color_red<rst> "
+			"more textx\r\n"
+			"<blue>color_blue<rst> <yellow>123<rst>x\r\n"
+			"<green>color_green<rst> zzzx<rst><c17>\r\n"
+			"x color_red more textx\r\n"
+			"color_blue 123x\r\n"
+			"color_green zzzx\r\n",
+			"color_red more textcolor_blue 123color_green zzz\n"
+		)
+		self_.check_scenario(
+			"<up><pgup><down><c-e><c-e><cr><c-d>",
+			"<c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><c20><u3><c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><u3><c9><d1><c9><c23><u1><c9><ceos>first line of "
+			"text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><c20><u3><c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><c20>\r\n"
+			"first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code\r\n",
+			"first line of textsecond verse of a poemnext passage of a scripturelast line of a code\n"
+		)
+	def test_hints_in_multiline( self_ ):
+		self_.check_scenario(
+			"<up><c-down><cr><c-d>",
+			"<c9><ceos>some text\r\n"
+			"color_b<rst>\r\n"
+			"<gray>color_black<rst>\r\n"
+			"<gray>color_brown<rst>\r\n"
+			"<gray>color_blue<rst><u3><c8><u1><c9><ceos>some text\r\n"
+			"color_b<rst><gray>lack<rst>\r\n"
+			"<gray>color_brown<rst>\r\n"
+			"<gray>color_blue<rst>\r\n"
+			"<gray>color_brightred<rst><u3><c8><u1><c9><ceos>some text\r\n"
+			"color_b<rst><c8>\r\n"
+			"some text\r\n"
+			"color_b\r\n",
+			"some textcolor_b\n"
+		)
+		self_.check_scenario(
+			"<up><c-down><cr><c-d>",
+			"<c9><ceos>some long text\r\n"
+			"        color_br<rst>\r\n"
+			"        <gray>color_brown<rst>\r\n"
+			"        <gray>color_brightred<rst>\r\n"
+			"        <gray>color_brightgreen<rst><u3><c17><u1><c9><ceos>some long text\r\n"
+			"        color_br<rst><gray>own<rst>\r\n"
+			"        <gray>color_brightred<rst>\r\n"
+			"        <gray>color_brightgreen<rst>\r\n"
+			"        <gray>color_brightblue<rst><u3><c17><u1><c9><ceos>some long text\r\n"
+			"        color_br<rst><c17>\r\n"
+			"some long text\r\n"
+			"color_br\r\n",
+			"some long textcolor_br\n",
+			command = [ ReplxxTests._cxxSample_, "I" ]
+		)
+		self_.check_scenario(
+			"<up><c-down><cr><c-d>",
+			"<c9><ceos>some text\r\n"
+			"not on start color_b<rst>\r\n"
+			"             <gray>color_black<rst>\r\n"
+			"             <gray>color_brown<rst>\r\n"
+			"             <gray>color_blue<rst><u3><c21><u1><c9><ceos>some text\r\n"
+			"not on start color_b<rst><gray>lack<rst>\r\n"
+			"             <gray>color_brown<rst>\r\n"
+			"             <gray>color_blue<rst>\r\n"
+			"             <gray>color_brightred<rst><u3><c21><u1><c9><ceos>some text\r\n"
+			"not on start color_b<rst><c21>\r\n"
+			"some text\r\n"
+			"not on start color_b\r\n",
+			"some textnot on start color_b\n"
+		)
+		self_.check_scenario(
+			"<up><c-down><cr><c-d>",
+			"<c9><ceos>some text\r\n"
+			"        not on start color_br<rst>\r\n"
+			"                     <gray>color_brown<rst>\r\n"
+			"                     <gray>color_brightred<rst>\r\n"
+			"                     <gray>color_brightgreen<rst><u3><c30><u1><c9><ceos>some "
+			"text\r\n"
+			"        not on start color_br<rst><gray>own<rst>\r\n"
+			"                     <gray>color_brightred<rst>\r\n"
+			"                     <gray>color_brightgreen<rst>\r\n"
+			"                     <gray>color_brightblue<rst><u3><c30><u1><c9><ceos>some "
+			"text\r\n"
+			"        not on start color_br<rst><c30>\r\n"
+			"some text\r\n"
+			"not on start color_br\r\n",
+			"some textnot on start color_br\n",
+			command = [ ReplxxTests._cxxSample_, "I" ]
+		)
+	def test_async_prompt( self_ ):
+		self_.check_scenario(
+			[ "<up>", "r", "i", "g", "h", "t", "g<tab><cr><c-d>" ], [
+				"<c1><ceos><brightgreen>replxx<rst>[-]> <c12><ceos><c12><c12>long line "
+				"<green>color_green<rst> and color_b<rst><ceos>\r\n"
+				"                                     <gray>color_black<rst>\r\n"
+				"                                     <gray>color_brown<rst>\r\n"
+				"                                     "
+				"<gray>color_blue<rst><u3><c45><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>long line <green>color_green<rst> and color_b<rst><ceos>\r\n"
+				"                                     <gray>color_black<rst>\r\n"
+				"                                     <gray>color_brown<rst>\r\n"
+				"                                     "
+				"<gray>color_blue<rst><u3><c45><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>long line <green>color_green<rst> and color_b<rst><ceos>\r\n"
+				"                                     <gray>color_black<rst>\r\n"
+				"                                     <gray>color_brown<rst>\r\n"
+				"                                     <gray>color_blue<rst><u3><c45><c12>long "
+				"line <green>color_green<rst> and color_br<rst><ceos>\r\n"
+				"                                     <gray>color_brown<rst>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     "
+				"<gray>color_brightgreen<rst><u3><c46><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>long line <green>color_green<rst> and color_br<rst><ceos>\r\n"
+				"                                     <gray>color_brown<rst>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     "
+				"<gray>color_brightgreen<rst><u3><c46><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>long line <green>color_green<rst> and color_br<rst><ceos>\r\n"
+				"                                     <gray>color_brown<rst>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     "
+				"<gray>color_brightgreen<rst><u3><c46><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>long line <green>color_green<rst> and color_br<rst><ceos>\r\n"
+				"                                     <gray>color_brown<rst>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     "
+				"<gray>color_brightgreen<rst><u3><c46><c12>long line <green>color_green<rst> "
+				"and color_bri<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c47><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>long line <green>color_green<rst> and color_bri<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c47><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>long line <green>color_green<rst> and color_bri<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c47><c12>long line <green>color_green<rst> "
+				"and color_brig<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c48><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>long line <green>color_green<rst> and color_brig<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c48><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>long line <green>color_green<rst> and color_brig<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c48><c12>long line <green>color_green<rst> "
+				"and color_brigh<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c49><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>long line <green>color_green<rst> and color_brigh<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c49><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>long line <green>color_green<rst> and color_brigh<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c49><c12>long line <green>color_green<rst> "
+				"and color_bright<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c50><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>long line <green>color_green<rst> and color_bright<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c50><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>long line <green>color_green<rst> and color_bright<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c50><c12>long line <green>color_green<rst> "
+				"and "
+				"color_brightg<rst><ceos><green>reen<rst><c51><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>long line <green>color_green<rst> and "
+				"color_brightg<rst><ceos><green>reen<rst><c51><c12>long line "
+				"<green>color_green<rst> and "
+				"<brightgreen>color_brightgreen<rst><ceos><c55><c12>long line "
+				"<green>color_green<rst> and "
+				"<brightgreen>color_brightgreen<rst><ceos><c55>\r\n"
+				"long line color_green and color_brightgreen\r\n",
+				"<c1><ceos><brightgreen>replxx<rst>[-]> <c12><ceos><c12><c12>long line "
+				"<green>color_green<rst> and color_b<rst><ceos>\r\n"
+				"                                     <gray>color_black<rst>\r\n"
+				"                                     <gray>color_brown<rst>\r\n"
+				"                                     "
+				"<gray>color_blue<rst><u3><c45><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>long line <green>color_green<rst> and color_b<rst><ceos>\r\n"
+				"                                     <gray>color_black<rst>\r\n"
+				"                                     <gray>color_brown<rst>\r\n"
+				"                                     "
+				"<gray>color_blue<rst><u3><c45><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>long line <green>color_green<rst> and color_b<rst><ceos>\r\n"
+				"                                     <gray>color_black<rst>\r\n"
+				"                                     <gray>color_brown<rst>\r\n"
+				"                                     <gray>color_blue<rst><u3><c45><c12>long "
+				"line <green>color_green<rst> and color_br<rst><ceos>\r\n"
+				"                                     <gray>color_brown<rst>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     "
+				"<gray>color_brightgreen<rst><u3><c46><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>long line <green>color_green<rst> and color_br<rst><ceos>\r\n"
+				"                                     <gray>color_brown<rst>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     "
+				"<gray>color_brightgreen<rst><u3><c46><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>long line <green>color_green<rst> and color_br<rst><ceos>\r\n"
+				"                                     <gray>color_brown<rst>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     "
+				"<gray>color_brightgreen<rst><u3><c46><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>long line <green>color_green<rst> and color_br<rst><ceos>\r\n"
+				"                                     <gray>color_brown<rst>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     "
+				"<gray>color_brightgreen<rst><u3><c46><c12>long line <green>color_green<rst> "
+				"and color_bri<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c47><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>long line <green>color_green<rst> and color_bri<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c47><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>long line <green>color_green<rst> and color_bri<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c47><c12>long line <green>color_green<rst> "
+				"and color_brig<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c48><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>long line <green>color_green<rst> and color_brig<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c48><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>long line <green>color_green<rst> and color_brig<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c48><c12>long line <green>color_green<rst> "
+				"and color_brigh<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c49><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>long line <green>color_green<rst> and color_brigh<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c49><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>long line <green>color_green<rst> and color_brigh<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c49><c12>long line <green>color_green<rst> "
+				"and color_bright<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c50><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>long line <green>color_green<rst> and color_bright<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c50><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>long line <green>color_green<rst> and color_bright<rst><ceos>\r\n"
+				"                                     <gray>color_brightred<rst>\r\n"
+				"                                     <gray>color_brightgreen<rst>\r\n"
+				"                                     "
+				"<gray>color_brightblue<rst><u3><c50><c12>long line <green>color_green<rst> "
+				"and "
+				"color_brightg<rst><ceos><green>reen<rst><c51><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>long line <green>color_green<rst> and "
+				"color_brightg<rst><ceos><green>reen<rst><c51><c12>long line "
+				"<green>color_green<rst> and "
+				"<brightgreen>color_brightgreen<rst><ceos><c55><c12>long line "
+				"<green>color_green<rst> and "
+				"<brightgreen>color_brightgreen<rst><ceos><c55>\r\n"
+				"long line color_green and color_brightgreen\r\n"
+				"<brightgreen>replxx<rst>> \r\n"
+			],
+			"long line color_green and color_b\n",
+			command = [ ReplxxTests._cxxSample_, "F" ],
+			pause = 0.5
+		)
+		self_.check_scenario(
+			[ "a", "b", "c", "d", "e", "f", "g<tab><cr><c-d>" ], [
+				"<c1><ceos>0\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c12><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c12><c12>a<rst><ceos><c13><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>a<rst><ceos><c13><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>a<rst><ceos><c13><c12>ab<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>ab<rst><ceos><c14><c1><ceos>1\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12>ab<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>ab<rst><ceos><c14><c12>abc<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>abc<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>abc<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>abc<rst><ceos><c15><c12>abcd<rst><ceos><c16><c1><ceos>2\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12>abcd<rst><ceos><c16><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>abcd<rst><ceos><c16><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>abcd<rst><ceos><c16><c12>abcde<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>abcde<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>abcde<rst><ceos><c17><c12>abcdef<rst><ceos><c18><c1><ceos>3\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12>abcdef<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>abcdef<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>abcdef<rst><ceos><c18><c12>abcdefg<rst><ceos><c19><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>abcdefg<rst><ceos><c19><bell><c12>abcdefg<rst><ceos><c19>\r\n"
+				"abcdefg\r\n"
+				"<brightgreen>replxx<rst>> \r\n",
+				"<c1><ceos>0\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c12><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c12><c12>a<rst><ceos><c13><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>a<rst><ceos><c13><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>a<rst><ceos><c13><c12>ab<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>ab<rst><ceos><c14><c1><ceos>1\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12>ab<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>ab<rst><ceos><c14><c12>abc<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>abc<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>abc<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>abc<rst><ceos><c15><c12>abcd<rst><ceos><c16><c1><ceos>2\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12>abcd<rst><ceos><c16><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>abcd<rst><ceos><c16><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>abcd<rst><ceos><c16><c12>abcde<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>abcde<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>abcde<rst><ceos><c17><c12>abcdef<rst><ceos><c18><c1><ceos>3\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12>abcdef<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>abcdef<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>abcdef<rst><ceos><c18><c12>abcdefg<rst><ceos><c19><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>abcdefg<rst><ceos><c19><bell><c12>abcdefg<rst><ceos><c19>\r\n"
+				"abcdefg\r\n",
+				"<c1><ceos>0\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c12><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c12><c12>a<rst><ceos><c13><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>a<rst><ceos><c13><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>a<rst><ceos><c13><c12>ab<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>ab<rst><ceos><c14><c1><ceos>1\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12>ab<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>ab<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>ab<rst><ceos><c14><c12>abc<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>abc<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>abc<rst><ceos><c15><c12>abcd<rst><ceos><c16><c1><ceos>2\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12>abcd<rst><ceos><c16><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>abcd<rst><ceos><c16><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>abcd<rst><ceos><c16><c12>abcde<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>abcde<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>abcde<rst><ceos><c17><c12>abcdef<rst><ceos><c18><c1><ceos>3\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12>abcdef<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>abcdef<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>abcdef<rst><ceos><c18><c12>abcdefg<rst><ceos><c19><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>abcdefg<rst><ceos><c19><bell><c12>abcdefg<rst><ceos><c19>\r\n"
+				"abcdefg\r\n",
+				"<c1><ceos>0\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c12><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c12><c12>a<rst><ceos><c13><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>a<rst><ceos><c13><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>a<rst><ceos><c13><c12>ab<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>ab<rst><ceos><c14><c1><ceos>1\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12>ab<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>ab<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>ab<rst><ceos><c14><c12>abc<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>abc<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>abc<rst><ceos><c15><c12>abcd<rst><ceos><c16><c1><ceos>2\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12>abcd<rst><ceos><c16><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>abcd<rst><ceos><c16><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>abcd<rst><ceos><c16><c12>abcde<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>abcde<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12>abcde<rst><ceos><c17><c12>abcdef<rst><ceos><c18><c1><ceos>3\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12>abcdef<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12>abcdef<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12>abcdef<rst><ceos><c18><c12>abcdefg<rst><ceos><c19><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12>abcdefg<rst><ceos><c19><bell><c12>abcdefg<rst><ceos><c19>\r\n"
+				"abcdefg\r\n"
+				"<brightgreen>replxx<rst>> \r\n"
+			],
+			command = [ ReplxxTests._cxxSample_, "m", "F" ],
+			pause = 0.5
+		)
+		self_.check_scenario(
+			[ "a", "b", "c", "d", "e", "f", "g<tab><cr><c-d>" ], [
+				"<c1><ceos>0\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c12><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c13><c12><yellow>1<rst><ceos><c13><c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos>1\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c16><c12><yellow>1<rst>ab<yellow>2<rst><ceos><c16><c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c18><c1><ceos>2\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c19><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst><ceos><c19><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst><ceos><c19><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c21><c1><ceos>3\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c21><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c22><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst><ceos><c22><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst><ceos><c22><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23><bell><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23>\r\n"
+				"1ab2cd3ef4g\r\n",
+				"<c9><yellow>1<rst><ceos><c10><c1><ceos>0\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst><ceos><c13><c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos>1\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c16><c12><yellow>1<rst>ab<yellow>2<rst><ceos><c16><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst><ceos><c16><c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c18><c1><ceos>2\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c19><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst><ceos><c19><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst><ceos><c19><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c21><c1><ceos>3\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c21><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c22><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst><ceos><c22><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst><ceos><c22><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23><bell><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23>\r\n"
+				"1ab2cd3ef4g\r\n",
+				"<c1><ceos>0\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c13><c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos>1\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c16><c12><yellow>1<rst>ab<yellow>2<rst><ceos><c16><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst><ceos><c16><c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c18><c1><ceos>2\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c19><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst><ceos><c19><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst><ceos><c19><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c21><c1><ceos>3\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c21><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c22><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst><ceos><c22><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst><ceos><c22><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23><bell><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23>\r\n"
+				"1ab2cd3ef4g\r\n",
+				"<c1><ceos>0\r\n"
+				"<brightgreen>replxx<rst>> "
+				"<c9><ceos><c9><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c13><c12><yellow>1<rst><ceos><c13><c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos>1\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c16><c12><yellow>1<rst>ab<yellow>2<rst><ceos><c16><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst><ceos><c16><c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c18><c1><ceos>2\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c19><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst><ceos><c19><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst><ceos><c19><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c21><c1><ceos>3\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c21><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c22><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst><ceos><c22><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst><ceos><c22><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23><bell><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23>\r\n"
+				"1ab2cd3ef4g\r\n",
+				"<c1><ceos>0\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c12><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c13><c12><yellow>1<rst><ceos><c13><c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos>1\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c16><c12><yellow>1<rst>ab<yellow>2<rst><ceos><c16><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst><ceos><c16><c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c18><c1><ceos>2\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c19><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst><ceos><c19><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst><ceos><c19><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c21><c1><ceos>3\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c21><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c22><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst><ceos><c22><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst><ceos><c22><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23><bell><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23>\r\n"
+				"1ab2cd3ef4g\r\n",
+				"<c1><ceos>0\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c12><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c13><c12><yellow>1<rst><ceos><c13><c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos>1\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c16><c12><yellow>1<rst>ab<yellow>2<rst><ceos><c16><c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c18><c1><ceos>2\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c19><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst><ceos><c19><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst><ceos><c19><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c21><c1><ceos>3\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c21><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c22><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst><ceos><c22><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst><ceos><c22><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23><bell><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23>\r\n"
+				"1ab2cd3ef4g\r\n"
+				"<brightgreen>replxx<rst>> <c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><ceos><c12>\r\n",
+				"<c1><ceos>0\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><ceos><c13><c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>a<rst><ceos><c14><c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos>1\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c15><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<rst><ceos><c16><c12><yellow>1<rst>ab<yellow>2<rst><ceos><c16><c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>c<rst><ceos><c17><c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c18><c1><ceos>2\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c18><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<rst><ceos><c19><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst><ceos><c19><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst><ceos><c19><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c1><ceos><brightgreen>replxx<rst>[/]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>e<rst><ceos><c20><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c21><c1><ceos>3\r\n"
+				"<brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c21><c1><ceos><brightgreen>replxx<rst>[-]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<rst><ceos><c22><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst><ceos><c22><c1><ceos><brightgreen>replxx<rst>[\\]> "
+				"<c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst><ceos><c22><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23><bell><c12><yellow>1<rst>ab<yellow>2<rst>cd<yellow>3<rst>ef<yellow>4<rst>g<rst><ceos><c23>\r\n"
+				"1ab2cd3ef4g\r\n"
+				"<brightgreen>replxx<rst>> <c1><ceos><brightgreen>replxx<rst>[|]> "
+				"<c12><ceos><c12>\r\n"
+			],
+			command = [ ReplxxTests._cxxSample_, "m", "F", "k123456" ],
+			pause = 0.487
+		)
+	def test_prompt_from_callback( self_ ):
+		self_.check_scenario(
+			"<up>ri<tab>b<tab><cr><c-d>",
+			"<c9>some text color_b<rst><ceos>\r\n"
+			"                  <gray>color_black<rst>\r\n"
+			"                  <gray>color_brown<rst>\r\n"
+			"                  "
+			"<gray>color_blue<rst><u3><c26><c1><ceos><brightgreen>replxx<rst>[17]> "
+			"<c13>some text color_b<rst><ceos>\r\n"
+			"                      <gray>color_black<rst>\r\n"
+			"                      <gray>color_brown<rst>\r\n"
+			"                      "
+			"<gray>color_blue<rst><u3><c30><c1><ceos><brightgreen>replxx<rst>[18]> "
+			"<c13>some text color_b<rst><ceos>\r\n"
+			"                      <gray>color_black<rst>\r\n"
+			"                      <gray>color_brown<rst>\r\n"
+			"                      "
+			"<gray>color_blue<rst><u3><c31><c1><ceos><brightgreen>replxx<rst>[18]> "
+			"<c13>some text color_br<rst><ceos>\r\n"
+			"                      <gray>color_brown<rst>\r\n"
+			"                      <gray>color_brightred<rst>\r\n"
+			"                      "
+			"<gray>color_brightgreen<rst><u3><c31><c1><ceos><brightgreen>replxx<rst>[19]> "
+			"<c13>some text color_br<rst><ceos>\r\n"
+			"                      <gray>color_brown<rst>\r\n"
+			"                      <gray>color_brightred<rst>\r\n"
+			"                      "
+			"<gray>color_brightgreen<rst><u3><c32><c1><ceos><brightgreen>replxx<rst>[19]> "
+			"<c13>some text color_bri<rst><ceos>\r\n"
+			"                      <gray>color_brightred<rst>\r\n"
+			"                      <gray>color_brightgreen<rst>\r\n"
+			"                      <gray>color_brightblue<rst><u3><c32><c13>some text "
+			"color_bright<rst><ceos>\r\n"
+			"                      <gray>color_brightred<rst>\r\n"
+			"                      <gray>color_brightgreen<rst>\r\n"
+			"                      "
+			"<gray>color_brightblue<rst><u3><c35><c1><ceos><brightgreen>replxx<rst>[22]> "
+			"<c13>some text color_bright<rst><ceos>\r\n"
+			"                      <gray>color_brightred<rst>\r\n"
+			"                      <gray>color_brightgreen<rst>\r\n"
+			"                      "
+			"<gray>color_brightblue<rst><u3><c35><c1><ceos><brightgreen>replxx<rst>[23]> "
+			"<c13>some text color_bright<rst><ceos>\r\n"
+			"                      <gray>color_brightred<rst>\r\n"
+			"                      <gray>color_brightgreen<rst>\r\n"
+			"                      "
+			"<gray>color_brightblue<rst><u3><c36><c1><ceos><brightgreen>replxx<rst>[23]> "
+			"<c13>some text color_brightb<rst><ceos><green>lue<rst><c36><c13>some text "
+			"<brightblue>color_brightblue<rst><ceos><c39><c1><ceos><brightgreen>replxx<rst>[26]> "
+			"<c13>some text <brightblue>color_brightblue<rst><ceos><c39><c13>some text "
+			"<brightblue>color_brightblue<rst><ceos><c39><c1><ceos><brightgreen>replxx<rst>[26]> \r\n"
+			"some text color_brightblue\r\n"
+			"<brightgreen>replxx<rst>> "
+			"<c9><rst><ceos><c9><c1><ceos><brightgreen>replxx<rst>[0]> "
+			"<c12><rst><ceos><c12>\r\n",
+			"some text color_b\n",
+			command = [ ReplxxTests._cxxSample_, "P" ]
+		)
+	def test_color_256( self_ ):
+		self_.check_scenario(
+			"<up><cr><c-d>",
+			"<c9>x <brown><bgcyan>c_3_6<rst> <color67>rgb123<rst> "
+			"<color205><bgcolor78>fg513bg142<rst> <color253>gs21<rst> "
+			"<color237>gs5<rst> <color251><bgcolor237>gs19gs5<rst> "
+			"x<rst><ceos><c53><c9>x <brown><bgcyan>c_3_6<rst> "
+			"<color67>rgb123<rst> <color205><bgcolor78>fg513bg142<rst> "
+			"<color253>gs21<rst> <color237>gs5<rst> "
+			"<color251><bgcolor237>gs19gs5<rst> x<rst><ceos><c53>\r\n"
+			"x c_3_6 rgb123 fg513bg142 gs21 gs5 gs19gs5 x\r\n",
+			"x c_3_6 rgb123 fg513bg142 gs21 gs5 gs19gs5 x\n"
+		)
+	def test_bold_and_underline_attributes( self_ ):
+		self_.check_scenario(
+			"<up><cr><c-d>",
+			"<c9><bold_brightred>bold_color_brightred<rst> "
+			"<brightred>color_brightred<rst> <bold_red>bold_color_red<rst> "
+			"<red>color_red<rst> <underline_red>underline_color_red<rst> "
+			"<bold_underline_red>bold_underline_color_red<rst><ceos><c35><u1><c9><bold_brightred>bold_color_brightred<rst> "
+			"<brightred>color_brightred<rst> <bold_red>bold_color_red<rst> "
+			"<red>color_red<rst> <underline_red>underline_color_red<rst> "
+			"<bold_underline_red>bold_underline_color_red<rst><ceos><c35>\r\n"
+			"bold_color_brightred color_brightred bold_color_red color_red "
+			"underline_color_red bold_underline_color_red\r\n",
+			"bold_color_brightred color_brightred bold_color_red color_red underline_color_red bold_underline_color_red\n"
+		)
+		self_.check_scenario(
+			"<up><cr><c-d>",
+			"<c9>normal_text <bold>bold_text<rst> <underline>underline_text<rst> "
+			"<bold_underline>bold_underline_text<rst><ceos><c65><c9>normal_text "
+			"<bold>bold_text<rst> <underline>underline_text<rst> "
+			"<bold_underline>bold_underline_text<rst><ceos><c65>\r\n"
+			"normal_text bold_text underline_text bold_underline_text\r\n",
+			"normal_text bold_text underline_text bold_underline_text\n"
+		)
+	def test_kill_to_begining_of_line_in_multiline( self_ ):
+		self_.check_scenario(
+			"<up><up><c-u><c-u><c-y><cr><c-d>",
+			"<c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><c20><u3><c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><u1><c20><u2><c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"cripture\r\n"
+			"last line of a code<rst><u1><c1><u2><c9><ceos>cripture\r\n"
+			"last line of a code<rst><u1><c9><c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><u1><c20><u2><c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><c20>\r\n"
+			"first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code\r\n",
+			"first line of textsecond verse of a poemnext passage of a scripturelast line of a code\n"
+		)
+	def test_kill_to_end_of_line_in_multiline( self_ ):
+		self_.check_scenario(
+			"<up><pgup><down><c-k><c-k><c-y><cr><c-d>",
+			"<c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><c20><u3><c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><u3><c9><d1><c9><u1><c9><ceos>first line of text\r\n"
+			"second v\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><u2><c9><u1><c9><ceos>first line of text\r\n"
+			"second v<rst><c9><u1><c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><c20><u3><c9><ceos>first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code<rst><c20>\r\n"
+			"first line of text\r\n"
+			"second verse of a poem\r\n"
+			"next passage of a scripture\r\n"
+			"last line of a code\r\n",
+			"first line of textsecond verse of a poemnext passage of a scripturelast line of a code\n"
+		)
+	def test_long_prompt_multiline_enabled_hints( self_ ):
+		prompt = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa> "
+		self_.check_scenario(
+			"<up><cr><c-d>",
+			"<c40>co<rst><ceos>\r\n"
+			"                                       <gray>color_black<rst>\r\n"
+			"                                       <gray>color_red<rst>\r\n"
+			"                                       "
+			"<gray>color_green<rst><u3><c42><c40>co<rst><ceos><c42>\r\n"
+			"co\r\n",
+			"co\n",
+			command = [ ReplxxTests._cxxSample_, "I", "p" + prompt ],
+			dimensions = ( 24, 64 ),
+			prompt = prompt
+		)
+	def test_ignore_case_hints_completions( self_ ):
+		self_.check_scenario(
+			"de<tab>e<tab><c-down><tab><cr><c-d>",
+			"<c9>d<rst><ceos><c10><c9>de<rst><ceos>\r\n"
+			"        <gray>determinANT<rst>\r\n"
+			"        <gray>determiNATION<rst>\r\n"
+			"        <gray>deterMINE<rst><u3><c11><c9>determin<rst><ceos>\r\n"
+			"        <gray>determinANT<rst>\r\n"
+			"        <gray>determiNATION<rst>\r\n"
+			"        <gray>deterMINE<rst><u3><c17><c9>determine<rst><ceos>\r\n"
+			"        <gray>deterMINE<rst>\r\n"
+			"        <gray>deTERMINED<rst><u2><c18><c9>determine<rst><ceos><c18>\r\n"
+			"<brightmagenta>deterMINE<rst>   <brightmagenta>deTERMINE<rst>D\r\n"
+			"<brightgreen>replxx<rst>> <c9>determine<rst><ceos>\r\n"
+			"        <gray>deterMINE<rst>\r\n"
+			"        <gray>deTERMINED<rst><u2><c18><c9>determine<rst><ceos>\r\n"
+			"        <gray>deTERMINED<rst>\r\n"
+			"        "
+			"<gray>determine<u2><c18><c9>deterMINE<rst><ceos><c18><c9>deterMINE<rst><ceos><c18>\r\n"
+			"deterMINE\r\n",
+			command = [ ReplxxTests._cxxSample_, "i" ]
+		)
+		self_.check_scenario(
+			"de<tab>e<tab>d<tab><cr><c-d>",
+			"<c9>d<rst><ceos><c10><c9>de<rst><ceos>\r\n"
+			"        <gray>determinANT<rst>\r\n"
+			"        <gray>determiNATION<rst>\r\n"
+			"        <gray>deterMINE<rst><u3><c11><c9>determin<rst><ceos>\r\n"
+			"        <gray>determinANT<rst>\r\n"
+			"        <gray>determiNATION<rst>\r\n"
+			"        <gray>deterMINE<rst><u3><c17><c9>determine<rst><ceos>\r\n"
+			"        <gray>deterMINE<rst>\r\n"
+			"        <gray>deTERMINED<rst><u2><c18><c9>determine<rst><ceos><c18>\r\n"
+			"<brightmagenta>deterMINE<rst>   <brightmagenta>deTERMINE<rst>D\r\n"
+			"<brightgreen>replxx<rst>> <c9>determine<rst><ceos>\r\n"
+			"        <gray>deterMINE<rst>\r\n"
+			"        "
+			"<gray>deTERMINED<rst><u2><c18><c9>determined<rst><ceos><c19><c9>deTERMINED<rst><ceos><c19><c9>deTERMINED<rst><ceos><c19>\r\n"
+			"deTERMINED\r\n",
+			command = [ ReplxxTests._cxxSample_, "i" ]
+		)
+	def test_ignore_case_history_search( self_ ):
+		self_.check_scenario(
+			"<c-r>er<backspace>R<cr><c-d>",
+			"<c1><ceos><c1><ceos>(reverse-i-search)`': "
+			"<c23><c1><ceos>(reverse-i-search)`e': "
+			"determinANT<c27><c1><ceos>(reverse-i-search)`er': "
+			"determinANT<c28><c1><ceos>(reverse-i-search)`e': "
+			"determinANT<c27><c1><ceos>(reverse-i-search)`eR': "
+			"deteRMINISM<c28><c1><ceos><brightgreen>replxx<rst>> "
+			"deteRMINISM<c12><c9>deteRMINISM<rst><ceos><c12><c9>deteRMINISM<rst><ceos><c20>\r\n"
+			"thanks for the input: deteRMINISM\r\n",
+			"deTERMINED\ndetERMINISTIC\ndeteRMINISM\ndeterMINE\ndetermiNATION\ndeterminANT\n",
+			command = [ ReplxxTests._cSample_, "i1" ]
+		)
+		self_.check_scenario(
+			"deter<m-p><cr><c-d>",
+			"<c9>d<rst><ceos><gray>b<rst><c10><c9>de<rst><ceos><c11><c9>det<rst><ceos><c12><c9>dete<rst><ceos><c13><c9>deter<rst><ceos><c14><c9>determinANT<rst><ceos><c20><c9>determinANT<rst><ceos><c20>\r\n"
+			"thanks for the input: determinANT\r\n",
+			"deTERMINED\ndetERMINISTIC\ndeteRMINISM\ndeterMINE\ndetermiNATION\ndeterminANT\n",
+			command = [ ReplxxTests._cSample_, "i1" ]
+		)
+		self_.check_scenario(
+			"deteR<m-p><cr><c-d>",
+			"<c9>d<rst><ceos><gray>b<rst><c10><c9>de<rst><ceos><c11><c9>det<rst><ceos><c12><c9>dete<rst><ceos><c13><c9>deteR<rst><ceos><c14><c9>deteRMINISM<rst><ceos><c20><c9>deteRMINISM<rst><ceos><c20>\r\n"
+			"thanks for the input: deteRMINISM\r\n",
+			"deTERMINED\ndetERMINISTIC\ndeteRMINISM\ndeterMINE\ndetermiNATION\ndeterminANT\n",
+			command = [ ReplxxTests._cSample_, "i1" ]
+		)
+	def test_history_scratch( self_ ):
+		self_.check_scenario(
+			"<up>x<up>y<up>z<down><up>Z<pgdown><up><pgup><cr><c-d>",
+			"<c9>three<rst><ceos><c14><c9>threex<rst><ceos><c15>"
+			"<c9>two<rst><ceos><c12><c9>twoy<rst><ceos><c13>"
+			"<c9>one<rst><ceos><c12><c9>onez<rst><ceos><c13>"
+			"<c9>twoy<rst><ceos><c13><c9>onez<rst><ceos><c13>"
+			"<c9>onezZ<rst><ceos><c14><c9><rst><ceos><c9>"
+			"<c9>threex<rst><ceos><c15><c9>onezZ<rst><ceos><c14>"
+			"<c9>onezZ<rst><ceos><c14>\r\n"
+			"onezZ\r\n",
+			"one\ntwo\nthree\n"
+		)
+		with open( "replxx_history.txt", "rb" ) as f:
+			data = f.read().decode()
+			origHist = "### 0000-00-00 00:00:00.000\none\n### 0000-00-00 00:00:00.000\ntwo\n### 0000-00-00 00:00:00.000\nthree\n";
+			self_.assertSequenceEqual( data[:len(origHist)], origHist )
+			self_.assertSequenceEqual( data[-6:], "onezZ\n" )
+		self_.check_scenario(
+			"<up>x<up>y<up>z<down><c-g><up><down><cr><c-d>",
+			"<c9>three<rst><ceos><c14><c9>threex<rst><ceos><c15>"
+			"<c9>two<rst><ceos><c12><c9>twoy<rst><ceos><c13>"
+			"<c9>one<rst><ceos><c12><c9>onez<rst><ceos><c13>"
+			"<c9>twoy<rst><ceos><c13><c9>two<rst><ceos><c12>"
+			"<c9>onez<rst><ceos><c13><c9>two<rst><ceos><c12>"
+			"<c9>two<rst><ceos><c12>\r\n"
+			"two\r\n",
+			"one\ntwo\nthree\n"
+		)
+		self_.check_scenario(
+			"<up>x<up>y<up>z<down><m-g><up><down><down><cr><c-d>",
+			"<c9>three<rst><ceos><c14><c9>threex<rst><ceos><c15>"
+			"<c9>two<rst><ceos><c12><c9>twoy<rst><ceos><c13>"
+			"<c9>one<rst><ceos><c12><c9>onez<rst><ceos><c13>"
+			"<c9>twoy<rst><ceos><c13><c9>two<rst><ceos><c12>"
+			"<c9>one<rst><ceos><c12><c9>two<rst><ceos><c12>"
+			"<c9>three<rst><ceos><c14><c9>three<rst><ceos><c14>\r\n"
+			"three\r\n",
+			"one\ntwo\nthree\n"
+		)
+	def test_move_up_over_multiline( self_ ):
+		self_.check_scenario(
+			"<m-up><m-up><m-up><cr><c-d>",
+			"<c9>ZZZ<rst><ceos><c12><c9><ceos>bbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbbbbb<rst><c24><u3><c9><yellow>123<rst><ceos><c12><c9><yellow>123<rst><ceos><c12>\r\n"
+			"123\r\n",
+			"123\nbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\nZZZ\n"
+		)
+	def test_move_down_over_multiline( self_ ):
+		self_.check_scenario(
+			"<pgup><m-down><pgup><m-down><m-down>x<cr><c-d>",
+			"<c9><yellow>123<rst><ceos><c12><c9><ceos>bbbbbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbb<rst><c17><u3><c9><ceos>bbbbbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbbbbbb\r\n"
+			"bbbbbbbbbbbbbbbb<rst><u3><c9><c9>ZZZ<rst><ceos><c12><c9><rst><ceos><c9><c9>x<rst><ceos><c10><c9>x<rst><ceos><c10>\r\n"
+			"x\r\n",
+			"123\nbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\nZZZ\n"
+		)
+	def test_position_tracking_no_color( self_ ):
+		self_.check_scenario(
+			"abcdef<home><cr><c-d>",
+			"abcdef<c9><c9>abcdef<ceos><c15>\r\nthanks for the input: abcdef\r\n",
+			command = [ ReplxxTests._cSample_, "m", "N", "S", "C", "M0" ]
+		)
+	def test_seeded_incremental_history_search( self_ ):
+		self_.check_scenario(
+			"for<m-r><m-r><cr><c-d>",
+			"<c9>f<rst><ceos><c10><c9>fo<rst><ceos><c11><c9>for<rst><ceos><c12><c1><ceos><c1><ceos>(reverse-i-search)`for': "
+			"for<c29><c1><ceos>(reverse-i-search)`for': "
+			"forth<c26><c1><ceos>(reverse-i-search)`for': "
+			"fortran<c26><c1><ceos><brightgreen>replxx<rst>> "
+			"fortran<c9><c9>fortran<rst><ceos><c9><c9>fortran<rst><ceos><c16>\r\n"
+			"fortran\r\n",
+			"\n".join( _words_[::-1] ) + "\n"
 		)
 
 def parseArgs( self, func, argv ):

--- a/vendor.yaml
+++ b/vendor.yaml
@@ -33,3 +33,5 @@ third-party/imgui:
   git: https://github.com/ocornut/imgui/tree/v1.89.2
 third-party/tree-sitter:
   git: https://github.com/tree-sitter/tree-sitter/tree/v0.20.8
+third-party/replxx:
+  git: https://github.com/AmokHuginnsson/replxx/commit/1f149bfe20bf6e49c1afd4154eaf0032c8c2fda2


### PR DESCRIPTION
Closes #722

Took another stab at this and did way too much reading into the current state of terminals.  The proper way to support pasting multiple lines in a terminal is via bracketed paste - https://en.wikipedia.org/wiki/Bracketed-paste

replxx supports this and looking at the implementation it seems to do it right.  This can be confirmed from basically any linux terminal. (Confirmed on macOS - good enough! https://github.com/open-goal/jak-project/pull/2784#issuecomment-1612725605)

The problem is, PowerShell does not support bracketed paste, and neither does the much older `cmd`.  So the problem isn't our code, we'd have to do a whole bunch of windows specific console code for the `paste` handler (this is what powershell apparently does _instead_ of just supporting bracketed paste like everyone is hoping they would).

However this does allow you to submit multi-line inputs via `ctrl+enter` or `ctrl+j` now.  You just can't paste them in (on windows).