### PR TITLE
ci: ensure linux runners have the proper OpenGL headers

### DIFF
--- a/.github/workflows/linux-build-clang.yaml
+++ b/.github/workflows/linux-build-clang.yaml
@@ -32,7 +32,7 @@ jobs:
           sudo apt install build-essential cmake
           clang gcc g++ lcov make nasm libxrandr-dev
           libxinerama-dev libxcursor-dev libpulse-dev
-          libxi-dev zip ninja-build
+          libxi-dev zip ninja-build libgl1-mesa-dev
 
       - name: Setup Buildcache
         uses: mikehardy/buildcache-action@v2.1.0

--- a/.github/workflows/linux-build-gcc.yaml
+++ b/.github/workflows/linux-build-gcc.yaml
@@ -32,7 +32,7 @@ jobs:
           sudo apt install build-essential cmake
           clang gcc g++ lcov make nasm libxrandr-dev
           libxinerama-dev libxcursor-dev libpulse-dev
-          libxi-dev zip ninja-build
+          libxi-dev zip ninja-build libgl1-mesa-dev
 
       - name: Setup Buildcache
         uses: mikehardy/buildcache-action@v2.1.0


### PR DESCRIPTION
This fixes an issue which causes `gk` to fail starting up on linux due to the way SDL's cmake works (it looks for this header while compiling, not when running)