### PR TITLE
[jak1] Merc for title - fixes blerc

### DIFF
--- a/goal_src/jak1/engine/gfx/foreground/bones.gc
+++ b/goal_src/jak1/engine/gfx/foreground/bones.gc
@@ -1417,9 +1417,6 @@
                   (pc-merc-vtx-update #f)
                   (blerc-weights (new 'stack-no-clear 'array 'float 40))
                   )
-              (when (logtest? (-> arg0 global-effect) (draw-effect title))
-                (set! pc-force-mercneric #t)
-                )
               ;; loop over effects, and set them up/pick renderers.
               (dotimes (effect-idx (the-as int (-> geom header effect-count)))
 


### PR DESCRIPTION
Removes a leftover case for falling to back to generic-merc in jak 1. This should fix the bug where daxter's face wasn't animated in the intro after floating-point blerc was added.