### PR TITLE
repl: separate history by game version

### DIFF
--- a/common/repl/config.cpp
+++ b/common/repl/config.cpp
@@ -11,6 +11,7 @@ void to_json(json& j, const Config& obj) {
       {"numConnectToTargetAttempts", obj.target_connect_attempts},
       {"asmFileSearchDirs", obj.asm_file_search_dirs},
       {"keybinds", obj.keybinds},
+      {"perGameHistory", obj.per_game_history},
   };
 }
 
@@ -50,6 +51,9 @@ void from_json(const json& j, Config& obj) {
       }
       obj.keybinds = keybinds;
     }
+  }
+  if (j.contains("perGameHistory")) {
+    j.at("perGameHistory").get_to(obj.per_game_history);
   }
   // if there is game specific configuration, override any values we just set
   if (j.contains(version_to_game_name(obj.game_version))) {

--- a/common/repl/config.h
+++ b/common/repl/config.h
@@ -44,6 +44,7 @@ struct Config {
       {KeyBind::Modifier::CTRL, "G", "Attach the debugger to the process", "(dbgc)"},
       {KeyBind::Modifier::CTRL, "B", "Displays the most recently caught backtrace", "(:di)"},
       {KeyBind::Modifier::CTRL, "N", "Full build of the game", "(mi)"}};
+  bool per_game_history = true;
 };
 void to_json(json& j, const Config& obj);
 void from_json(const json& j, Config& obj);

--- a/common/repl/util.cpp
+++ b/common/repl/util.cpp
@@ -57,13 +57,25 @@ void Wrapper::add_to_history(const std::string& line) {
 }
 
 void Wrapper::save_history() {
-  fs::path path = file_util::get_user_config_dir() / ".opengoal.repl.history";
+  fs::path path;
+  if (repl_config.per_game_history) {
+    path = file_util::get_user_config_dir() / game_version_names[repl_config.game_version] /
+           ".opengoal.repl.history";
+  } else {
+    path = file_util::get_user_config_dir() / ".opengoal.repl.history";
+  }
   file_util::create_dir_if_needed_for_file(path.string());
   repl.history_save(path.string());
 }
 
 void Wrapper::load_history() {
-  fs::path path = file_util::get_user_config_dir() / ".opengoal.repl.history";
+  fs::path path;
+  if (repl_config.per_game_history) {
+    path = file_util::get_user_config_dir() / game_version_names[repl_config.game_version] /
+           ".opengoal.repl.history";
+  } else {
+    path = file_util::get_user_config_dir() / ".opengoal.repl.history";
+  }
   if (fs::exists(path)) {
     repl.history_load(path.string());
   } else {

--- a/goal_src/user/README.md
+++ b/goal_src/user/README.md
@@ -39,7 +39,8 @@ Additionally, you can provide a `repl-config.json` to set various REPL settings,
       "description": "Test Bind",
       "command": "(format 0 \"hello world\")"
     }
-  ]
+  ],
+  "perGameHistory": false // do not use separate history files for each game version
 }
 ```
 


### PR DESCRIPTION
Turned on by default, REPL history files are now stored separately per game version.

Users can enable the old behavior by adding `"perGameHistory": false` to their REPL config.