### PR TITLE
Make Jak1 playable on macOS (intel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Then build the entire project as `Windows Release (clang)`. You can also press C
 
 ### MacOS
 
-> NOTE: At this time you still cannot run the game on macOS due to OpenGL version limitations.  But you can build the project and use most of the tooling.
+> NOTE: At this time you can only run the game on macOS if you have an Intel processor.
 
 Ensure that you have Xcode command line tools installed (this installs things like Apple Clang).  If you don't, you can run the following command:
 

--- a/game/graphics/gfx_test.cpp
+++ b/game/graphics/gfx_test.cpp
@@ -23,6 +23,9 @@ GPUTestOutput run_gpu_test(const std::string& test_type) {
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+#ifdef __APPLE__
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+#endif
     SDL_Window* window =
         SDL_CreateWindow("OpenGL Version", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 800,
                          600, SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);

--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -74,11 +74,14 @@ OpenGLRenderer::OpenGLRenderer(std::shared_ptr<TexturePool> texture_pool,
       m_version(version) {
   // setup OpenGL errors
   glEnable(GL_DEBUG_OUTPUT);
+  // requires OpenGL 4.3
+#ifndef __APPLE__
   glDebugMessageCallback(opengl_error_callback, nullptr);
   // disable specific errors
   const GLuint gl_error_ignores_api_other[1] = {0x20071};
   glDebugMessageControl(GL_DEBUG_SOURCE_API, GL_DEBUG_TYPE_OTHER, GL_DONT_CARE, 1,
                         &gl_error_ignores_api_other[0], GL_FALSE);
+#endif
 
   lg::debug("OpenGL context information: {}", (const char*)glGetString(GL_VERSION));
 

--- a/game/graphics/opengl_renderer/Shader.cpp
+++ b/game/graphics/opengl_renderer/Shader.cpp
@@ -11,8 +11,6 @@ Shader::Shader(const std::string& shader_name, GameVersion version) : m_name(sha
   const std::string scissor_height = version == GameVersion::Jak1 ? "448.0" : "416.0";
   const std::string scissor_adjust = "512.0 / " + scissor_height;
 
-  lg::debug("Loading shader {}", shader_name);
-
   // read the shader source
   auto vert_src =
       file_util::read_text_file(file_util::get_file_path({shader_folder, shader_name + ".vert"}));
@@ -73,14 +71,12 @@ Shader::Shader(const std::string& shader_name, GameVersion version) : m_name(sha
     std::string uniformName = "tex_T" + std::to_string(i);
     GLint texLoc = glGetUniformLocation(m_program, uniformName.c_str());
     if (texLoc != -1) {
-      lg::debug("Shader {}: setting up texture uniform {}", shader_name, uniformName);
       glUniform1i(texLoc, i);
     }
   }
   // assuming that the bones uniform block is always using binding point 1
   GLint bonesLoc = glGetUniformBlockIndex(m_program, "ub_bones");
   if (bonesLoc != -1) {
-    lg::debug("Shader {}: setting up bones uniform block", shader_name);
     glUniformBlockBinding(m_program, bonesLoc, 1);
   }
 

--- a/game/graphics/opengl_renderer/Shader.cpp
+++ b/game/graphics/opengl_renderer/Shader.cpp
@@ -74,8 +74,8 @@ Shader::Shader(const std::string& shader_name, GameVersion version) : m_name(sha
     GLint texLoc = glGetUniformLocation(m_program, uniformName.c_str());
     if (texLoc != -1) {
       lg::debug("Shader {}: setting up texture uniform {}", shader_name, uniformName);
+      glUniform1i(texLoc, i);
     }
-    glUniform1i(texLoc, i);
   }
   // assuming that the bones uniform block is always using binding point 1
   GLint bonesLoc = glGetUniformBlockIndex(m_program, "ub_bones");

--- a/game/graphics/opengl_renderer/Shader.cpp
+++ b/game/graphics/opengl_renderer/Shader.cpp
@@ -73,14 +73,14 @@ Shader::Shader(const std::string& shader_name, GameVersion version) : m_name(sha
     std::string uniformName = "tex_T" + std::to_string(i);
     GLint texLoc = glGetUniformLocation(m_program, uniformName.c_str());
     if (texLoc != -1) {
-      lg::debug("Shader {} has texture uniform {} at location {}", shader_name, uniformName, texLoc);
+      lg::debug("Shader {}: setting up texture uniform {}", shader_name, uniformName);
     }
     glUniform1i(texLoc, i);
   }
   // assuming that the bones uniform block is always using binding point 1
   GLint bonesLoc = glGetUniformBlockIndex(m_program, "ub_bones");
   if (bonesLoc != -1) {
-    lg::debug("Shader {} has bones uniform block at location {}", shader_name, bonesLoc);
+    lg::debug("Shader {}: setting up bones uniform block", shader_name);
     glUniformBlockBinding(m_program, bonesLoc, 1);
   }
 

--- a/game/graphics/opengl_renderer/Shader.cpp
+++ b/game/graphics/opengl_renderer/Shader.cpp
@@ -10,6 +10,9 @@ Shader::Shader(const std::string& shader_name, GameVersion version) : m_name(sha
   const std::string height_scale = version == GameVersion::Jak1 ? "1.0" : "0.5";
   const std::string scissor_height = version == GameVersion::Jak1 ? "448.0" : "416.0";
   const std::string scissor_adjust = "512.0 / " + scissor_height;
+
+  lg::debug("Loading shader {}", shader_name);
+
   // read the shader source
   auto vert_src =
       file_util::read_text_file(file_util::get_file_path({shader_folder, shader_name + ".vert"}));
@@ -62,6 +65,23 @@ Shader::Shader(const std::string& shader_name, GameVersion version) : m_name(sha
     lg::error("Failed to link shader {}:\n{}", shader_name.c_str(), err);
     m_is_okay = false;
     return;
+  }
+
+  // uniform samplers must be named matching the texture unit
+  glUseProgram(m_program);
+  for (int i = 1; i < 30; ++i) {
+    std::string uniformName = "tex_T" + std::to_string(i);
+    GLint texLoc = glGetUniformLocation(m_program, uniformName.c_str());
+    if (texLoc != -1) {
+      lg::debug("Shader {} has texture uniform {} at location {}", shader_name, uniformName, texLoc);
+    }
+    glUniform1i(texLoc, i);
+  }
+  // assuming that the bones uniform block is always using binding point 1
+  GLint bonesLoc = glGetUniformBlockIndex(m_program, "ub_bones");
+  if (bonesLoc != -1) {
+    lg::debug("Shader {} has bones uniform block at location {}", shader_name, bonesLoc);
+    glUniformBlockBinding(m_program, bonesLoc, 1);
   }
 
   glDeleteShader(m_vert_shader);

--- a/game/graphics/opengl_renderer/shaders/collision.frag
+++ b/game/graphics/opengl_renderer/shaders/collision.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 

--- a/game/graphics/opengl_renderer/shaders/collision.vert
+++ b/game/graphics/opengl_renderer/shaders/collision.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 layout (location = 1) in uint flags;
@@ -30,9 +30,9 @@ const int MODE_MODE = 1;
 const int MODE_EVENT = 2;
 const int MODE_MATERIAL = 3;
 
-uint pat_get_mode(uint p) { return version == 2 ? (p >> 7) & 0x7 : (p >> 3) & 0x7; }
-uint pat_get_material(uint p) { return version == 2 ? (p >> 10) & 0x3f : (p >> 6) & 0x3f; }
-uint pat_get_event(uint p) { return version == 2 ? (p >> 18) & 0x3f : (p >> 14) & 0x3f; }
+uint pat_get_mode(uint p) { return version == 2 ? (p >> 7) & 0x7u : (p >> 3) & 0x7u; }
+uint pat_get_material(uint p) { return version == 2 ? (p >> 10) & 0x3fu : (p >> 6) & 0x3fu; }
+uint pat_get_event(uint p) { return version == 2 ? (p >> 18) & 0x3fu : (p >> 14) & 0x3fu; }
 
 bool logtest(uint a, uint b) { return (a & b) != 0; }
 bool logtesta(uint a, uint b) { return (a & b) == b; }
@@ -93,9 +93,9 @@ void main() {
     uint pMode = pat_get_mode(pat);
     uint pMat = pat_get_material(pat);
     uint pEvent = pat_get_event(pat);
-    if (logtest(collision_mode_mask[pMode/32], 1 << (pMode & 0x1f)) &&
-      logtest(collision_material_mask[pMat/32], 1 << (pMat & 0x1f)) &&
-      logtest(collision_event_mask[pEvent/32], 1 << (pEvent & 0x1f)) &&
+    if (logtest(collision_mode_mask[pMode/32], 1 << (pMode & 0x1fu)) &&
+      logtest(collision_material_mask[pMat/32], 1 << (pMat & 0x1fu)) &&
+      logtest(collision_event_mask[pEvent/32], 1 << (pEvent & 0x1fu)) &&
       logtesta(collision_skip_mask, pat)) {
       // fancy colors
       if (mode == MODE_MODE) {

--- a/game/graphics/opengl_renderer/shaders/debug_red.frag
+++ b/game/graphics/opengl_renderer/shaders/debug_red.frag
@@ -1,6 +1,6 @@
 // Debug shader for drawing things in red.  Uses the same conventions as direct_basic, see there for more details
 
-#version 430 core
+#version 410 core
 
 out vec4 color;
 

--- a/game/graphics/opengl_renderer/shaders/debug_red.vert
+++ b/game/graphics/opengl_renderer/shaders/debug_red.vert
@@ -1,6 +1,6 @@
 // Debug shader for drawing things in red. Uses the same conventions as direct_basic, see there for more details
 
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 

--- a/game/graphics/opengl_renderer/shaders/depth_cue.frag
+++ b/game/graphics/opengl_renderer/shaders/depth_cue.frag
@@ -1,6 +1,6 @@
-#version 430 core
+#version 410 core
 
-in flat vec4 fragment_color;
+flat in vec4 fragment_color;
 in vec2 tex_coord;
 
 uniform sampler2D tex;

--- a/game/graphics/opengl_renderer/shaders/depth_cue.vert
+++ b/game/graphics/opengl_renderer/shaders/depth_cue.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec2 xy;
 layout (location = 1) in vec2 st;
@@ -6,7 +6,7 @@ layout (location = 1) in vec2 st;
 uniform vec4 u_color;
 uniform float u_depth;
 
-out flat vec4 fragment_color;
+flat out vec4 fragment_color;
 out vec2 tex_coord;
 
 void main() {

--- a/game/graphics/opengl_renderer/shaders/direct2.frag
+++ b/game/graphics/opengl_renderer/shaders/direct2.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 
@@ -8,19 +8,19 @@ uniform float alpha_reject;
 uniform float color_mult;
 uniform vec4 fog_color;
 
-in flat uvec2 tex_info;
+flat in uvec2 tex_info;
 in float fog;
 
-layout (binding = 0) uniform sampler2D tex_T0;
-layout (binding = 1) uniform sampler2D tex_T1;
-layout (binding = 2) uniform sampler2D tex_T2;
-layout (binding = 3) uniform sampler2D tex_T3;
-layout (binding = 4) uniform sampler2D tex_T4;
-layout (binding = 5) uniform sampler2D tex_T5;
-layout (binding = 6) uniform sampler2D tex_T6;
-layout (binding = 7) uniform sampler2D tex_T7;
-layout (binding = 8) uniform sampler2D tex_T8;
-layout (binding = 9) uniform sampler2D tex_T9;
+uniform sampler2D tex_T0;
+uniform sampler2D tex_T1;
+uniform sampler2D tex_T2;
+uniform sampler2D tex_T3;
+uniform sampler2D tex_T4;
+uniform sampler2D tex_T5;
+uniform sampler2D tex_T6;
+uniform sampler2D tex_T7;
+uniform sampler2D tex_T8;
+uniform sampler2D tex_T9;
 
 
 vec4 sample_tex(vec2 coord, uint unit) {

--- a/game/graphics/opengl_renderer/shaders/direct2.vert
+++ b/game/graphics/opengl_renderer/shaders/direct2.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 layout (location = 1) in vec4 rgba_in;
@@ -11,7 +11,7 @@ out vec3 tex_coord;
 out float fog;
 
 // putting all texture info stuff here so it's easier to copy-paste
-out flat uvec2 tex_info;
+flat out uvec2 tex_info;
 
 void main() {
   gl_Position = vec4((position_in.x - 0x8000) / 0x1000,

--- a/game/graphics/opengl_renderer/shaders/direct_basic.frag
+++ b/game/graphics/opengl_renderer/shaders/direct_basic.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 

--- a/game/graphics/opengl_renderer/shaders/direct_basic.vert
+++ b/game/graphics/opengl_renderer/shaders/direct_basic.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 layout (location = 1) in vec4 rgba_in;

--- a/game/graphics/opengl_renderer/shaders/direct_basic_textured.frag
+++ b/game/graphics/opengl_renderer/shaders/direct_basic_textured.frag
@@ -1,10 +1,10 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 
 in vec4 fragment_color;
 in vec3 tex_coord;
-in flat uint use_uv;
+flat in uint use_uv;
 in vec4 gs_scissor;
 uniform float alpha_reject;
 uniform float color_mult;
@@ -17,20 +17,20 @@ uniform vec4 game_sizes;
 
 uniform vec4 fog_color;
 
-in flat uvec4 tex_info;
+flat in uvec4 tex_info;
 in float fog;
 
-layout (binding = 20) uniform sampler2D tex_T0;
+uniform sampler2D tex_T20;
 
 vec4 sample_tex(vec2 coord, uint unit) {
-  return texture(tex_T0, coord);
+  return texture(tex_T20, coord);
 }
 
 vec4 sample_tex_px(vec2 coordf, uint unit) {
   ivec2 coord;
   coord.x = int(coordf.x / 16);
   coord.y = int(coordf.y / 16);
-  return texelFetch(tex_T0, coord, 0);
+  return texelFetch(tex_T20, coord, 0);
 }
 
 void main() {

--- a/game/graphics/opengl_renderer/shaders/direct_basic_textured.vert
+++ b/game/graphics/opengl_renderer/shaders/direct_basic_textured.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec4 position_in;
 layout (location = 1) in vec4 rgba_in;
@@ -13,8 +13,8 @@ out vec4 gs_scissor;
 // putting all texture info stuff here so it's easier to copy-paste
 layout (location = 3) in uvec4 tex_info_in;
 layout (location = 4) in uint use_uv_in;
-out flat uvec4 tex_info;
-out flat uint use_uv;
+flat out uvec4 tex_info;
+flat out uint use_uv;
 uniform int offscreen_mode;
 
 void main() {

--- a/game/graphics/opengl_renderer/shaders/direct_basic_textured_multi_unit.frag
+++ b/game/graphics/opengl_renderer/shaders/direct_basic_textured_multi_unit.frag
@@ -1,10 +1,10 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 
 in vec4 fragment_color;
 in vec3 tex_coord;
-in flat uint use_uv;
+flat in uint use_uv;
 in vec4 gs_scissor;
 uniform float alpha_reject;
 uniform float color_mult;
@@ -17,32 +17,32 @@ uniform vec4 game_sizes;
 
 uniform vec4 fog_color;
 
-in flat uvec4 tex_info;
+flat in uvec4 tex_info;
 in float fog;
 
-layout (binding = 20) uniform sampler2D tex_T0;
-layout (binding = 21) uniform sampler2D tex_T1;
-layout (binding = 22) uniform sampler2D tex_T2;
-layout (binding = 23) uniform sampler2D tex_T3;
-layout (binding = 24) uniform sampler2D tex_T4;
-layout (binding = 25) uniform sampler2D tex_T5;
-layout (binding = 26) uniform sampler2D tex_T6;
-layout (binding = 27) uniform sampler2D tex_T7;
-layout (binding = 28) uniform sampler2D tex_T8;
-layout (binding = 29) uniform sampler2D tex_T9;
+uniform sampler2D tex_T20;
+uniform sampler2D tex_T21;
+uniform sampler2D tex_T22;
+uniform sampler2D tex_T23;
+uniform sampler2D tex_T24;
+uniform sampler2D tex_T25;
+uniform sampler2D tex_T26;
+uniform sampler2D tex_T27;
+uniform sampler2D tex_T28;
+uniform sampler2D tex_T29;
 
 vec4 sample_tex(vec2 coord, uint unit) {
   switch (unit) {
-    case 0: return texture(tex_T0, coord);
-    case 1: return texture(tex_T1, coord);
-    case 2: return texture(tex_T2, coord);
-    case 3: return texture(tex_T3, coord);
-    case 4: return texture(tex_T4, coord);
-    case 5: return texture(tex_T5, coord);
-    case 6: return texture(tex_T6, coord);
-    case 7: return texture(tex_T7, coord);
-    case 8: return texture(tex_T8, coord);
-    case 9: return texture(tex_T9, coord);
+    case 0: return texture(tex_T20, coord);
+    case 1: return texture(tex_T21, coord);
+    case 2: return texture(tex_T22, coord);
+    case 3: return texture(tex_T23, coord);
+    case 4: return texture(tex_T24, coord);
+    case 5: return texture(tex_T25, coord);
+    case 6: return texture(tex_T26, coord);
+    case 7: return texture(tex_T27, coord);
+    case 8: return texture(tex_T28, coord);
+    case 9: return texture(tex_T29, coord);
     default : return vec4(1.0, 0, 1.0, 1.0);
   }
 }
@@ -52,16 +52,16 @@ vec4 sample_tex_px(vec2 coordf, uint unit) {
   coord.x = int(coordf.x / 16);
   coord.y = int(coordf.y / 16);
   switch (unit) {
-    case 0: return texelFetch(tex_T0, coord, 0);
-    case 1: return texelFetch(tex_T1, coord, 0);
-    case 2: return texelFetch(tex_T2, coord, 0);
-    case 3: return texelFetch(tex_T3, coord, 0);
-    case 4: return texelFetch(tex_T4, coord, 0);
-    case 5: return texelFetch(tex_T5, coord, 0);
-    case 6: return texelFetch(tex_T6, coord, 0);
-    case 7: return texelFetch(tex_T7, coord, 0);
-    case 8: return texelFetch(tex_T8, coord, 0);
-    case 9: return texelFetch(tex_T9, coord, 0);
+    case 0: return texelFetch(tex_T20, coord, 0);
+    case 1: return texelFetch(tex_T21, coord, 0);
+    case 2: return texelFetch(tex_T22, coord, 0);
+    case 3: return texelFetch(tex_T23, coord, 0);
+    case 4: return texelFetch(tex_T24, coord, 0);
+    case 5: return texelFetch(tex_T25, coord, 0);
+    case 6: return texelFetch(tex_T26, coord, 0);
+    case 7: return texelFetch(tex_T27, coord, 0);
+    case 8: return texelFetch(tex_T28, coord, 0);
+    case 9: return texelFetch(tex_T29, coord, 0);
     default : return vec4(1.0, 0, 1.0, 1.0);
   }
 }

--- a/game/graphics/opengl_renderer/shaders/direct_basic_textured_multi_unit.vert
+++ b/game/graphics/opengl_renderer/shaders/direct_basic_textured_multi_unit.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec4 position_in;
 layout (location = 1) in vec4 rgba_in;
@@ -13,8 +13,8 @@ out vec4 gs_scissor;
 // putting all texture info stuff here so it's easier to copy-paste
 layout (location = 3) in uvec4 tex_info_in;
 layout (location = 4) in uint use_uv_in;
-out flat uvec4 tex_info;
-out flat uint use_uv;
+flat out uvec4 tex_info;
+flat out uint use_uv;
 uniform int offscreen_mode;
 
 void main() {

--- a/game/graphics/opengl_renderer/shaders/emerc.frag
+++ b/game/graphics/opengl_renderer/shaders/emerc.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 in vec3 vtx_color;

--- a/game/graphics/opengl_renderer/shaders/emerc.vert
+++ b/game/graphics/opengl_renderer/shaders/emerc.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 // merc vertex definition
 layout (location = 0) in vec3 position_in;
@@ -28,7 +28,7 @@ struct MercMatrixData {
   vec4 pad;
 };
 
-layout (std140, binding = 1) uniform ub_bones {
+layout (std140) uniform ub_bones {
   MercMatrixData bones[128];
 };
 

--- a/game/graphics/opengl_renderer/shaders/etie.frag
+++ b/game/graphics/opengl_renderer/shaders/etie.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 

--- a/game/graphics/opengl_renderer/shaders/etie.vert
+++ b/game/graphics/opengl_renderer/shaders/etie.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 layout (location = 1) in vec3 tex_coord_in;
@@ -12,7 +12,7 @@ uniform float fog_constant;
 uniform float fog_min;
 uniform float fog_max;
 uniform vec4 envmap_tod_tint;
-layout (binding = 10) uniform sampler1D tex_T1; // note, sampled in the vertex shader on purpose.
+uniform sampler1D tex_T10; // note, sampled in the vertex shader on purpose.
 uniform int decal;
 
 out vec4 fragment_color;

--- a/game/graphics/opengl_renderer/shaders/etie_base.frag
+++ b/game/graphics/opengl_renderer/shaders/etie_base.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 

--- a/game/graphics/opengl_renderer/shaders/etie_base.vert
+++ b/game/graphics/opengl_renderer/shaders/etie_base.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 layout (location = 1) in vec3 tex_coord_in;
@@ -9,7 +9,7 @@ uniform mat4 camera;
 uniform float fog_constant;
 uniform float fog_min;
 uniform float fog_max;
-layout (binding = 10) uniform sampler1D tex_T1; // note, sampled in the vertex shader on purpose.
+uniform sampler1D tex_T10; // note, sampled in the vertex shader on purpose.
 uniform int decal;
 uniform float fog_hack_threshold;
 
@@ -56,7 +56,7 @@ void main() {
     fragment_color = vec4(1.0, 1.0, 1.0, 1.0);
   } else {
     // time of day lookup
-    fragment_color = texelFetch(tex_T1, time_of_day_index, 0);
+    fragment_color = texelFetch(tex_T10, time_of_day_index, 0);
     // color adjustment
     fragment_color *= 2;
     fragment_color.a *= 2;

--- a/game/graphics/opengl_renderer/shaders/eye.frag
+++ b/game/graphics/opengl_renderer/shaders/eye.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 in vec2 st;

--- a/game/graphics/opengl_renderer/shaders/eye.vert
+++ b/game/graphics/opengl_renderer/shaders/eye.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 layout (location = 0) in vec4 xyst_in;
 
 out vec2 st;

--- a/game/graphics/opengl_renderer/shaders/generic.frag
+++ b/game/graphics/opengl_renderer/shaders/generic.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 
 out vec4 color;
@@ -10,11 +10,11 @@ uniform vec4 fog_color;
 in float fog;
 in vec4 fragment_color;
 
-in flat uvec2 tex_info;
+flat in uvec2 tex_info;
 
 uniform int gfx_hack_no_tex;
 
-layout (binding = 0) uniform sampler2D tex_T0;
+uniform sampler2D tex_T0;
 
 vec4 sample_tex(vec2 coord, uint unit) {
   return texture(tex_T0, coord);

--- a/game/graphics/opengl_renderer/shaders/generic.vert
+++ b/game/graphics/opengl_renderer/shaders/generic.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 layout (location = 1) in vec4 rgba_in;
@@ -18,7 +18,7 @@ out vec2 tex_coord;
 out vec4 fragment_color;
 out float fog;
 
-out flat uvec2 tex_info;
+flat out uvec2 tex_info;
 
 const float warp_off = 1.0f - (SCISSOR_HEIGHT / 512.0f);
 

--- a/game/graphics/opengl_renderer/shaders/glow_draw.frag
+++ b/game/graphics/opengl_renderer/shaders/glow_draw.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 
@@ -6,12 +6,12 @@ in vec4 fragment_color;
 in float discard_flag;
 in vec2 uv_texture;
 
-layout (binding = 0) uniform sampler2D tex;
+uniform sampler2D tex_T0;
 uniform float glow_boost;
 
 
 void main() {
-  vec4 texture_color = texture(tex, uv_texture);
+  vec4 texture_color = texture(tex_T0, uv_texture);
   color.xyz = texture_color.xyz * fragment_color.xyz * 2.f * discard_flag / 128.f * glow_boost;
   color.w = fragment_color.w * texture_color.w;
 }

--- a/game/graphics/opengl_renderer/shaders/glow_draw.vert
+++ b/game/graphics/opengl_renderer/shaders/glow_draw.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec4 position_in;
 layout (location = 1) in vec4 rgba_in;
@@ -9,7 +9,7 @@ out vec4 fragment_color;
 out vec2 uv_texture;
 out float discard_flag;
 
-layout (binding = 1) uniform sampler2D probe_tex;
+uniform sampler2D tex_T1;
 
 
 void main() {
@@ -25,5 +25,5 @@ void main() {
   gl_Position = transformed;
   fragment_color = rgba_in;
   uv_texture = uv_texture_in;
-  discard_flag = texture(probe_tex, uv_probe_in).a;
+  discard_flag = texture(tex_T1, uv_probe_in).a;
 }

--- a/game/graphics/opengl_renderer/shaders/glow_probe.frag
+++ b/game/graphics/opengl_renderer/shaders/glow_probe.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 

--- a/game/graphics/opengl_renderer/shaders/glow_probe.vert
+++ b/game/graphics/opengl_renderer/shaders/glow_probe.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec4 position_in;
 layout (location = 1) in vec4 rgba_in;

--- a/game/graphics/opengl_renderer/shaders/glow_probe_downsample.frag
+++ b/game/graphics/opengl_renderer/shaders/glow_probe_downsample.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 out_color;
 

--- a/game/graphics/opengl_renderer/shaders/glow_probe_downsample.vert
+++ b/game/graphics/opengl_renderer/shaders/glow_probe_downsample.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec4 position_in;
 

--- a/game/graphics/opengl_renderer/shaders/glow_probe_read.frag
+++ b/game/graphics/opengl_renderer/shaders/glow_probe_read.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 out_color;
 

--- a/game/graphics/opengl_renderer/shaders/glow_probe_read.vert
+++ b/game/graphics/opengl_renderer/shaders/glow_probe_read.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec4 position_in;
 layout (location = 1) in vec4 rgba_in;

--- a/game/graphics/opengl_renderer/shaders/glow_probe_read_debug.frag
+++ b/game/graphics/opengl_renderer/shaders/glow_probe_read_debug.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 out_color;
 

--- a/game/graphics/opengl_renderer/shaders/glow_probe_read_debug.vert
+++ b/game/graphics/opengl_renderer/shaders/glow_probe_read_debug.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec4 position_in;
 layout (location = 1) in vec4 rgba_in;

--- a/game/graphics/opengl_renderer/shaders/merc2.frag
+++ b/game/graphics/opengl_renderer/shaders/merc2.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 in vec4 vtx_color;

--- a/game/graphics/opengl_renderer/shaders/merc2.vert
+++ b/game/graphics/opengl_renderer/shaders/merc2.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 // merc vertex definition
 layout (location = 0) in vec3 position_in;
@@ -35,7 +35,7 @@ struct MercMatrixData {
   vec4 pad;
 };
 
-layout (std140, binding = 1) uniform ub_bones {
+layout (std140) uniform ub_bones {
   MercMatrixData bones[128];
 };
 

--- a/game/graphics/opengl_renderer/shaders/ocean_common.frag
+++ b/game/graphics/opengl_renderer/shaders/ocean_common.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 

--- a/game/graphics/opengl_renderer/shaders/ocean_common.vert
+++ b/game/graphics/opengl_renderer/shaders/ocean_common.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 layout (location = 1) in vec4 rgba_in;

--- a/game/graphics/opengl_renderer/shaders/ocean_texture.frag
+++ b/game/graphics/opengl_renderer/shaders/ocean_texture.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 in vec2 tex_coord;

--- a/game/graphics/opengl_renderer/shaders/ocean_texture.vert
+++ b/game/graphics/opengl_renderer/shaders/ocean_texture.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec2 position_in;
 layout (location = 1) in vec4 rgba_in;

--- a/game/graphics/opengl_renderer/shaders/ocean_texture_mipmap.frag
+++ b/game/graphics/opengl_renderer/shaders/ocean_texture_mipmap.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 in vec2 tex_coord;

--- a/game/graphics/opengl_renderer/shaders/ocean_texture_mipmap.vert
+++ b/game/graphics/opengl_renderer/shaders/ocean_texture_mipmap.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec2 position_in;
 layout (location = 1) in vec2 tex_coord_in;

--- a/game/graphics/opengl_renderer/shaders/post_processing.frag
+++ b/game/graphics/opengl_renderer/shaders/post_processing.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 in vec2 screen_pos;
 
@@ -6,8 +6,8 @@ out vec4 color;
 
 uniform vec4 fragment_color;
 
-layout (binding = 0) uniform sampler2D screen_tex;
+uniform sampler2D tex_T0;
 
 void main() {
-  color = vec4(texture(screen_tex, screen_pos).rgb * fragment_color.a, 1.0);
+  color = vec4(texture(tex_T0, screen_pos).rgb * fragment_color.a, 1.0);
 }

--- a/game/graphics/opengl_renderer/shaders/post_processing.vert
+++ b/game/graphics/opengl_renderer/shaders/post_processing.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec2 position_in;
 

--- a/game/graphics/opengl_renderer/shaders/shadow.frag
+++ b/game/graphics/opengl_renderer/shaders/shadow.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 uniform vec4 color_uniform;

--- a/game/graphics/opengl_renderer/shaders/shadow.vert
+++ b/game/graphics/opengl_renderer/shaders/shadow.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 

--- a/game/graphics/opengl_renderer/shaders/shadow2.frag
+++ b/game/graphics/opengl_renderer/shaders/shadow2.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 uniform vec4 color_uniform;

--- a/game/graphics/opengl_renderer/shaders/shadow2.vert
+++ b/game/graphics/opengl_renderer/shaders/shadow2.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 

--- a/game/graphics/opengl_renderer/shaders/shrub.frag
+++ b/game/graphics/opengl_renderer/shaders/shrub.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 

--- a/game/graphics/opengl_renderer/shaders/shrub.vert
+++ b/game/graphics/opengl_renderer/shaders/shrub.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 layout (location = 1) in vec3 tex_coord_in;
@@ -11,7 +11,7 @@ uniform float fog_constant;
 uniform float fog_min;
 uniform float fog_max;
 uniform int decal;
-layout (binding = 10) uniform sampler1D tex_T1; // note, sampled in the vertex shader on purpose.
+uniform sampler1D tex_T10; // note, sampled in the vertex shader on purpose.
 
 out vec4 fragment_color;
 out vec3 tex_coord;
@@ -66,7 +66,7 @@ void main() {
   // start with the vertex color (only rgb, VIF filled in the 255.)
   fragment_color =  vec4(rgba_base, 1);
   // get the time of day multiplier
-  vec4 tod_color = texelFetch(tex_T1, time_of_day_index, 0);
+  vec4 tod_color = texelFetch(tex_T10, time_of_day_index, 0);
   // combine
   fragment_color *= tod_color * 4;
   fragment_color.a *= 2;

--- a/game/graphics/opengl_renderer/shaders/sky.frag
+++ b/game/graphics/opengl_renderer/shaders/sky.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 

--- a/game/graphics/opengl_renderer/shaders/sky.vert
+++ b/game/graphics/opengl_renderer/shaders/sky.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 layout (location = 1) in vec4 rgba_in;

--- a/game/graphics/opengl_renderer/shaders/sky_blend.frag
+++ b/game/graphics/opengl_renderer/shaders/sky_blend.frag
@@ -1,9 +1,9 @@
-#version 430 core
+#version 410 core
 
 layout(location = 0) out vec4 color;
 
 in vec3 tex_coord;
-layout (binding = 0) uniform sampler2D tex_T0;
+uniform sampler2D tex_T0;
 
 void main() {
   vec4 T0 = texture(tex_T0, tex_coord.xy);

--- a/game/graphics/opengl_renderer/shaders/sky_blend.vert
+++ b/game/graphics/opengl_renderer/shaders/sky_blend.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 

--- a/game/graphics/opengl_renderer/shaders/solid_color.frag
+++ b/game/graphics/opengl_renderer/shaders/solid_color.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 

--- a/game/graphics/opengl_renderer/shaders/solid_color.vert
+++ b/game/graphics/opengl_renderer/shaders/solid_color.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec2 position_in;
 

--- a/game/graphics/opengl_renderer/shaders/sprite3_3d.frag
+++ b/game/graphics/opengl_renderer/shaders/sprite3_3d.frag
@@ -1,10 +1,10 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 
-in flat vec4 fragment_color;
+flat in vec4 fragment_color;
 in vec3 tex_coord;
-in flat uvec2 tex_info;
+flat in uvec2 tex_info;
 
 uniform sampler2D tex_T0;
 uniform float alpha_min;

--- a/game/graphics/opengl_renderer/shaders/sprite3_3d.vert
+++ b/game/graphics/opengl_renderer/shaders/sprite3_3d.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec4 xyz_sx;
 layout (location = 1) in vec4 quat_sy;
@@ -24,9 +24,9 @@ uniform vec4 xy_array[8];
 uniform vec4 xyz_array[4];
 uniform vec4 st_array[4];
 
-out flat vec4 fragment_color;
+flat out vec4 fragment_color;
 out vec3 tex_coord;
-out flat uvec2 tex_info;
+flat out uvec2 tex_info;
 
 vec4 matrix_transform(mat4 mtx, vec3 pt) {
   return mtx[3]

--- a/game/graphics/opengl_renderer/shaders/sprite_3d.frag
+++ b/game/graphics/opengl_renderer/shaders/sprite_3d.frag
@@ -1,34 +1,34 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 
-in flat vec4 fragment_color;
+flat in vec4 fragment_color;
 in vec3 tex_coord;
-in flat uvec2 tex_info;
+flat in uvec2 tex_info;
 
-layout (binding = 20) uniform sampler2D tex_T0;
-layout (binding = 21) uniform sampler2D tex_T1;
-layout (binding = 22) uniform sampler2D tex_T2;
-layout (binding = 23) uniform sampler2D tex_T3;
-layout (binding = 24) uniform sampler2D tex_T4;
-layout (binding = 25) uniform sampler2D tex_T5;
-layout (binding = 26) uniform sampler2D tex_T6;
-layout (binding = 27) uniform sampler2D tex_T7;
-layout (binding = 28) uniform sampler2D tex_T8;
-layout (binding = 29) uniform sampler2D tex_T9;
+uniform sampler2D tex_T20;
+uniform sampler2D tex_T21;
+uniform sampler2D tex_T22;
+uniform sampler2D tex_T23;
+uniform sampler2D tex_T24;
+uniform sampler2D tex_T25;
+uniform sampler2D tex_T26;
+uniform sampler2D tex_T27;
+uniform sampler2D tex_T28;
+uniform sampler2D tex_T29;
 
 vec4 sample_tex(vec2 coord, uint unit) {
   switch (unit) {
-    case 0: return texture(tex_T0, coord);
-    case 1: return texture(tex_T1, coord);
-    case 2: return texture(tex_T2, coord);
-    case 3: return texture(tex_T3, coord);
-    case 4: return texture(tex_T4, coord);
-    case 5: return texture(tex_T5, coord);
-    case 6: return texture(tex_T6, coord);
-    case 7: return texture(tex_T7, coord);
-    case 8: return texture(tex_T8, coord);
-    case 9: return texture(tex_T9, coord);
+    case 0: return texture(tex_T20, coord);
+    case 1: return texture(tex_T21, coord);
+    case 2: return texture(tex_T22, coord);
+    case 3: return texture(tex_T23, coord);
+    case 4: return texture(tex_T24, coord);
+    case 5: return texture(tex_T25, coord);
+    case 6: return texture(tex_T26, coord);
+    case 7: return texture(tex_T27, coord);
+    case 8: return texture(tex_T28, coord);
+    case 9: return texture(tex_T29, coord);
     default: return vec4(1.0, 0, 1.0, 1.0);
   }
 }

--- a/game/graphics/opengl_renderer/shaders/sprite_3d.vert
+++ b/game/graphics/opengl_renderer/shaders/sprite_3d.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec4 xyz_sx;
 layout (location = 1) in vec4 quat_sy;
@@ -26,9 +26,9 @@ uniform vec4 xy_array[8];
 uniform vec4 xyz_array[4];
 uniform vec4 st_array[4];
 
-out flat vec4 fragment_color;
+flat out vec4 fragment_color;
 out vec3 tex_coord;
-out flat uvec2 tex_info;
+flat out uvec2 tex_info;
 
 vec4 matrix_transform(mat4 mtx, vec3 pt) {
   return mtx[3]

--- a/game/graphics/opengl_renderer/shaders/sprite_distort.frag
+++ b/game/graphics/opengl_renderer/shaders/sprite_distort.frag
@@ -1,10 +1,10 @@
-#version 430 core
+#version 410 core
 
 out vec4 out_color;
 
 uniform sampler2D framebuffer_tex;
 
-in flat vec4 fragment_color;
+flat in vec4 fragment_color;
 in vec2 tex_coord;
 
 void main() {

--- a/game/graphics/opengl_renderer/shaders/sprite_distort.vert
+++ b/game/graphics/opengl_renderer/shaders/sprite_distort.vert
@@ -1,11 +1,11 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 xyz;
 layout (location = 1) in vec2 st;
 
 uniform vec4 u_color;
 
-out flat vec4 fragment_color;
+flat out vec4 fragment_color;
 out vec2 tex_coord;
 
 void main() {

--- a/game/graphics/opengl_renderer/shaders/sprite_distort_instanced.frag
+++ b/game/graphics/opengl_renderer/shaders/sprite_distort_instanced.frag
@@ -1,10 +1,10 @@
-#version 430 core
+#version 410 core
 
 out vec4 out_color;
 
 uniform sampler2D framebuffer_tex;
 
-in flat vec4 fragment_color;
+flat in vec4 fragment_color;
 in vec2 tex_coord;
 
 void main() {

--- a/game/graphics/opengl_renderer/shaders/sprite_distort_instanced.vert
+++ b/game/graphics/opengl_renderer/shaders/sprite_distort_instanced.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 xyz;                  // position from sine table
 layout (location = 1) in vec2 st;                   // tex coord from sine table
@@ -7,7 +7,7 @@ layout (location = 3) in vec4 instance_scale_t;     // sprite scale + texture T-
 
 uniform vec4 u_color;
 
-out flat vec4 fragment_color;
+flat out vec4 fragment_color;
 out vec2 tex_coord;
 
 void main() {

--- a/game/graphics/opengl_renderer/shaders/tfrag3.frag
+++ b/game/graphics/opengl_renderer/shaders/tfrag3.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 

--- a/game/graphics/opengl_renderer/shaders/tfrag3.vert
+++ b/game/graphics/opengl_renderer/shaders/tfrag3.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 layout (location = 1) in vec3 tex_coord_in;
@@ -9,7 +9,7 @@ uniform mat4 camera;
 uniform float fog_constant;
 uniform float fog_min;
 uniform float fog_max;
-layout (binding = 10) uniform sampler1D tex_T1; // note, sampled in the vertex shader on purpose.
+uniform sampler1D tex_T10; // note, sampled in the vertex shader on purpose.
 uniform int decal;
 uniform float fog_hack_threshold;
 
@@ -63,7 +63,7 @@ void main() {
   gl_Position = transformed;
 
   // time of day lookup
-  fragment_color = texelFetch(tex_T1, time_of_day_index, 0);
+  fragment_color = texelFetch(tex_T10, time_of_day_index, 0);
   // color adjustment
   fragment_color *= 2;
   fragment_color.a *= 2;

--- a/game/graphics/opengl_renderer/shaders/tfrag3_no_tex.frag
+++ b/game/graphics/opengl_renderer/shaders/tfrag3_no_tex.frag
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 out vec4 color;
 

--- a/game/graphics/opengl_renderer/shaders/tfrag3_no_tex.vert
+++ b/game/graphics/opengl_renderer/shaders/tfrag3_no_tex.vert
@@ -1,4 +1,4 @@
-#version 430 core
+#version 410 core
 
 layout (location = 0) in vec3 position_in;
 layout (location = 1) in vec4 rgba_in;

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -129,6 +129,9 @@ static int gl_init(GfxGlobalSettings& settings) {
     }
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+#ifdef __APPLE__
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+#endif
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
@@ -304,7 +307,11 @@ static std::shared_ptr<GfxDisplay> gl_make_display(int width,
   {
     auto p = scoped_prof("startup::sdl::init_imgui");
     // setup imgui
+#ifdef __APPLE__
+    init_imgui(window, gl_context, "#version 410");
+#else
     init_imgui(window, gl_context, "#version 430");
+#endif
   }
 
   return std::static_pointer_cast<GfxDisplay>(display);


### PR DESCRIPTION
## Problem

OpenGOAL uses OpenGL 4.3.

Apple stopped upgrading OpenGL after 4.1, so the way OpenGOAL currently works will never be playable on Macs using OpenGL.

## Solution

Luckily, downgrading to OpenGL 4.1 is not a huge change (at least it doesn't seem like it to my untrained eyes).

## Changes

* set hints for OpenGL 4.1 instead of 4.3 for __APPLE__
* skip the OpenGL debugging callback setup for macOS (requires 4.3)
* bump down the version string for all shaders
* stop using the `binding` layout qualifier in shader code
* move the `flat` qualifier first (not sure if this is a 4.1 thing or just Macs being more strict)
* don't mix signed and unsigned ints in shaders (not sure if this is a 4.1 thing or just Macs being more strict)
* add some hacky CPP to the Shader constructor for binding texture units and bones buffers based on variable names in the shader code

## Results

![image](https://github.com/open-goal/jak-project/assets/33322/dd487c2a-61ac-4e36-a595-976204302977)
![Skärmavbild 2023-07-07 kl  13 10 30](https://github.com/open-goal/jak-project/assets/33322/7976d411-0604-4046-9e8a-123106cedf57)
![Skärmavbild 2023-07-07 kl  13 13 48](https://github.com/open-goal/jak-project/assets/33322/78db4f0c-da31-4889-995c-8f54e56deb5c)
