### PR TITLE
implement eval msgs

### DIFF
--- a/common/repl/nrepl/ReplServer.cpp
+++ b/common/repl/nrepl/ReplServer.cpp
@@ -73,8 +73,8 @@ void ReplServer::eval_response(int socket, const std::string& request) {
 
 void ReplServer::shutdown_response(int socket) {
   // Send a farewell message
-  std::string ping = fmt::format("Disconnecting from OpenGOAL nREPL. Goodbye.\n");
-  respond(socket, ping);
+  std::string bye = fmt::format("Disconnecting from OpenGOAL nREPL. Goodbye.\n");
+  respond(socket, bye);
 
   // shut down the socket
   close_socket(socket);

--- a/common/repl/nrepl/ReplServer.cpp
+++ b/common/repl/nrepl/ReplServer.cpp
@@ -22,11 +22,6 @@
 //
 // TODO - The server also needs to eventually return the result of the evaluation
 
-// Constructor
-ReplServer::ReplServer() {
-  m_compiler = new Compiler();
-}
-
 // Destructor
 ReplServer::~ReplServer() {
   // Close all our client sockets!
@@ -44,8 +39,7 @@ void ReplServer::respond(int socket, std::string response) {
   // Send response over socket
   auto resp = write_to_socket(socket, response.c_str(), response.size());
   if (resp == -1) {
-    fmt::print("[nREPL:{}] Client Disconnected: {}\n", tcp_port, inet_ntoa(addr.sin_addr),
-               ntohs(addr.sin_port), socket);
+    fmt::print("[nREPL:{}] Client Disconnected: {}\n", tcp_port, inet_ntoa(addr.sin_addr));
     close_socket(socket);
     client_sockets.erase(socket);
   }
@@ -55,20 +49,22 @@ void ReplServer::ping_response(int socket) {
   // Send a ping
   std::string ping = fmt::format("Connected to OpenGOAL v{}.{} nREPL!",
                                  versions::GOAL_VERSION_MAJOR, versions::GOAL_VERSION_MINOR);
-  respond(socket, ping)
+  respond(socket, ping);
 }
 
 void ReplServer::eval_response(int socket, std::string request) {
-  // Pass request to REPL to evaluate
-  auto response = m_compiler->print_to_repl(request);
-
-  // Read result from REPL
-  std::string result = m_compiler->get_repl_input();
 
   // Send it back to requester in a string
   // may not be necessary
-  std::string eval = fmt::format("{}", result);
-  respond(socket, eval)
+  std::string eval = fmt::format("{}", request); // parroting for now
+  respond(socket, eval);
+}
+
+void ReplServer::send_msg(std::string message) {
+  //std::string message = "hello";
+  for (const int& sock : client_sockets) {
+    eval_response(sock, message);
+  }
 }
 
 std::optional<std::string> ReplServer::get_msg() {
@@ -172,7 +168,6 @@ std::optional<std::string> ReplServer::get_msg() {
           // message is making a specific request, return the value
           case ReplServerMessageType::EVAL:
             std::string msg(buffer.data(), header->length);
-            eval_response(sock, msg);
             return std::make_optional(msg);
         }
       }

--- a/common/repl/nrepl/ReplServer.cpp
+++ b/common/repl/nrepl/ReplServer.cpp
@@ -40,7 +40,7 @@ void ReplServer::post_init() {
   fmt::print("[nREPL:{}:{}] awaiting connections\n", tcp_port, listening_socket);
 }
 
-void ReplServer::respond(int socket, const std::string& response) {
+void ReplServer::respond(int socket, std::string response) {
   // Send response over socket
   auto resp = write_to_socket(socket, response.c_str(), response.size());
   if (resp == -1) {
@@ -53,14 +53,14 @@ void ReplServer::respond(int socket, const std::string& response) {
 
 void ReplServer::ping_response(int socket) {
   // Send a ping
-  std::string ping = fmt::format("Connected to OpenGOAL v{}.{} nREPL!\n",
+  std::string ping = fmt::format("Connected to OpenGOAL v{}.{} nREPL!",
                                  versions::GOAL_VERSION_MAJOR, versions::GOAL_VERSION_MINOR);
-  respond(socket, ping);
+  respond(socket, ping)
 }
 
-void ReplServer::eval_response(int socket, const std::string& request) {
+void ReplServer::eval_response(int socket, std::string request) {
   // Pass request to REPL to evaluate
-  m_compiler->print_to_repl(request);
+  auto response = m_compiler->print_to_repl(request);
 
   // Read result from REPL
   std::string result = m_compiler->get_repl_input();
@@ -68,16 +68,7 @@ void ReplServer::eval_response(int socket, const std::string& request) {
   // Send it back to requester in a string
   // may not be necessary
   std::string eval = fmt::format("{}", result);
-  respond(socket, eval);
-}
-
-void ReplServer::shutdown_response(int socket) {
-  // Send a farewell message
-  std::string ping = fmt::format("Disconnecting from OpenGOAL nREPL. Goodbye.\n");
-  respond(socket, ping);
-
-  // shut down the socket
-  close_socket(socket);
+  respond(socket, eval)
 }
 
 std::optional<std::string> ReplServer::get_msg() {
@@ -174,22 +165,14 @@ std::optional<std::string> ReplServer::get_msg() {
         // Messaging logic
 
         switch (header->type) {
-
           // message is just a ping, ping back
           case ReplServerMessageType::PING:
             ping_response(sock);
             return std::nullopt;
-            
           // message is making a specific request, return the value
           case ReplServerMessageType::EVAL:
             std::string msg(buffer.data(), header->length);
             eval_response(sock, msg);
-            return std::make_optional(msg);
-            
-          // message is asking us to shutdown the socket
-          case ReplServerMessageType::SHUTDOWN:
-            std::string msg(buffer.data(), header->length);
-            shutdown_response(sock);
             return std::make_optional(msg);
         }
       }

--- a/common/repl/nrepl/ReplServer.cpp
+++ b/common/repl/nrepl/ReplServer.cpp
@@ -73,8 +73,8 @@ void ReplServer::eval_response(int socket, const std::string& request) {
 
 void ReplServer::shutdown_response(int socket) {
   // Send a farewell message
-  std::string bye = fmt::format("Disconnecting from OpenGOAL nREPL. Goodbye.\n");
-  respond(socket, bye);
+  std::string ping = fmt::format("Disconnecting from OpenGOAL nREPL. Goodbye.\n");
+  respond(socket, ping);
 
   // shut down the socket
   close_socket(socket);

--- a/common/repl/nrepl/ReplServer.h
+++ b/common/repl/nrepl/ReplServer.h
@@ -32,7 +32,6 @@ class ReplServer : public XSocketServer {
   std::set<int> client_sockets = {};
 
   void respond(int socket, std::string request);
-  
   void ping_response(int socket);
   void eval_response(int socket, std::string request);
   void shutdown_response(int socket);

--- a/common/repl/nrepl/ReplServer.h
+++ b/common/repl/nrepl/ReplServer.h
@@ -21,11 +21,16 @@ class ReplServer : public XSocketServer {
 
   std::optional<std::string> get_msg();
 
+  // reference to compiler to access the repl
+  Compiler* m_compiler;
+
  private:
   int max_clients = 50;
   std::vector<char> header_buffer = std::vector<char>((int)sizeof(ReplServerHeader));
   fd_set read_sockets;
   std::set<int> client_sockets = {};
 
+  void respond(int socket, std::string request);
   void ping_response(int socket);
+  void eval_response(int socket, std::string request);
 };

--- a/common/repl/nrepl/ReplServer.h
+++ b/common/repl/nrepl/ReplServer.h
@@ -32,6 +32,7 @@ class ReplServer : public XSocketServer {
   std::set<int> client_sockets = {};
 
   void respond(int socket, std::string request);
+  
   void ping_response(int socket);
   void eval_response(int socket, std::string request);
   void shutdown_response(int socket);

--- a/common/repl/nrepl/ReplServer.h
+++ b/common/repl/nrepl/ReplServer.h
@@ -4,7 +4,6 @@
 #include <set>
 
 #include "common/cross_sockets/XSocketServer.h"
-#include "goalc/compiler/Compiler.h"
 
 enum ReplServerMessageType { PING = 0, EVAL = 10, SHUTDOWN = 20 };
 
@@ -34,5 +33,4 @@ class ReplServer : public XSocketServer {
   void respond(int socket, std::string request);
   void ping_response(int socket);
   void eval_response(int socket, std::string request);
-  void shutdown_response(int socket);
 };

--- a/common/repl/nrepl/ReplServer.h
+++ b/common/repl/nrepl/ReplServer.h
@@ -4,6 +4,7 @@
 #include <set>
 
 #include "common/cross_sockets/XSocketServer.h"
+#include "goalc/compiler/Compiler.h"
 
 enum ReplServerMessageType { PING = 0, EVAL = 10, SHUTDOWN = 20 };
 
@@ -33,4 +34,5 @@ class ReplServer : public XSocketServer {
   void respond(int socket, std::string request);
   void ping_response(int socket);
   void eval_response(int socket, std::string request);
+  void shutdown_response(int socket);
 };

--- a/common/repl/nrepl/ReplServer.h
+++ b/common/repl/nrepl/ReplServer.h
@@ -20,9 +20,7 @@ class ReplServer : public XSocketServer {
   void post_init() override;
 
   std::optional<std::string> get_msg();
-
-  // reference to compiler to access the repl
-  Compiler* m_compiler;
+  void send_msg(std::string message);
 
  private:
   int max_clients = 50;

--- a/goalc/main.cpp
+++ b/goalc/main.cpp
@@ -125,6 +125,8 @@ int main(int argc, char** argv) {
           if (resp) {
             std::lock_guard<std::mutex> lock(compiler_mutex);
             status = compiler->handle_repl_string(resp.value());
+            //test
+            repl_server.send_msg(resp.value());
             // Print out the prompt, just for better UX
             compiler->print_to_repl(compiler->get_prompt());
           }


### PR DESCRIPTION
added functionality beyond pinging, let me know how this looks.

I split off respond() since the functionality inside ping_response() was reusable for eval_response()

I added a reference to the compiler in the .h so we can pass arguments to the REPL, not sure if this is best
then I made a constructor to assign the compiler ref and send a message along it in eval_response()

lastly I updated the logic at the bottom to switch between ping and eval methods