### PR TITLE
increase max minimap icons 64 -> 256

### DIFF
--- a/goal_src/jak2/engine/ui/minimap.gc
+++ b/goal_src/jak2/engine/ui/minimap.gc
@@ -834,7 +834,8 @@
         )
 
 (let ((gp-0 *minimap*))
-  (set! (-> gp-0 engine) (new 'global 'engine-minimap '*minimap* 64 connection-minimap))
+  ;; note : minimap engine connections raised for pc port
+  (set! (-> gp-0 engine) (new 'global 'engine-minimap '*minimap* (#if PC_PORT 256 64) connection-minimap))
   (countdown (v1-7 6)
     (set! (-> gp-0 trail v1-7 used-by) #f)
     )


### PR DESCRIPTION
Some missions add way too many icons so the limit is reached. It seems safe to increase by a large amount.

Fixes #2779 