### PR TITLE
[jak2] More progress on texture animations

### DIFF
--- a/common/texture/texture_slots.cpp
+++ b/common/texture/texture_slots.cpp
@@ -31,6 +31,7 @@ std::vector<std::string> jak2_slots = {
     "security-env-dest",
     "security-dot-dest",
     "waterfall-dest",
+    "dig-lava-01-dest",
 };
 
 }

--- a/common/texture/texture_slots.cpp
+++ b/common/texture/texture_slots.cpp
@@ -30,6 +30,7 @@ std::vector<std::string> jak2_slots = {
     "cas-conveyor-dest-03",
     "security-env-dest",
     "security-dot-dest",
+    "waterfall-dest",
 };
 
 }

--- a/common/texture/texture_slots.cpp
+++ b/common/texture/texture_slots.cpp
@@ -33,6 +33,9 @@ std::vector<std::string> jak2_slots = {
     "waterfall-dest",
     "dig-lava-01-dest",
     "stdmb-energy-wall-01-dest",
+    "robotank-tread-l-dest",
+    "robotank-tread-r-dest",
+    "fort-roboscreen-dest",
 };
 
 }

--- a/common/texture/texture_slots.cpp
+++ b/common/texture/texture_slots.cpp
@@ -28,6 +28,8 @@ std::vector<std::string> jak2_slots = {
     "cas-conveyor-dest-01",
     "cas-conveyor-dest-02",
     "cas-conveyor-dest-03",
+    "security-env-dest",
+    "security-dot-dest",
 };
 
 }

--- a/common/texture/texture_slots.cpp
+++ b/common/texture/texture_slots.cpp
@@ -32,6 +32,7 @@ std::vector<std::string> jak2_slots = {
     "security-dot-dest",
     "waterfall-dest",
     "dig-lava-01-dest",
+    "stdmb-energy-wall-01-dest",
 };
 
 }

--- a/decompiler/config/jak2/ntsc_v1/inputs.jsonc
+++ b/decompiler/config/jak2/ntsc_v1/inputs.jsonc
@@ -529,7 +529,16 @@
 
     // Stadiumb
     "stdmb-energy-wall-01-dest",
-    "stdmb-energy-wall-01"
+    "stdmb-energy-wall-01",
+
+    // Fortress pris
+    "robotank-tread-l-dest",
+    "robotank-tread-r-dest",
+    "robotank-tread",
+
+    // Fortress warp
+    "fort-roboscreen-dest",
+    "fort-roboscreen-env"
 
     // "kor-eyeeffect-formorph",
     // "kor-eyeeffect-formorph-start",

--- a/decompiler/config/jak2/ntsc_v1/inputs.jsonc
+++ b/decompiler/config/jak2/ntsc_v1/inputs.jsonc
@@ -516,11 +516,11 @@
     "security-env-uscroll",
     "security-dot-dest",
     "common-white",
-    "security-dot-src"
+    "security-dot-src",
 
-    // Waterfall
-    // "waterfall",
-    // "waterfall-dest"
+    // Waterfall (and waterfall-b)
+    "waterfall",
+    "waterfall-dest"
 
     // "kor-eyeeffect-formorph",
     // "kor-eyeeffect-formorph-start",

--- a/decompiler/config/jak2/ntsc_v1/inputs.jsonc
+++ b/decompiler/config/jak2/ntsc_v1/inputs.jsonc
@@ -444,6 +444,7 @@
   "streamed_audio_file_names": [],
 
   // Textures that should be extracted in a special way for use in animated textures.
+  // these will be present in the common FR3, and stored as index textures.
   "animated_textures": [
     // Dark Jak (small gameplay model)
     "jakbsmall-eyebrow",
@@ -524,7 +525,11 @@
 
     // Lava (and lava b)
     "dig-lava-01-dest",
-    "dig-lava-01"
+    "dig-lava-01",
+
+    // Stadiumb
+    "stdmb-energy-wall-01-dest",
+    "stdmb-energy-wall-01"
 
     // "kor-eyeeffect-formorph",
     // "kor-eyeeffect-formorph-start",

--- a/decompiler/config/jak2/ntsc_v1/inputs.jsonc
+++ b/decompiler/config/jak2/ntsc_v1/inputs.jsonc
@@ -509,7 +509,18 @@
     "cas-conveyor-dest",
     "cas-conveyor-dest-01",
     "cas-conveyor-dest-02",
-    "cas-conveyor-dest-03"
+    "cas-conveyor-dest-03",
+
+    // Security Wall
+    "security-env-dest",
+    "security-env-uscroll",
+    "security-dot-dest",
+    "common-white",
+    "security-dot-src"
+
+    // Waterfall
+    // "waterfall",
+    // "waterfall-dest"
 
     // "kor-eyeeffect-formorph",
     // "kor-eyeeffect-formorph-start",

--- a/decompiler/config/jak2/ntsc_v1/inputs.jsonc
+++ b/decompiler/config/jak2/ntsc_v1/inputs.jsonc
@@ -520,7 +520,11 @@
 
     // Waterfall (and waterfall-b)
     "waterfall",
-    "waterfall-dest"
+    "waterfall-dest",
+
+    // Lava (and lava b)
+    "dig-lava-01-dest",
+    "dig-lava-01"
 
     // "kor-eyeeffect-formorph",
     // "kor-eyeeffect-formorph-start",

--- a/game/graphics/opengl_renderer/TextureAnimator.cpp
+++ b/game/graphics/opengl_renderer/TextureAnimator.cpp
@@ -71,7 +71,7 @@ OpenGLTexturePool::OpenGLTexturePool() {
                                           {64, 32, 6},
                                           {64, 64, 20},
                                           {64, 128, 4},
-                                          {128, 128, 8},
+                                          {128, 128, 10},
                                           {256, 1, 2},
                                           {256, 256, 7}}) {
     auto& l = textures[(a.w << 32) | a.h];
@@ -553,6 +553,8 @@ enum PcTextureAnimCodes {
   LAVA = 33,
   LAVA_B = 34,
   STADIUMB = 35,
+  FORTRESS_PRIS = 36,
+  FORTRESS_WARP = 37,
 };
 
 // metadata for an upload from GOAL memory
@@ -696,7 +698,15 @@ void TextureAnimator::handle_texture_anim_data(DmaFollower& dma,
         case STADIUMB: {
           auto p = scoped_prof("stadiumb");
           run_fixed_animation_array(m_stadiumb_anim_array_idx, tf, texture_pool);
-        }break;
+        } break;
+        case FORTRESS_PRIS: {
+          auto p = scoped_prof("fort-pris");
+          run_fixed_animation_array(m_fortress_pris_anim_array_idx, tf, texture_pool);
+        } break;
+        case FORTRESS_WARP: {
+          auto p = scoped_prof("fort-warp");
+          run_fixed_animation_array(m_fortress_warp_anim_array_idx, tf, texture_pool);
+        } break;
         default:
           fmt::print("bad imm: {}\n", vif0.immediate);
           ASSERT_NOT_REACHED();
@@ -2147,5 +2157,45 @@ void TextureAnimator::setup_texture_anims() {
       src.tex_name = "stdmb-energy-wall-01";
     }
     m_stadiumb_anim_array_idx = create_fixed_anim_array({def});
+  }
+
+  // Fortress pris
+  {
+    FixedAnimDef l_tread;
+    l_tread.color = math::Vector4<u8>(0, 0, 0, 0x80);
+    l_tread.tex_name = "robotank-tread-l-dest";
+    auto& l_src = l_tread.layers.emplace_back();
+    l_src.set_blend_b1_d1();
+    l_src.set_no_z_write_no_z_test();
+    l_src.channel_masks[3] = false;  // no alpha writes.
+    l_src.end_time = 1.f;
+    l_src.tex_name = "robotank-tread";
+
+    FixedAnimDef r_tread;
+    r_tread.color = math::Vector4<u8>(0, 0, 0, 0x80);
+    r_tread.tex_name = "robotank-tread-r-dest";
+    auto& r_src = r_tread.layers.emplace_back();
+    r_src.set_blend_b1_d1();
+    r_src.set_no_z_write_no_z_test();
+    r_src.channel_masks[3] = false;  // no alpha writes.
+    r_src.end_time = 1.f;
+    r_src.tex_name = "robotank-tread";
+
+    m_fortress_pris_anim_array_idx = create_fixed_anim_array({l_tread, r_tread});
+  }
+
+  // Fortress Warp
+  {
+    FixedAnimDef def;
+    def.color = math::Vector4<u8>(0, 0, 0, 0x80);
+    def.move_to_pool = true;
+    def.tex_name = "fort-roboscreen-dest";
+    auto& src = def.layers.emplace_back();
+    src.set_blend_b2_d1();
+    src.channel_masks[3] = false;  // no alpha writes.
+    src.set_no_z_write_no_z_test();
+    src.end_time = 300.f;
+    src.tex_name = "fort-roboscreen-env";
+    m_fortress_warp_anim_array_idx = create_fixed_anim_array({def});
   }
 }

--- a/game/graphics/opengl_renderer/TextureAnimator.cpp
+++ b/game/graphics/opengl_renderer/TextureAnimator.cpp
@@ -71,7 +71,7 @@ OpenGLTexturePool::OpenGLTexturePool() {
                                           {64, 32, 6},
                                           {64, 64, 20},
                                           {64, 128, 4},
-                                          {128, 128, 6},
+                                          {128, 128, 8},
                                           {256, 1, 2},
                                           {256, 256, 7}}) {
     auto& l = textures[(a.w << 32) | a.h];
@@ -552,6 +552,7 @@ enum PcTextureAnimCodes {
   WATERFALL_B = 32,
   LAVA = 33,
   LAVA_B = 34,
+  STADIUMB = 35,
 };
 
 // metadata for an upload from GOAL memory
@@ -692,6 +693,10 @@ void TextureAnimator::handle_texture_anim_data(DmaFollower& dma,
           auto p = scoped_prof("lava-b");
           run_fixed_animation_array(m_lava_b_anim_array_idx, tf, texture_pool);
         } break;
+        case STADIUMB: {
+          auto p = scoped_prof("stadiumb");
+          run_fixed_animation_array(m_stadiumb_anim_array_idx, tf, texture_pool);
+        }break;
         default:
           fmt::print("bad imm: {}\n", vif0.immediate);
           ASSERT_NOT_REACHED();
@@ -2078,7 +2083,7 @@ void TextureAnimator::setup_texture_anims() {
     waterfall.tex_name = "waterfall-dest";
     for (int i = 0; i < 4; i++) {
       auto& src = waterfall.layers.emplace_back();
-      src.set_blend_b2_d1();
+      src.set_blend_b1_d1();
       src.set_no_z_write_no_z_test();
       src.end_time = 450.f;
       src.tex_name = "waterfall";
@@ -2092,7 +2097,7 @@ void TextureAnimator::setup_texture_anims() {
     waterfall.tex_name = "waterfall-dest";
     for (int i = 0; i < 4; i++) {
       auto& src = waterfall.layers.emplace_back();
-      src.set_blend_b2_d1();
+      src.set_blend_b1_d1();
       src.set_no_z_write_no_z_test();
       src.end_time = 450.f;
       src.tex_name = "waterfall";
@@ -2107,7 +2112,7 @@ void TextureAnimator::setup_texture_anims() {
     lava.tex_name = "dig-lava-01-dest";
     for (int i = 0; i < 2; i++) {
       auto& src = lava.layers.emplace_back();
-      src.set_blend_b2_d1();
+      src.set_blend_b1_d1();
       src.set_no_z_write_no_z_test();
       src.end_time = 3600.f;
       src.tex_name = "dig-lava-01";
@@ -2121,11 +2126,26 @@ void TextureAnimator::setup_texture_anims() {
     lava.tex_name = "dig-lava-01-dest";
     for (int i = 0; i < 2; i++) {
       auto& src = lava.layers.emplace_back();
-      src.set_blend_b2_d1();
+      src.set_blend_b1_d1();
       src.set_no_z_write_no_z_test();
       src.end_time = 3600.f;
       src.tex_name = "dig-lava-01";
     }
     m_lava_b_anim_array_idx = create_fixed_anim_array({lava});
+  }
+
+  // Stadiumb
+  {
+    FixedAnimDef def;
+    def.color = math::Vector4<u8>(0, 0, 0, 0x80);
+    def.tex_name = "stdmb-energy-wall-01-dest";
+    for (int i = 0; i < 2; i++) {
+      auto& src = def.layers.emplace_back();
+      src.set_blend_b1_d1();
+      src.set_no_z_write_no_z_test();
+      src.end_time = 300.f;
+      src.tex_name = "stdmb-energy-wall-01";
+    }
+    m_stadiumb_anim_array_idx = create_fixed_anim_array({def});
   }
 }

--- a/game/graphics/opengl_renderer/TextureAnimator.cpp
+++ b/game/graphics/opengl_renderer/TextureAnimator.cpp
@@ -69,7 +69,7 @@ OpenGLTexturePool::OpenGLTexturePool() {
                                           {32, 32, 8},
                                           {32, 64, 1},
                                           {64, 32, 6},
-                                          {64, 64, 15},
+                                          {64, 64, 20},
                                           {64, 128, 4},
                                           {128, 128, 5},
                                           {256, 1, 2},
@@ -548,6 +548,8 @@ enum PcTextureAnimCodes {
   BOMB = 28,
   CAS_CONVEYOR = 29,
   SECURITY = 30,
+  WATERFALL = 31,
+  WATERFALL_B = 32,
 };
 
 // metadata for an upload from GOAL memory
@@ -671,8 +673,17 @@ void TextureAnimator::handle_texture_anim_data(DmaFollower& dma,
         case SECURITY: {
           auto p = scoped_prof("security");
           run_fixed_animation_array(m_security_anim_array_idx, tf);
-          break;
-        }
+        } break;
+        case WATERFALL: {
+          printf("run waterfall A\n");
+          auto p = scoped_prof("waterfall");
+          run_fixed_animation_array(m_waterfall_anim_array_idx, tf);
+        } break;
+        case WATERFALL_B: {
+          printf("run waterfall B\n");
+          auto p = scoped_prof("waterfall-b");
+          run_fixed_animation_array(m_waterfall_b_anim_array_idx, tf);
+        } break;
         default:
           fmt::print("bad imm: {}\n", vif0.immediate);
           ASSERT_NOT_REACHED();
@@ -2027,5 +2038,34 @@ void TextureAnimator::setup_texture_anims() {
     }
 
     m_security_anim_array_idx = create_fixed_anim_array({env, dot});
+  }
+
+  // WATERFALL
+  {
+    FixedAnimDef waterfall;
+    waterfall.color = math::Vector4<u8>(0, 0, 0, 0x80);
+    waterfall.tex_name = "waterfall-dest";
+    for (int i = 0; i < 4; i++) {
+      auto& src = waterfall.layers.emplace_back();
+      src.set_blend_b2_d1();
+      src.set_no_z_write_no_z_test();
+      src.end_time = 450.f;
+      src.tex_name = "waterfall";
+    }
+    m_waterfall_anim_array_idx = create_fixed_anim_array({waterfall});
+  }
+
+  {
+    FixedAnimDef waterfall;
+    waterfall.color = math::Vector4<u8>(0, 0, 0, 0x80);
+    waterfall.tex_name = "waterfall-dest";
+    for (int i = 0; i < 4; i++) {
+      auto& src = waterfall.layers.emplace_back();
+      src.set_blend_b2_d1();
+      src.set_no_z_write_no_z_test();
+      src.end_time = 450.f;
+      src.tex_name = "waterfall";
+    }
+    m_waterfall_b_anim_array_idx = create_fixed_anim_array({waterfall});
   }
 }

--- a/game/graphics/opengl_renderer/TextureAnimator.h
+++ b/game/graphics/opengl_renderer/TextureAnimator.h
@@ -347,5 +347,7 @@ class TextureAnimator {
   int m_lava_anim_array_idx = -1;
   int m_lava_b_anim_array_idx = -1;
   int m_stadiumb_anim_array_idx = -1;
+  int m_fortress_pris_anim_array_idx = -1;
+  int m_fortress_warp_anim_array_idx = -1;
   std::vector<FixedAnimArray> m_fixed_anim_arrays;
 };

--- a/game/graphics/opengl_renderer/TextureAnimator.h
+++ b/game/graphics/opengl_renderer/TextureAnimator.h
@@ -332,5 +332,7 @@ class TextureAnimator {
   int m_bomb_fixed_anim_array_idx = -1;
   int m_cas_conveyor_anim_array_idx = -1;
   int m_security_anim_array_idx = -1;
+  int m_waterfall_anim_array_idx = -1;
+  int m_waterfall_b_anim_array_idx = -1;
   std::vector<FixedAnimArray> m_fixed_anim_arrays;
 };

--- a/game/graphics/opengl_renderer/TextureAnimator.h
+++ b/game/graphics/opengl_renderer/TextureAnimator.h
@@ -118,7 +118,11 @@ struct LayerVals {
   math::Vector2f st_scale = math::Vector2f::zero();
   math::Vector2f st_offset = math::Vector2f::zero();
   math::Vector4f qs = math::Vector4f(1, 1, 1, 1);
+  float rot = 0;
+  float st_rot = 0;
+  u8 pad[8];
 };
+static_assert(sizeof(LayerVals) == 80);
 
 /*!
  * A single layer in a FixedAnimationDef.
@@ -138,7 +142,6 @@ struct FixedLayerDef {
   bool channel_masks[4] = {true, true, true, true};
   GsAlpha::BlendMode blend_modes[4];  // abcd
   u8 blend_fix = 0;
-  LayerVals start_vals, end_vals;
 
   void set_blend_b2_d1() {
     blend_modes[0] = GsAlpha::BlendMode::SOURCE;
@@ -163,8 +166,13 @@ struct FixedAnimDef {
   std::vector<FixedLayerDef> layers;
 };
 
+struct DynamicLayerData {
+  LayerVals start_vals, end_vals;
+};
+
 struct FixedAnim {
   FixedAnimDef def;
+  std::vector<DynamicLayerData> dynamic_data;
   // GLint dest_texture;
   std::optional<FramebufferTexturePair> fbt;
   int dest_slot;
@@ -214,7 +222,7 @@ class TextureAnimator {
   void force_to_gpu(int tbp);
 
   int create_fixed_anim_array(const std::vector<FixedAnimDef>& defs);
-  void run_fixed_animation_array(int idx, const float* times);
+  void run_fixed_animation_array(int idx, const DmaTransfer& transfer);
   void run_fixed_animation(FixedAnim& anim, float time);
 
   struct DrawData {

--- a/game/graphics/opengl_renderer/TextureAnimator.h
+++ b/game/graphics/opengl_renderer/TextureAnimator.h
@@ -331,5 +331,6 @@ class TextureAnimator {
   int m_skull_gem_fixed_anim_array_idx = -1;
   int m_bomb_fixed_anim_array_idx = -1;
   int m_cas_conveyor_anim_array_idx = -1;
+  int m_security_anim_array_idx = -1;
   std::vector<FixedAnimArray> m_fixed_anim_arrays;
 };

--- a/game/graphics/opengl_renderer/TextureAnimator.h
+++ b/game/graphics/opengl_renderer/TextureAnimator.h
@@ -225,8 +225,7 @@ class TextureAnimator {
   void force_to_gpu(int tbp);
 
   int create_fixed_anim_array(const std::vector<FixedAnimDef>& defs);
-  void run_fixed_animation_array(int idx, const DmaTransfer& transfer,
-                                 TexturePool* texture_pool);
+  void run_fixed_animation_array(int idx, const DmaTransfer& transfer, TexturePool* texture_pool);
   void run_fixed_animation(FixedAnim& anim, float time);
 
   struct DrawData {

--- a/game/graphics/opengl_renderer/TextureAnimator.h
+++ b/game/graphics/opengl_renderer/TextureAnimator.h
@@ -151,6 +151,13 @@ struct FixedLayerDef {
     blend_fix = 0;
   }
 
+  void set_blend_b1_d1() {
+    blend_modes[0] = GsAlpha::BlendMode::SOURCE;
+    blend_modes[1] = GsAlpha::BlendMode::DEST;
+    blend_modes[2] = GsAlpha::BlendMode::SOURCE;
+    blend_modes[3] = GsAlpha::BlendMode::DEST;
+    blend_fix = 0;
+  }
   void set_no_z_write_no_z_test() {
     z_writes = false;
     z_test = false;
@@ -339,5 +346,6 @@ class TextureAnimator {
   int m_waterfall_b_anim_array_idx = -1;
   int m_lava_anim_array_idx = -1;
   int m_lava_b_anim_array_idx = -1;
+  int m_stadiumb_anim_array_idx = -1;
   std::vector<FixedAnimArray> m_fixed_anim_arrays;
 };

--- a/game/graphics/opengl_renderer/TextureAnimator.h
+++ b/game/graphics/opengl_renderer/TextureAnimator.h
@@ -164,6 +164,7 @@ struct FixedAnimDef {
   // assuming (new 'static 'gs-test :ate #x1 :afail #x1 :zte #x1 :ztst (gs-ztest always))
   // alpha blend off, so alpha doesn't matter i think.
   std::vector<FixedLayerDef> layers;
+  bool move_to_pool = false;
 };
 
 struct DynamicLayerData {
@@ -177,6 +178,8 @@ struct FixedAnim {
   std::optional<FramebufferTexturePair> fbt;
   int dest_slot;
   std::vector<GLint> src_textures;
+
+  GpuTexture* pool_gpu_tex = nullptr;
 };
 
 struct FixedAnimArray {
@@ -222,7 +225,8 @@ class TextureAnimator {
   void force_to_gpu(int tbp);
 
   int create_fixed_anim_array(const std::vector<FixedAnimDef>& defs);
-  void run_fixed_animation_array(int idx, const DmaTransfer& transfer);
+  void run_fixed_animation_array(int idx, const DmaTransfer& transfer,
+                                 TexturePool* texture_pool);
   void run_fixed_animation(FixedAnim& anim, float time);
 
   struct DrawData {
@@ -334,5 +338,7 @@ class TextureAnimator {
   int m_security_anim_array_idx = -1;
   int m_waterfall_anim_array_idx = -1;
   int m_waterfall_b_anim_array_idx = -1;
+  int m_lava_anim_array_idx = -1;
+  int m_lava_b_anim_array_idx = -1;
   std::vector<FixedAnimArray> m_fixed_anim_arrays;
 };

--- a/goal_src/jak2/engine/collide/collide-shape.gc
+++ b/goal_src/jak2/engine/collide/collide-shape.gc
@@ -1026,7 +1026,7 @@ it returns a triangle and normal direction to push in.
 
      ;; hack: things have gone very wrong.
      ;; added print
-     (format 0 "very far in collision hack running~%")
+     ;; (format 0 "very far in collision hack running~%")
      (set! (-> sv-48 quad) (-> arg1 best-other-tri normal quad)) ;; just use the triangle's normal, things are bad.
      (set! (-> arg0 coverage) 0.0)
      )

--- a/goal_src/jak2/engine/gfx/texture/texture-anim.gc
+++ b/goal_src/jak2/engine/gfx/texture/texture-anim.gc
@@ -598,24 +598,36 @@
                                bucket
                                )
     ;; determine how many texture we have:
-    (let ((num 0))
+    (let ((num-anims 0)
+          (num-qwc-floats 0))
       (dotimes (i (-> anim-array length))
         (when (-> anim-array array-data i tex)
-          (+! num 1)
+          (+! num-anims 1)
+          (+! num-qwc-floats 1) ;; for times
+          (+! num-qwc-floats (* 10 (-> anim-array array-data i num-layers)))
           )
         )
 
       ;; (format 0 "pc-update-fixed-anim: ~d layers~%" num)
-      (let ((num-qw (/ (+ num 3) 4)))
-        (pc-texture-anim-flag start-anim-array dma-buf)
-        (pc-texture-anim-flag-id anim-id dma-buf :qwc num-qw)
+      (pc-texture-anim-flag start-anim-array dma-buf)
+      (pc-texture-anim-flag-id anim-id dma-buf :qwc num-qwc-floats)
 
-        (dotimes (i num)
+      (let ((out-ptr (the (inline-array vector) (-> dma-buf base)))
+            )
+        (dotimes (i num-anims)
           (let ((anim (-> anim-array array-data i))
-                (out-slot (the (pointer float) (&+ (-> dma-buf base) (* 4 i))))
+                (out-slot (the (pointer float) (&+ (-> dma-buf base) (* 11 16 i))))
                 )
 
-            (set! (-> out-slot) (-> anim frame-time))
+            (set! (-> out-ptr 0 x) (-> anim frame-time))
+            (&+! out-ptr 16)
+
+            (dotimes (j (-> anim num-layers))
+              (quad-copy! (the pointer out-ptr) (the pointer (-> anim data j start-vectors)) 5)
+              (&+! out-ptr 80)
+              (quad-copy! (the pointer out-ptr) (the pointer (-> anim data j end-vectors)) 5)
+              (&+! out-ptr 80)
+              )
 
             (when (not (paused?))
               (with-pp
@@ -631,10 +643,10 @@
               )
             )
           )
-
-        (&+! (-> dma-buf base) (* 16 num-qw))
-        (pc-texture-anim-flag finish-anim-array dma-buf)
         )
+
+      (&+! (-> dma-buf base) (* 16 num-qwc-floats))
+      (pc-texture-anim-flag finish-anim-array dma-buf)
       )
     )
 

--- a/goal_src/jak2/engine/gfx/texture/texture-anim.gc
+++ b/goal_src/jak2/engine/gfx/texture/texture-anim.gc
@@ -188,6 +188,8 @@
   (security 30)
   (waterfall 31)
   (waterfall-b 32)
+  (lava 33)
+  (lava-b 34)
   )
 
 (deftype texture-anim-pc-upload (structure)
@@ -597,6 +599,8 @@
 (define-extern *security-texture-anim-array* (texture-anim-array texture-anim))
 (define-extern *waterfall-texture-anim-array* (texture-anim-array texture-anim))
 (define-extern *waterfall-b-texture-anim-array* (texture-anim-array texture-anim))
+(define-extern *lava-texture-anim-array* (texture-anim-array texture-anim))
+(define-extern *lava-b-texture-anim-array* (texture-anim-array texture-anim))
 
 
 (defun pc-update-fixed-anim ((bucket bucket-id) (anim-id texture-anim-pc) (anim-array texture-anim-array))
@@ -627,6 +631,12 @@
                 )
 
             (set! (-> out-ptr 0 x) (-> anim frame-time))
+            (set! (-> out-ptr 0 y) (the-as float (if (-> anim tex)
+                                                     (-> anim tex dest 0)
+                                                     -1
+                                                     )
+                                           )
+                  )
             (&+! out-ptr 16)
 
             (dotimes (j (-> anim num-layers))
@@ -693,13 +703,19 @@
      (return #f)
      )
     ((= anim-array *waterfall-texture-anim-array*)
-     (format 0 "goal runs a~%")
      (pc-update-fixed-anim bucket (texture-anim-pc waterfall) anim-array)
      (return #f)
      )
     ((= anim-array *waterfall-b-texture-anim-array*)
-     (format 0 "goal runs b~%")
      (pc-update-fixed-anim bucket (texture-anim-pc waterfall-b) anim-array)
+     (return #f)
+     )
+    ((= anim-array *lava-texture-anim-array*)
+     (pc-update-fixed-anim bucket (texture-anim-pc lava) anim-array)
+     (return #f)
+     )
+    ((= anim-array *lava-b-texture-anim-array*)
+     (pc-update-fixed-anim bucket (texture-anim-pc lava-b) anim-array)
      (return #f)
      )
     ((= anim-array *darkjak-texture-anim-array*)

--- a/goal_src/jak2/engine/gfx/texture/texture-anim.gc
+++ b/goal_src/jak2/engine/gfx/texture/texture-anim.gc
@@ -186,6 +186,8 @@
   (bomb 28)
   (cas-conveyor 29)
   (security 30)
+  (waterfall 31)
+  (waterfall-b 32)
   )
 
 (deftype texture-anim-pc-upload (structure)
@@ -593,6 +595,9 @@
 (define-extern *bomb-texture-anim-array* (texture-anim-array texture-anim))
 (define-extern *cas-conveyor-texture-anim-array* (texture-anim-array texture-anim))
 (define-extern *security-texture-anim-array* (texture-anim-array texture-anim))
+(define-extern *waterfall-texture-anim-array* (texture-anim-array texture-anim))
+(define-extern *waterfall-b-texture-anim-array* (texture-anim-array texture-anim))
+
 
 (defun pc-update-fixed-anim ((bucket bucket-id) (anim-id texture-anim-pc) (anim-array texture-anim-array))
   "Run a 'fixed' texture-anim, which should run entirely in C++."
@@ -685,6 +690,16 @@
      )
     ((= anim-array *security-texture-anim-array*)
      (pc-update-fixed-anim bucket (texture-anim-pc security) anim-array)
+     (return #f)
+     )
+    ((= anim-array *waterfall-texture-anim-array*)
+     (format 0 "goal runs a~%")
+     (pc-update-fixed-anim bucket (texture-anim-pc waterfall) anim-array)
+     (return #f)
+     )
+    ((= anim-array *waterfall-b-texture-anim-array*)
+     (format 0 "goal runs b~%")
+     (pc-update-fixed-anim bucket (texture-anim-pc waterfall-b) anim-array)
      (return #f)
      )
     ((= anim-array *darkjak-texture-anim-array*)

--- a/goal_src/jak2/engine/gfx/texture/texture-anim.gc
+++ b/goal_src/jak2/engine/gfx/texture/texture-anim.gc
@@ -191,6 +191,8 @@
   (lava 33)
   (lava-b 34)
   (stadiumb 35)
+  (fortress-pris 36)
+  (fortress-warp 37)
   )
 
 (deftype texture-anim-pc-upload (structure)
@@ -603,6 +605,8 @@
 (define-extern *lava-texture-anim-array* (texture-anim-array texture-anim))
 (define-extern *lava-b-texture-anim-array* (texture-anim-array texture-anim))
 (define-extern *stadiumb-energy-wall-anim-array* (texture-anim-array texture-anim))
+(define-extern *fortress-pris-texture-anim-array* (texture-anim-array texture-anim))
+(define-extern *fortress-warp-texture-anim-array* (texture-anim-array texture-anim))
 
 
 (defun pc-update-fixed-anim ((bucket bucket-id) (anim-id texture-anim-pc) (anim-array texture-anim-array))
@@ -722,6 +726,14 @@
      )
     ((= anim-array *stadiumb-energy-wall-anim-array*)
      (pc-update-fixed-anim bucket (texture-anim-pc stadiumb) anim-array)
+     (return #f)
+     )
+    ((= anim-array *fortress-pris-texture-anim-array*)
+     (pc-update-fixed-anim bucket (texture-anim-pc fortress-pris) anim-array)
+     (return #f)
+     )
+    ((= anim-array *fortress-warp-texture-anim-array*)
+     (pc-update-fixed-anim bucket (texture-anim-pc fortress-warp) anim-array)
      (return #f)
      )
     ((= anim-array *darkjak-texture-anim-array*)

--- a/goal_src/jak2/engine/gfx/texture/texture-anim.gc
+++ b/goal_src/jak2/engine/gfx/texture/texture-anim.gc
@@ -190,6 +190,7 @@
   (waterfall-b 32)
   (lava 33)
   (lava-b 34)
+  (stadiumb 35)
   )
 
 (deftype texture-anim-pc-upload (structure)
@@ -601,6 +602,7 @@
 (define-extern *waterfall-b-texture-anim-array* (texture-anim-array texture-anim))
 (define-extern *lava-texture-anim-array* (texture-anim-array texture-anim))
 (define-extern *lava-b-texture-anim-array* (texture-anim-array texture-anim))
+(define-extern *stadiumb-energy-wall-anim-array* (texture-anim-array texture-anim))
 
 
 (defun pc-update-fixed-anim ((bucket bucket-id) (anim-id texture-anim-pc) (anim-array texture-anim-array))
@@ -716,6 +718,10 @@
      )
     ((= anim-array *lava-b-texture-anim-array*)
      (pc-update-fixed-anim bucket (texture-anim-pc lava-b) anim-array)
+     (return #f)
+     )
+    ((= anim-array *stadiumb-energy-wall-anim-array*)
+     (pc-update-fixed-anim bucket (texture-anim-pc stadiumb) anim-array)
      (return #f)
      )
     ((= anim-array *darkjak-texture-anim-array*)

--- a/goal_src/jak2/engine/gfx/texture/texture-anim.gc
+++ b/goal_src/jak2/engine/gfx/texture/texture-anim.gc
@@ -185,6 +185,7 @@
   (skull-gem 27)
   (bomb 28)
   (cas-conveyor 29)
+  (security 30)
   )
 
 (deftype texture-anim-pc-upload (structure)
@@ -591,6 +592,7 @@
 (define-extern *skull-gem-texture-anim-array* (texture-anim-array texture-anim))
 (define-extern *bomb-texture-anim-array* (texture-anim-array texture-anim))
 (define-extern *cas-conveyor-texture-anim-array* (texture-anim-array texture-anim))
+(define-extern *security-texture-anim-array* (texture-anim-array texture-anim))
 
 (defun pc-update-fixed-anim ((bucket bucket-id) (anim-id texture-anim-pc) (anim-array texture-anim-array))
   "Run a 'fixed' texture-anim, which should run entirely in C++."
@@ -679,6 +681,10 @@
      )
     ((= anim-array *cas-conveyor-texture-anim-array*)
      (pc-update-fixed-anim bucket (texture-anim-pc cas-conveyor) anim-array)
+     (return #f)
+     )
+    ((= anim-array *security-texture-anim-array*)
+     (pc-update-fixed-anim bucket (texture-anim-pc security) anim-array)
      (return #f)
      )
     ((= anim-array *darkjak-texture-anim-array*)

--- a/goal_src/jak2/engine/level/level.gc
+++ b/goal_src/jak2/engine/level/level.gc
@@ -1074,7 +1074,6 @@ into 7 sections, which might explain the weird sizes in the center.
        (dotimes (s4-0 10)
          (let ((a0-8 (-> obj info texture-anim s4-0)))
            (when a0-8
-             (set! (-> obj info texture-anim s4-0) #f)
              (set! (-> obj texture-anim-array s4-0)
                    (init! (the-as texture-anim-array (-> a0-8 value)))
                    )


### PR DESCRIPTION
- Add security wall animation
- Add waterfall animations
- Add lava animations
- Update layer values from the game to fix the security wall
- Remove leftover debug in `level.gc` that would break level-specific animations on the second time you visited the level
- Optionally load animated slot textures to the pool so generic can use them (fixes skull gems in UI)