### PR TITLE
Change force-actors? to ps2-actor-vis?

### DIFF
--- a/goal_src/jak1/engine/entity/entity.gc
+++ b/goal_src/jak1/engine/entity/entity.gc
@@ -1779,7 +1779,7 @@
                     (set! sv-32 (-> s3-5 data s1-2))
                     (cond
                       ((and (#if PC_PORT
-                                (or (with-pc (-> *pc-settings* force-actors?)) (is-object-visible? s4-2 (-> sv-32 vis-id)))
+                                (or (with-pc (not (-> *pc-settings* ps2-actor-vis?))) (is-object-visible? s4-2 (-> sv-32 vis-id)))
                                 (is-object-visible? s4-2 (-> sv-32 vis-id))
                                 )
                             (zero? (logand (-> sv-32 perm status) (entity-perm-status bit-9 bit-10)))

--- a/goal_src/jak1/engine/level/level.gc
+++ b/goal_src/jak1/engine/level/level.gc
@@ -1055,7 +1055,7 @@
   "Is arg0 visible? Note that this will return #f if the visibility data is not loaded."
 
   ;; note : pc port added option to show every actor regardless
-  (with-pc (if (-> *pc-settings* force-actors?) (return #t)))
+  (with-pc (if (not (-> *pc-settings* ps2-actor-vis?)) (return #t)))
 
   ;; check the vis bits!
   (let* (;; lwu v1, 388(a0)

--- a/goal_src/jak1/pc/debug/default-menu-pc.gc
+++ b/goal_src/jak1/pc/debug/default-menu-pc.gc
@@ -755,6 +755,7 @@
          (menu "PS2 settings"
             ;(flag "PS2 Load speed" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-read-speed?)))
             (flag "PS2 Particles" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-parts?)))
+            (flag "PS2 Actor Vis" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-actor-vis?)))
             ;(flag "PS2 Music" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-music?)))
             ;(flag "PS2 Sound effects" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-se?)))
             ;(flag "PS2 Hints" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-hints?)))
@@ -795,7 +796,6 @@
             (flag "heat" #f ,(dm-lambda-boolean-flag (-> *pc-settings* controller-heat-led?)))
             )
          (flag "V-sync" #f ,(dm-lambda-boolean-flag (-> *pc-settings* vsync?)))
-         (flag "All actors" #f ,(dm-lambda-boolean-flag (-> *pc-settings* force-actors?)))
          (flag "Display actor counts" *display-actor-counts* dm-boolean-toggle-pick-func)
          (flag "Display git commit" *display-sha* dm-boolean-toggle-pick-func)
          (flag "Extra hud elements" #f ,(dm-lambda-boolean-flag (-> *pc-settings* extra-hud?)))

--- a/goal_src/jak1/pc/debug/default-menu-pc.gc
+++ b/goal_src/jak1/pc/debug/default-menu-pc.gc
@@ -795,7 +795,7 @@
             (flag "heat" #f ,(dm-lambda-boolean-flag (-> *pc-settings* controller-heat-led?)))
             )
          (flag "V-sync" #f ,(dm-lambda-boolean-flag (-> *pc-settings* vsync?)))
-         (flag "PS2 Actor Vis" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-actor-vis??)))
+         (flag "PS2 Actor Vis" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-actor-vis?)))
          (flag "Display actor counts" *display-actor-counts* dm-boolean-toggle-pick-func)
          (flag "Display git commit" *display-sha* dm-boolean-toggle-pick-func)
          (flag "Extra hud elements" #f ,(dm-lambda-boolean-flag (-> *pc-settings* extra-hud?)))

--- a/goal_src/jak1/pc/debug/default-menu-pc.gc
+++ b/goal_src/jak1/pc/debug/default-menu-pc.gc
@@ -755,7 +755,6 @@
          (menu "PS2 settings"
             ;(flag "PS2 Load speed" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-read-speed?)))
             (flag "PS2 Particles" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-parts?)))
-            (flag "PS2 Actor Vis" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-actor-vis?)))
             ;(flag "PS2 Music" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-music?)))
             ;(flag "PS2 Sound effects" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-se?)))
             ;(flag "PS2 Hints" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-hints?)))
@@ -796,6 +795,7 @@
             (flag "heat" #f ,(dm-lambda-boolean-flag (-> *pc-settings* controller-heat-led?)))
             )
          (flag "V-sync" #f ,(dm-lambda-boolean-flag (-> *pc-settings* vsync?)))
+         (flag "PS2 Actor Vis" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-actor-vis??)))
          (flag "Display actor counts" *display-actor-counts* dm-boolean-toggle-pick-func)
          (flag "Display git commit" *display-sha* dm-boolean-toggle-pick-func)
          (flag "Extra hud elements" #f ,(dm-lambda-boolean-flag (-> *pc-settings* extra-hud?)))

--- a/goal_src/jak1/pc/features/speedruns.gc
+++ b/goal_src/jak1/pc/features/speedruns.gc
@@ -233,7 +233,7 @@
       )
     )
   ;; ensure `force actors` is not enabled
-  (set! (-> *pc-settings* force-actors?) #f)
+  (set! (-> *pc-settings* ps2-actor-vis?) #t)
   ;; force FPS to `60`
   (set-frame-rate! *pc-settings* 60 #t)
   ;; enable auto saving by default

--- a/goal_src/jak1/pc/pckernel-common.gc
+++ b/goal_src/jak1/pc/pckernel-common.gc
@@ -302,7 +302,7 @@
     (update-video-hacks obj)
     )
   (cond
-    ((-> obj force-actors?)
+    ((not (-> obj ps2-actor-vis?))
       ;; kinda overkill.
       (set! (-> *ACTOR-bank* birth-dist) (meters 10000))
       (set! (-> *ACTOR-bank* pause-dist) (meters 10000))
@@ -697,7 +697,7 @@
     (("ps2-hints?") (set! (-> obj ps2-hints?) (file-stream-read-symbol file)))
     (("ps2-lod-dist?") (set! (-> obj ps2-lod-dist?) (file-stream-read-symbol file)))
     (("force-envmap?") (set! (-> obj force-envmap?) (file-stream-read-symbol file)))
-    (("force-actors?") (set! (-> obj force-actors?) (file-stream-read-symbol file)))
+    (("ps2-actor-vis?") (set! (-> obj ps2-actor-vis?) (file-stream-read-symbol file)))
     (("music-fade?") (file-stream-read-symbol file)) ;; TODO remove
     (("use-vis?") (set! (-> obj use-vis?) (file-stream-read-symbol file)))
     (("hinttitles?") (set! (-> obj hinttitles?) (file-stream-read-symbol file)))
@@ -784,7 +784,7 @@
   (format file "  (first-camera-v-inverted? ~A)~%" (-> obj first-camera-v-inverted?))
   (format file "  (third-camera-h-inverted? ~A)~%" (-> obj third-camera-h-inverted?))
   (format file "  (third-camera-v-inverted? ~A)~%" (-> obj third-camera-v-inverted?))
-  (format file "  (force-actors? ~A)~%" (-> obj force-actors?))
+  (format file "  (ps2-actor-vis? ~A)~%" (-> obj ps2-actor-vis?))
   (format file "  (music-fadein? ~A)~%" (-> obj music-fadein?))
   (format file "  (music-fadeout? ~A)~%" (-> obj music-fadeout?))
   (format file "  (hinttitles? ~A)~%" (-> obj hinttitles?))

--- a/goal_src/jak1/pc/pckernel-common.gc
+++ b/goal_src/jak1/pc/pckernel-common.gc
@@ -697,7 +697,7 @@
     (("ps2-hints?") (set! (-> obj ps2-hints?) (file-stream-read-symbol file)))
     (("ps2-lod-dist?") (set! (-> obj ps2-lod-dist?) (file-stream-read-symbol file)))
     (("force-envmap?") (set! (-> obj force-envmap?) (file-stream-read-symbol file)))
-    (("ps2-actor-vis?") (set! (-> obj ps2-actor-vis?) (file-stream-read-symbol file)))
+    (("force-actors?") (set! (-> obj ps2-actor-vis?) (file-stream-read-symbol file)))
     (("music-fade?") (file-stream-read-symbol file)) ;; TODO remove
     (("use-vis?") (set! (-> obj use-vis?) (file-stream-read-symbol file)))
     (("hinttitles?") (set! (-> obj hinttitles?) (file-stream-read-symbol file)))
@@ -784,7 +784,7 @@
   (format file "  (first-camera-v-inverted? ~A)~%" (-> obj first-camera-v-inverted?))
   (format file "  (third-camera-h-inverted? ~A)~%" (-> obj third-camera-h-inverted?))
   (format file "  (third-camera-v-inverted? ~A)~%" (-> obj third-camera-v-inverted?))
-  (format file "  (ps2-actor-vis? ~A)~%" (-> obj ps2-actor-vis?))
+  (format file "  (force-actors? ~A)~%" (-> obj ps2-actor-vis?))
   (format file "  (music-fadein? ~A)~%" (-> obj music-fadein?))
   (format file "  (music-fadeout? ~A)~%" (-> obj music-fadeout?))
   (format file "  (hinttitles? ~A)~%" (-> obj hinttitles?))

--- a/goal_src/jak1/pc/pckernel-h.gc
+++ b/goal_src/jak1/pc/pckernel-h.gc
@@ -214,7 +214,7 @@
    (lod-force-actor int8) ;; merc lod tier override
 
    ;; misc settings
-   (force-actors? symbol) ;; skips vis check for actor entity
+   (ps2-actor-vis? symbol) ;; skips vis check for actor entity
    (use-vis? symbol) ;; if off, don't use vis trees. this MUST be off for custom (non-cropping) aspect ratios.
    (hinttitles? symbol) ;; if on, non-cutscene subtitles will show up
    (subtitle-speaker? symbol) ;; #f (force off), #t (force on), auto (on for offscreen)
@@ -424,7 +424,7 @@
 (defmethod reset-misc pc-settings ((obj pc-settings) (call-handlers symbol))
   "Set the default misc settings"
 
-  (set! (-> obj force-actors?) #f)
+  (set! (-> obj ps2-actor-vis?) #t)
   (set! (-> obj hinttitles?) #t)
   (set! (-> obj subtitle-speaker?) 'auto)
   (reset-camera obj call-handlers)

--- a/goal_src/jak1/pc/progress-pc.gc
+++ b/goal_src/jak1/pc/progress-pc.gc
@@ -1012,7 +1012,7 @@
   (set! (-> *gfx-ps2-options* 1 value-to-modify) (&-> *progress-carousell* int-backup))
   (set! (-> *gfx-ps2-options* 2 value-to-modify) (&-> *pc-settings* ps2-parts?))
   (set! (-> *gfx-ps2-options* 3 value-to-modify) (&-> *pc-settings* force-envmap?))
-  (set! (-> *gfx-ps2-options* 4 value-to-modify) (&-> *pc-settings* force-actors?))
+  (set! (-> *gfx-ps2-options* 4 value-to-modify) (&-> *pc-settings* ps2-actor-vis?))
 
   (set! (-> *sound-options-pc* 0 value-to-modify) (&-> *setting-control* default sfx-volume))
   (set! (-> *sound-options-pc* 1 value-to-modify) (&-> *setting-control* default music-volume))

--- a/goal_src/jak2/engine/entity/entity.gc
+++ b/goal_src/jak2/engine/entity/entity.gc
@@ -2229,7 +2229,7 @@
                     (dotimes (s1-1 s2-3)
                       (set! sv-48 (-> s3-4 data s1-1))
                       (cond
-                        ((and (#if PC_PORT (or (with-pc (and (-> *pc-settings* force-actors?)
+                        ((and (#if PC_PORT (or (with-pc (and (not (-> *pc-settings* ps2-actor-vis?))
                                                              ;; ban specific entities
                                                              (not (let ((name (res-lump-struct (-> sv-48 entity) 'name string)))
                                                                   (or (string= name "fort-entry-gate-11")

--- a/goal_src/jak2/pc/debug/default-menu-pc.gc
+++ b/goal_src/jak2/pc/debug/default-menu-pc.gc
@@ -883,7 +883,7 @@
             (flag "heat" #f ,(dm-lambda-boolean-flag (-> *pc-settings* controller-heat-led?)))
             )
          (flag "V-sync" #f ,(dm-lambda-boolean-flag (-> *pc-settings* vsync?)))
-         (flag "PS2 Actor Vis" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-actor-vis??)))
+         (flag "All actors" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-actor-vis?)))
          (flag "Display actor counts" *display-actor-counts* dm-boolean-toggle-pick-func)
          (flag "Display git commit" *display-sha* dm-boolean-toggle-pick-func)
          (flag "Music fadein" #f ,(dm-lambda-boolean-flag (-> *pc-settings* music-fadein?)))

--- a/goal_src/jak2/pc/debug/default-menu-pc.gc
+++ b/goal_src/jak2/pc/debug/default-menu-pc.gc
@@ -883,7 +883,7 @@
             (flag "heat" #f ,(dm-lambda-boolean-flag (-> *pc-settings* controller-heat-led?)))
             )
          (flag "V-sync" #f ,(dm-lambda-boolean-flag (-> *pc-settings* vsync?)))
-         (flag "All actors" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-actor-vis?)))
+         (flag "PS2 Actor Vis" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-actor-vis?)))
          (flag "Display actor counts" *display-actor-counts* dm-boolean-toggle-pick-func)
          (flag "Display git commit" *display-sha* dm-boolean-toggle-pick-func)
          (flag "Music fadein" #f ,(dm-lambda-boolean-flag (-> *pc-settings* music-fadein?)))

--- a/goal_src/jak2/pc/debug/default-menu-pc.gc
+++ b/goal_src/jak2/pc/debug/default-menu-pc.gc
@@ -840,6 +840,7 @@
          (menu "PS2 settings"
             ;(flag "PS2 Load speed" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-read-speed?)))
             (flag "PS2 Particles" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-parts?)))
+            (flag "PS2 Actor Vis" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-actor-vis?)))
             ;(flag "PS2 Music" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-music?)))
             ;(flag "PS2 Sound effects" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-se?)))
             ;(flag "PS2 Hints" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-hints?)))
@@ -883,7 +884,6 @@
             (flag "heat" #f ,(dm-lambda-boolean-flag (-> *pc-settings* controller-heat-led?)))
             )
          (flag "V-sync" #f ,(dm-lambda-boolean-flag (-> *pc-settings* vsync?)))
-         (flag "All actors" #f ,(dm-lambda-boolean-flag (-> *pc-settings* force-actors?)))
          (flag "Display actor counts" *display-actor-counts* dm-boolean-toggle-pick-func)
          (flag "Display git commit" *display-sha* dm-boolean-toggle-pick-func)
          (flag "Music fadein" #f ,(dm-lambda-boolean-flag (-> *pc-settings* music-fadein?)))

--- a/goal_src/jak2/pc/debug/default-menu-pc.gc
+++ b/goal_src/jak2/pc/debug/default-menu-pc.gc
@@ -840,7 +840,6 @@
          (menu "PS2 settings"
             ;(flag "PS2 Load speed" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-read-speed?)))
             (flag "PS2 Particles" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-parts?)))
-            (flag "PS2 Actor Vis" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-actor-vis?)))
             ;(flag "PS2 Music" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-music?)))
             ;(flag "PS2 Sound effects" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-se?)))
             ;(flag "PS2 Hints" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-hints?)))
@@ -884,6 +883,7 @@
             (flag "heat" #f ,(dm-lambda-boolean-flag (-> *pc-settings* controller-heat-led?)))
             )
          (flag "V-sync" #f ,(dm-lambda-boolean-flag (-> *pc-settings* vsync?)))
+         (flag "PS2 Actor Vis" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-actor-vis??)))
          (flag "Display actor counts" *display-actor-counts* dm-boolean-toggle-pick-func)
          (flag "Display git commit" *display-sha* dm-boolean-toggle-pick-func)
          (flag "Music fadein" #f ,(dm-lambda-boolean-flag (-> *pc-settings* music-fadein?)))


### PR DESCRIPTION
Closes #2815

Follows the lead set by `ps2-parts?` and changes `force-actors?` to `ps2-actor-vis?` and inverts all the conditions that use this value, so now it shows all actors when `ACTOR CULLING` is set to `OFF` in the menu

The other solution would I could do would be to leave it how it was, and just change the `ACTOR CULLING` text in the menu to say something like `PC ACTOR DISTANCE` or something... so then it would describe the expected behavior when turned on.

I opt'd for the first option just to be more consistent with the already established `ps2-parts?` and avoid translation issues when possible but can change if needed just let me know.