### PR TITLE
game: add a clear text label for how to hide the top bar

### DIFF
--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -162,6 +162,7 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
       }
       ImGui::EndMenu();
     }
+    ImGui::Text("Press F12 to hide this menu");
   }
   ImGui::EndMainMenuBar();
 


### PR DESCRIPTION
This coming release will change the keybind to hide the topbar.

This is in an effort to avoid answering the question many times.

![image](https://github.com/open-goal/jak-project/assets/13153231/ef5fb16e-d84f-459c-abfd-51f1cf8446a3)
