### PR TITLE
Fix possible crash when loading files

### DIFF
--- a/game/graphics/opengl_renderer/TextureAnimator.cpp
+++ b/game/graphics/opengl_renderer/TextureAnimator.cpp
@@ -279,7 +279,7 @@ GLuint ClutBlender::run(const float* weights) {
   }
 
   // do texture lookups
-  for (int i = 0; i < m_temp_rgba.size(); i++) {
+  for (size_t i = 0; i < m_temp_rgba.size(); i++) {
     memcpy(&m_temp_rgba[i], m_temp_clut[m_dest->index_data[i]].data(), 4);
   }
 
@@ -472,7 +472,7 @@ void TextureAnimator::draw_debug_window() {
     int w, h;
     glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
     glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
-    ImGui::Image((void*)m_private_output_slots[i], ImVec2(w, h));
+    ImGui::Image((void*)(u64)m_private_output_slots[i], ImVec2(w, h));
     ImGui::Checkbox(fmt::format("mark {}", i).c_str(), &m_output_debug_flags.at(i).b);
   }
   glBindTexture(GL_TEXTURE_2D, 0);

--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -165,10 +165,10 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
       ImGui::EndMenu();
     }
     ImGui::Text("Press F11 to toggle this toolbar");
-    ImGui::Text(fmt::format("Press {} to toggle this toolbar",
-                            sdl_util::get_keyboard_button_name(Gfx::g_debug_settings.hide_imgui_key,
-                                                               InputModifiers()))
-                    .c_str());
+    ImGui::Text("%s", fmt::format("Press {} to toggle this toolbar",
+                                  sdl_util::get_keyboard_button_name(
+                                      Gfx::g_debug_settings.hide_imgui_key, InputModifiers()))
+                          .c_str());
   }
   ImGui::EndMainMenuBar();
 

--- a/game/overlord/common/fake_iso.cpp
+++ b/game/overlord/common/fake_iso.cpp
@@ -36,7 +36,7 @@ BS::thread_pool thpool(4);
  */
 struct FakeIsoEntry {
   char iso_name[16];
-  char file_path[128];
+  std::string full_path;
 };
 
 FakeIsoEntry fake_iso_entries[MAX_ISO_FILES];  //! List of all known files
@@ -63,8 +63,8 @@ int fake_iso_FS_Init() {
       std::string file_name = f.path().filename().string();
       ASSERT(file_name.length() < 16);  // should be 8.3.
       strcpy(e->iso_name, file_name.c_str());
-      strcpy(e->file_path,
-             fmt::format("out/{}/iso/{}", game_version_names[g_game_version], file_name).c_str());
+      e->full_path = fmt::format("{}/out/{}/iso/{}", file_util::get_jak_project_dir().string(),
+                                 game_version_names[g_game_version], file_name);
       fake_iso_entry_count++;
     }
   }
@@ -118,11 +118,7 @@ FileRecord* FS_FindIN(const char* iso_name) {
  */
 const char* get_file_path(FileRecord* fr) {
   ASSERT(fr->location < fake_iso_entry_count);
-  static char path_buffer[1024];
-  strcpy(path_buffer, file_util::get_jak_project_dir().string().c_str());
-  strcat(path_buffer, "/");
-  strcat(path_buffer, fake_iso_entries[fr->location].file_path);
-  return path_buffer;
+  return fake_iso_entries[fr->location].full_path.c_str();
 }
 
 /*!


### PR DESCRIPTION
There was a single static path buffer being shared between multiple file i/o threads. So sometimes you would end up using the wrong path for the file, and getting size/data for the wrong file.

I think the original reason to have this buffer was just me being lazy when we changed how project paths works a long time ago. It was a bad idea in the first place.