### PR TITLE
[jak2] fix transparent shrub blending

### DIFF
--- a/game/graphics/opengl_renderer/shaders/shrub.vert
+++ b/game/graphics/opengl_renderer/shaders/shrub.vert
@@ -69,7 +69,6 @@ void main() {
   vec4 tod_color = texelFetch(tex_T10, time_of_day_index, 0);
   // combine
   fragment_color *= tod_color * 4;
-  fragment_color.a *= 2;
 
   if (decal == 1) {
     fragment_color.xyz = vec3(1.0, 1.0, 1.0);


### PR DESCRIPTION
![image](https://github.com/open-goal/jak-project/assets/48171810/ae4d40bf-b061-45af-ba20-c546fc935f11)

Should probably wait until the release just in case. But I'm 99% sure this line was just a mistake in the original implementation.