### PR TITLE
[jak2] workaround for missing yakow textures

### DIFF
--- a/decompiler/level_extractor/extract_level.cpp
+++ b/decompiler/level_extractor/extract_level.cpp
@@ -263,7 +263,6 @@ void extract_common(const ObjectFileDB& db,
   for (const auto& [id, normal_texture] : tex_db.textures) {
     if (config.common_tpages.count(normal_texture.page) &&
         !textures_we_have.count(normal_texture.name)) {
-      lg::info("Adding common texture {}", normal_texture.name);
       textures_we_have.insert(normal_texture.name);
       tfrag_level.textures.push_back(
           make_texture(id, normal_texture, tex_db.tpage_names.at(normal_texture.page), true));
@@ -274,7 +273,6 @@ void extract_common(const ObjectFileDB& db,
   for (const auto& [id, normal_texture] : tex_db.textures) {
     if (config.animated_textures.count(normal_texture.name) &&
         !textures_we_have.count(normal_texture.name)) {
-      lg::info("Adding anim texture {}", normal_texture.name);
       textures_we_have.insert(normal_texture.name);
       tfrag_level.textures.push_back(
           make_texture(id, normal_texture, tex_db.tpage_names.at(normal_texture.page), false));

--- a/decompiler/level_extractor/extract_merc.cpp
+++ b/decompiler/level_extractor/extract_merc.cpp
@@ -745,9 +745,22 @@ s32 find_or_add_texture_to_level(tfrag3::Level& out,
     // not added to level, add it
     auto tex_it = tex_db.textures.find(pc_combo_tex_id);
     if (tex_it == tex_db.textures.end()) {
-      lg::error("merc failed to find texture: 0x{:x} for {}. Should be in tpage {}",
-                pc_combo_tex_id, debug_name, pc_combo_tex_id >> 16);
-      idx_in_level_texture = 0;
+      if (pc_combo_tex_id == 0 && debug_name == "yakow-lod0") {
+        // this texture is missing in the real game, and it ends up using an invalid texture
+        // configuration, making it completely black. Instead of that, just pick a similar-ish
+        // yakow fur texture. It's not perfect, but it's better than nothing.
+        for (size_t i = 0; i < out.textures.size(); i++) {
+          auto& existing = out.textures[i];
+          if (existing.debug_name == "yak-medfur-end") {
+            idx_in_level_texture = i;
+            break;
+          }
+        }
+      } else {
+        lg::error("merc failed to find texture: 0x{:x} for {}. Should be in tpage {}",
+                  pc_combo_tex_id, debug_name, pc_combo_tex_id >> 16);
+        idx_in_level_texture = 0;
+      }
     } else {
       idx_in_level_texture = out.textures.size();
       auto& new_tex = out.textures.emplace_back();


### PR DESCRIPTION
The yakow texture is actually missing from the real game too. 

This adds a special case in the extractor to replace it with a similar-ish fur texture:
![image](https://github.com/open-goal/jak-project/assets/48171810/db429e70-e5c5-4302-824a-238e94cf3d69)
