### PR TITLE
[jak2] Fix ocean culling when using camera-other

### DIFF
--- a/goal_src/jak2/engine/gfx/ocean/ocean-h.gc
+++ b/goal_src/jak2/engine/gfx/ocean/ocean-h.gc
@@ -938,3 +938,54 @@
     :mask-lo (new 'static 'vector4w :x #xffff :y #xffff :z #xffff :w #xffff)
     )
   )
+
+(defun sphere-cull-for-ocean ((arg0 vector))
+  "Is the given sphere in the view frustum?
+  PC-port ocean version"
+  (local-vars (v1-0 uint128) (v1-1 uint128) (v1-2 uint128))
+  (rlet ((acc :class vf)
+         (vf0 :class vf)
+         (vf10 :class vf)
+         (vf16 :class vf)
+         (vf17 :class vf)
+         (vf18 :class vf)
+         (vf19 :class vf)
+         (vf9 :class vf)
+         )
+        ;; modified for PC: these register would be loaded by the draw method of bsp.
+        (cond
+          ((-> *time-of-day-context* use-camera-other)
+           (let ((at-0 *math-camera*))
+             (.lvf vf16 (&-> at-0 plane-other 0 quad))
+             (.lvf vf17 (&-> at-0 plane-other 1 quad))
+             (.lvf vf18 (&-> at-0 plane-other 2 quad))
+             (.lvf vf19 (&-> at-0 plane-other 3 quad))
+             )
+           )
+          (else
+            (let ((at-0 *math-camera*))
+              (.lvf vf16 (&-> at-0 plane 0 quad))
+              (.lvf vf17 (&-> at-0 plane 1 quad))
+              (.lvf vf18 (&-> at-0 plane 2 quad))
+              (.lvf vf19 (&-> at-0 plane 3 quad))
+              )
+            )
+          )
+
+        (init-vf0-vector)
+        (.lvf vf10 (&-> arg0 quad))
+        (.mul.x.vf acc vf16 vf10)
+        (.add.mul.y.vf acc vf17 vf10 acc)
+        (.add.mul.z.vf acc vf18 vf10 acc)
+        (.sub.mul.w.vf vf9 vf19 vf0 acc)
+
+        ;; checking to see if we are inside all 4 planes.
+
+        ;; using the inside part of the sphere
+        (.add.w.vf vf9 vf9 vf10)
+        (.mov v1-0 vf9)
+        (.pcgtw v1-1 0 v1-0)
+        (.ppach v1-2 (the-as uint128 0) v1-1)
+        (zero? (the-as int v1-2))
+        )
+  )

--- a/goal_src/jak2/engine/gfx/ocean/ocean-mid.gc
+++ b/goal_src/jak2/engine/gfx/ocean/ocean-mid.gc
@@ -1017,7 +1017,7 @@
         (while (>= s1-0 s2-0)
           (set! (-> sv-36 x) (+ 196608.0 (* 393216.0 (the float s2-0)) (-> obj start-corner x)))
           (set! (-> sv-36 z) (+ 196608.0 (* 393216.0 (the float s4-0)) (-> obj start-corner z)))
-          (when (sphere-cull sv-36)
+          (when (sphere-cull-for-ocean sv-36) ;; modified
             (cond
               ((= s4-0 sv-34)
                (ocean-mid-add-upload-top obj arg0 s4-0 s2-0)
@@ -1105,7 +1105,7 @@
                  (s0-0 (-> obj ocean-spheres spheres s1-0))
                  )
             (set! sv-32 (-> (the-as (pointer int16) (+ (* s1-0 2) (the-as int (-> obj ocean-mid-indices))))))
-            (when (sphere-cull s0-0)
+            (when (sphere-cull-for-ocean s0-0) ;; modified
               (cond
                 ((< sv-32 0)
                  )

--- a/goal_src/jak2/engine/gfx/ocean/ocean-transition.gc
+++ b/goal_src/jak2/engine/gfx/ocean/ocean-transition.gc
@@ -651,7 +651,7 @@
           (while (>= s1-0 s2-0)
             (set! (-> sv-36 x) (+ 49152.0 (* 98304.0 (the float s2-0)) (-> obj start-corner x)))
             (set! (-> sv-36 z) (+ 49152.0 (* 98304.0 (the float s4-0)) (-> obj start-corner z)))
-            (when (sphere-cull sv-36)
+            (when (sphere-cull-for-ocean sv-36) ;; modified
               (if (not (ocean-trans-camera-masks-bit? obj s4-0 s2-0))
                   (ocean-trans-add-upload obj arg0 s4-0 s2-0)
                   )
@@ -741,7 +741,7 @@
             (when (ocean-mid-camera-masks-bit? obj s4-0 s2-0)
               (set! (-> sv-36 x) (+ 196608.0 (* 393216.0 (the float s2-0)) (-> obj start-corner x)))
               (set! (-> sv-36 z) (+ 196608.0 (* 393216.0 (the float s4-0)) (-> obj start-corner z)))
-              (if (sphere-cull sv-36)
+              (if (sphere-cull-for-ocean sv-36) ;; modified
                   (ocean-make-trans-camera-masks obj s4-0 s2-0 (- s4-0 sv-34) (- s2-0 sv-32))
                   )
               )


### PR DESCRIPTION
When drawing the spinning palace, there's a terrible hack that lets some stuff be drawn with different camera matrices.

The ocean is drawn with camera-other (which spins), but was being culled with camera (doesn't spin). This changes ocean to use the right camera matrix.

Note that the ocean is special when it comes to camera-other - it always uses camera-other if there is one. Other uses are set per-level and should already be handled correctly.