### PR TITLE
[jak2] disable envmap when it should be

### DIFF
--- a/game/graphics/opengl_renderer/foreground/Merc2.cpp
+++ b/game/graphics/opengl_renderer/foreground/Merc2.cpp
@@ -538,8 +538,9 @@ void Merc2::handle_pc_model(const DmaTransfer& setup,
   u64 current_ignore_alpha_bits = flags->ignore_alpha_mask;  // shader settings
   u64 current_effect_enable_bits = flags->enable_mask;       // mask for game to disable an effect
   bool model_uses_mod = flags->bitflags & 1;  // if we should update vertices from game.
-  bool model_disables_fog = (flags->bitflags & 2);
+  bool model_disables_fog = flags->bitflags & 2;
   bool model_uses_pc_blerc = flags->bitflags & 4;
+  bool model_disables_envmap = flags->bitflags & 8;
   input_data += 32;
 
   float blerc_weights[kMaxBlerc];
@@ -570,7 +571,7 @@ void Merc2::handle_pc_model(const DmaTransfer& setup,
   // stats
   stats->num_models++;
   for (const auto& effect : model_ref->model->effects) {
-    bool envmap = effect.has_envmap;
+    bool envmap = effect.has_envmap && !model_disables_envmap;
     stats->num_effects++;
     stats->num_predicted_draws += effect.all_draws.size();
     if (envmap) {
@@ -623,7 +624,7 @@ void Merc2::handle_pc_model(const DmaTransfer& setup,
     bool ignore_alpha = !!(current_ignore_alpha_bits & (1ull << ei));
     auto& effect = model->effects[ei];
 
-    bool should_envmap = effect.has_envmap;
+    bool should_envmap = effect.has_envmap && !model_disables_envmap;
     bool should_mod = (model_uses_pc_blerc || model_uses_mod) && effect.has_mod_draw;
 
     if (should_mod) {

--- a/goal_src/jak2/engine/gfx/foreground/foreground.gc
+++ b/goal_src/jak2/engine/gfx/foreground/foreground.gc
@@ -971,6 +971,7 @@
   (update-verts 0)
   (disable-fog 1)
   (pc-blerc 2)
+  (disable-envmap 3)
   )
 
 (deftype pc-merc-flags (structure)
@@ -1084,6 +1085,9 @@
               )
             (when (logtest? (-> dc status) (draw-control-status disable-fog))
               (logior! (-> flags bit-flags) (pc-merc-bits disable-fog))
+              )
+            (when (logtest? (-> dc global-effect) (draw-control-global-effect disable-envmap))
+              (logior! (-> flags bit-flags) (pc-merc-bits disable-envmap))
               )
             (set! (-> flags enable-mask) enable-mask)
             (set! (-> flags ignore-alpha-mask) ignore-alpha-mask)


### PR DESCRIPTION
In jak 2, there's an option to disable envmap. It's used on krew holograms, hiphog trophies, and baron bosses in palace/tomb.