### PR TITLE
ci: strip binaries in their respective runners

### DIFF
--- a/.github/scripts/releases/extract_build_unix.sh
+++ b/.github/scripts/releases/extract_build_unix.sh
@@ -15,10 +15,6 @@ if [ "$PREP_BIN" = "true" ]; then
   cp $BIN_SOURCE/goalc/goalc $DEST
   cp $BIN_SOURCE/decompiler/extractor $DEST
 
-  strip $DEST/gk
-  strip $DEST/goalc
-  strip $DEST/extractor
-
   chmod +x $DEST/gk
   chmod +x $DEST/goalc
   chmod +x $DEST/extractor

--- a/.github/workflows/linux-build-clang.yaml
+++ b/.github/workflows/linux-build-clang.yaml
@@ -9,6 +9,10 @@ on:
       cachePrefix:
         required: true
         type: string
+      uploadArtifacts:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -57,8 +61,17 @@ jobs:
           GTEST_OUTPUT: "xml:opengoal-test-report.xml"
         run: ./test.sh
 
+      - name: Prepare artifacts
+        if: ${{ inputs.uploadArtifacts }}
+        run: |
+          strip ./build/goalc/goalc
+          strip ./build/decompiler/extractor
+          strip ./build/game/gk
+          strip ./build/lsp/lsp
+
       - name: Upload artifact
         uses: actions/upload-artifact@v3
+        if: ${{ inputs.uploadArtifacts }}
         with:
           name: opengoal-linux-${{ inputs.cachePrefix }}
           if-no-files-found: error

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -9,6 +9,10 @@ on:
       cachePrefix:
         required: true
         type: string
+      uploadArtifacts:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -51,8 +55,17 @@ jobs:
       - name: Run Tests
         run: ./test.sh
 
+      - name: Prepare artifacts
+        if: ${{ inputs.uploadArtifacts }}
+        run: |
+          strip ./build/goalc/goalc
+          strip ./build/decompiler/extractor
+          strip ./build/game/gk
+          strip ./build/lsp/lsp
+
       - name: Upload artifact
         uses: actions/upload-artifact@v3
+        if: ${{ inputs.uploadArtifacts }}
         with:
           name: opengoal-macos-${{ inputs.cachePrefix }}
           if-no-files-found: error

--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -87,7 +87,7 @@ jobs:
           tar czf ../final/opengoal-macos-intel-${TAG_VAL}.tar.gz .
           popd
           chmod +x ./ci-artifacts/opengoal-macos-static/lsp/lsp
-          cp ./ci-artifacts/opengoal-macos-static/lsp/lsp ./ci-artifacts/final/opengoal-lsp-macos-intel${TAG_VAL}.bin
+          cp ./ci-artifacts/opengoal-macos-static/lsp/lsp ./ci-artifacts/final/opengoal-lsp-macos-intel-${TAG_VAL}.bin
 
       - name: Upload Assets
         env:

--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -13,6 +13,7 @@ jobs:
     with:
       cmakePreset: "Release-windows-clang-static"
       cachePrefix: "static"
+      uploadArtifacts: true
     secrets: inherit
 
   # Linux
@@ -22,15 +23,17 @@ jobs:
     with:
       cmakePreset: "Release-linux-clang-static"
       cachePrefix: "static"
+      uploadArtifacts: true
     secrets: inherit
 
   # macOS
-  build_macos_clang:
+  build_macos_intel:
     name: "🍎 MacOS"
     uses: ./.github/workflows/macos-build.yaml
     with:
       cmakePreset: "Release-macos-clang-static"
       cachePrefix: "static"
+      uploadArtifacts: true
     secrets: inherit
 
   # Upload the Artifacts
@@ -39,7 +42,7 @@ jobs:
     needs:
       - build_windows_clang
       - build_linux_clang
-      - build_macos_clang
+      - build_macos_intel
     name: "Upload Artifacts"
     runs-on: ubuntu-latest
     steps:
@@ -64,7 +67,6 @@ jobs:
           TAG_VAL=$(echo ${{ github.REF }} | awk -F'refs/tags/' '{print $2}')
           tar czf ../final/opengoal-linux-${TAG_VAL}.tar.gz .
           popd
-          strip ./ci-artifacts/opengoal-linux-static/lsp/lsp
           chmod +x ./ci-artifacts/opengoal-linux-static/lsp/lsp
           cp ./ci-artifacts/opengoal-linux-static/lsp/lsp ./ci-artifacts/final/opengoal-lsp-linux-${TAG_VAL}.bin
 
@@ -84,7 +86,6 @@ jobs:
           TAG_VAL=$(echo ${{ github.REF }} | awk -F'refs/tags/' '{print $2}')
           tar czf ../final/opengoal-macos-intel-${TAG_VAL}.tar.gz .
           popd
-          strip ./ci-artifacts/opengoal-macos-static/lsp/lsp
           chmod +x ./ci-artifacts/opengoal-macos-static/lsp/lsp
           cp ./ci-artifacts/opengoal-macos-static/lsp/lsp ./ci-artifacts/final/opengoal-lsp-macos-intel${TAG_VAL}.bin
 

--- a/.github/workflows/windows-build-clang.yaml
+++ b/.github/workflows/windows-build-clang.yaml
@@ -9,6 +9,10 @@ on:
       cachePrefix:
         required: true
         type: string
+      uploadArtifacts:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -61,6 +65,7 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
+        if: ${{ inputs.uploadArtifacts }}
         with:
           name: opengoal-windows-${{ inputs.cachePrefix }}
           if-no-files-found: error


### PR DESCRIPTION
Was causing the macOS release to fail, you can't `strip` a Mach-O binary with gnu's `strip`.  This has the added benefit of majorly reducing binary size which should have a noticable impact in the upload/download steps.