### PR TITLE
jak1: start a new game correctly when speedrunner mode is enabled

### DIFF
--- a/goal_src/jak1/engine/ui/progress/progress.gc
+++ b/goal_src/jak1/engine/ui/progress/progress.gc
@@ -1732,15 +1732,14 @@
                                (let ((gp-1 (-> *setting-control* default auto-save)))
                                  (sound-volume-off)
                                  (set! (-> *game-info* mode) 'play)
-                                 (initialize! *game-info* 'game (the-as game-save #f) "intro-start")
                                  (cond
                                   ;; Start a new game differently if speedrunning mode is active
                                   ((= (-> *pc-settings* speedrunner-mode?) #t)
                                    (speedrun-start-full-game-run))
-                                 ;; start the game normally
-                                 (else
-                                   (initialize! *game-info* 'game (the-as game-save #f) "intro-start")
-                                   (set! (-> *setting-control* default auto-save) gp-1)))
+                                  ;; start the game normally
+                                  (else
+                                    (initialize! *game-info* 'game (the-as game-save #f) "intro-start")
+                                    (set! (-> *setting-control* default auto-save) gp-1)))
                                  )
                                (the-as object (set-master-mode 'game))
                                )

--- a/goal_src/jak1/pc/progress-pc.gc
+++ b/goal_src/jak1/pc/progress-pc.gc
@@ -1937,9 +1937,12 @@
               (sound-play "starts-options")
               (sound-volume-off)
               (set! (-> *game-info* mode) 'play)
-              (initialize! *game-info* 'game (the-as game-save #f) "intro-start")
-              (set-master-mode 'game)
-              )
+              (if (= (-> *pc-settings* speedrunner-mode?) #t)
+                  ;; Start a new game differently if speedrunning mode is active
+                  (speedrun-start-full-game-run)
+                  ;; start the game normally
+                  (initialize! *game-info* 'game (the-as game-save #f) "intro-start"))
+              (set-master-mode 'game))
              (else
                (sound-play "cursor-options")
                (set! (-> obj next-display-state) (progress-screen invalid))


### PR DESCRIPTION
Fixes #2871 