### PR TITLE
log: don't recursively iterate when rotating log files

### DIFF
--- a/common/log/log.cpp
+++ b/common/log/log.cpp
@@ -132,15 +132,16 @@ void set_file(const std::string& filename,
   if (should_rotate) {
     complete_filename += "." + str_util::current_local_timestamp_no_colons() + ".log";
     // remove any log files with the old format
-    auto old_log_files = file_util::find_files_recursively(
-        fs::path(file_path).parent_path(), std::regex(fmt::format("{}\\.(\\d\\.)?log", filename)));
+    auto old_log_files =
+        file_util::find_files_in_dir(fs::path(complete_filename).parent_path(),
+                                     std::regex(fmt::format("{}\\.(\\d\\.)?log", filename)));
     for (const auto& file : old_log_files) {
       lg::info("removing {}", file.string());
       fs::remove(file);
     }
     // remove the oldest log file if there are more than LOG_ROTATE_MAX
-    auto existing_log_files = file_util::find_files_recursively(
-        fs::path(file_path).parent_path(), std::regex(fmt::format("{}.*\\.log", filename)));
+    auto existing_log_files = file_util::find_files_in_dir(
+        fs::path(complete_filename).parent_path(), std::regex(fmt::format("{}.*\\.log", filename)));
     // sort the names and remove them
     existing_log_files = file_util::sort_filepaths(existing_log_files, true);
     if (existing_log_files.size() > (LOG_ROTATE_MAX - 1)) {

--- a/common/util/FileUtil.cpp
+++ b/common/util/FileUtil.cpp
@@ -622,6 +622,18 @@ FILE* open_file(const fs::path& path, const std::string& mode) {
 #endif
 }
 
+std::vector<fs::path> find_files_in_dir(const fs::path& dir, const std::regex& pattern) {
+  std::vector<fs::path> files = {};
+  for (auto& p : fs::directory_iterator(dir)) {
+    if (p.is_regular_file()) {
+      if (std::regex_match(p.path().filename().string(), pattern)) {
+        files.push_back(p.path());
+      }
+    }
+  }
+  return files;
+}
+
 std::vector<fs::path> find_files_recursively(const fs::path& base_dir, const std::regex& pattern) {
   std::vector<fs::path> files = {};
   for (auto& p : fs::recursive_directory_iterator(base_dir)) {

--- a/common/util/FileUtil.h
+++ b/common/util/FileUtil.h
@@ -62,6 +62,7 @@ void assert_file_exists(const char* path, const char* error_message);
 bool dgo_header_is_compressed(const std::vector<u8>& data);
 std::vector<u8> decompress_dgo(const std::vector<u8>& data_in);
 FILE* open_file(const fs::path& path, const std::string& mode);
+std::vector<fs::path> find_files_in_dir(const fs::path& dir, const std::regex& pattern);
 std::vector<fs::path> find_files_recursively(const fs::path& base_dir, const std::regex& pattern);
 std::vector<fs::path> find_directories_in_dir(const fs::path& base_dir);
 std::vector<fs::path> sort_filepaths(const std::vector<fs::path>& paths, const bool aescending);


### PR DESCRIPTION
Small improvement to prevent accidental file deletion.  Shouldn't really happen for the normal `jak-project` logs.  But the LSP for example takes a log-file path, if you put that as your root directory that could cause issues, atleast performance ones (it currently doesn't rotate but that's an unrelated bool that could be flipped without realizing/forgetting about this).

So just look at the immediate directory contents for the expected logs.