### PR TITLE
[jak1] Fix texture-related custom level crash

### DIFF
--- a/goal_src/jak1/engine/gfx/texture/texture.gc
+++ b/goal_src/jak1/engine/gfx/texture/texture.gc
@@ -2492,7 +2492,12 @@
     )
   )
 
-(when (not *debug-segment*)
+;; modified for PC port: never bother with the debug-mode texture login.
+;; it will never work on PC, and it causes problems with custom levels, due to the way that it allocates the link
+;; array for texture-pages that don't exist, which are never then set to false, causing them to be referenced
+;; after the level is unloaded. This probably works fine if you are playing one level at a time, or if the backup
+;; texture page loading actually works.
+(when (or (not *debug-segment*) PC_PORT)
   ;; when not debugging, use the "fast" logins. There's no way we can load a texture over the network anyway.
   (set! adgif-shader-login adgif-shader-login-fast)
   (set! adgif-shader-login-no-remap adgif-shader-login-no-remap-fast)

--- a/goalc/build_level/build_level.cpp
+++ b/goalc/build_level/build_level.cpp
@@ -3,6 +3,7 @@
 #include "common/util/FileUtil.h"
 #include "common/util/compress.h"
 #include "common/util/json_util.h"
+#include "common/util/string_util.h"
 
 #include "goalc/build_level/Entity.h"
 #include "goalc/build_level/FileInfo.h"
@@ -25,8 +26,8 @@ void save_pc_data(const std::string& nickname,
   print_memory_usage(data, ser.get_save_result().second);
   lg::print("compressed: {} -> {} ({:.2f}%)\n", ser.get_save_result().second, compressed.size(),
             100.f * compressed.size() / ser.get_save_result().second);
-  file_util::write_binary_file(fr3_output_dir / fmt::format("{}.fr3", nickname), compressed.data(),
-                               compressed.size());
+  file_util::write_binary_file(fr3_output_dir / fmt::format("{}.fr3", str_util::to_upper(nickname)),
+                               compressed.data(), compressed.size());
 }
 
 std::vector<std::string> get_build_level_deps(const std::string& input_file) {


### PR DESCRIPTION
Force FR3 file name for custom levels to be uppercase, fixes the crash described in 
https://github.com/open-goal/jak-project/issues/2534
and 
https://github.com/open-goal/jak-project/issues/2897