### PR TITLE
[jak2] small minor fixes

### DIFF
--- a/game/kernel/jak2/kmachine.cpp
+++ b/game/kernel/jak2/kmachine.cpp
@@ -37,6 +37,7 @@
 #include "game/kernel/jak2/kscheme.h"
 #include "game/kernel/jak2/ksound.h"
 #include "game/overlord/jak2/iso.h"
+#include "game/sce/deci2.h"
 #include "game/sce/libdma.h"
 #include "game/sce/libgraph.h"
 #include "game/sce/sif_ee.h"
@@ -393,6 +394,9 @@ int InitMachine() {
   // }
   if (MasterDebug) {
     InitGoalProto();
+  } else {
+    // shut down the deci2 stuff, we don't need it.
+    ee::sceDeci2Disable();
   }
 
   printf("InitSound\n");

--- a/goal_src/jak1/pc/pckernel-h.gc
+++ b/goal_src/jak1/pc/pckernel-h.gc
@@ -328,9 +328,10 @@
   (set! (-> obj vsync?) #t)
   (set! (-> obj letterbox?) #t)
 
-  ;; get screen size and set to borderless at screen res
+  ;; get screen size and set to borderless at screen res (if retail)
   (pc-get-active-display-size (&-> obj width) (&-> obj height))
-  (set-display-mode! obj 'borderless call-handlers)
+  (if (not *debug-segment*)
+      (set-display-mode! obj 'borderless call-handlers))
   (set! (-> obj gfx-msaa) PC_DEFAULT_MSAA) ;; default msaa
   0)
 

--- a/goal_src/jak2/engine/ui/bigmap.gc
+++ b/goal_src/jak2/engine/ui/bigmap.gc
@@ -347,7 +347,7 @@
       )
     (dma-buffer-add-gs-set arg0
                            (tex0-1 (new 'static 'gs-tex0 :tbp0 #x8 :tbw #x8 :psm #x13 :tw #x9 :th #x9 :cld #x1))
-                           (tex1-1 (new 'static 'gs-tex1))
+                           (tex1-1 (new 'static 'gs-tex1 :mmag #x1 :mmin #x1)) ;; pc port note : originally mmag and mmin 0
                            (texflush 1)
                            )
     (sprite-dma obj arg0 (-> obj x0) (-> obj y0) (-> obj x1) (-> obj y2))
@@ -400,7 +400,7 @@
       )
     (dma-buffer-add-gs-set arg0
                            (tex0-1 (new 'static 'gs-tex0 :tbp0 #x8 :tbw #x8 :psm #x13 :tw #x9 :th #x9 :cld #x1))
-                           (tex1-1 (new 'static 'gs-tex1))
+                           (tex1-1 (new 'static 'gs-tex1 :mmag #x1 :mmin #x1)) ;; pc port note : originally mmag and mmin 0
                            (texflush 1)
                            )
     (sprite-dma obj arg0 (-> obj x0) (-> obj y0) (-> obj x1) (-> obj y2))


### PR DESCRIPTION
- fix deci2 hang when closing the game in retail mode.
- change bigmap to always filter because the pixels look really ugly.
- don't start the game in fullscreen by default if we're debugging.