### PR TITLE
[jak2] fix glow sprite flickering

### DIFF
--- a/game/graphics/opengl_renderer/sprite/GlowRenderer.cpp
+++ b/game/graphics/opengl_renderer/sprite/GlowRenderer.cpp
@@ -539,6 +539,8 @@ void GlowRenderer::draw_probes(SharedRenderState* render_state,
   glBindVertexArray(m_ogl.vao);
   glEnable(GL_PRIMITIVE_RESTART);
   glPrimitiveRestartIndex(UINT32_MAX);
+  // don't want to write to the depth buffer we just copied, just test against it.
+  glDepthMask(GL_FALSE);
   GLint old_viewport[4];
   glGetIntegerv(GL_VIEWPORT, old_viewport);
   glViewport(0, 0, m_ogl.probe_fbo_w, m_ogl.probe_fbo_h);


### PR DESCRIPTION
oops, forgot to set `glDepthMask`, so sometimes it was enabled, and the drawing for the clear was writing into the depth buffer.
Fixes https://github.com/open-goal/jak-project/issues/2735