### PR TITLE
[jak2] fix a few silly texture bugs

### DIFF
--- a/game/graphics/opengl_renderer/DirectRenderer.h
+++ b/game/graphics/opengl_renderer/DirectRenderer.h
@@ -81,7 +81,11 @@ class DirectRenderer : public BucketRenderer {
   void handle_rgbaq(u64 val);
   void handle_xyzf2(u64 val, SharedRenderState* render_state, ScopedProfilerNode& prof);
   void lookup_textures_again(SharedRenderState* render_state);
-  void reinit_hack() { m_prim_gl_state_needs_gl_update = true; }
+  void reinitialize_gl_state() {
+    m_prim_gl_state_needs_gl_update = true;
+    m_test_state_needs_gl_update = true;
+    m_blend_state_needs_gl_update = true;
+  }
 
  protected:
   virtual void handle_frame(u64 val, SharedRenderState* render_state, ScopedProfilerNode& prof);

--- a/game/graphics/opengl_renderer/TextureAnimator.cpp
+++ b/game/graphics/opengl_renderer/TextureAnimator.cpp
@@ -108,6 +108,8 @@ GLuint OpenGLTexturePool::allocate(u64 w, u64 h) {
     lg::warn("OpenGLTexturePool creating texture for {} x {}", w, h);
     GLuint slot;
     glGenTextures(1, &slot);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, slot);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, nullptr);
     return slot;
   }

--- a/game/graphics/opengl_renderer/TextureUploadHandler.cpp
+++ b/game/graphics/opengl_renderer/TextureUploadHandler.cpp
@@ -49,7 +49,7 @@ void TextureUploadHandler::render(DmaFollower& dma,
                                                      render_state->frame_idx);
         if (m_direct) {
           m_direct->lookup_textures_again(render_state);
-          m_direct->reinit_hack();
+          m_direct->reinitialize_gl_state();
         }
       }
     }
@@ -115,4 +115,7 @@ void TextureUploadHandler::flush_uploads(std::vector<TextureUpload>& uploads,
 void TextureUploadHandler::draw_debug_window() {
   ImGui::Checkbox("Fake Uploads", &m_fake_uploads);
   ImGui::Text("Uploads: %d", m_upload_count);
+  if (m_direct) {
+    m_direct->draw_debug_window();
+  }
 }

--- a/goal_src/jak2/pc/pckernel.gc
+++ b/goal_src/jak2/pc/pckernel.gc
@@ -83,7 +83,7 @@
 
 (defmethod initialize pc-settings-jak2 ((obj pc-settings-jak2))
   "initial initialize method to be run after allocating"
-  
+
   (set! (-> obj music-unlocked) (new 'global 'bit-array (-> *music-player-tracks* length)))
   ((method-of-type pc-settings initialize) obj)
   obj)
@@ -240,7 +240,7 @@
       (clear-cheat-state-flag! turbo-board)
       )
     )
-  
+
   (pc-set-gfx-hack (pc-gfx-hack no-tex) (pc-cheats? (-> obj cheats) no-textures))
 
   ;; run cheats end!!!
@@ -258,7 +258,7 @@
       (set-bit (-> obj music-unlocked) i)
       )
     )
-  
+
   (true! (-> obj flava-unlocked 0)) ;; default always unlocked
   (if (task-node-closed? (game-task-node city-red-gun-training-resolution)) (true! (-> obj flava-unlocked 1))) ;; gun
   (if (task-node-closed? (game-task-node forest-scouts-resolution)) (true! (-> obj flava-unlocked 2))) ;; board
@@ -327,7 +327,7 @@
 
 (defmethod handle-output-settings pc-settings-jak2 ((obj pc-settings-jak2) (file file-stream))
   "handle the text writing output for the 'settings' group"
-  
+
   ((method-of-type pc-settings handle-output-settings) obj file)
   (format file "  (jetboard-trick-text? ~A)~%" (-> obj jetboard-trick-text?))
   (format file "  (fast-airlock? ~A)~%" (-> obj fast-airlock?))
@@ -365,12 +365,18 @@
 
 (defun draw-build-revision ()
   (with-dma-buffer-add-bucket ((buf (-> (current-frame) global-buf))
-                                     (bucket-id debug-no-zbuf1))
-          (draw-string-xy *pc-settings-built-sha*
-                          buf
-                          512 14
-                          (font-color flat-yellow)
-                          (font-flags right shadow kerning))))
+                               (bucket-id debug-no-zbuf1))
+    ;; reset bucket settings prior to drawing - font won't do this for us, and
+    ;; draw-raw-image can sometimes mess them up.
+    (dma-buffer-add-gs-set-flusha buf
+                                  (alpha-1 (new 'static 'gs-alpha :b #x1 :d #x1))
+                                  (tex1-1 (new 'static 'gs-tex1 :mmag #x1 :mmin #x1))
+                                  )
+    (draw-string-xy *pc-settings-built-sha*
+                    buf
+                    512 14
+                    (font-color flat-yellow)
+                    (font-flags right shadow kerning))))
 
 
 


### PR DESCRIPTION
Fix an issue where the commit sha would not use the right blending mode if `draw-raw-image` is running at the same time.
Fix an issue where japanese subtitles would accidentally overwrite other textures, leading to random textures missing. (in particular, glows would disappear after watching a cutscene with the subtitles on)