### PR TITLE
ckernel: fix file paths for art groups and tpages

### DIFF
--- a/game/kernel/jak1/fileio.cpp
+++ b/game/kernel/jak1/fileio.cpp
@@ -92,12 +92,12 @@ char* MakeFileName(int type, const char* name, int new_string) {
     // GOAL object file, but containing data instead of code.
     // likely packed by a tool that isn't the GOAL compiler.
     // sprintf(buf, "%sdata/%s.go", prefix, name);
-    sprintf(buf, "%sout/obj/%s.go", prefix, name);
+    sprintf(buf, "%sout/jak1/obj/%s.go", prefix, name);
   } else if (type == TX_PAGE_FILE_TYPE) {
     // Texture Page
     // part of level files, so it has a version number.
     // sprintf(buf, "%sdata/texture-page%d/%s.go", prefix, TX_PAGE_VERSION, name);
-    sprintf(buf, "%sout/obj/%s.go", prefix, name);
+    sprintf(buf, "%sout/jak1/obj/%s.go", prefix, name);
   } else if (type == JA_FILE_TYPE) {
     // Art JA (joint animation? no idea)
     // part of level files, so it has a version number

--- a/game/kernel/jak2/fileio.cpp
+++ b/game/kernel/jak2/fileio.cpp
@@ -96,12 +96,12 @@ char* MakeFileName(int type, const char* name, int new_string) {
     // GOAL object file, but containing data instead of code.
     // likely packed by a tool that isn't the GOAL compiler.
     // sprintf(buf, "%sfinal/%s.go", prefix, name);
-    sprintf(buf, "%sout/obj/%s.go", prefix, name);
+    sprintf(buf, "%sout/jak2/obj/%s.go", prefix, name);
   } else if (type == TX_PAGE_FILE_TYPE) {
     // Texture Page
     // part of level files, so it has a version number.
     // sprintf(buf, "%sdata/texture-page%d/%s.go", prefix, TX_PAGE_VERSION, name);
-    sprintf(buf, "%sout/obj/%s.go", prefix, name);
+    sprintf(buf, "%sout/jak2/obj/%s.go", prefix, name);
   } else if (type == JA_FILE_TYPE) {
     // Art JA (joint animation? no idea)
     // part of level files, so it has a version number

--- a/test/test_kernel_jak1.cpp
+++ b/test/test_kernel_jak1.cpp
@@ -115,7 +115,7 @@ TEST(Kernel, basename) {
 TEST(Kernel, DecodeFileName) {
   std::string x;
   x = DecodeFileName("$TEXTURE/beans");
-  EXPECT_EQ(x, "out/obj/beans.go");
+  EXPECT_EQ(x, "out/jak1/obj/beans.go");
 
   x = DecodeFileName("$ART_GROUP/stuff");
   EXPECT_EQ(x, "data/art-group6/stuff-ag.go");

--- a/test/test_kernel_jak1.cpp
+++ b/test/test_kernel_jak1.cpp
@@ -127,7 +127,7 @@ TEST(Kernel, DecodeFileName) {
   EXPECT_EQ(x, "data/level30/my-level.123");
 
   x = DecodeFileName("$DATA/my-data");
-  EXPECT_EQ(x, "out/obj/my-data.go");
+  EXPECT_EQ(x, "out/jak1/obj/my-data.go");
 
   x = DecodeFileName("$CODE/my-code");
   EXPECT_EQ(x, "game/obj/my-code.o");


### PR DESCRIPTION
Ever since we started splitting files up by game version in #1559, these file paths were broken, so whenever the game tried to link art group files, you would get this error because the file is actually located in `out/jak1/obj`:
```
dkernel: file read !open 'out/obj/plat-ag.go' (-1)
ERROR: art-group "plat" is not a valid file.
****** CALL TO loado(plat-ag) ******
[SCE] sceOpen(jak-project/out/obj/plat-ag.go) failed.
```
This was a particular problem in custom levels, causing actors like platforms to not show up.