### PR TITLE
various subtitle editor fixes

### DIFF
--- a/game/tools/subtitle_editor/subtitle_editor.cpp
+++ b/game/tools/subtitle_editor/subtitle_editor.cpp
@@ -240,9 +240,15 @@ void SubtitleEditor::draw_scene_section_header(const bool non_cutscenes) {
           new_scene.m_hint_id = 0;
         }
         m_subtitle_db.m_banks.at(m_current_language)->m_scenes.emplace(m_new_scene_name, new_scene);
+        if (m_new_scene_as_current) {
+          m_current_scene =
+              &m_subtitle_db.m_banks.at(m_current_language)->m_scenes.at(m_new_scene_name);
+        }
+
         m_new_scene_name = "";
       }
-      ImGui::NewLine();
+      ImGui::SameLine();
+      ImGui::Checkbox("Set Scene as Current", &m_new_scene_as_current);
     }
     ImGui::TreePop();
   }

--- a/game/tools/subtitle_editor/subtitle_editor.cpp
+++ b/game/tools/subtitle_editor/subtitle_editor.cpp
@@ -99,7 +99,11 @@ void SubtitleEditor::draw_window() {
   } else {
     ImGui::PushStyleColor(ImGuiCol_Text, m_selected_text_color);
   }
-  if (ImGui::TreeNode("Currently Selected Cutscene")) {
+  if (ImGui::TreeNode(
+          "current_scene", "%s",
+          m_current_scene
+              ? fmt::format("Currently Selected Scene - {}", m_current_scene->m_name).c_str()
+              : "Currently Selected Scene")) {
     ImGui::PopStyleColor();
     if (m_current_scene) {
       draw_subtitle_options(*m_current_scene, true);
@@ -367,21 +371,23 @@ std::string SubtitleEditor::subtitle_line_summary(
   // V1
   if (is_v1_format()) {
     if (line.text.empty()) {
-      return fmt::format("{}] {}", info_header, line_text);
+      return fmt::format("[{}] {}", line_meta.frame_start, line_text);
+    } else {
+      return fmt::format(
+          "[{}] {}: {}", line_meta.frame_start,
+          m_subtitle_db.m_banks[m_current_language]->m_speakers.at(line_meta.speaker), line_text);
     }
-    return fmt::format("{}] {} - '{}'", info_header,
-                       m_subtitle_db.m_banks[m_current_language]->m_speakers.at(line_meta.speaker),
-                       line_text);
   }
   // V2
-  if (line_meta.merge) {
-    return fmt::format("{}-{}] {} - {}", info_header, line_meta.frame_end,
-                       m_subtitle_db.m_banks[m_current_language]->m_speakers.at(line_meta.speaker),
+  else {
+    auto speaker_text =
+        line_meta.speaker == "none"
+            ? ""
+            : fmt::format("{}: ", m_subtitle_db.m_banks[m_current_language]->m_speakers.at(
+                                       line_meta.speaker));
+    return fmt::format("[{}-{}] {}{}", line_meta.frame_start, line_meta.frame_end, speaker_text,
                        line_text);
   }
-  return fmt::format("{}-{}] {} - '{}'", info_header, line_meta.frame_end,
-                     m_subtitle_db.m_banks[m_current_language]->m_speakers.at(line_meta.speaker),
-                     line_text);
 }
 
 void SubtitleEditor::draw_subtitle_options(GameSubtitleSceneInfo& scene, bool current_scene) {

--- a/game/tools/subtitle_editor/subtitle_editor.cpp
+++ b/game/tools/subtitle_editor/subtitle_editor.cpp
@@ -207,6 +207,8 @@ void SubtitleEditor::draw_speaker_options() {
     const auto& bank = m_subtitle_db.m_banks[m_current_language];
     for (auto& [speaker_id, speaker_localized] : bank->m_speakers) {
       if (speaker_id == "none") {
+        // this is a special speaker that has ID zero and does not appear in-game
+        // it means there was no speaker for the line. (e.g. text-only, not vocal)
         continue;
       }
       // Insertion or deletion not needed here as it has to be wired up in .gc and C++ code

--- a/game/tools/subtitle_editor/subtitle_editor.cpp
+++ b/game/tools/subtitle_editor/subtitle_editor.cpp
@@ -384,7 +384,7 @@ std::string SubtitleEditor::subtitle_line_summary(
         line_meta.speaker == "none"
             ? ""
             : fmt::format("{}: ", m_subtitle_db.m_banks[m_current_language]->m_speakers.at(
-                                       line_meta.speaker));
+                                      line_meta.speaker));
     return fmt::format("[{}-{}] {}{}", line_meta.frame_start, line_meta.frame_end, speaker_text,
                        line_text);
   }
@@ -477,8 +477,7 @@ void SubtitleEditor::draw_subtitle_options(GameSubtitleSceneInfo& scene, bool cu
           }
           ImGui::EndCombo();
         }
-        ImGui::InputText("Text", &line_text,
-                         line_meta.merge ? ImGuiInputTextFlags_ReadOnly : 0);
+        ImGui::InputText("Text", &line_text, line_meta.merge ? ImGuiInputTextFlags_ReadOnly : 0);
         ImGui::Checkbox("Offscreen?", &subtitle_line->metadata.offscreen);
         if (!is_v1_format()) {
           ImGui::SameLine();

--- a/game/tools/subtitle_editor/subtitle_editor.h
+++ b/game/tools/subtitle_editor/subtitle_editor.h
@@ -67,6 +67,7 @@ class SubtitleEditor {
   bool m_current_scene_offscreen = false;
   bool m_current_scene_merge = false;
 
+  bool m_new_scene_as_current = true;
   std::string m_new_scene_name = "";
   std::string m_new_scene_id = "0";
 

--- a/goalc/data_compiler/game_text_common.cpp
+++ b/goalc/data_compiler/game_text_common.cpp
@@ -99,7 +99,6 @@ void compile_text(GameTextDB& db, const std::string& output_prefix) {
  */
 void compile_subtitles_v1(GameSubtitleDB& db, const std::string& output_prefix) {
   for (const auto& [lang, bank] : db.m_banks) {
-
     // get font encoding information
     auto font = get_font_bank(bank->m_text_version);
 

--- a/goalc/data_compiler/game_text_common.cpp
+++ b/goalc/data_compiler/game_text_common.cpp
@@ -99,7 +99,18 @@ void compile_text(GameTextDB& db, const std::string& output_prefix) {
  */
 void compile_subtitles_v1(GameSubtitleDB& db, const std::string& output_prefix) {
   for (const auto& [lang, bank] : db.m_banks) {
+
+    // get font encoding information
     auto font = get_font_bank(bank->m_text_version);
+
+    // convert speakers once.
+    auto speakers_converted = bank->m_speakers;
+    for (auto& [id, name] : speakers_converted) {
+      // convert name in-place. we copied the map earlier so this is safe.
+      // the subtitle lines have the speaker "id" stored in them, which is the map key here.
+      name = font->convert_utf8_to_game(name);
+    }
+
     DataObjectGenerator gen;
     gen.add_type_tag("subtitle-text-info");  // type
     gen.add_word(bank->m_scenes.size());     // length
@@ -128,9 +139,18 @@ void compile_subtitles_v1(GameSubtitleDB& db, const std::string& output_prefix) 
       for (auto& subtitle : scene.m_lines) {
         gen.add_word(subtitle.metadata.frame_start);                               // frame
         gen.add_ref_to_string_in_pool(font->convert_utf8_to_game(subtitle.text));  // line
-        gen.add_ref_to_string_in_pool(
-            font->convert_utf8_to_game(subtitle.metadata.speaker));  // speaker
-        gen.add_word(subtitle.metadata.offscreen);                   // offscreen
+        // speaker
+        if (subtitle.metadata.speaker.empty()) {
+          gen.add_ref_to_string_in_pool("");
+        } else {
+          auto it = speakers_converted.find(subtitle.metadata.speaker);
+          if (it == speakers_converted.end()) {
+            throw std::runtime_error(fmt::format("in file `{}`: could not find speaker {}",
+                                                 bank->m_file_path, subtitle.metadata.speaker));
+          }
+          gen.add_ref_to_string_in_pool(it->second);
+        }
+        gen.add_word(subtitle.metadata.offscreen);  // offscreen
       }
     }
 


### PR DESCRIPTION
- fix speaker names and time frames being uneditable in Jak 1
- added toggle to auto-selected a newly created scene as current
- changed the subtitle summary format slightly.
- current scene's name now appears in the UI