### PR TITLE
[sprite3] fix max sprite number being wrong

### DIFF
--- a/game/graphics/opengl_renderer/sprite/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/sprite/Sprite3.cpp
@@ -34,7 +34,7 @@ u32 process_sprite_chunk_header(DmaFollower& dma) {
   return header[0];
 }
 
-constexpr int SPRITE_RENDERER_MAX_SPRITES = 1920 * 10;
+constexpr int SPRITE_RENDERER_MAX_SPRITES = 1920 * 12;
 }  // namespace
 
 Sprite3::Sprite3(const std::string& name, int my_id)


### PR DESCRIPTION
I don't think this fixes anything, but the number was wrong so might as well fix it.