### PR TITLE
CI: check for removed goal_src code that we want or need to perserve

### DIFF
--- a/.github/workflows/inform-pages-repo.yaml
+++ b/.github/workflows/inform-pages-repo.yaml
@@ -25,11 +25,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Package Dependencies
-        run: >
-          sudo apt install build-essential cmake
-          clang gcc g++ lcov make nasm libxrandr-dev
-          libxinerama-dev libxcursor-dev libpulse-dev
-          libxi-dev zip ninja-build
+        run: |
+          sudo apt update
+          sudo apt install build-essential cmake \
+            clang gcc g++ lcov make nasm libxrandr-dev \
+            libxinerama-dev libxcursor-dev libpulse-dev \
+            libxi-dev zip ninja-build libgl1-mesa-dev
 
       - name: Setup Buildcache
         uses: mikehardy/buildcache-action@v2.1.0

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -41,12 +41,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Python Dependencies
-        run: pip install pydriller colorama
+        run: pip install unidiff colorama
 
       - name: Check for Removed goal_src/ Code
         # FYI - if you run this `git diff` on windows, it creates a utf-16 LE file
         run: |
-          git diff master > lint-changes.diff
+          git fetch origin
+          git diff origin/master > lint-changes.diff
           python ./scripts/ci/lint-gsrc-removals.py
 
       - name: Check for Unresolved Conflicts

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -40,6 +40,15 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
+      - name: Install Python Dependencies
+        run: pip install pydriller colorama
+
+      - name: Check for Removed goal_src/ Code
+        # FYI - if you run this `git diff` on windows, it creates a utf-16 LE file
+        run: |
+          git diff master > lint-changes.diff
+          python ./scripts/ci/lint-gsrc-removals.py
+
       - name: Check for Unresolved Conflicts
         run: python ./scripts/gsrc/check-for-conflicts.py
 

--- a/.github/workflows/linux-build-clang.yaml
+++ b/.github/workflows/linux-build-clang.yaml
@@ -32,11 +32,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Package Dependencies
-        run: >
-          sudo apt install build-essential cmake
-          clang gcc g++ lcov make nasm libxrandr-dev
-          libxinerama-dev libxcursor-dev libpulse-dev
-          libxi-dev zip ninja-build libgl1-mesa-dev
+        run: |
+          sudo apt update
+          sudo apt install build-essential cmake \
+            clang gcc g++ lcov make nasm libxrandr-dev \
+            libxinerama-dev libxcursor-dev libpulse-dev \
+            libxi-dev zip ninja-build libgl1-mesa-dev
 
       - name: Setup Buildcache
         uses: mikehardy/buildcache-action@v2.1.0

--- a/.github/workflows/linux-build-gcc.yaml
+++ b/.github/workflows/linux-build-gcc.yaml
@@ -28,11 +28,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Package Dependencies
-        run: >
-          sudo apt install build-essential cmake
-          clang gcc g++ lcov make nasm libxrandr-dev
-          libxinerama-dev libxcursor-dev libpulse-dev
-          libxi-dev zip ninja-build libgl1-mesa-dev
+        run: |
+          sudo apt update
+          sudo apt install build-essential cmake \
+            clang gcc g++ lcov make nasm libxrandr-dev \
+            libxinerama-dev libxcursor-dev libpulse-dev \
+            libxi-dev zip ninja-build libgl1-mesa-dev
 
       - name: Setup Buildcache
         uses: mikehardy/buildcache-action@v2.1.0

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ __pycache__/
 /jak2-*.json
 /TODO.md
 unifont-15.0.03.ttf
+*.diff

--- a/.vscode/opengoal.code-snippets
+++ b/.vscode/opengoal.code-snippets
@@ -17,12 +17,6 @@
     "body": [";; og:ignore-form:${1:substr}"],
     "description": "If the provided substr is found in the starting line of a form, the entire form will be omitted when copying decompiled code into the file"
   },
-  "og:update-with-merge": {
-		"scope": "opengoal",
-    "prefix": ["og:update-with-merge"],
-    "body": [";; og:update-with-merge"],
-    "description": "The file will be updated with a git merge-file instead of naive copy-paste"
-  },
   "og:preserve-this": {
 		"scope": "opengoal",
     "prefix": ["og:preserve-this"],

--- a/goal_src/jak1/engine/common-obs/generic-obs.gc
+++ b/goal_src/jak1/engine/common-obs/generic-obs.gc
@@ -538,6 +538,7 @@
     ((nonzero? (-> self skel))
      (set! (-> self new-joint-anim) (ja-group))
      (set! (-> self anim-mode) 'loop)
+     ;; og:preserve-this
      (#when PC_PORT
        (set! (-> self skel postbind-function) process-drawable-joint-callback-pc))
      )

--- a/goal_src/jak1/engine/common-obs/generic-obs.gc
+++ b/goal_src/jak1/engine/common-obs/generic-obs.gc
@@ -538,7 +538,6 @@
     ((nonzero? (-> self skel))
      (set! (-> self new-joint-anim) (ja-group))
      (set! (-> self anim-mode) 'loop)
-     ;; og:preserve-this
      (#when PC_PORT
        (set! (-> self skel postbind-function) process-drawable-joint-callback-pc))
      )

--- a/goal_src/jak2/engine/collide/collide-mesh.gc
+++ b/goal_src/jak2/engine/collide/collide-mesh.gc
@@ -25,8 +25,6 @@ a single mesh, so it's limited to tests like single foreground mesh vs. sphere.
 Another limitation is that triangles don't have per-tri pat info.
 |#
 
-;; og:update-with-merge
-
 ;; DECOMP BEGINS
 
 

--- a/goal_src/jak2/levels/castle/castle-obs.gc
+++ b/goal_src/jak2/levels/castle/castle-obs.gc
@@ -5,8 +5,6 @@
 ;; name in dgo: castle-obs
 ;; dgos: CAS
 
-;; og:update-with-merge:substr
-
 ;; DECOMP BEGINS
 
 (define *cas-conveyor-room-id* 0)

--- a/goal_src/jak2/levels/city/helldog/helldog.gc
+++ b/goal_src/jak2/levels/city/helldog/helldog.gc
@@ -13,8 +13,6 @@
    )
   )
 
-;; og:update-with-merge
-
 ;; DECOMP BEGINS
 
 (defmethod draw hud-helldog ((obj hud-helldog))

--- a/goal_src/jak2/levels/city/palace/ctypal-obs.gc
+++ b/goal_src/jak2/levels/city/palace/ctypal-obs.gc
@@ -5,8 +5,6 @@
 ;; name in dgo: ctypal-obs
 ;; dgos: CPA
 
-;; og:update-with-merge:substr
-
 ;; DECOMP BEGINS
 
 (deftype water-anim-ctypal (water-anim)

--- a/goal_src/jak2/levels/common/airlock.gc
+++ b/goal_src/jak2/levels/common/airlock.gc
@@ -5,8 +5,6 @@
 ;; name in dgo: airlock
 ;; dgos: GAME, COMMON
 
-;; og:update-with-merge
-
 ;; DECOMP BEGINS
 
 (deftype com-airlock (process-drawable)

--- a/goal_src/jak2/levels/palace/pal-obs.gc
+++ b/goal_src/jak2/levels/palace/pal-obs.gc
@@ -5,8 +5,6 @@
 ;; name in dgo: pal-obs
 ;; dgos: PAE, PAC
 
-;; og:update-with-merge:substr
-
 ;; DECOMP BEGINS
 
 (deftype pal-falling-plat (process-drawable)

--- a/scripts/ci/lint-gsrc-removals.py
+++ b/scripts/ci/lint-gsrc-removals.py
@@ -1,0 +1,51 @@
+# Gets the diff between this PR and `origin/master`
+# If there are any 'og:preserve-this' lines removed, the script returns 1
+
+import unidiff
+from colorama import Fore
+
+with open("lint-changes.diff", encoding="utf-8") as f:
+    diff = f.read()
+
+patch_set = unidiff.PatchSet.from_string(diff)
+
+flagged_deletions = []
+
+for patched_file in patch_set:
+    file_path = patched_file.path
+    for hunk in patched_file:
+        for line in hunk:
+            if line.is_removed and "og:preserve-this" in line.value.strip():
+                flagged_deletions.append(
+                    {
+                        "file": file_path,
+                        "line_num": line.source_line_no,
+                        "deletion": line.value.strip(),
+                    }
+                )
+
+print(flagged_deletions)
+
+if len(flagged_deletions) > 0:
+    print(
+        Fore.RED
+        + "Flagged goal_src code has been deleted, either you made a mistake or you better know what you're doing!" + Fore.RESET
+    )
+    for flagged_deletion in flagged_deletions:
+        print(
+            "  - {}{}{}:{}{}{} - {}{}{}".format(
+                Fore.CYAN,
+                flagged_deletion["file"],
+                Fore.RESET,
+                Fore.GREEN,
+                flagged_deletion["line_num"],
+                Fore.RESET,
+                Fore.RED,
+                flagged_deletion["deletion"],
+                Fore.RESET,
+            )
+        )
+    print(Fore.RESET)
+    exit(1)
+print("No flagged goal_src code was deleted (hopefully!)")
+exit(0)


### PR DESCRIPTION
This is something that's caught us a few times, code is patched and then accidentally removed when doing a big decompilation or cleanup pass.  By flagging such patches with `og:preserve-this` comments, The CI will pick up on them, fail loudly, and it can either be merged anyway or be fixed before merging -- avoiding a regression.