### PR TITLE
[jak2] ckernel: implement `loado` and `load_and_link`

### DIFF
--- a/game/kernel/jak2/kscheme.h
+++ b/game/kernel/jak2/kscheme.h
@@ -3,6 +3,7 @@
 
 #include "game/kernel/common/Ptr.h"
 #include "game/kernel/common/Symbol4.h"
+#include "game/kernel/common/kmalloc.h"
 #include "game/kernel/common/kscheme.h"
 
 namespace jak2 {
@@ -56,6 +57,7 @@ u64 load(u32 file_name_in, u32 heap_in);
 u64 loadb(u32 file_name_in, u32 heap_in, u32 param3);
 u64 loado(u32 file_name_in, u32 heap_in);
 u64 unload(u32 name);
+s64 load_and_link(const char* filename, char* decode_name, kheapinfo* heap, u32 flags);
 u64 call_method_of_type(u32 arg, Ptr<Type> type, u32 method_id);
 u64 call_goal_function_by_name(const char* name);
 u64 alloc_heap_memory(u32 heap, u32 size);

--- a/goal_src/jak2/engine/load/file-io.gc
+++ b/goal_src/jak2/engine/load/file-io.gc
@@ -151,19 +151,21 @@ NOTE: this is a special type in three ways:
      (format *file-temp-string* "map~D/~S-mp" MAP_FILE_VERSION arg1)
      )
     ((= arg0 (file-kind art-group))
-     (format
-       *file-temp-string*
-       "art-group~D/~S-ag"
-       (cond
-         ((> arg2 0)
-          arg2
-          )
-         (else
-           ART_GROUP_FILE_VERSION
-           )
-         )
-       arg1
-       )
+     ;; og:preserve-this removed art-group prefix
+     ; (format
+     ;   *file-temp-string*
+     ;   "art-group~D/~S-ag"
+     ;   (cond
+     ;     ((> arg2 0)
+     ;      arg2
+     ;      )
+     ;     (else
+     ;       ART_GROUP_FILE_VERSION
+     ;       )
+     ;     )
+     ;   arg1
+     ;   )
+     (format *file-temp-string* "~S-ag" arg1)
      )
     )
   *file-temp-string*


### PR DESCRIPTION
These two functions were stubbed out in the Jak 2 C kernel, making it not possible to dynamically link art groups when e.g. manually spawning `process-drawable`s.

I copied them from Jak 1 verbatim and they seem to work fine.