### PR TITLE
g/j2: don't force auto-save on in jak 2 when starting a speedrun

### DIFF
--- a/goal_src/jak2/pc/features/speedruns.gc
+++ b/goal_src/jak2/pc/features/speedruns.gc
@@ -20,9 +20,6 @@
       (initialize! *game-info* 'game (the-as game-save #f) "game-start"))
     (((speedrun-category newgame-heromode))
       (initialize! *game-info* 'game (the-as game-save #f) "game-start-hero")))
-  ;; enable auto saving by default, no downside on PC
-  ;; this has to come after the `initialize!` call as it sets it to false!
-  (set! (-> *setting-control* user-default auto-save) #t)
   (none))
 
 (defmethod enforce-settings! speedrun-info ((this speedrun-info))

--- a/goal_src/jak2/pc/pckernel.gc
+++ b/goal_src/jak2/pc/pckernel.gc
@@ -138,7 +138,6 @@
 
 (defun vector3-copy!! ((dest vector) (src vector))
   "copy just the xyz fields of src into dest"
-  (declare (print-asm))
   (rlet ((vf0 :class vf)
          (dest-vf :class vf)
          (src-vf :class vf))


### PR DESCRIPTION
This was a copy-paste from jak1's implementation, it's not needed in Jak 2. This fixes a crash when explicitly picking "continue without saving" and the game hits an auto-save trigger.