### PR TITLE
[jak2] new glow fix

### DIFF
--- a/game/graphics/opengl_renderer/shaders/glow_depth_copy.frag
+++ b/game/graphics/opengl_renderer/shaders/glow_depth_copy.frag
@@ -9,7 +9,7 @@ in vec2 tex_coord;
 void main() {
   vec2 texture_coords = vec2(tex_coord.x, tex_coord.y);
   out_color = vec4(0, 0, 0, 0);
-  if (texture_coords.x < 0 || texture_coords.x > 1 || texture_coords.y > 1 || texture_coords.x < 0) {
+  if (texture_coords.x < 0 || texture_coords.x > 1 || texture_coords.y > 1 || texture_coords.y < 0) {
     gl_FragDepth = 1;
   } else {
     gl_FragDepth = texture(tex, texture_coords).r;

--- a/game/graphics/opengl_renderer/sprite/GlowRenderer.cpp
+++ b/game/graphics/opengl_renderer/sprite/GlowRenderer.cpp
@@ -192,7 +192,7 @@ GlowRenderer::GlowRenderer() {
 
   glBindTexture(GL_TEXTURE_2D, m_ogl.probe_fbo_depth_tex);
   glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, m_ogl.probe_fbo_w, m_ogl.probe_fbo_h, 0,
-               GL_DEPTH_COMPONENT, GL_FLOAT, NULL);
+               GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL);
   glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
                          m_ogl.probe_fbo_depth_tex, 0);
 


### PR DESCRIPTION
Fix a typo in the shader. (fixes https://github.com/open-goal/jak-project/issues/3045, and fixes fadeout when glows move offscreen on the bottom).

Also, try a different format for the depth blit, in an attempt to fix this issue https://github.com/open-goal/jak-project/issues/3065.