### PR TITLE
[jak2] fix minor original game visual bugs

### DIFF
--- a/goal_src/jak2/engine/ui/minimap.gc
+++ b/goal_src/jak2/engine/ui/minimap.gc
@@ -833,6 +833,12 @@
                                )
         )
 
+(#when PC_PORT
+;; og:preserve-this fix icon colors
+(set! (-> *minimap-class-list* (minimap-class consite) color) (static-rgba #xff #xff #xff #x80))
+(set! (-> *minimap-class-list* (minimap-class underport) color) (static-rgba #xff #xff #xff #x80))
+)
+
 (let ((gp-0 *minimap*))
   ;; og:preserve-this minimap engine connections raised for pc port
   (set! (-> gp-0 engine) (new 'global 'engine-minimap '*minimap* (#if PC_PORT 256 64) connection-minimap))

--- a/goal_src/jak2/levels/common/race/race-hud.gc
+++ b/goal_src/jak2/levels/common/race/race-hud.gc
@@ -36,9 +36,11 @@
   )
 
 (defmethod update-values hud-race-timer ((this hud-race-timer))
-  (set! (-> this values 0 target) (/ (the-as int (-> *game-info* race-timer)) #x4650))
-  (set! (-> this values 1 target) (/ (mod (the-as int (-> *game-info* race-timer)) #x4650) 300))
-  (set! (-> this values 2 target) (/ (mod (mod (the-as int (-> *game-info* race-timer)) #x4650) 300) 5))
+  (set! (-> this values 0 target) (/ (the-as int (-> *game-info* race-timer)) (seconds 60)))
+  (set! (-> this values 1 target) (/ (mod (the-as int (-> *game-info* race-timer)) (seconds 60)) (seconds 1)))
+  ;(set! (-> this values 2 target) (/ (mod (mod (the-as int (-> *game-info* race-timer)) (seconds 60)) (seconds 1)) (/ (seconds 1) 60)))
+  ;; og:preserve-this fix wrong hundredths counter...
+  (set! (-> this values 2 target) (/ (mod (mod (the-as int (-> *game-info* race-timer)) (seconds 60)) (seconds 1)) (seconds 0.01)))
   (logclear! (-> this flags) (hud-flags disable))
   ((method-of-type hud update-values) this)
   0


### PR DESCRIPTION
Fixes #2994 the underport and consite icons being green (same color as the goal, likely copy-pasta).

Fixes the hundredths timer in the race timer actually being a 60ths timer.