### PR TITLE
Add label_types file merge for PAL version

### DIFF
--- a/decompiler/config/jak2/jak2_config.jsonc
+++ b/decompiler/config/jak2/jak2_config.jsonc
@@ -138,6 +138,7 @@
     "pal": {
       "game_name": "jak2_pal",
       "expected_elf_name": "SCES_516.08",
+      "label_types_merge_file": "decompiler/config/jak2/pal/label_types.jsonc",
       "is_pal": true,
       "object_patches": {}
     },

--- a/decompiler/config/jak2/pal/label_types.jsonc
+++ b/decompiler/config/jak2/pal/label_types.jsonc
@@ -1,5 +1,6 @@
 {
   "progress": [
+    ["L879", "progress-global-state"],
     ["L880", "uint64", true],
     ["L881", "uint64", true],
     ["L882", "uint64", true],


### PR DESCRIPTION
This was added as the progress file's L879 has a different type in the PAL
 version of the game: being 'progress-global-state' rather than 'unit64'.
The difference caused the decompiler to die with a mismatched type error.