### PR TITLE
Fix build failure at llvm-rc on windows due to codepage error on zydis

### DIFF
--- a/third-party/zydis/resources/VersionInfo.rc
+++ b/third-party/zydis/resources/VersionInfo.rc
@@ -47,7 +47,7 @@ BEGIN
             VALUE "FileDescription", "Zyan Disassembler Library"
             VALUE "FileVersion", "4.0.0.0"
             VALUE "InternalName", "Zydis"
-            VALUE "LegalCopyright", "Copyright © 2014-2021 by zyantific.com"
+            VALUE "LegalCopyright", "Copyright (C) 2014-2021 by zyantific.com"
             VALUE "OriginalFilename", "Zydis.dll"
             VALUE "ProductName", "Zyan Disassembler Library"
             VALUE "ProductVersion", "4.0.0.0"


### PR DESCRIPTION
This fix is for the following error when building with llvm on windows

```
[build] llvm-rc: Error in VERSIONINFO statement (ID 1): 
[proc] The command: "C:\Program Files\CMake\bin\cmake.exe" --build C:/.../git/jak-project-test/out/build/Release --parallel 8 exited with code: 1
[build] Non-ASCII 8-bit codepoint (´┐¢) can't be interpreted in the current codepage
[build] ninja: build stopped: subcommand failed.
```

It's caused by llvm-rc not handling non 8-bit characters.
The same issue is discussed in the curl project here
https://github.com/curl/curl/issues/7765

This commit copies the fix from curl, replacing '©' with '(C)'.
