### PR TITLE
ci: Workaround CMake/Perl regression in recent windows-2022 images

### DIFF
--- a/.github/workflows/windows-build-msvc.yaml
+++ b/.github/workflows/windows-build-msvc.yaml
@@ -44,6 +44,12 @@ jobs:
 
       - uses: ilammy/msvc-dev-cmd@v1
 
+      # Fixes an issue with the image causing builds to fail - https://github.com/actions/runner-images/issues/8598
+      - name: Remove Strawberry Perl from PATH
+        run: |
+          $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", ""
+          "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: CMake Generation - MSVC
         shell: cmd
         run: cmake -B build --preset=${{ inputs.cmakePreset }} -DCMAKE_C_COMPILER_LAUNCHER=${{ github.workspace }}/buildcache/bin/buildcache.exe -DCMAKE_CXX_COMPILER_LAUNCHER=${{ github.workspace }}/buildcache/bin/buildcache.exe .


### PR DESCRIPTION
Related to https://github.com/actions/runner-images/issues/8598

For whatever reason, this updating of perl causes cmake to behave totally differently, leading to a consistent failure in SDL.  One glaring difference I noticed was the value of `CMAKE_SYSTEM` was `Windows-6.2.9200` which is for windows 8! instead of what the runners actually use, windows server 2022