### PR TITLE
Fix starting continue point for Hub 2/3 category extensions

### DIFF
--- a/goal_src/jak1/pc/features/speedruns.gc
+++ b/goal_src/jak1/pc/features/speedruns.gc
@@ -213,12 +213,12 @@
       (initialize! *game-info* 'game (the-as game-save #f) "game-start")
       )
     (((speedrun-category hub2-100))
-      ;; spawn at rock village start
-      (initialize! *game-info* 'game (the-as game-save #f) "village2-start")
+      ;; spawn at end of fire canyon
+      (initialize! *game-info* 'game (the-as game-save #f) "firecanyon-end")
       )
     (((speedrun-category hub3-100))
-      ;; spawn at start of volcanic crater
-      (initialize! *game-info* 'game (the-as game-save #f) "village3-start")
+      ;; spawn at end of mountain pass
+      (initialize! *game-info* 'game (the-as game-save #f) "ogre-end")
       )
     (((speedrun-category all-cutscenes))
       ;; turn play hints back on


### PR DESCRIPTION
This fixes hub2 and hub3 100% categories to start at the same continue point as PS2 runs (also let's you submit a section from a full 100% run)