### PR TITLE
Add fallback text functionality to Jak 2

### DIFF
--- a/goal_src/jak1/engine/ui/text.gc
+++ b/goal_src/jak1/engine/ui/text.gc
@@ -242,7 +242,7 @@
     (load-game-text-info "common" '*common-text* *common-text-heap*)
     (#when PC_PORT
       (protect ((-> *pc-settings* text-language))
-        (set! (-> *pc-settings* text-language) (the language-enum (pc-language english)))
+        (set! (-> *pc-settings* text-language)  (pc-language english))
         (load-game-text-info "common" '*fallback-text* *fallback-text-heap*)
       )
     )

--- a/goal_src/jak1/engine/ui/text.gc
+++ b/goal_src/jak1/engine/ui/text.gc
@@ -233,100 +233,6 @@
   v0-2
   )
 
-(defun load-fallback-game-text-info ((txt-name string) (curr-text symbol) (heap kheap))
-  "Largely duplication of `load-game-text-info` but is hardcoded to load english (language 0)"
-  (local-vars
-   (v0-2 int)
-   (heap-sym-heap game-text-info)
-   (lang language-enum)
-   (load-status int)
-   (heap-free int)
-   )
-  (set! heap-sym-heap (the-as game-text-info (-> curr-text value)))
-  (set! lang (language-enum english))
-  (set! load-status 0)
-  (set! heap-free (&- (-> heap top) (the-as uint (-> heap base))))
-
-  ;; only load if we actually need to
-  (when (or (= heap-sym-heap #f) ;; nothing loaded
-            (!= (-> heap-sym-heap language-id) (the-as uint lang)) ;; loaded, but wrong lang
-            (not (string= (-> heap-sym-heap group-name) txt-name)) ;; loaded, but wrong group
-            )
-
-    ;; clear the heap!
-    (let ((v1-16 heap))
-      (set! (-> v1-16 current) (-> v1-16 base))
-      )
-    (b! #t cfg-14)
-    (label cfg-13)
-    (load-dbg "Strange error during text load.~%")
-    (set! v0-2 0)
-    (b! #t cfg-27)
-    (label cfg-14)
-
-    ;; call str-load to start loading the TXT file to the heap
-    (let ((s3-0 str-load))
-      (format (clear *temp-string*) "~D~S.TXT" lang txt-name)
-      ;; this branch is super weird.
-      (b! (not (s3-0
-                *temp-string*
-                -1
-                (logand -64 (&+ (-> heap current) 63))
-                (&- (-> heap top) (the-as uint (-> heap current)))
-                )
-               )
-          cfg-13
-          )
-      )
-
-    ;; loop to wait until loading is complete
-    (label cfg-16)
-    (let ((v1-20 (str-load-status (the-as (pointer int32) (& load-status)))))
-      (cond
-        ((= v1-20 'error)
-         (format 0 "Error loading text~%")
-         (return 0)
-         )
-        ((>= load-status (+ heap-free -300))
-         (format 0 "Game text heap overrun!~%")
-         (return 0)
-         )
-        ((= v1-20 'busy)
-         (begin
-          (nop!)
-          (nop!)
-          (nop!)
-          (nop!)
-          (nop!)
-          (nop!)
-          (goto cfg-16)
-          )
-         )
-        )
-      )
-
-    ;; loading is done. now we link.
-    (let ((s2-1 (logand -64 (&+ (-> heap current) 63))))
-      (flush-cache 0)
-      (let ((s3-1 link))
-        (format (clear *temp-string*) "~D~S.TXT" lang txt-name)
-        (set! (-> curr-text value)
-         (s3-1 s2-1 (-> *temp-string* data) load-status heap 0)
-         )
-        )
-      )
-
-    ;; linking error occured?
-    (if (<= (the-as int (-> curr-text value)) 0)
-        (set! (-> curr-text value) (the-as object #f))
-        )
-    )
-  (set! v0-2 0)
-  (label cfg-27)
-
-  v0-2
-  )
-
 (defun load-level-text-files ((arg0 int))
   "Load the text files needed for level idx.
    This function made more sense back when text files were split up, but in the end they put everything
@@ -335,8 +241,12 @@
   (when (or *level-text-file-load-flag* (>= arg0 0))
     (load-game-text-info "common" '*common-text* *common-text-heap*)
     (#when PC_PORT
-      (load-fallback-game-text-info "common" '*fallback-text* *fallback-text-heap*))
+      (protect ((-> *pc-settings* text-language))
+        (set! (-> *pc-settings* text-language) (the language-enum (pc-language english)))
+        (load-game-text-info "common" '*fallback-text* *fallback-text-heap*)
+      )
     )
+  )
   (none)
   )
 

--- a/goal_src/jak2/engine/ui/text-h.gc
+++ b/goal_src/jak2/engine/ui/text-h.gc
@@ -41,3 +41,18 @@
 (define *common-text-heap* (new 'global 'kheap))
 
 (define *common-text* (the-as game-text-info #f))
+
+;; og:preserve-this
+;; NOTE - PC PORT difference
+;; Partial translations are a thing that we should support. Parts of translating the game are intentionally made
+;; difficult for normal translators due to not wanting to make all the strings public (or in the case of subtitles,
+;; we straight up didn't have them yet)
+;;
+;; So to remedy this, we always load the english text as a fallback so that if there is only a partial translation
+;; the UX won't be horrible with everything displaying as UNKNOWN.
+;;
+;; One of the reasons we didn't do this is because it makes it obvious which strings are remaining,
+;; but there are better ways to keep track or check if strings are missing.
+(#when PC_PORT
+  (kheap-alloc (define *fallback-text-heap* (new 'global 'kheap)) (* 48 1024)) ;; 48K heap, should be plenty
+  (define *fallback-text* (the-as game-text-info #f)))

--- a/goal_src/jak2/engine/ui/text.gc
+++ b/goal_src/jak2/engine/ui/text.gc
@@ -195,8 +195,16 @@
                (the-as string #f)
                )
              (else
-               (format (clear *temp-string*) "UNKNOWN ID ~X" arg0)
-               *temp-string*
+             ;; og:preserve-this Added fallback to english is string is not found.
+                (#if PC_PORT
+                  (if *fallback-text-lookup?*
+                    (let ((fallback-result (lookup-text! *fallback-text* arg0 #t)))
+                    (if (!= fallback-result #f)
+                      fallback-result
+                      (string-format "UNKNOWN ID ~D" arg0)))
+                  )
+                  (string-format "UNKNOWN ID ~D" arg0)
+                )
                )
              )
            )
@@ -302,12 +310,94 @@ the game-text-info, and heap is the heap to load to. The heap will be cleared."
   v0-3
   )
 
+;; WARN: Found some very strange gotos. Check result carefully, this is not well tested.
+(defun load-fallback-game-text-info ((arg0 string) (arg1 (pointer object)) (arg2 kheap))
+"Largely duplication of `load-game-text-info` but is hardcoded to load english (language 0)"
+  (local-vars (v0-3 int) (sv-16 game-text-info) (sv-24 int) (sv-32 int) (sv-40 int))
+  (set! sv-16 (the-as game-text-info (-> arg1 0)))
+  (set! sv-24 0)
+  (set! sv-32 0)
+  (set! sv-40 (&- (-> arg2 top) (the-as uint (-> arg2 base))))
+  ;; (if (and (= (scf-get-territory) 1) (= sv-24 (language-enum english)) (not (demo?)))
+  ;;     (set! sv-24 7)
+  ;;     )
+  (when (or (= sv-16 #f) (!= (-> sv-16 language-id) sv-24) (not (string= (-> sv-16 group-name) arg0)))
+    (let ((v1-16 arg2))
+      (set! (-> v1-16 current) (-> v1-16 base))
+      )
+    (b! #t cfg-17 :delay (nop!))
+    (label cfg-16)
+    (set! v0-3 0)
+    (b! #t cfg-30 :delay (nop!))
+    (label cfg-17)
+    (let ((s3-0 str-load))
+      (format (clear *temp-string*) "~D~S.TXT" sv-24 arg0)
+      (b!
+        (not (s3-0
+               *temp-string*
+               -1
+               (logand -64 (&+ (-> arg2 current) 63))
+               (&- (-> arg2 top) (the-as uint (-> arg2 current)))
+               )
+             )
+        cfg-16
+        :delay (nop!)
+        )
+      )
+    (label cfg-19)
+    (let ((v1-20 (str-load-status (the-as (pointer int32) (& sv-32)))))
+      (b! (!= v1-20 'error) cfg-22 :delay (empty-form))
+      (format 0 "Error loading text~%")
+      (set! v0-3 0)
+      (b! #t cfg-30 :delay (nop!))
+      (the-as none 0)
+      (b! #t cfg-27 :delay (nop!))
+      (label cfg-22)
+      (cond
+        ((>= sv-32 (+ sv-40 -300))
+         (format 0 "Game text heap overrun!~%")
+         (return 0)
+         )
+        ((= v1-20 'busy)
+         (nop!)
+         (nop!)
+         (nop!)
+         (nop!)
+         (nop!)
+         (nop!)
+         (goto cfg-19)
+         )
+        )
+      )
+    (label cfg-27)
+    (let ((s2-1 (logand -64 (&+ (-> arg2 current) 63))))
+      (flush-cache 0)
+      (let ((s3-1 link))
+        (format (clear *temp-string*) "~D~S.TXT" sv-24 arg0)
+        (set! (-> arg1 0) (s3-1 s2-1 (-> *temp-string* data) sv-32 arg2 0))
+        )
+      )
+    (if (<= (the-as int (-> arg1 0)) 0)
+        (set! (-> arg1 0) (the-as object #f))
+        )
+    )
+  (set! v0-3 0)
+  (label cfg-30)
+  v0-3
+  )
+
+
+
+
 (defun load-level-text-files ((arg0 int))
   "Load the text files needed for level idx.
 This function made more sense back when text files were split up, but in the end they put everything
 in a single text group and file."
-  (if (or *level-text-file-load-flag* (>= arg0 0))
+;; og:preserve-this Load in english file to use as a fallback
+  (when (or *level-text-file-load-flag* (>= arg0 0))
       (load-game-text-info "common" (&-> '*common-text* value) *common-text-heap*)
+      (#when PC_PORT
+        (load-fallback-game-text-info "common" (&-> '*fallback-text* value) *fallback-text-heap*))
       )
   0
   (none)

--- a/goal_src/jak2/engine/ui/text.gc
+++ b/goal_src/jak2/engine/ui/text.gc
@@ -310,85 +310,6 @@ the game-text-info, and heap is the heap to load to. The heap will be cleared."
   v0-3
   )
 
-;; WARN: Found some very strange gotos. Check result carefully, this is not well tested.
-(defun load-fallback-game-text-info ((arg0 string) (arg1 (pointer object)) (arg2 kheap))
-"Largely duplication of `load-game-text-info` but is hardcoded to load english (language 0)"
-  (local-vars (v0-3 int) (sv-16 game-text-info) (sv-24 int) (sv-32 int) (sv-40 int))
-  (set! sv-16 (the-as game-text-info (-> arg1 0)))
-  (set! sv-24 0)
-  (set! sv-32 0)
-  (set! sv-40 (&- (-> arg2 top) (the-as uint (-> arg2 base))))
-  ;; (if (and (= (scf-get-territory) 1) (= sv-24 (language-enum english)) (not (demo?)))
-  ;;     (set! sv-24 7)
-  ;;     )
-  (when (or (= sv-16 #f) (!= (-> sv-16 language-id) sv-24) (not (string= (-> sv-16 group-name) arg0)))
-    (let ((v1-16 arg2))
-      (set! (-> v1-16 current) (-> v1-16 base))
-      )
-    (b! #t cfg-17 :delay (nop!))
-    (label cfg-16)
-    (set! v0-3 0)
-    (b! #t cfg-30 :delay (nop!))
-    (label cfg-17)
-    (let ((s3-0 str-load))
-      (format (clear *temp-string*) "~D~S.TXT" sv-24 arg0)
-      (b!
-        (not (s3-0
-               *temp-string*
-               -1
-               (logand -64 (&+ (-> arg2 current) 63))
-               (&- (-> arg2 top) (the-as uint (-> arg2 current)))
-               )
-             )
-        cfg-16
-        :delay (nop!)
-        )
-      )
-    (label cfg-19)
-    (let ((v1-20 (str-load-status (the-as (pointer int32) (& sv-32)))))
-      (b! (!= v1-20 'error) cfg-22 :delay (empty-form))
-      (format 0 "Error loading text~%")
-      (set! v0-3 0)
-      (b! #t cfg-30 :delay (nop!))
-      (the-as none 0)
-      (b! #t cfg-27 :delay (nop!))
-      (label cfg-22)
-      (cond
-        ((>= sv-32 (+ sv-40 -300))
-         (format 0 "Game text heap overrun!~%")
-         (return 0)
-         )
-        ((= v1-20 'busy)
-         (nop!)
-         (nop!)
-         (nop!)
-         (nop!)
-         (nop!)
-         (nop!)
-         (goto cfg-19)
-         )
-        )
-      )
-    (label cfg-27)
-    (let ((s2-1 (logand -64 (&+ (-> arg2 current) 63))))
-      (flush-cache 0)
-      (let ((s3-1 link))
-        (format (clear *temp-string*) "~D~S.TXT" sv-24 arg0)
-        (set! (-> arg1 0) (s3-1 s2-1 (-> *temp-string* data) sv-32 arg2 0))
-        )
-      )
-    (if (<= (the-as int (-> arg1 0)) 0)
-        (set! (-> arg1 0) (the-as object #f))
-        )
-    )
-  (set! v0-3 0)
-  (label cfg-30)
-  v0-3
-  )
-
-
-
-
 (defun load-level-text-files ((arg0 int))
   "Load the text files needed for level idx.
 This function made more sense back when text files were split up, but in the end they put everything
@@ -397,8 +318,11 @@ in a single text group and file."
   (when (or *level-text-file-load-flag* (>= arg0 0))
       (load-game-text-info "common" (&-> '*common-text* value) *common-text-heap*)
       (#when PC_PORT
-        (load-fallback-game-text-info "common" (&-> '*fallback-text* value) *fallback-text-heap*))
+        (protect ((-> *setting-control* user-current language))
+        (set! (-> *setting-control* user-current language) (language-enum english))
+        (load-game-text-info "common" (&-> '*fallback-text* value) *fallback-text-heap*))
       )
+  )
   0
   (none)
   )

--- a/goal_src/jak2/pc/pckernel-impl.gc
+++ b/goal_src/jak2/pc/pckernel-impl.gc
@@ -178,6 +178,7 @@
 (define *debug-region-show-bsphere* #f)
 (define *debug-region-hide-water* #t)
 (define *debug-region-hide-empty* #t)
+(define *fallback-text-lookup?* #t)
 
 
 ;; for debugging


### PR DESCRIPTION
It works now so I figured Id open it for input on the final remaining things.

Things Im not satisfied with

*fallback-text-lookup?* being defined in pc-kernel-impl.gc, Isnt there a way to just add this to pc-kernel-common??

I would like a close double check on the logic on lines 198-207 I'm pretty sure all the bases are still covered and it will never not find anything but I just want a double check

Fixes #3118