### PR TITLE
[jak2] Pass 0x01 through format

### DIFF
--- a/game/kernel/jak2/kprint.cpp
+++ b/game/kernel/jak2/kprint.cpp
@@ -229,6 +229,7 @@ s32 format_impl_jak2(uint64_t* args) {
         case 'w':
         case 'y':
         case 'z':
+        case 1: // jak 2 japanese encoding
           while (arg_start < format_ptr + 1) {
             *output_ptr = *arg_start;
             arg_start++;

--- a/game/kernel/jak2/kprint.cpp
+++ b/game/kernel/jak2/kprint.cpp
@@ -229,7 +229,7 @@ s32 format_impl_jak2(uint64_t* args) {
         case 'w':
         case 'y':
         case 'z':
-        case 1: // jak 2 japanese encoding
+        case 1:  // jak 2 japanese encoding
           while (arg_start < format_ptr + 1) {
             *output_ptr = *arg_start;
             arg_start++;


### PR DESCRIPTION
fixes the crash when this message is displayed:

![image](https://github.com/open-goal/jak-project/assets/48171810/eb53c121-8e35-4268-b7fb-c5a6ce9c0946)

as far as I can tell, it looks right.

