### PR TITLE
[jak2] Fix palace rotation at high fps

### DIFF
--- a/goal_src/jak2/engine/gfx/mood/mood-funcs.gc
+++ b/goal_src/jak2/engine/gfx/mood/mood-funcs.gc
@@ -995,6 +995,26 @@
     )
   )
 
+;; og:preserve-this High FPS fix
+(defun rotate-quat-y-high-fps-fix ((quat quaternion) (rate float))
+  "This function does: (quaternion-rotate-y! quat quat (* rate (seconds-per-frame)))
+   But fixes an issue where a small rate will cause no change to the quaternion."
+  (let* ((new-Q-old (new-stack-quaternion0))
+         (delta-angle (* rate (seconds-per-frame)))
+         (delta-angle-unwrapped (unwrap-angle-small-angle-fix delta-angle))
+         (delta-angle-rad (* delta-angle-unwrapped ROT_TO_RAD))
+         (sincos-out (new-stack-vector0))
+         )
+    (sincos-rad! sincos-out delta-angle-rad)
+
+    (set! (-> new-Q-old x) 0.0)
+    (set! (-> new-Q-old y) (-> sincos-out x)) ;; sin
+    (set! (-> new-Q-old z) 0.0)
+    (set! (-> new-Q-old w) (-> sincos-out y)) ;; cos
+    (quaternion-normalize! (quaternion*! quat new-Q-old quat))
+    )
+  )
+
 (defbehavior update-mood-drillmnt time-of-day-proc ((arg0 mood-context) (arg1 float) (arg2 int))
   (copy-mood-exterior-ambi arg0 #t)
   (update-drill-lights arg0)
@@ -1004,7 +1024,9 @@
     (let ((s5-1 *math-camera*))
       (set! (-> arg0 times 5 w) 1.0)
       (if (not (paused?))
-          (quaternion-rotate-y! (-> s5-1 quat-other) (-> s5-1 quat-other) (* 273.06668 (seconds-per-frame)))
+          ;; og:preserve-this High FPS fix
+          ;; (quaternion-rotate-y! (-> s5-1 quat-other) (-> s5-1 quat-other) (* 273.06668 (seconds-per-frame)))
+          (rotate-quat-y-high-fps-fix (-> s5-1 quat-other) 273.06668)
           )
       )
     )
@@ -1206,7 +1228,9 @@
     (update-mood-flames arg0 6 2 8 0.5 0.0009765625 1.5)
     (let ((gp-1 *math-camera*))
       (if (not (paused?))
-          (quaternion-rotate-y! (-> gp-1 quat-other) (-> gp-1 quat-other) (* 273.06668 (seconds-per-frame)))
+          ;; og:preserve-this High FPS fix
+          (rotate-quat-y-high-fps-fix (-> gp-1 quat-other) 273.06668)
+          ;(quaternion-rotate-y! (-> gp-1 quat-other) (-> gp-1 quat-other) (* 273.06668 (seconds-per-frame)))
           )
       )
     )

--- a/goal_src/jak2/engine/math/trigonometry.gc
+++ b/goal_src/jak2/engine/math/trigonometry.gc
@@ -34,6 +34,18 @@ normally.
 (defconstant PI_OVER_2 (the-as float #x3fc90fda))
 (defconstant TWO_PI (the-as float #x40c90fda))
 
+(defmacro unwrap-angle (angle)
+  `(the float (sar (shl (the int ,angle) 48) 48))
+  )
+
+(defmacro unwrap-angle-small-angle-fix (angle)
+  "Same as unwrap angle, but small angles are not rounded to zero."
+  `(if (< (fabs ,angle) 1.1)
+      ,angle
+      (the float (sar (shl (the int ,angle) 48) 48))
+      )
+  )
+
 ;; DECOMP BEGINS
 
 (defun radmod ((arg0 float))
@@ -189,7 +201,7 @@ normally.
 
 (defun sin ((arg0 float))
   "Compute the sine of an angle in rotation units. Unwraps it."
-  (let ((f2-0 (* 0.000095873795 (the float (sar (shl (the int arg0) 48) 48)))))
+  (let ((f2-0 (* 0.000095873795 (unwrap-angle arg0))))
     f2-0
     (let* ((f1-4 (* 0.999998 f2-0))
            (f0-3 (* f2-0 f2-0))
@@ -566,7 +578,7 @@ normally.
   "Compute the sine and cosine of x, store it in the output array.
    The input is in rotation units, and is unwrapped properly.
    Also has the cosine bug"
-  (sincos-rad-asm out (* ROT_TO_RAD (the float (sar (shl (the int x) 48) 48))))
+  (sincos-rad-asm out (* ROT_TO_RAD (unwrap-angle x)))
   )
 
 (defun vector-rad<-vector-deg! ((out vector) (in vector))


### PR DESCRIPTION
This patches the rotation of the palace so that it works in high fps mode.

I didn't change the behavior of anything in `trigonometry.gc` - just added an `unwrap-angle` macro so we could try changing the behavior more easily when debugging high-fps issues in the future. (interestingly, nothing obvious is wrong with using the higher accuracy unwrap function for all trig functions).