### PR TITLE
cmake: use static OpenSSL libraries on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,9 @@ if(WIN32)
 elseif(APPLE)
     set(CURL_USE_SECTRANSP ON) # native macOS SSL support
 else()
+    if(STATICALLY_LINK)
+        set(OPENSSL_USE_STATIC_LIBS TRUE)
+    endif()
     set(CURL_USE_OPENSSL ON) # not native, but seems to be the best choice for linux
 endif()
 include_directories(third-party/curl/include)


### PR DESCRIPTION
No longer dependent on those libraries:
![image](https://github.com/open-goal/jak-project/assets/13153231/daa113ed-85e1-42fa-98fb-e5ed1c4944c1)

Fixes #3160 