### PR TITLE
reduce glow renderer vram usage + raise glow sprite limit

### DIFF
--- a/game/graphics/opengl_renderer/sprite/GlowRenderer.cpp
+++ b/game/graphics/opengl_renderer/sprite/GlowRenderer.cpp
@@ -267,6 +267,10 @@ void copy_to_vertex(GlowRenderer::Vertex* vtx, const Vector4f& xyzw) {
 }
 }  // namespace
 
+bool GlowRenderer::at_max_capacity() {
+  return m_next_sprite == m_sprite_data_buffer.size();
+}
+
 SpriteGlowOutput* GlowRenderer::alloc_sprite() {
   ASSERT(m_next_sprite < m_sprite_data_buffer.size());
   return &m_sprite_data_buffer[m_next_sprite++];

--- a/game/graphics/opengl_renderer/sprite/GlowRenderer.h
+++ b/game/graphics/opengl_renderer/sprite/GlowRenderer.h
@@ -6,6 +6,7 @@
 class GlowRenderer {
  public:
   GlowRenderer();
+  bool at_max_capacity();
   SpriteGlowOutput* alloc_sprite();
   void cancel_sprite();
 
@@ -87,8 +88,7 @@ class GlowRenderer {
 
   // max sprites should be 128 in simple sprite, plus 256 from aux = 384
   // 20 width = 20 * 20 = 400 sprites > 384.
-  // we multiply by 2 to get 4x as many max sprites (in-game the max is 4x)
-  static constexpr int kDownsampleBatchWidth = 20 * 2;
+  static constexpr int kDownsampleBatchWidth = 20;
   static constexpr int kMaxSprites = kDownsampleBatchWidth * kDownsampleBatchWidth;
   static constexpr int kMaxVertices = kMaxSprites * 32;  // check.
   static constexpr int kMaxIndices = kMaxSprites * 32;   // check.

--- a/game/graphics/opengl_renderer/sprite/Sprite3_Glow.cpp
+++ b/game/graphics/opengl_renderer/sprite/Sprite3_Glow.cpp
@@ -220,6 +220,9 @@ void Sprite3::glow_dma_and_draw(DmaFollower& dma,
     ASSERT(shader_xfer.size_bytes == 5 * 16);
 
     if (m_enable_glow) {
+      if (m_glow_renderer.at_max_capacity()) {
+        m_glow_renderer.flush(render_state, prof);
+      }
       auto* out = m_glow_renderer.alloc_sprite();
       if (!glow_math(&consts, m_glow_renderer.new_mode, vecdata_xfer.data, shader_xfer.data, out)) {
         m_glow_renderer.cancel_sprite();

--- a/goal_src/jak2/engine/gfx/sprite/particles/sparticle.gc
+++ b/goal_src/jak2/engine/gfx/sprite/particles/sparticle.gc
@@ -709,6 +709,14 @@
           (-> *sp-particle-system-2d* num-alloc 1)
           )
         )
+      (#when PC_PORT
+        (when (= *cheat-mode* 'debug)
+          (if (= (-> *sp-particle-system-2d* num-alloc 0) (-> *sp-particle-system-2d* length 0)) (format *stdcon* "2d sprite out of memory~%"))
+          (if (= (-> *sp-particle-system-3d* num-alloc 0) (-> *sp-particle-system-3d* length 0)) (format *stdcon* "3d sprite out of memory~%"))
+          (if (= (-> *sp-particle-system-2d* num-alloc 1) (-> *sp-particle-system-2d* length 1)) (format *stdcon* "hud sprite out of memory~%"))
+          (if (= (-> *sprite-aux-list* entry) (-> *sprite-aux-list* num-entries)) (format *stdcon* "aux sprite out of memory~%"))
+          )
+        )
       )
     0
     (none)

--- a/goal_src/jak2/engine/gfx/sprite/sprite-h.gc
+++ b/goal_src/jak2/engine/gfx/sprite/sprite-h.gc
@@ -11,7 +11,6 @@
 (define-extern sprite-glow-draw (function dma-buffer none))
 
 (#when PC_BIG_MEMORY (defconstant SPRITE_MAX_AMOUNT_MULT 12))
-(#when PC_BIG_MEMORY (defconstant SPRITE_AUX_MAX_AMOUNT_MULT 4))
 
 
 ;; DECOMP BEGINS

--- a/goal_src/jak2/engine/gfx/sprite/sprite.gc
+++ b/goal_src/jak2/engine/gfx/sprite/sprite.gc
@@ -98,7 +98,7 @@ the sprite renderer draw 2D or 3D sprites
 (defmethod new sprite-aux-list ((allocation symbol) (type-to-make type) (size int))
   ;; og:preserve-this
   (#when PC_BIG_MEMORY
-    (*! size SPRITE_AUX_MAX_AMOUNT_MULT))
+    (*! size SPRITE_MAX_AMOUNT_MULT))
 
   (let ((v0-0 (object-new allocation type-to-make (the-as int (+ (-> type-to-make size) (* size 16))))))
     (set! (-> v0-0 num-entries) size)


### PR DESCRIPTION
Makes the glow sprite renderer flush when full capacity is reached, instead of at the end. Also allows us to reduce the textures used for it (finally). Worst case scenario there's 4-5 flushes per frame.

Fixes incessant flickering in the dig.