### PR TITLE
fix forest youngsamos crash when he runs out of health

### DIFF
--- a/goal_src/jak2/levels/forest/forest-obs.gc
+++ b/goal_src/jak2/levels/forest/forest-obs.gc
@@ -402,6 +402,7 @@ This commonly includes things such as:
 - collision information
 - loading the skeleton group / bones
 - sounds"
+  (stack-size-set! (-> this main-thread) 384) ;; og:preserve-this
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum hit-by-others))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) forest-youngsamos-bounce-reaction)


### PR DESCRIPTION
Thought this may have been a regression but apparently we never patched this one.

Fixes #3196 