### PR TITLE
[Loader] Unload less stuff per frame

### DIFF
--- a/game/graphics/opengl_renderer/loader/Loader.cpp
+++ b/game/graphics/opengl_renderer/loader/Loader.cpp
@@ -475,30 +475,29 @@ void Loader::update(TexturePool& texture_pool) {
               }
             }
           }
-
-          glBindTexture(GL_TEXTURE_2D, tex);
-          glDeleteTextures(1, &tex);
+          m_garbage_textures.push_back(tex);
         }
 
         for (auto& tie_geo : lev->tie_data) {
           for (auto& tie_tree : tie_geo) {
-            glDeleteBuffers(1, &tie_tree.vertex_buffer);
+            m_garbage_buffers.push_back(tie_tree.vertex_buffer);
             if (tie_tree.has_wind) {
-              glDeleteBuffers(1, &tie_tree.wind_indices);
+              m_garbage_buffers.push_back(tie_tree.wind_indices);
+
             }
-            glDeleteBuffers(1, &tie_tree.index_buffer);
+            m_garbage_buffers.push_back(tie_tree.index_buffer);
           }
         }
 
         for (auto& tfrag_geo : lev->tfrag_vertex_data) {
           for (auto& tfrag_buff : tfrag_geo) {
-            glDeleteBuffers(1, &tfrag_buff);
+            m_garbage_buffers.push_back(tfrag_buff);
           }
         }
 
-        glDeleteBuffers(1, &lev->collide_vertices);
-        glDeleteBuffers(1, &lev->merc_vertices);
-        glDeleteBuffers(1, &lev->merc_indices);
+        m_garbage_buffers.push_back(lev->collide_vertices);
+        m_garbage_buffers.push_back(lev->merc_vertices);
+        m_garbage_buffers.push_back(lev->merc_indices);
 
         for (auto& model : lev->level->merc_data.models) {
           auto& mercs = m_all_merc_models.at(model.name);
@@ -514,6 +513,23 @@ void Loader::update(TexturePool& texture_pool) {
 
     if (unload_timer.getMs() > 5.f) {
       fmt::print("Unload took {:.2f}\n", unload_timer.getMs());
+    }
+
+    if (!m_garbage_buffers.empty()) {
+      did_gpu_stuff = true;
+      int i;
+      for (i = 0; i < 5 && !m_garbage_buffers.empty(); i++) {
+        glDeleteBuffers(1, &m_garbage_buffers.back());
+        m_garbage_buffers.pop_back();
+      }
+    }
+
+    if (!did_gpu_stuff && !m_garbage_textures.empty()) {
+      int i;
+      for (i = 0; i < 20 && !m_garbage_textures.empty(); i++) {
+        glDeleteTextures(1, &m_garbage_textures.back());
+        m_garbage_textures.pop_back();
+      }
     }
   }
 

--- a/game/graphics/opengl_renderer/loader/Loader.cpp
+++ b/game/graphics/opengl_renderer/loader/Loader.cpp
@@ -483,7 +483,6 @@ void Loader::update(TexturePool& texture_pool) {
             m_garbage_buffers.push_back(tie_tree.vertex_buffer);
             if (tie_tree.has_wind) {
               m_garbage_buffers.push_back(tie_tree.wind_indices);
-
             }
             m_garbage_buffers.push_back(tie_tree.index_buffer);
           }
@@ -517,16 +516,14 @@ void Loader::update(TexturePool& texture_pool) {
 
     if (!m_garbage_buffers.empty()) {
       did_gpu_stuff = true;
-      int i;
-      for (i = 0; i < 5 && !m_garbage_buffers.empty(); i++) {
+      for (int i = 0; i < 5 && !m_garbage_buffers.empty(); i++) {
         glDeleteBuffers(1, &m_garbage_buffers.back());
         m_garbage_buffers.pop_back();
       }
     }
 
     if (!did_gpu_stuff && !m_garbage_textures.empty()) {
-      int i;
-      for (i = 0; i < 20 && !m_garbage_textures.empty(); i++) {
+      for (int i = 0; i < 20 && !m_garbage_textures.empty(); i++) {
         glDeleteTextures(1, &m_garbage_textures.back());
         m_garbage_textures.pop_back();
       }

--- a/game/graphics/opengl_renderer/loader/Loader.h
+++ b/game/graphics/opengl_renderer/loader/Loader.h
@@ -55,6 +55,8 @@ class Loader {
   std::vector<std::string> m_desired_levels;
   std::vector<std::string> m_active_levels;
   std::vector<std::unique_ptr<LoaderStage>> m_loader_stages;
+  std::vector<GLuint> m_garbage_textures;
+  std::vector<GLuint> m_garbage_buffers;
 
   fs::path m_base_path;
   int m_max_levels = 0;

--- a/game/graphics/opengl_renderer/loader/LoaderStages.cpp
+++ b/game/graphics/opengl_renderer/loader/LoaderStages.cpp
@@ -4,7 +4,7 @@
 
 #include "common/global_profiler/GlobalProfiler.h"
 
-constexpr float LOAD_BUDGET = 2.5f;
+constexpr float LOAD_BUDGET = 4.5f;
 
 /*!
  * Upload a texture to the GPU, and give it to the pool.
@@ -40,7 +40,7 @@ class TextureLoaderStage : public LoaderStage {
  public:
   TextureLoaderStage() : LoaderStage("texture") {}
   bool run(Timer& timer, LoaderInput& data) override {
-    constexpr int MAX_TEX_BYTES_PER_FRAME = 1024 * 512;
+    constexpr int MAX_TEX_BYTES_PER_FRAME = 1024 * 1024;
 
     int bytes_this_run = 0;
     int tex_this_run = 0;
@@ -84,7 +84,6 @@ class TfragLoadStage : public LoaderStage {
           GLuint& tree_out = data.lev_data->tfrag_vertex_data[geo].emplace_back();
           glGenBuffers(1, &tree_out);
           glBindBuffer(GL_ARRAY_BUFFER, tree_out);
-
           glBufferData(GL_ARRAY_BUFFER,
                        in_tree.unpacked.vertices.size() * sizeof(tfrag3::PreloadedVertex), nullptr,
                        GL_STATIC_DRAW);
@@ -149,7 +148,6 @@ class TfragLoadStage : public LoaderStage {
             return true;
           }
         }
-
         return false;
       }
 


### PR DESCRIPTION
This should avoid the stuttering due to slow unloading on some drivers.

I also turned up the amount of stuff we load per frame since nobody has been complaining about stutters there, but there has been a few cases of levels loading in too slowly.

(this only changes graphics, not actual GOAL level load times).