### PR TITLE
[jak2] Support per-proto shrub visibility

### DIFF
--- a/common/custom_data/TFrag3Data.cpp
+++ b/common/custom_data/TFrag3Data.cpp
@@ -42,6 +42,7 @@ void ShrubDraw::serialize(Serializer& ser) {
   ser.from_ptr(&num_triangles);
   ser.from_ptr(&first_index_index);
   ser.from_ptr(&num_indices);
+  ser.from_ptr(&proto_idx);
 }
 
 void InstancedStripDraw::serialize(Serializer& ser) {
@@ -416,6 +417,9 @@ void ShrubTree::serialize(Serializer& ser) {
   for (auto& draw : static_draws) {
     draw.serialize(ser);
   }
+
+  ser.from_ptr(&has_per_proto_visibility_toggle);
+  ser.from_string_vector(&proto_names);
 }
 
 void BVH::serialize(Serializer& ser) {

--- a/common/custom_data/Tfrag3Data.h
+++ b/common/custom_data/Tfrag3Data.h
@@ -18,7 +18,7 @@ namespace tfrag3 {
 // - if changing any large things (vertices, vis, bvh, colors, textures) update get_memory_usage
 // - if adding a new category to the memory usage, update extract_level to print it.
 
-constexpr int TFRAG3_VERSION = 38;
+constexpr int TFRAG3_VERSION = 39;
 
 enum MemoryUsageCategory {
   TEXTURE,
@@ -219,6 +219,8 @@ struct ShrubDraw {
 
   // for debug counting.
   u32 num_triangles = 0;
+
+  u16 proto_idx = 0;
   void serialize(Serializer& ser);
 };
 
@@ -429,6 +431,10 @@ struct ShrubTree {
   struct {
     std::vector<ShrubGpuVertex> vertices;  // mesh vertices
   } unpacked;
+
+  // jak 2 and later can toggle on and off visibility per proto by name
+  bool has_per_proto_visibility_toggle = false;
+  std::vector<std::string> proto_names;
 
   void serialize(Serializer& ser);
   void memory_usage(MemoryUsageTracker* tracker) const;

--- a/common/formatter/rules/rule_config.h
+++ b/common/formatter/rules/rule_config.h
@@ -21,8 +21,8 @@ struct FormFormattingConfig {
   bool combine_first_two_lines =
       false;  // NOTE - basically hang, but will probably stick around after hang is gone, may be
               // redundant (inline_until_index!)
-  std::function<std::optional<int>(const std::vector<std::string>& curr_lines)> inline_until_index =
-      [](std::vector<std::string> curr_lines) { return std::nullopt; };
+  std::function<std::optional<int>(const std::vector<std::string>& /*curr_lines*/)>
+      inline_until_index = [](std::vector<std::string> /*curr_lines*/) { return std::nullopt; };
   bool has_constant_pairs = false;
   bool prevent_inlining = false;  // TODO - duplicate of below
   std::function<bool(FormFormattingConfig, int num_refs)> should_prevent_inlining =

--- a/game/graphics/opengl_renderer/background/Shrub.h
+++ b/game/graphics/opengl_renderer/background/Shrub.h
@@ -42,6 +42,8 @@ class Shrub : public BucketRenderer {
     const std::vector<tfrag3::TimeOfDayColor>* colors = nullptr;
     const u32* index_data = nullptr;
     SwizzledTimeOfDay tod_cache;
+    std::vector<bool> proto_vis_mask;
+    std::unordered_map<std::string, std::vector<u32>> proto_name_to_idx;
 
     struct {
       u32 draws = 0;
@@ -78,4 +80,6 @@ class Shrub : public BucketRenderer {
     std::vector<void*> multidraw_index_offset_buffer;
   } m_cache;
   TfragPcPortData m_pc_port_data;
+  const u8* m_proto_vis_data = nullptr;
+  int m_proto_vis_data_size = 0;
 };

--- a/goal_src/jak2/engine/gfx/shrub/shrubbery.gc
+++ b/goal_src/jak2/engine/gfx/shrub/shrubbery.gc
@@ -10,6 +10,58 @@
 
 ;; DECOMP BEGINS
 
+(defun pc-add-shrub-vis-mask ((dma-buf dma-buffer) (lev level))
+  "Add data so Proto.cpp can disable drawing for disabled protos."
+  (let ((packet (the-as dma-packet (-> dma-buf base))))
+    (set! (-> packet vif0) (new 'static 'vif-tag))
+    (set! (-> packet vif1) (new 'static 'vif-tag :cmd (vif-cmd pc-port)))
+    (set! (-> dma-buf base) (the pointer (&+ packet 16)))
+
+    (let ((lev-trees (-> lev bsp drawable-trees))
+          (data-ptr (the (pointer uint8) (-> dma-buf base)))
+          )
+      (dotimes (tree-idx (-> lev-trees length))
+        (let ((tree (-> lev-trees data tree-idx)))
+          (when (= (-> tree type) drawable-tree-instance-shrub)
+            (let* ((shrub-tree (the drawable-tree-instance-shrub tree))
+                   (protos (-> shrub-tree info prototype-inline-array-shrub))
+                   )
+              (dotimes (i (-> protos length))
+                (let ((proto (-> protos data i)))
+                  (when (logtest? (-> proto flags) (prototype-flags visible))
+                    ;; invisible!
+                    ;; (format 0 "invis: ~A~%" (-> proto name))
+                    (let ((src (-> proto name data)))
+                      (while (nonzero? (-> src))
+                        (set! (-> data-ptr) (-> src))
+                        (&+! src 1)
+                        (&+! data-ptr 1)
+                        )
+                      (set! (-> data-ptr) 0)
+                      (&+! data-ptr 1)
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      ;; align
+      (while (nonzero? (logand data-ptr #xf))
+        (set! (-> data-ptr) 0)
+        (&+! data-ptr 1)
+        )
+      (set! (-> packet dma) (new 'static 'dma-tag
+                                 :id (dma-tag-id cnt)
+                                 :qwc (/ (&- data-ptr (-> dma-buf base)) 16))
+            )
+      (set! (-> dma-buf base) data-ptr)
+      #f
+      )
+    )
+  )
+
 (defmethod login ((this billboard))
   "Set up the billboard adgif shader"
   (adgif-shader-login (-> this flat))
@@ -481,6 +533,7 @@
               (let* ((shrub-dma-buff (-> *display* frames (-> *display* on-screen) global-buf))
                      (dma-start (-> shrub-dma-buff base)))
                 (add-pc-tfrag3-data shrub-dma-buff (-> *level* draw-level *draw-index*))
+                (pc-add-shrub-vis-mask shrub-dma-buff (-> *level* draw-level *draw-index*))
                 (let ((a3-22 (-> shrub-dma-buff base)))
                   (let ((v1-57 (the-as object (-> shrub-dma-buff base))))
                     (set! (-> (the-as dma-packet v1-57) dma) (new 'static 'dma-tag :id (dma-tag-id next)))


### PR DESCRIPTION
Fixes the issue reported in https://github.com/open-goal/jak-project/issues/3168, https://github.com/open-goal/jak-project/issues/3189, https://github.com/open-goal/jak-project/issues/3166, https://github.com/open-goal/jak-project/issues/3152, https://github.com/open-goal/jak-project/issues/3224 where a small part of the pipes in the `strip-grenade` mission appear, but shouldn't.