### PR TITLE
Fix cases of string formatting with non string literals

### DIFF
--- a/common/goos/Interpreter.cpp
+++ b/common/goos/Interpreter.cpp
@@ -1888,7 +1888,7 @@ Object Interpreter::eval_format(const Object& form,
                    fmt::format_args(args2.data(), static_cast<unsigned>(args2.size())));
 
   if (truthy(dest)) {
-    lg::print(formatted.c_str());
+    lg::print("{}", formatted.c_str());
   }
 
   return StringObject::make_new(formatted);

--- a/common/log/log.cpp
+++ b/common/log/log.cpp
@@ -106,7 +106,7 @@ void log_print(const char* message) {
     }
 
     if (gLogger.stdout_log_level < lg::level::off_unless_die) {
-      fmt::print(message);
+      fmt::print("{}", message);
       fflush(stdout);
       fflush(stderr);
     }

--- a/common/serialization/subtitles/subtitles_v2.cpp
+++ b/common/serialization/subtitles/subtitles_v2.cpp
@@ -373,7 +373,7 @@ bool GameSubtitleDB::write_subtitle_db_to_files(const GameVersion game_version) 
       file_util::write_text_file(dump_path, lines_file.dump(2));
     }
   } catch (std::exception& ex) {
-    lg::error(ex.what());
+    lg::error("{}", ex.what());
     return false;
   }
   return true;

--- a/common/util/Assert.cpp
+++ b/common/util/Assert.cpp
@@ -16,12 +16,12 @@ void private_assert_failed(const char* expr,
   if (!msg || msg[0] == '\0') {
     std::string log = fmt::format("Assertion failed: '{}'\n\tSource: {}:{}\n\tFunction: {}\n", expr,
                                   file, line, function);
-    lg::die(log);
+    lg::die("{}", log);
   } else {
     std::string log =
         fmt::format("Assertion failed: '{}'\n\tMessage: {}\n\tSource: {}:{}\n\tFunction: {}\n",
                     expr, msg, file, line, function);
-    lg::die(log);
+    lg::die("{}", log);
   }
   abort();
 }

--- a/decompiler/ObjectFile/ObjectFileDB_IR2.cpp
+++ b/decompiler/ObjectFile/ObjectFileDB_IR2.cpp
@@ -802,7 +802,7 @@ void ObjectFileDB::ir2_insert_lets(int seg, ObjectFileData& data) {
             "Error while inserting lets: {}. Make sure that the return type is not "
             "none if something is actually returned.",
             e.what());
-        lg::warn(err);
+        lg::warn("{}", err);
         func.warnings.error(err);
       }
     }

--- a/decompiler/analysis/expression_build.cpp
+++ b/decompiler/analysis/expression_build.cpp
@@ -172,7 +172,7 @@ bool convert_to_expressions(
             "statement.",
             f.name());
         f.warnings.warning(warn);
-        lg::warn(warn);
+        lg::warn("{}", warn);
       }
     }
 

--- a/decompiler/analysis/inline_asm_rewrite.cpp
+++ b/decompiler/analysis/inline_asm_rewrite.cpp
@@ -87,7 +87,7 @@ bool rewrite_inline_asm_instructions(Form* top_level_form,
   } catch (std::exception& e) {
     std::string warning =
         fmt::format("ASM instruction re-writing failed in {}: {}", f.name(), e.what());
-    lg::warn(warning);
+    lg::warn("{}", warning);
     f.warnings.error(";; {}", warning);
     return false;
   }

--- a/decompiler/level_extractor/extract_collide_frags.cpp
+++ b/decompiler/level_extractor/extract_collide_frags.cpp
@@ -1,5 +1,4 @@
 #include "extract_collide_frags.h"
-#include "common/log/log.h"
 
 #include "common/log/log.h"
 #include "common/util/FileUtil.h"

--- a/decompiler/level_extractor/extract_collide_frags.cpp
+++ b/decompiler/level_extractor/extract_collide_frags.cpp
@@ -1,4 +1,5 @@
 #include "extract_collide_frags.h"
+#include "common/log/log.h"
 
 #include "common/log/log.h"
 #include "common/util/FileUtil.h"

--- a/game/main.cpp
+++ b/game/main.cpp
@@ -127,7 +127,7 @@ int main(int argc, char** argv) {
   CLI11_PARSE(app, argc, argv);
 
   if (show_version) {
-    lg::print(build_revision());
+    lg::print("{}", build_revision());
     return 0;
   }
 

--- a/goalc/compiler/Compiler.cpp
+++ b/goalc/compiler/Compiler.cpp
@@ -197,7 +197,7 @@ Val* Compiler::compile_error_guard(const goos::Object& code, Env* env) {
       auto loc_info = m_goos.reader.db.get_info_for(code, &term);
       if (term) {
         lg::print(fg(fmt::color::yellow) | fmt::emphasis::bold, "Location:\n");
-        lg::print(loc_info);
+        lg::print("{}", loc_info);
       }
 
       lg::print(fg(fmt::color::yellow) | fmt::emphasis::bold, "Code:\n");
@@ -212,7 +212,7 @@ Val* Compiler::compile_error_guard(const goos::Object& code, Env* env) {
       }
       std::string line(80, '-');
       line.push_back('\n');
-      lg::print(line);
+      lg::print("{}", line);
     }
     throw ce;
   }
@@ -224,7 +224,7 @@ Val* Compiler::compile_error_guard(const goos::Object& code, Env* env) {
     auto loc_info = m_goos.reader.db.get_info_for(code, &term);
     if (term) {
       lg::print(fg(fmt::color::yellow) | fmt::emphasis::bold, "Location:\n");
-      lg::print(loc_info);
+      lg::print("{}", loc_info);
     }
 
     lg::print(fg(fmt::color::yellow) | fmt::emphasis::bold, "Code:\n");
@@ -240,7 +240,7 @@ Val* Compiler::compile_error_guard(const goos::Object& code, Env* env) {
     }
     std::string line(80, '-');
     line.push_back('\n');
-    lg::print(line);
+    lg::print("{}", line);
     throw ce;
   }
 }

--- a/goalc/compiler/Util.cpp
+++ b/goalc/compiler/Util.cpp
@@ -162,7 +162,7 @@ goos::Arguments Compiler::get_va(const goos::Object& form, const goos::Object& r
 
   std::string err;
   if (!goos::get_va(rest, &err, &args)) {
-    throw_compiler_error(form, err);
+    throw_compiler_error(form, "{}", err);
   }
   return args;
 }
@@ -189,7 +189,7 @@ void Compiler::va_check(
         named) {
   std::string err;
   if (!goos::va_check(args, unnamed, named, &err)) {
-    throw_compiler_error(form, err);
+    throw_compiler_error(form, "{}", err);
   }
 }
 

--- a/goalc/compiler/compilation/Macro.cpp
+++ b/goalc/compiler/compilation/Macro.cpp
@@ -66,7 +66,7 @@ Val* Compiler::compile_goos_macro(const goos::Object& o,
       }
       std::string line(80, '-');
       line.push_back('\n');
-      lg::print(line);
+      lg::print("{}", line);
     }
 
     throw;
@@ -87,7 +87,7 @@ Val* Compiler::compile_goos_macro(const goos::Object& o,
     }
     std::string line(80, '-');
     line.push_back('\n');
-    lg::print(line);
+    lg::print("{}", line);
 
     throw;
   }

--- a/goalc/debugger/Debugger.cpp
+++ b/goalc/debugger/Debugger.cpp
@@ -224,7 +224,7 @@ InstructionPointerInfo Debugger::get_rip_info(u64 rip) {
 
 void print_and_append_to_string(std::string& str, const std::string& log) {
   str += log;
-  lg::print(log);
+  lg::print("{}", log);
 }
 
 std::vector<BacktraceFrame> Debugger::get_backtrace(u64 rip,

--- a/test/offline/framework/file_management.cpp
+++ b/test/offline/framework/file_management.cpp
@@ -75,7 +75,7 @@ std::vector<OfflineTestSourceFile> find_source_files(const std::string& game_nam
         msg += fmt::format("\n- '{}'", path);
       }
     }
-    lg::die(msg);
+    lg::die("{}", msg);
   }
 
   return result;


### PR DESCRIPTION
The logger used in `goalc` tries to print an already-formatted string `message` using `fmt::print(message);` Usually this doesn't cause problems, but if you try to print, for example, an exception that has special characters (notably `{`) it will try to do another round of formatting/replacements, despite not having any args to replace with, which ends up throwing another exception. This is why errors when parsing custom level JSON cause the REPL to exit.

I've hopefully identified all the various instances of this across the codebase