### PR TITLE
fix zydis alignment issue during build for intel macs

### DIFF
--- a/third-party/zydis/include/Zydis/ShortString.h
+++ b/third-party/zydis/include/Zydis/ShortString.h
@@ -44,7 +44,7 @@ extern "C" {
 /* Enums and types                                                                                */
 /* ============================================================================================== */
 
-#if !(defined(ZYAN_AARCH64) && defined(ZYAN_APPLE))
+#if !defined(ZYAN_APPLE)
 #   pragma pack(push, 1)
 #endif
 
@@ -68,7 +68,7 @@ typedef struct ZydisShortString_
     ZyanU8 size;
 } ZydisShortString;
 
-#if !(defined(ZYAN_AARCH64) && defined(ZYAN_APPLE))
+#if !defined(ZYAN_APPLE)
 #   pragma pack(pop)
 #endif
 


### PR DESCRIPTION
Fix zydis alignment issues when building on Intel macOS builds was discussed with zydis devs https://github.com/zyantific/zydis/issues/474

Verified locally that I can run open goal with the change.