### PR TITLE
[gltf] Support either u16 or float for colors

### DIFF
--- a/goalc/build_level/common/gltf_mesh_extract.cpp
+++ b/goalc/build_level/common/gltf_mesh_extract.cpp
@@ -75,6 +75,23 @@ std::vector<math::Vector<u8, 4>> extract_color_from_vec4_float(const u8* data,
 }
 
 /*!
+ * Convert a GLTF color buffer (u16 format) to u8 colors.
+ */
+std::vector<math::Vector<u8, 4>> extract_color_from_vec4_u16(const u8* data,
+                                                             u32 count,
+                                                             u32 stride) {
+  std::vector<math::Vector<u8, 4>> result;
+  result.reserve(count);
+  for (u32 i = 0; i < count; i++) {
+    math::Vector<u16, 4> temp;
+    memcpy(&temp, data, sizeof(math::Vector<u16, 4>));
+    data += stride;
+    result.emplace_back(temp.x() >> 8, temp.y() >> 8, temp.z() >> 8, temp.w() >> 8);
+  }
+  return result;
+}
+
+/*!
  * Convert a GLTF index buffer
  */
 std::vector<u32> gltf_index_buffer(const tinygltf::Model& model,
@@ -169,14 +186,22 @@ ExtractedVertices gltf_vertices(const tinygltf::Model& model,
       const auto count = attrib_accessor.count;
 
       ASSERT_MSG(attrib_accessor.type == TINYGLTF_TYPE_VEC4, "COLOR_0 wasn't vec4");
+      std::vector<math::Vector<u8, 4>> colors;
+      switch (attrib_accessor.componentType) {
+        case TINYGLTF_COMPONENT_TYPE_FLOAT:
+          colors = extract_color_from_vec4_float(data_ptr, count, byte_stride);
+          break;
+        case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT:
+          colors = extract_color_from_vec4_u16(data_ptr, count, byte_stride);
+          break;
+        default:
+          lg::die("Unknown component type for COLOR_0: {}", attrib_accessor.componentType);
+      }
       ASSERT_MSG(
           attrib_accessor.componentType == TINYGLTF_COMPONENT_TYPE_FLOAT,
           fmt::format("COLOR_0 wasn't float, got {} instead", attrib_accessor.componentType));
-      auto colors = extract_color_from_vec4_float(data_ptr, count, byte_stride);
       vtx_colors.insert(vtx_colors.end(), colors.begin(), colors.end());
     }
-
-    // ASSERT_MSG(color_attrib != attributes.end(), "Did not find color attribute.");
   }
 
   bool got_texture = false;

--- a/goalc/build_level/common/gltf_mesh_extract.cpp
+++ b/goalc/build_level/common/gltf_mesh_extract.cpp
@@ -197,9 +197,6 @@ ExtractedVertices gltf_vertices(const tinygltf::Model& model,
         default:
           lg::die("Unknown component type for COLOR_0: {}", attrib_accessor.componentType);
       }
-      ASSERT_MSG(
-          attrib_accessor.componentType == TINYGLTF_COMPONENT_TYPE_FLOAT,
-          fmt::format("COLOR_0 wasn't float, got {} instead", attrib_accessor.componentType));
       vtx_colors.insert(vtx_colors.end(), colors.begin(), colors.end());
     }
   }


### PR DESCRIPTION
It seems like this depends on the version of blender, so we should support both.