### PR TITLE
custom levels: `cell-info` and `buzzer-info` lumps

### DIFF
--- a/custom_levels/jak1/test-zone/test-zone.jsonc
+++ b/custom_levels/jak1/test-zone/test-zone.jsonc
@@ -21,9 +21,10 @@
   "double_sided_collide": false,
 
   // available res-lump tag types:
-  // value types: int32, uint32, enum-int32, enum-uint32, float, meters (1 meter = 4096.0 units), degrees (65536.0 = 360°)
+  // integer types: int32, uint32, enum-int32, enum-uint32
+  // float types: float, meters (1 meter = 4096.0 units), degrees (65536.0 = 360°)
   // vector types: vector (normal floats), vector4m (meters), vector3m (meters with w set to 1.0), vector-vol (normal floats with w in meters), movie-pos (meters with w in degrees)
-  // special types: eco-info, water-height
+  // special types: eco-info, cell-info, buzzer-info, water-height
   //
   // examples:
   //
@@ -44,6 +45,12 @@
   //
   // adds an eco-info tag:
   // "eco-info": ["eco-info", "(pickup-type health)", 2]
+  //
+  // adds a cell-info tag:
+  // "eco-info": ["cell-info", "(game-task training-gimmie)"]
+  //
+  // adds a buzzer-info tag:
+  // "eco-info": ["buzzer-info", "(game-task training-buzzer)", 5]
 
    // The base actor id for your custom level. If you have multiple levels this should be unique!
    "base_id": 100,
@@ -93,7 +100,8 @@
       "quat": [0, 0, 0, 1], // quaternion
       "bsphere": [-21.6238, 19.3496, 17.1191, 10], // bounding sphere
       "lump": {
-        "name": "test-fuel-cell"
+        "name": "test-fuel-cell",
+        "eco-info": ["cell-info", "(game-task none)"]
       }
     },
 


### PR DESCRIPTION
Adds two new lump types: `cell-info` and `buzzer-info`.

`cell-info` takes a `game-task` enum value and defines an `eco-info` lump for power cells.

`buzzer-info` takes a `game-task` enum value and an integer and automatically calculates the required value for the buzzer task with the formula `task + buzzer * (1 << 16)`.