### PR TITLE
game: fix intermittent sprite_distort related crash

### DIFF
--- a/game/graphics/opengl_renderer/sprite/Sprite3_Distort.cpp
+++ b/game/graphics/opengl_renderer/sprite/Sprite3_Distort.cpp
@@ -424,6 +424,7 @@ void Sprite3::distort_setup_instanced(ScopedProfilerNode& /*prof*/) {
 
     for (int res = 3; res < 12; res++) {
       int entry_index = m_sprite_distorter_sine_tables.ientry[res - 3].x() - 352;
+      ASSERT_MSG(entry_index >= 0, "weird sprite_distort startup crash happened again!");
 
       for (int i = 0; i < res; i++) {
         math::Vector3f vf06 = m_sprite_distorter_sine_tables.entry[entry_index++].xyz();

--- a/goal_src/jak1/engine/gfx/sprite/sprite-distort.gc
+++ b/goal_src/jak1/engine/gfx/sprite/sprite-distort.gc
@@ -35,7 +35,8 @@
           (cam-aspy (- (-> *math-camera* perspective vector 1 y)))
           )
       ;; regenerate if aspect ratio changed
-      (when (or (!= cam-aspx (-> tables aspx)) (!= cam-aspy (-> tables aspy)))
+      ;; og:preserve-this Fix intermittent crash on start up due to a race with the DMA
+      (when #t
         (set! (-> tables aspx) cam-aspx)
         (set! (-> tables aspy) cam-aspy)
         (while (< iterations 12)
@@ -382,3 +383,6 @@
     (none)
     )
   )
+
+;; og:preserve-this Fix intermittent crash on start up due to a race with the DMA
+(sprite-distorter-generate-tables)

--- a/goal_src/jak2/engine/gfx/sprite/sprite-distort.gc
+++ b/goal_src/jak2/engine/gfx/sprite/sprite-distort.gc
@@ -66,7 +66,8 @@ across the screen. The resolution of the circle is defined by the number of "tur
           (cam-aspx (- (-> *math-camera* perspective vector 0 x)))
           (cam-aspy (- (-> *math-camera* perspective vector 1 y)))
           )
-      (when (or (!= cam-aspx (-> tbls aspx)) (!= cam-aspy (-> tbls aspy)))
+      ;; og:preserve-this Fix intermittent crash on start up due to a race with the DMA
+      (when #t
         (set! (-> tbls aspx) cam-aspx)
         (set! (-> tbls aspy) cam-aspy)
         (while (< turns 12)
@@ -431,3 +432,6 @@ across the screen. The resolution of the circle is defined by the number of "tur
     (none)
     )
   )
+
+;; og:preserve-this Fix intermittent crash on start up due to a race with the DMA
+(sprite-distorter-generate-tables)


### PR DESCRIPTION
Apparently a long standing bug, with https://github.com/open-goal/jak-project/pull/3194 making it more likely to occur.