### PR TITLE
g/j2: properly wireup mouse settings, properly detect when the mouse has stopped moving

### DIFF
--- a/game/system/hid/devices/mouse.cpp
+++ b/game/system/hid/devices/mouse.cpp
@@ -21,8 +21,34 @@ bool MouseDevice::is_action_already_active(const u32 sdl_code, const bool player
 
 void MouseDevice::poll_state(std::shared_ptr<PadData> data) {
   auto& binds = m_settings->mouse_binds;
-  const auto mouse_state = SDL_GetMouseState(NULL, NULL);
+  int curr_mouse_x;
+  int curr_mouse_y;
+  const auto mouse_state = SDL_GetMouseState(&curr_mouse_x, &curr_mouse_y);
   const auto keyboard_modifier_state = SDL_GetModState();
+
+  // We also poll for mouse position to see if the mouse has stopped moving
+  // if it has, and we are controlling the camera, neutralize the stick direction
+  //
+  // This can all be cleaned up if the game ever has proper mouse motion integration
+  // since you would normally just map the motion of the camera to the relative motion
+  // instead of mapping it to a virtual analog stick.
+  m_frame_counter++;
+  if (m_frame_counter > 3) {
+    m_frame_counter = 0;
+    if (m_control_camera) {
+      int curr_mouse_relx;
+      int curr_mouse_rely;
+      const auto mouse_state_rel = SDL_GetRelativeMouseState(&curr_mouse_relx, &curr_mouse_rely);
+      if (m_last_xcoord == curr_mouse_x && curr_mouse_relx == 0) {
+        data->analog_data.at(2) = 127;
+      }
+      if (m_last_ycoord == curr_mouse_y && curr_mouse_rely == 0) {
+        data->analog_data.at(3) = 127;
+      }
+      m_last_xcoord = curr_mouse_x;
+      m_last_ycoord = curr_mouse_y;
+    }
+  }
 
   // Iterate binds, see if there are any new actions we need to track
   // - Normal Buttons
@@ -111,9 +137,11 @@ void MouseDevice::process_event(const SDL_Event& event,
     m_xcoord = event.motion.x;
     m_ycoord = event.motion.y;
     if (m_control_camera) {
-      const auto xadjust = std::clamp(127 + int(float(event.motion.xrel) * m_xsens), 0, 255);
-      const auto yadjust = std::clamp(127 + int(float(event.motion.yrel) * m_ysens), 0, 255);
+      const auto xrel_amount = float(event.motion.xrel);
+      const auto xadjust = std::clamp(127 + int(xrel_amount * m_xsens), 0, 255);
       data->analog_data.at(2) = xadjust;
+      const auto yrel_amount = float(event.motion.yrel);
+      const auto yadjust = std::clamp(127 + int(yrel_amount * m_ysens), 0, 255);
       data->analog_data.at(3) = yadjust;
     }
   } else if (event.type == SDL_MOUSEBUTTONDOWN || event.type == SDL_MOUSEBUTTONUP) {

--- a/game/system/hid/devices/mouse.h
+++ b/game/system/hid/devices/mouse.h
@@ -56,5 +56,10 @@ class MouseDevice : public InputDevice {
   float m_xsens = -15.0;
   float m_ysens = 10.0;
 
+  // Tracking motion
+  int m_last_xcoord = 0;
+  int m_last_ycoord = 0;
+  int m_frame_counter = 0;
+
   bool is_action_already_active(const u32 sdl_keycode, const bool player_movement);
 };

--- a/goal_src/jak2/pc/progress/progress-static-pc.gc
+++ b/goal_src/jak2/pc/progress/progress-static-pc.gc
@@ -83,8 +83,182 @@ This gives us more freedom to write code how we want.
 
 ;; TODO - there is a bug where if you restore default binds and that changes your `X` bind,
 ;; the next X input is ignored, figure this out eventually / make an issue for it.
-(defmacro progress-new-generic-keybinds-page-link ()
-    `(progress-new-generic-link-to-scrolling-page (text-id progress-menu-reassign-binds)
+
+;; TODO - this is a gross misuse of macros, instead if we want to hide a very small amount of options in one menu versus another
+;; it's a clear indication of a missing feature (add a lambda that determines visibility, or just the use disabled one)
+(defmacro game-options-pc-input-options ()
+  `(progress-new-generic-link-to-scrolling-page (text-id progress-menu-input-options)
+    (progress-new-generic-link-to-scrolling-page (text-id progress-camera-options)
+      (new 'static 'menu-generic-boolean-option
+        :name (text-id progress-camera-options-first-horz)
+        :truthy-text (text-id progress-normal)
+        :falsey-text (text-id progress-inverted)
+        :get-value-fn (lambda () (-> *pc-settings* first-camera-h-inverted?))
+        :on-confirm (lambda ((val symbol))
+          (set! (-> *pc-settings* first-camera-h-inverted?) val)
+          (pc-settings-save)))
+      (new 'static 'menu-generic-boolean-option
+        :name (text-id progress-camera-options-first-vert)
+        :truthy-text (text-id progress-normal)
+        :falsey-text (text-id progress-inverted)
+        :get-value-fn (lambda () (-> *pc-settings* first-camera-v-inverted?))
+        :on-confirm (lambda ((val symbol))
+          (set! (-> *pc-settings* first-camera-v-inverted?) val)
+          (pc-settings-save)))
+      (new 'static 'menu-generic-boolean-option
+        :name (text-id progress-camera-options-third-horz)
+        :truthy-text (text-id progress-normal)
+        :falsey-text (text-id progress-inverted)
+        :get-value-fn (lambda () (-> *pc-settings* third-camera-h-inverted?))
+        :on-confirm (lambda ((val symbol))
+          (set! (-> *pc-settings* third-camera-h-inverted?) val)
+          (pc-settings-save)))
+      (new 'static 'menu-generic-boolean-option
+        :name (text-id progress-camera-options-third-vert)
+        :truthy-text (text-id progress-normal)
+        :falsey-text (text-id progress-inverted)
+        :get-value-fn (lambda () (-> *pc-settings* third-camera-v-inverted?))
+        :on-confirm (lambda ((val symbol))
+          (set! (-> *pc-settings* third-camera-v-inverted?) val)
+          (pc-settings-save)))
+      (new 'static 'menu-generic-confirm-option
+        :name (text-id progress-restore-defaults)
+        :on-confirm (lambda ((val symbol))
+          (reset-camera *pc-settings* #t)
+          (pc-settings-save))))
+    (progress-new-generic-link-to-scrolling-page (text-id progress-menu-controller-options) :should-disable? (lambda () (<= (pc-get-controller-count) 0))
+      (new 'static 'menu-generic-carousel-option
+        :name (text-id progress-controller-options-select-controller)
+        :get-max-size-fn (lambda () (pc-get-controller-count))
+        :get-item-label-fn (lambda ((index int))
+          (pc-get-controller-name index *pc-cpp-temp-string*)
+          *pc-cpp-temp-string*)
+        :get-item-index-fn (lambda () (pc-get-controller-index 0))
+        :on-confirm (lambda ((index int) (the-progress progress)) (pc-set-controller! index 0)))
+      (new 'static 'menu-generic-boolean-option
+        :name (text-id progress-vibration)
+        :should-disable? (lambda () (not (pc-current-controller-has-rumble?)))
+        :truthy-text (text-id progress-on)
+        :falsey-text (text-id progress-off)
+        :get-value-fn (lambda () (-> *setting-control* user-default vibration))
+        :on-confirm (lambda ((val symbol)) (set! (-> *setting-control* user-default vibration) val)))
+      (new 'static 'menu-generic-slider-option
+        :name (text-id progress-controller-options-analog-deadzone)
+        :min-value 0.0
+        :max-value 1.0
+        :step 0.01
+        :show-decimal? #t
+        :get-value-fn (lambda () (-> *pc-settings* stick-deadzone))
+        :on-confirm (lambda ((val float))
+          (set! (-> *pc-settings* stick-deadzone) val)
+          (pc-settings-save)))
+      (new 'static 'menu-generic-boolean-option
+        :name (text-id progress-controller-options-ignore-if-unfocused)
+        :truthy-text (text-id progress-on)
+        :falsey-text (text-id progress-off)
+        :get-value-fn (lambda () (-> *pc-settings* ignore-controller-win-unfocused?))
+        :on-confirm (lambda ((val symbol))
+          (set! (-> *pc-settings* ignore-controller-win-unfocused?) val)
+          (pc-settings-save)))
+      (new 'static 'menu-generic-boolean-option
+        :name (text-id progress-controller-options-led-hp)
+        :should-disable? (lambda () (not (pc-current-controller-has-led?)))
+        :truthy-text (text-id progress-on)
+        :falsey-text (text-id progress-off)
+        :get-value-fn (lambda () (-> *pc-settings* controller-led-hp?))
+        :on-confirm (lambda ((val symbol))
+          (set! (-> *pc-settings* controller-led-hp?) val)
+          (pc-settings-save)))
+      (new 'static 'menu-generic-boolean-option
+        :name (text-id progress-controller-options-led-state)
+        :should-disable? (lambda () (not (pc-current-controller-has-led?)))
+        :truthy-text (text-id progress-on)
+        :falsey-text (text-id progress-off)
+        :get-value-fn (lambda () (-> *pc-settings* controller-led-eco?))
+        :on-confirm (lambda ((val symbol))
+          (set! (-> *pc-settings* controller-led-eco?) val)
+          (pc-settings-save)))
+      (new 'static 'menu-generic-confirm-option
+        :name (text-id progress-restore-defaults)
+        :on-confirm (lambda ((val symbol))
+          (reset-input *pc-settings* 'controller #t)
+          (set-ignore-controller-in-bg! *pc-settings* (-> *pc-settings* ignore-controller-win-unfocused?))
+          (pc-settings-save))))
+    (new 'static 'menu-generic-boolean-option
+      :name (text-id progress-input-options-enable-keyboard)
+      :truthy-text (text-id progress-on)
+      :falsey-text (text-id progress-off)
+      :get-value-fn (lambda () (-> *pc-settings* keyboard-enabled?))
+      :on-confirm (lambda ((val symbol))
+        (set! (-> *pc-settings* keyboard-enabled?) val)
+        (pc-settings-save)))
+    (new 'static 'menu-generic-boolean-option
+      :name (text-id progress-input-options-enable-mouse)
+      :truthy-text (text-id progress-on)
+      :falsey-text (text-id progress-off)
+      :get-value-fn (lambda () (-> *pc-settings* mouse-enabled?))
+      :on-confirm (lambda ((val symbol))
+        (set! (-> *pc-settings* mouse-enabled?) val)
+        (pc-settings-save)))
+    (progress-new-generic-link-to-scrolling-page (text-id progress-menu-mouse-options) :should-disable? (lambda () (not (-> *pc-settings* mouse-enabled?)))
+      (new 'static 'menu-generic-boolean-option
+        :name (text-id progress-mouse-options-track-camera)
+        :truthy-text (text-id progress-on)
+        :falsey-text (text-id progress-off)
+        :get-value-fn (lambda () (-> *pc-settings* mouse-camera?))
+        :on-confirm (lambda ((val symbol))
+          (set! (-> *pc-settings* mouse-camera?) val)
+          (update-mouse-controls! *pc-settings*)
+          (pc-settings-save)))
+      (new 'static 'menu-generic-slider-option
+        :name (text-id progress-mouse-options-horz-sens)
+        :should-disable? (lambda () (not (-> *pc-settings* mouse-camera?)))
+        :min-value -100.0
+        :max-value 100.0
+        :step 0.10
+        :show-decimal? #t
+        :get-value-fn (lambda () (-> *pc-settings* mouse-xsens))
+        :on-confirm (lambda ((val float))
+          (set! (-> *pc-settings* mouse-xsens) val)
+          (update-mouse-controls! *pc-settings*)
+          (pc-settings-save)))
+      (new 'static 'menu-generic-slider-option
+        :name (text-id progress-mouse-options-vert-sens)
+        :should-disable? (lambda () (not (-> *pc-settings* mouse-camera?)))
+        :min-value -100.0
+        :max-value 100.0
+        :step 0.10
+        :show-decimal? #t
+        :get-value-fn (lambda () (-> *pc-settings* mouse-ysens))
+        :on-confirm (lambda ((val float))
+          (set! (-> *pc-settings* mouse-ysens) val)
+          (update-mouse-controls! *pc-settings*)
+          (pc-settings-save)))
+      (new 'static 'menu-generic-boolean-option
+        :name (text-id progress-mouse-options-player-movement)
+        :truthy-text (text-id progress-on)
+        :falsey-text (text-id progress-off)
+        :get-value-fn (lambda () (-> *pc-settings* mouse-movement?))
+        :on-confirm (lambda ((val symbol))
+          (set! (-> *pc-settings* mouse-movement?) val)
+          (update-mouse-controls! *pc-settings*)
+          (pc-settings-save)))
+      (new 'static 'menu-generic-confirm-option
+        :name (text-id progress-restore-defaults)
+        :on-confirm (lambda ((val symbol))
+          (reset-input *pc-settings* 'mouse #t)
+          (update-mouse-controls! *pc-settings*)
+          (pc-settings-save))))
+    (new 'static 'menu-generic-boolean-option
+      :name (text-id progress-input-options-auto-hide-cursor)
+      :truthy-text (text-id progress-on)
+      :falsey-text (text-id progress-off)
+      :get-value-fn (lambda () (-> *pc-settings* auto-hide-cursor?))
+      :on-confirm (lambda ((val symbol))
+        (set! (-> *pc-settings* auto-hide-cursor?) val)
+        (update-mouse-controls! *pc-settings*)
+        (pc-settings-save)))
+    (progress-new-generic-link-to-scrolling-page (text-id progress-menu-reassign-binds)
       (progress-new-generic-link-to-keybind-details-page (text-id progress-reassign-binds-controller)
           :should-disable? (lambda () (<= (pc-get-controller-count) 0))
           :device-type controller
@@ -100,192 +274,25 @@ This gives us more freedom to write code how we want.
           :should-disable? (lambda () (not (-> *pc-settings* mouse-enabled?)))
           :device-type mouse
           :entries (select l3 r3 start dpad-up dpad-right dpad-down dpad-left l2 r2 l1 r1 triangle circle cross square)
-          :confirm ((text-id progress-restore-defaults) (lambda () (pc-reset-bindings-to-defaults! 0 2))))))
+          :confirm ((text-id progress-restore-defaults) (lambda () (pc-reset-bindings-to-defaults! 0 2)))))
+    (new 'static 'menu-generic-confirm-option
+      :name (text-id progress-restore-defaults)
+      :on-confirm (lambda ((val symbol))
+        (reset-input *pc-settings* 'input #t)
+        (set-enable-keyboard! *pc-settings* (-> *pc-settings* keyboard-enabled?))
+        (update-mouse-controls! *pc-settings*)
+        (pc-settings-save)))))
 
-(define *game-options-pc*
-  (progress-new-generic-scrolling-page (text-id progress-root-game-options)
-    (progress-new-generic-link-to-scrolling-page (text-id progress-menu-input-options)
-      (progress-new-generic-link-to-scrolling-page (text-id progress-camera-options)
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-camera-options-first-horz)
-          :truthy-text (text-id progress-normal)
-          :falsey-text (text-id progress-inverted)
-          :get-value-fn (lambda () (-> *pc-settings* first-camera-h-inverted?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* first-camera-h-inverted?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-camera-options-first-vert)
-          :truthy-text (text-id progress-normal)
-          :falsey-text (text-id progress-inverted)
-          :get-value-fn (lambda () (-> *pc-settings* first-camera-v-inverted?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* first-camera-v-inverted?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-camera-options-third-horz)
-          :truthy-text (text-id progress-normal)
-          :falsey-text (text-id progress-inverted)
-          :get-value-fn (lambda () (-> *pc-settings* third-camera-h-inverted?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* third-camera-h-inverted?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-camera-options-third-vert)
-          :truthy-text (text-id progress-normal)
-          :falsey-text (text-id progress-inverted)
-          :get-value-fn (lambda () (-> *pc-settings* third-camera-v-inverted?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* third-camera-v-inverted?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-confirm-option
-          :name (text-id progress-restore-defaults)
-          :on-confirm (lambda ((val symbol))
-            (reset-camera *pc-settings* #t)
-            (pc-settings-save))))
-      (progress-new-generic-link-to-scrolling-page (text-id progress-menu-controller-options) :should-disable? (lambda () (<= (pc-get-controller-count) 0))
-        (new 'static 'menu-generic-carousel-option
-          :name (text-id progress-controller-options-select-controller)
-          :get-max-size-fn (lambda () (pc-get-controller-count))
-          :get-item-label-fn (lambda ((index int))
-            (pc-get-controller-name index *pc-cpp-temp-string*)
-            *pc-cpp-temp-string*)
-          :get-item-index-fn (lambda () (pc-get-controller-index 0))
-          :on-confirm (lambda ((index int) (the-progress progress)) (pc-set-controller! index 0)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-vibration)
-          :should-disable? (lambda () (not (pc-current-controller-has-rumble?)))
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *setting-control* user-default vibration))
-          :on-confirm (lambda ((val symbol)) (set! (-> *setting-control* user-default vibration) val)))
-        (new 'static 'menu-generic-slider-option
-          :name (text-id progress-controller-options-analog-deadzone)
-          :min-value 0.0
-          :max-value 1.0
-          :step 0.01
-          :show-decimal? #t
-          :get-value-fn (lambda () (-> *pc-settings* stick-deadzone))
-          :on-confirm (lambda ((val float))
-            (set! (-> *pc-settings* stick-deadzone) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-controller-options-ignore-if-unfocused)
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *pc-settings* ignore-controller-win-unfocused?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* ignore-controller-win-unfocused?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-controller-options-led-hp)
-          :should-disable? (lambda () (not (pc-current-controller-has-led?)))
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *pc-settings* controller-led-hp?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* controller-led-hp?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-controller-options-led-state)
-          :should-disable? (lambda () (not (pc-current-controller-has-led?)))
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *pc-settings* controller-led-eco?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* controller-led-eco?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-confirm-option
-          :name (text-id progress-restore-defaults)
-          :on-confirm (lambda ((val symbol))
-            (reset-input *pc-settings* 'controller #t)
-            (set-ignore-controller-in-bg! *pc-settings* (-> *pc-settings* ignore-controller-win-unfocused?))
-            (pc-settings-save))))
-      (new 'static 'menu-generic-boolean-option
-        :name (text-id progress-input-options-enable-keyboard)
-        :truthy-text (text-id progress-on)
-        :falsey-text (text-id progress-off)
-        :get-value-fn (lambda () (-> *pc-settings* keyboard-enabled?))
-        :on-confirm (lambda ((val symbol))
-          (set! (-> *pc-settings* keyboard-enabled?) val)
-          (pc-settings-save)))
-      (new 'static 'menu-generic-boolean-option
-        :name (text-id progress-input-options-enable-mouse)
-        :truthy-text (text-id progress-on)
-        :falsey-text (text-id progress-off)
-        :get-value-fn (lambda () (-> *pc-settings* mouse-enabled?))
-        :on-confirm (lambda ((val symbol))
-          (set! (-> *pc-settings* mouse-enabled?) val)
-          (pc-settings-save)))
-      (progress-new-generic-link-to-scrolling-page (text-id progress-menu-mouse-options) :should-disable? (lambda () (not (-> *pc-settings* mouse-enabled?)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-mouse-options-track-camera)
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *pc-settings* mouse-camera?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* mouse-camera?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-slider-option
-          :name (text-id progress-mouse-options-horz-sens)
-          :should-disable? (lambda () (not (-> *pc-settings* mouse-camera?)))
-          :min-value -30.0
-          :max-value 30.0
-          :step 0.10
-          :show-decimal? #t
-          :get-value-fn (lambda () (-> *pc-settings* mouse-xsens))
-          :on-confirm (lambda ((val float))
-            (set! (-> *pc-settings* mouse-xsens) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-slider-option
-          :name (text-id progress-mouse-options-vert-sens)
-          :should-disable? (lambda () (not (-> *pc-settings* mouse-camera?)))
-          :min-value -30.0
-          :max-value 30.0
-          :step 0.10
-          :show-decimal? #t
-          :get-value-fn (lambda () (-> *pc-settings* mouse-ysens))
-          :on-confirm (lambda ((val float))
-            (set! (-> *pc-settings* mouse-ysens) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-mouse-options-player-movement)
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *pc-settings* mouse-movement?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* mouse-movement?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-confirm-option
-          :name (text-id progress-restore-defaults)
-          :on-confirm (lambda ((val symbol))
-            (reset-input *pc-settings* 'mouse #t)
-            (update-mouse-controls! *pc-settings*)
-            (pc-settings-save))))
-      (new 'static 'menu-generic-boolean-option
-        :name (text-id progress-input-options-auto-hide-cursor)
-        :truthy-text (text-id progress-on)
-        :falsey-text (text-id progress-off)
-        :get-value-fn (lambda () (-> *pc-settings* auto-hide-cursor?))
-        :on-confirm (lambda ((val symbol))
-          (set! (-> *pc-settings* auto-hide-cursor?) val)
-          (update-mouse-controls! *pc-settings*)
-          (pc-settings-save)))
-      (progress-new-generic-keybinds-page-link)
-      (new 'static 'menu-generic-confirm-option
-        :name (text-id progress-restore-defaults)
-        :on-confirm (lambda ((val symbol))
-          (reset-input *pc-settings* 'input #t)
-          (set-enable-keyboard! *pc-settings* (-> *pc-settings* keyboard-enabled?))
-          (update-mouse-controls! *pc-settings*)
-          (pc-settings-save))))
-    (new 'static 'menu-generic-boolean-option
+(defmacro game-options-pc-subtitle-toggle ()
+  `(new 'static 'menu-generic-boolean-option
       :name (text-id progress-subtitles)
       :truthy-text (text-id progress-on)
       :falsey-text (text-id progress-off)
       :get-value-fn (lambda () (-> *setting-control* user-default subtitle))
-      :on-confirm (lambda ((val symbol)) (set! (-> *setting-control* user-default subtitle) val)))
-    (new 'static 'menu-generic-carousel-option
+      :on-confirm (lambda ((val symbol)) (set! (-> *setting-control* user-default subtitle) val))))
+
+(defmacro game-options-pc-subtitle-language ()
+  `(new 'static 'menu-generic-carousel-option
       :name (text-id progress-sound-subtitle-language)
       :items (new 'static 'boxed-array :type text-id
                   (text-id language-name-english)
@@ -298,8 +305,10 @@ This gives us more freedom to write code how we want.
                   (text-id language-name-english-uk))
       :get-item-index-fn (lambda () (-> *setting-control* user-default subtitle-language))
       :on-confirm (lambda ((index int) (the-progress progress))
-          (set! (-> *setting-control* user-default subtitle-language) (the-as language-enum index))))
-    (new 'static 'menu-generic-carousel-option
+          (set! (-> *setting-control* user-default subtitle-language) (the-as language-enum index)))))
+
+(defmacro game-options-pc-sound-language ()
+  `(new 'static 'menu-generic-carousel-option
       :name (text-id progress-sound-language)
       :items (new 'static 'boxed-array :type text-id
                   (text-id language-name-english)
@@ -311,8 +320,10 @@ This gives us more freedom to write code how we want.
                   (text-id language-name-korean))
       :get-item-index-fn (lambda () (-> *setting-control* user-default language))
       :on-confirm (lambda ((index int) (the-progress progress))
-          (set! (-> *setting-control* user-default language) (the-as language-enum index))))
-    (new 'static 'menu-generic-carousel-option
+          (set! (-> *setting-control* user-default language) (the-as language-enum index)))))
+
+(defmacro game-options-pc-text-language ()
+  `(new 'static 'menu-generic-carousel-option
       :name (text-id progress-text-language)
       :items (new 'static 'boxed-array :type text-id
                   (text-id language-name-english)
@@ -329,17 +340,20 @@ This gives us more freedom to write code how we want.
           ;; NOTE - this doesn't actually work (naughty dog tried it too in their progress code)
           ;; fix it eventually
           (load-level-text-files (the-as int (-> *pc-settings* text-language)))
-          (pc-settings-save)))
-    (progress-new-generic-link-to-scrolling-page (text-id progress-misc-game-options)
-      (new 'static 'menu-generic-boolean-option
+          (pc-settings-save))))
+
+(defmacro misc-options-pc-discord-rpc ()
+  `(new 'static 'menu-generic-boolean-option
         :name (text-id progress-discord-rpc)
         :truthy-text (text-id progress-on)
         :falsey-text (text-id progress-off)
         :get-value-fn (lambda () (-> *pc-settings* discord-rpc?))
         :on-confirm (lambda ((val symbol))
           (set! (-> *pc-settings* discord-rpc?) val)
-          (pc-settings-save)))
-      (new 'static 'menu-generic-boolean-option
+          (pc-settings-save))))
+
+(defmacro misc-options-pc-speedrunner-mode ()
+  `(new 'static 'menu-generic-boolean-option
         :name (text-id progress-speedrunner-mode)
         :truthy-text (text-id progress-on)
         :falsey-text (text-id progress-off)
@@ -351,244 +365,38 @@ This gives us more freedom to write code how we want.
           (if (-> *pc-settings* speedrunner-mode?)
               (set! (-> *pc-settings* cheats-backup) (-> *pc-settings* cheats))
               (set! (-> *pc-settings* cheats) (-> *pc-settings* cheats-backup)))
-          (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-fast-progress)
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *pc-settings* fast-progress?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* fast-progress?) val)
-            (pc-settings-save))))))
+          (pc-settings-save))))
+
+(defmacro misc-options-pc-fast-progress ()
+  `(new 'static 'menu-generic-boolean-option
+        :name (text-id progress-fast-progress)
+        :truthy-text (text-id progress-on)
+        :falsey-text (text-id progress-off)
+        :get-value-fn (lambda () (-> *pc-settings* fast-progress?))
+        :on-confirm (lambda ((val symbol))
+          (set! (-> *pc-settings* fast-progress?) val)
+          (pc-settings-save))))
+
+(define *game-options-pc*
+  (progress-new-generic-scrolling-page (text-id progress-root-game-options)
+    (game-options-pc-input-options)
+    (game-options-pc-subtitle-toggle)
+    (game-options-pc-subtitle-language)
+    (game-options-pc-sound-language)
+    (game-options-pc-text-language)
+    (progress-new-generic-link-to-scrolling-page (text-id progress-misc-game-options)
+      (misc-options-pc-discord-rpc)
+      (misc-options-pc-speedrunner-mode)
+      (misc-options-pc-fast-progress))))
 
 (define *game-options-title-pc*
   (progress-new-generic-scrolling-page (text-id progress-root-game-options)
-    (progress-new-generic-link-to-scrolling-page (text-id progress-menu-input-options)
-      (progress-new-generic-link-to-scrolling-page (text-id progress-camera-options)
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-camera-options-first-horz)
-          :truthy-text (text-id progress-normal)
-          :falsey-text (text-id progress-inverted)
-          :get-value-fn (lambda () (-> *pc-settings* first-camera-h-inverted?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* first-camera-h-inverted?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-camera-options-first-vert)
-          :truthy-text (text-id progress-normal)
-          :falsey-text (text-id progress-inverted)
-          :get-value-fn (lambda () (-> *pc-settings* first-camera-v-inverted?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* first-camera-v-inverted?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-camera-options-third-horz)
-          :truthy-text (text-id progress-normal)
-          :falsey-text (text-id progress-inverted)
-          :get-value-fn (lambda () (-> *pc-settings* third-camera-h-inverted?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* third-camera-h-inverted?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-camera-options-third-vert)
-          :truthy-text (text-id progress-normal)
-          :falsey-text (text-id progress-inverted)
-          :get-value-fn (lambda () (-> *pc-settings* third-camera-v-inverted?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* third-camera-v-inverted?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-confirm-option
-          :name (text-id progress-restore-defaults)
-          :on-confirm (lambda ((val symbol))
-            (reset-camera *pc-settings* #t)
-            (pc-settings-save))))
-      (progress-new-generic-link-to-scrolling-page (text-id progress-menu-controller-options) :should-disable? (lambda () (<= (pc-get-controller-count) 0))
-        (new 'static 'menu-generic-carousel-option
-          :name (text-id progress-controller-options-select-controller)
-          :get-max-size-fn (lambda () (pc-get-controller-count))
-          :get-item-label-fn (lambda ((index int))
-            (pc-get-controller-name index *pc-cpp-temp-string*)
-            *pc-cpp-temp-string*)
-          :get-item-index-fn (lambda () (pc-get-controller-index 0))
-          :on-confirm (lambda ((index int) (the-progress progress)) (pc-set-controller! index 0)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-vibration)
-          :should-disable? (lambda () (not (pc-current-controller-has-rumble?)))
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *setting-control* user-default vibration))
-          :on-confirm (lambda ((val symbol)) (set! (-> *setting-control* user-default vibration) val)))
-        (new 'static 'menu-generic-slider-option
-          :name (text-id progress-controller-options-analog-deadzone)
-          :min-value 0.0
-          :max-value 1.0
-          :step 0.01
-          :show-decimal? #t
-          :get-value-fn (lambda () (-> *pc-settings* stick-deadzone))
-          :on-confirm (lambda ((val float))
-            (set! (-> *pc-settings* stick-deadzone) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-controller-options-ignore-if-unfocused)
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *pc-settings* ignore-controller-win-unfocused?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* ignore-controller-win-unfocused?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-controller-options-led-hp)
-          :should-disable? (lambda () (not (pc-current-controller-has-led?)))
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *pc-settings* controller-led-hp?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* controller-led-hp?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-controller-options-led-state)
-          :should-disable? (lambda () (not (pc-current-controller-has-led?)))
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *pc-settings* controller-led-eco?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* controller-led-eco?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-confirm-option
-          :name (text-id progress-restore-defaults)
-          :on-confirm (lambda ((val symbol))
-            (reset-input *pc-settings* 'controller #t)
-            (set-ignore-controller-in-bg! *pc-settings* (-> *pc-settings* ignore-controller-win-unfocused?))
-            (pc-settings-save))))
-      (new 'static 'menu-generic-boolean-option
-        :name (text-id progress-input-options-enable-keyboard)
-        :truthy-text (text-id progress-on)
-        :falsey-text (text-id progress-off)
-        :get-value-fn (lambda () (-> *pc-settings* keyboard-enabled?))
-        :on-confirm (lambda ((val symbol))
-          (set! (-> *pc-settings* keyboard-enabled?) val)
-          (pc-settings-save)))
-      (new 'static 'menu-generic-boolean-option
-        :name (text-id progress-input-options-enable-mouse)
-        :truthy-text (text-id progress-on)
-        :falsey-text (text-id progress-off)
-        :get-value-fn (lambda () (-> *pc-settings* mouse-enabled?))
-        :on-confirm (lambda ((val symbol))
-          (set! (-> *pc-settings* mouse-enabled?) val)
-          (pc-settings-save)))
-      (progress-new-generic-link-to-scrolling-page (text-id progress-menu-mouse-options) :should-disable? (lambda () (not (-> *pc-settings* mouse-enabled?)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-mouse-options-track-camera)
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *pc-settings* mouse-camera?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* mouse-camera?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-slider-option
-          :name (text-id progress-mouse-options-horz-sens)
-          :should-disable? (lambda () (not (-> *pc-settings* mouse-camera?)))
-          :min-value -30.0
-          :max-value 30.0
-          :step 0.10
-          :show-decimal? #t
-          :get-value-fn (lambda () (-> *pc-settings* mouse-xsens))
-          :on-confirm (lambda ((val float))
-            (set! (-> *pc-settings* mouse-xsens) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-slider-option
-          :name (text-id progress-mouse-options-vert-sens)
-          :should-disable? (lambda () (not (-> *pc-settings* mouse-camera?)))
-          :min-value -30.0
-          :max-value 30.0
-          :step 0.10
-          :show-decimal? #t
-          :get-value-fn (lambda () (-> *pc-settings* mouse-ysens))
-          :on-confirm (lambda ((val float))
-            (set! (-> *pc-settings* mouse-ysens) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-mouse-options-player-movement)
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *pc-settings* mouse-movement?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* mouse-movement?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-confirm-option
-          :name (text-id progress-restore-defaults)
-          :on-confirm (lambda ((val symbol))
-            (reset-input *pc-settings* 'mouse #t)
-            (update-mouse-controls! *pc-settings*)
-            (pc-settings-save))))
-      (new 'static 'menu-generic-boolean-option
-        :name (text-id progress-input-options-auto-hide-cursor)
-        :truthy-text (text-id progress-on)
-        :falsey-text (text-id progress-off)
-        :get-value-fn (lambda () (-> *pc-settings* auto-hide-cursor?))
-        :on-confirm (lambda ((val symbol))
-          (set! (-> *pc-settings* auto-hide-cursor?) val)
-          (update-mouse-controls! *pc-settings*)
-          (pc-settings-save)))
-      (progress-new-generic-keybinds-page-link)
-      (new 'static 'menu-generic-confirm-option
-        :name (text-id progress-restore-defaults)
-        :on-confirm (lambda ((val symbol))
-          (reset-input *pc-settings* 'input #t)
-          (set-enable-keyboard! *pc-settings* (-> *pc-settings* keyboard-enabled?))
-          (update-mouse-controls! *pc-settings*)
-          (pc-settings-save))))
-    (new 'static 'menu-generic-boolean-option
-      :name (text-id progress-subtitles)
-      :truthy-text (text-id progress-on)
-      :falsey-text (text-id progress-off)
-      :get-value-fn (lambda () (-> *setting-control* user-default subtitle))
-      :on-confirm (lambda ((val symbol)) (set! (-> *setting-control* user-default subtitle) val)))
-    (new 'static 'menu-generic-carousel-option
-      :name (text-id progress-sound-subtitle-language)
-      :items (new 'static 'boxed-array :type text-id
-                  (text-id language-name-english)
-                  (text-id language-name-french)
-                  (text-id language-name-german)
-                  (text-id language-name-spanish)
-                  (text-id language-name-italian)
-                  (text-id language-name-japanese)
-                  (text-id language-name-korean)
-                  (text-id language-name-english-uk))
-      :get-item-index-fn (lambda () (-> *setting-control* user-default subtitle-language))
-      :on-confirm (lambda ((index int) (the-progress progress))
-          (set! (-> *setting-control* user-default subtitle-language) (the-as language-enum index))))
-    (new 'static 'menu-generic-carousel-option
-      :name (text-id progress-sound-language)
-      :items (new 'static 'boxed-array :type text-id
-                  (text-id language-name-english)
-                  (text-id language-name-french)
-                  (text-id language-name-german)
-                  (text-id language-name-spanish)
-                  (text-id language-name-italian)
-                  (text-id language-name-japanese)
-                  (text-id language-name-korean))
-      :get-item-index-fn (lambda () (-> *setting-control* user-default language))
-      :on-confirm (lambda ((index int) (the-progress progress))
-          (set! (-> *setting-control* user-default language) (the-as language-enum index))))
-    (new 'static 'menu-generic-carousel-option
-      :name (text-id progress-text-language)
-      :items (new 'static 'boxed-array :type text-id
-                  (text-id language-name-english)
-                  (text-id language-name-french)
-                  (text-id language-name-german)
-                  (text-id language-name-spanish)
-                  (text-id language-name-italian)
-                  (text-id language-name-japanese)
-                  (text-id language-name-korean)
-                  (text-id language-name-english-uk))
-      :get-item-index-fn (lambda () (-> *pc-settings* text-language))
-      :on-confirm (lambda ((index int) (the-progress progress))
-          (set! (-> *pc-settings* text-language) (the-as pc-language index))
-          ;; NOTE - this doesn't actually work (naughty dog tried it too in their progress code)
-          ;; fix it eventually
-          (load-level-text-files (the-as int (-> *pc-settings* text-language)))
-          (pc-settings-save)))
+    (game-options-pc-input-options)
+    (game-options-pc-subtitle-toggle)
+    (game-options-pc-subtitle-language)
+    (game-options-pc-sound-language)
+    (game-options-pc-text-language)
+    ;; TODO - is there a reason we only display the territory setting on the title screen?
     (new 'static 'menu-generic-carousel-option
       :name (text-id progress-territory)
       :items (new 'static 'boxed-array :type text-id
@@ -600,46 +408,26 @@ This gives us more freedom to write code how we want.
       :get-item-index-fn (lambda () (1+ (-> *pc-settings* territory)))
       :on-confirm (lambda ((index int) (the-progress progress)) (set! (-> *pc-settings* territory) (1- index)) (pc-settings-save)))
     (progress-new-generic-link-to-scrolling-page (text-id progress-misc-game-options)
+      (misc-options-pc-discord-rpc)
+      (misc-options-pc-speedrunner-mode)
+      ;; TODO - is there a reason we only display the fast airlock and fast-elevator setting on the title screen (worried about people changing it mid game?)
       (new 'static 'menu-generic-boolean-option
-        :name (text-id progress-discord-rpc)
+        :name (text-id progress-fast-airlock)
         :truthy-text (text-id progress-on)
         :falsey-text (text-id progress-off)
-        :get-value-fn (lambda () (-> *pc-settings* discord-rpc?))
+        :get-value-fn (lambda () (-> *pc-settings* fast-airlock?))
         :on-confirm (lambda ((val symbol))
-          (set! (-> *pc-settings* discord-rpc?) val)
+          (set! (-> *pc-settings* fast-airlock?) val)
           (pc-settings-save)))
       (new 'static 'menu-generic-boolean-option
-        :name (text-id progress-speedrunner-mode)
+        :name (text-id progress-fast-elevator)
         :truthy-text (text-id progress-on)
         :falsey-text (text-id progress-off)
-        :get-value-fn (lambda () (-> *pc-settings* speedrunner-mode?))
+        :get-value-fn (lambda () (-> *pc-settings* fast-elevator?))
         :on-confirm (lambda ((val symbol))
-          (set! (-> *pc-settings* speedrunner-mode?) val)
+          (set! (-> *pc-settings* fast-elevator?) val)
           (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-fast-airlock)
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *pc-settings* fast-airlock?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* fast-airlock?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-fast-elevator)
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *pc-settings* fast-elevator?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* fast-elevator?) val)
-            (pc-settings-save)))
-        (new 'static 'menu-generic-boolean-option
-          :name (text-id progress-fast-progress)
-          :truthy-text (text-id progress-on)
-          :falsey-text (text-id progress-off)
-          :get-value-fn (lambda () (-> *pc-settings* fast-progress?))
-          :on-confirm (lambda ((val symbol))
-            (set! (-> *pc-settings* fast-progress?) val)
-            (pc-settings-save))))))
+      (misc-options-pc-fast-progress))))
 
 
 (define *msaa-options* (new 'static 'boxed-array :type int16 1 2 4 8 16))


### PR DESCRIPTION
- Wired up the menu settings to change the settings in game, not just on boot
- Removed all the duplication in the game options menu code
- Fixed the mouse code so that it properly brings the virtual analog stick back to neutral when the mouse stops
- Extended the sensitivity min/max for those that want to ensure the slightest movement maxes out virtual analog stick.