### PR TITLE
ci: move to `sccache`

### DIFF
--- a/.github/workflows/linux-build-clang.yaml
+++ b/.github/workflows/linux-build-clang.yaml
@@ -20,13 +20,6 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
 
-    env: # overrides: https://github.com/mbitsnbites/buildcache/blob/master/doc/configuration.md
-      BUILDCACHE_MAX_CACHE_SIZE: 1000000000 # 1gb
-      BUILDCACHE_COMPRESS_FORMAT: ZSTD
-      BUILDCACHE_COMPRESS_LEVEL: 19
-      BUILDCACHE_DIRECT_MODE: true
-      BUILDCACHE_LOG_FILE: ${{ github.workspace }}/buildcache.log
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -39,11 +32,13 @@ jobs:
             libxinerama-dev libxcursor-dev libpulse-dev \
             libxi-dev zip ninja-build libgl1-mesa-dev libssl-dev
 
-      - name: Setup Buildcache
-        uses: mikehardy/buildcache-action@v2.1.0
+      - name: Setup sccache
+        uses: hendrikmuhs/ccache-action@v1.2.12
         with:
-          cache_key: linux-ubuntu-20.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
-          buildcache_tag: v0.28.1
+          variant: sccache
+          key: linux-ubuntu-20.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
+          restore-keys: linux-ubuntu-20.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          max-size: 1000M
 
       - name: CMake Generation
         env:
@@ -51,8 +46,8 @@ jobs:
           CXX: clang++
         run: |
           cmake -B build --preset=${{ inputs.cmakePreset }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=${{ github.workspace }}/buildcache/bin/buildcache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=${{ github.workspace }}/buildcache/bin/buildcache
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build Project
         run: cmake --build build --parallel $((`nproc`))

--- a/.github/workflows/linux-build-gcc.yaml
+++ b/.github/workflows/linux-build-gcc.yaml
@@ -16,13 +16,6 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
 
-    env: # overrides: https://github.com/mbitsnbites/buildcache/blob/master/doc/configuration.md
-      BUILDCACHE_MAX_CACHE_SIZE: 1000000000 # 1gb
-      BUILDCACHE_COMPRESS_FORMAT: ZSTD
-      BUILDCACHE_COMPRESS_LEVEL: 19
-      BUILDCACHE_DIRECT_MODE: true
-      BUILDCACHE_LOG_FILE: ${{ github.workspace }}/buildcache.log
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -40,11 +33,13 @@ jobs:
             sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
             sudo update-alternatives --set g++ /usr/bin/g++-10
 
-      - name: Setup Buildcache
-        uses: mikehardy/buildcache-action@v2.1.0
+      - name: Setup sccache
+        uses: hendrikmuhs/ccache-action@v1.2.12
         with:
-          cache_key: linux-ubuntu-20.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
-          buildcache_tag: v0.28.1
+          variant: sccache
+          key: linux-ubuntu-20.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
+          restore-keys: linux-ubuntu-20.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          max-size: 1000M
 
       - name: CMake Generation
         env:
@@ -53,18 +48,11 @@ jobs:
         run: |
           cmake -B build --preset=${{ inputs.cmakePreset }} \
             -DCODE_COVERAGE=OFF \
-            -DCMAKE_C_COMPILER_LAUNCHER=${{ github.workspace }}/buildcache/bin/buildcache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=${{ github.workspace }}/buildcache/bin/buildcache
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build Project
         run: cmake --build build --parallel $((`nproc`)) -- -w dupbuild=warn
 
       - name: Run Tests
         run: ./test.sh
-
-      # - name: Submit Coverage Report to Codacy
-      #   uses: codacy/codacy-coverage-reporter-action@v1
-      #   continue-on-error: true
-      #   with:
-      #     project-token: ${{ secrets.CODACY_PROJECT_KEY }}
-      #     coverage-reports: ./build/goalc-test_coverage.info

--- a/.github/workflows/macos-build-arm.yaml
+++ b/.github/workflows/macos-build-arm.yaml
@@ -16,13 +16,6 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 120
 
-    env: # overrides: https://github.com/mbitsnbites/buildcache/blob/master/doc/configuration.md
-      BUILDCACHE_MAX_CACHE_SIZE: 1000000000 # 1gb
-      BUILDCACHE_COMPRESS_FORMAT: ZSTD
-      BUILDCACHE_COMPRESS_LEVEL: 19
-      BUILDCACHE_DIRECT_MODE: true
-      BUILDCACHE_LOG_FILE: ${{ github.workspace }}/buildcache.log
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -33,11 +26,13 @@ jobs:
       - name: Install Package Dependencies
         run: arch -arm64 brew install cmake ninja
 
-      - name: Setup Buildcache
-        uses: mikehardy/buildcache-action@v2.1.0
+      - name: Setup sccache
+        uses: hendrikmuhs/ccache-action@v1.2.12
         with:
-          cache_key: macos-12-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
-          buildcache_tag: v0.28.1
+          variant: sccache
+          key: macos-12-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
+          restore-keys: macos-12-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          max-size: 1000M
 
       - name: CMake Generation
         env:
@@ -45,8 +40,8 @@ jobs:
           CXX: clang++
         run: |
           cmake -B build --preset=${{ inputs.cmakePreset }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=${{ github.workspace }}/buildcache/bin/buildcache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=${{ github.workspace }}/buildcache/bin/buildcache
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build Project
         run: cmake --build build --parallel $((`sysctl -n hw.logicalcpu`))

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -20,13 +20,6 @@ jobs:
     runs-on: macos-11
     timeout-minutes: 120
 
-    env: # overrides: https://github.com/mbitsnbites/buildcache/blob/master/doc/configuration.md
-      BUILDCACHE_MAX_CACHE_SIZE: 1000000000 # 1gb
-      BUILDCACHE_COMPRESS_FORMAT: ZSTD
-      BUILDCACHE_COMPRESS_LEVEL: 19
-      BUILDCACHE_DIRECT_MODE: true
-      BUILDCACHE_LOG_FILE: ${{ github.workspace }}/buildcache.log
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -34,11 +27,13 @@ jobs:
       - name: Install Package Dependencies
         run: brew install cmake nasm ninja
 
-      - name: Setup Buildcache
-        uses: mikehardy/buildcache-action@v2.1.0
+      - name: Setup sccache
+        uses: hendrikmuhs/ccache-action@v1.2.12
         with:
-          cache_key: macos-11-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
-          buildcache_tag: v0.28.1
+          variant: sccache
+          key: macos-11-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
+          restore-keys: macos-11-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          max-size: 1000M
 
       - name: CMake Generation
         env:
@@ -46,8 +41,8 @@ jobs:
           CXX: clang++
         run: |
           cmake -B build --preset=${{ inputs.cmakePreset }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=${{ github.workspace }}/buildcache/bin/buildcache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=${{ github.workspace }}/buildcache/bin/buildcache
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build Project
         run: cmake --build build --parallel $((`sysctl -n hw.logicalcpu`))

--- a/.github/workflows/windows-build-clang.yaml
+++ b/.github/workflows/windows-build-clang.yaml
@@ -21,13 +21,6 @@ jobs:
     # Set some sort of timeout in the event of run-away builds.  We are limited on concurrent jobs so, get rid of them.
     timeout-minutes: 60
 
-    env: # overrides: https://github.com/mbitsnbites/buildcache/blob/master/doc/configuration.md
-      BUILDCACHE_MAX_CACHE_SIZE: 1000000000 # 1gb
-      BUILDCACHE_COMPRESS_FORMAT: ZSTD
-      BUILDCACHE_COMPRESS_LEVEL: 19
-      BUILDCACHE_DIRECT_MODE: true
-      BUILDCACHE_LOG_FILE: ${{ github.workspace }}/buildcache.log
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -42,10 +35,13 @@ jobs:
             choco install ${{ github.workspace }}/third-party/nasm/old/nasm.2.15.05.nupkg
           }
 
-      - name: Setup Buildcache
-        uses: mikehardy/buildcache-action@v2.1.0
+      - name: Setup sccache
+        uses: hendrikmuhs/ccache-action@v1.2.12
         with:
-          cache_key: windows-2022-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          variant: sccache
+          key: windows-2022-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
+          restore-keys: windows-2022-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          max-size: 1000M
 
       - uses: ilammy/msvc-dev-cmd@v1
 
@@ -58,7 +54,7 @@ jobs:
 
       - name: CMake Generation
         shell: cmd
-        run: cmake -B build --preset=${{ inputs.cmakePreset }} -DCMAKE_C_COMPILER_LAUNCHER=${{ github.workspace }}/buildcache/bin/buildcache.exe -DCMAKE_CXX_COMPILER_LAUNCHER=${{ github.workspace }}/buildcache/bin/buildcache.exe .
+        run: cmake -B build --preset=${{ inputs.cmakePreset }} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache .
 
       - name: Build Project
         shell: cmd

--- a/.github/workflows/windows-build-msvc.yaml
+++ b/.github/workflows/windows-build-msvc.yaml
@@ -16,13 +16,6 @@ jobs:
     runs-on: windows-2022
     timeout-minutes: 60
 
-    env: # overrides: https://github.com/mbitsnbites/buildcache/blob/master/doc/configuration.md
-      BUILDCACHE_MAX_CACHE_SIZE: 1000000000 # 1gb
-      BUILDCACHE_COMPRESS_FORMAT: ZSTD
-      BUILDCACHE_COMPRESS_LEVEL: 19
-      BUILDCACHE_DIRECT_MODE: true
-      BUILDCACHE_LOG_FILE: ${{ github.workspace }}/buildcache.log
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -37,10 +30,13 @@ jobs:
             choco install ${{ github.workspace }}/third-party/nasm/old/nasm.2.15.05.nupkg
           }
 
-      - name: Setup Buildcache
-        uses: mikehardy/buildcache-action@v2.1.0
+      - name: Setup sccache
+        uses: hendrikmuhs/ccache-action@v1.2.12
         with:
-          cache_key: windows-2022-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          variant: sccache
+          key: windows-2022-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
+          restore-keys: windows-2022-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          max-size: 1000M
 
       - uses: ilammy/msvc-dev-cmd@v1
 
@@ -52,7 +48,7 @@ jobs:
 
       - name: CMake Generation - MSVC
         shell: cmd
-        run: cmake -B build --preset=${{ inputs.cmakePreset }} -DCMAKE_C_COMPILER_LAUNCHER=${{ github.workspace }}/buildcache/bin/buildcache.exe -DCMAKE_CXX_COMPILER_LAUNCHER=${{ github.workspace }}/buildcache/bin/buildcache.exe .
+        run: cmake -B build --preset=${{ inputs.cmakePreset }} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache .
 
       - name: Build Project
         shell: cmd


### PR DESCRIPTION
The original buildcache action has been archived, and buildcache itself has also moved to github.

I forked the action and was updating it to work, but then the latest buildcache release once again breaks support for older runners (in our case, macos-12 is the lowest, which is acceptable as 11 is EOL).

Either way, switching to sccache is not only a way cleaner solution but it is also well maintained (and works!)