### PR TITLE
ci: move to macos-12

### DIFF
--- a/.github/workflows/macos-build-arm.yaml
+++ b/.github/workflows/macos-build-arm.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: ARM
-    runs-on: macos-latest
+    runs-on: macos-12
     timeout-minutes: 120
 
     steps:

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     name: Intel
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 120
 
     steps:
@@ -31,8 +31,8 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.12
         with:
           variant: sccache
-          key: macos-11-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
-          restore-keys: macos-11-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          key: macos-12-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
+          restore-keys: macos-12-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
           max-size: 1000M
 
       - name: CMake Generation


### PR DESCRIPTION
macos-11 is end of life, it has been for 5 months https://endoflife.date/macos, it will be removed as a runner on github in Q2 2024.  Next release will require atleast macOS 12.

![300882082-ac6ef1f1-8e18-4af1-a97f-d38cf82885df](https://github.com/open-goal/jak-project/assets/13153231/88bed2ae-8059-4d01-b4a6-8994af131c89)