### PR TITLE
g/j1: remove the redundant graphics menu

### DIFF
--- a/goal_src/jak1/pc/progress-pc.gc
+++ b/goal_src/jak1/pc/progress-pc.gc
@@ -153,18 +153,8 @@
     (new 'static 'game-option :option-type (game-option-type on-off) :name (text-id vsync) :scale #t)
     (new 'static 'game-option :option-type (game-option-type menu) :name (text-id aspect-ratio) :scale #t :param3 (game-option-menu aspect-ratio))
     (new 'static 'game-option :option-type (game-option-type msaa) :name (text-id msaa) :scale #t)
-    (new 'static 'game-option :option-type (game-option-type frame-rate) :name (text-id frame-rate) :scale #t)
-    (new 'static 'game-option :option-type (game-option-type menu) :name (text-id ps2-options) :scale #t :param3 (game-option-menu gfx-ps2-options))
-    (new 'static 'game-option :option-type (game-option-type button) :name (text-id back) :scale #t)
-    )
-  )
-
-(define *graphic-options-no-frame-rate-pc* (new 'static 'boxed-array :type game-option
-    (new 'static 'game-option :option-type (game-option-type menu) :name (text-id game-resolution) :scale #t :param3 (game-option-menu resolution))
-    (new 'static 'game-option :option-type (game-option-type display-mode) :name (text-id display-mode) :scale #t)
-    (new 'static 'game-option :option-type (game-option-type on-off) :name (text-id vsync) :scale #t)
-    (new 'static 'game-option :option-type (game-option-type menu) :name (text-id aspect-ratio) :scale #t :param3 (game-option-menu aspect-ratio))
-    (new 'static 'game-option :option-type (game-option-type msaa) :name (text-id msaa) :scale #t)
+    (new 'static 'game-option :option-type (game-option-type frame-rate) :name (text-id frame-rate) :scale #t
+      :option-disabled-func (lambda () (or (-> *pc-settings* speedrunner-mode?) (<= (pc-get-active-display-refresh-rate) 60))))
     (new 'static 'game-option :option-type (game-option-type menu) :name (text-id ps2-options) :scale #t :param3 (game-option-menu gfx-ps2-options))
     (new 'static 'game-option :option-type (game-option-type button) :name (text-id back) :scale #t)
     )
@@ -884,9 +874,6 @@
         (set! (-> *options-remap* (progress-screen graphic-settings)) *graphic-options-pc*)
         (set! *carousell-frame-rate* *carousell-frame-rate-100fps*)
         )
-      (else
-        (set! (-> *options-remap* (progress-screen graphic-settings)) *graphic-options-no-frame-rate-pc*)
-        )
       ))
 
   (set! (-> *options-remap* (progress-screen sound-settings))             *sound-options-pc*)
@@ -975,13 +962,6 @@
   (set! (-> *graphic-options-pc* 3 value-to-modify) (&-> *pc-settings* vsync?))
   (set! (-> *graphic-options-pc* 5 value-to-modify) (&-> *progress-carousell* int-backup))
   (set! (-> *graphic-options-pc* 6 value-to-modify) (&-> *progress-carousell* int-backup))
-  ;; disable changes to frame-rate while in speedrunner mode
-  ;; todo move this to the creation
-  (set! (-> *graphic-options-pc* 6 option-disabled-func) (lambda () (-> *pc-settings* speedrunner-mode?)))
-
-  (set! (-> *graphic-options-no-frame-rate-pc* 1 value-to-modify) (&-> *progress-carousell* int-backup))
-  (set! (-> *graphic-options-no-frame-rate-pc* 2 value-to-modify) (&-> *pc-settings* vsync?))
-  (set! (-> *graphic-options-no-frame-rate-pc* 4 value-to-modify) (&-> *progress-carousell* int-backup))
 
   (set! (-> *misc-options* 0 value-to-modify) (&-> *pc-settings* money-starburst?))
   (set! (-> *misc-options* 1 value-to-modify) (&-> *pc-settings* discord-rpc?))
@@ -2442,7 +2422,7 @@
                   )
                 )
                 (else
-                  ;; this option is not selected :-(
+                  ;; this option is not selected
                   (case (-> options index option-type)
                     (((game-option-type slider)
                       (game-option-type aspect-ratio)


### PR DESCRIPTION
This was hiding options for people that only had 60hz monitors since the two menus drifted -- it is not necessary for an entire separate menu, just disable the option if applicable.

Don't merge this without testing it throughly