### PR TITLE
Fix bad speedrun Select pause behavior

### DIFF
--- a/goal_src/jak1/engine/game/main.gc
+++ b/goal_src/jak1/engine/game/main.gc
@@ -124,16 +124,14 @@
        ;; allow the menu to run.
        (logclear! (-> *setting-control* default process-mask) (process-mask menu))
 
+       ;; ??
+       (set! *pause-lock* #f)
+       (sound-group-pause (sound-group sfx music dialog sog3 ambient sog5 sog6 sog7))
        ;; modified for PC port - show hidden speedrun progress menu if L1+R1+X are held
        (if (and PC_PORT (-> *pc-settings* speedrunner-mode?) (cpad-hold? 0 l1) (cpad-hold? 0 r1) (cpad-hold? 0 x))
-        (activate-progress *dproc* (progress-screen speedrun-options))
-        (begin
-          ;; ??
-          (set! *pause-lock* #f)
-          (sound-group-pause (sound-group sfx music dialog sog3 ambient sog5 sog6 sog7))
+          (activate-progress *dproc* (progress-screen speedrun-options))
           (hide-progress-screen)
           )
-        )
        )
       (('menu)
        ;; I believe these masks are just to make the progress go away work.


### PR DESCRIPTION
fixes this crap - happens if you use the Select variation of the speedrun menu combo (hold L1+R1+X) during movies

https://github.com/open-goal/jak-project/assets/2515356/52ffe700-0662-42d5-aa7d-1d9d71bb94fb

With the changes in this PR, it now behaves as you'd expect - the same as a normal Select pause

For reference, original changes adding the combo on Select - https://github.com/open-goal/jak-project/pull/2196/files