### PR TITLE
ci: pin to avx for macos

### DIFF
--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -47,8 +47,8 @@ jobs:
       - name: Build Project
         run: cmake --build build --parallel $((`sysctl -n hw.logicalcpu`))
 
-      # - name: Run Tests
-      #   run: ./test.sh
+      - name: Run Tests
+        run: ./test.sh
 
       - name: Prepare artifacts
         if: ${{ inputs.uploadArtifacts }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,6 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     message(STATUS "AppleClang detected - Setting Defaults")
     set(CMAKE_CXX_FLAGS
         "${CMAKE_CXX_FLAGS} \
-        -march=native \
         -Wall \
         -Winit-self \
         -ggdb \
@@ -117,6 +116,12 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         -Wsign-promo \
         -fdiagnostics-color=always"
         )
+    
+    # pin to AVX for macOS, hopefully all macOS runners have atleast this architecture
+    # technically speaking, SSE4 is the cutoff for Apple Silicon so...only a matter of time!
+    if(NOT CMAKE_CXX_COMPILER_TARGET STREQUAL "arm64-apple-darwin")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
+    endif()
 
     # additional c++ flags for release mode for our projects
     if(CMAKE_BUILD_TYPE MATCHES "Release")


### PR DESCRIPTION
Related to #3439

Will see after a few weeks if the problem resurfaces. All macos related caches have been purged to eliminate that as a possibility.