### PR TITLE
g/j2: add some debug menu options to unlock things and give orbs/gems/ammo

### DIFF
--- a/goal_src/jak2/engine/debug/default-menu.gc
+++ b/goal_src/jak2/engine/debug/default-menu.gc
@@ -3055,6 +3055,13 @@
   #f
   )
 
+(defun dm-game-opengoal-cheat-toggle-pick-func ((arg0 int) (arg1 debug-menu-msg))
+  (if (= arg1 (debug-menu-msg press))
+      (logxor! (-> *pc-settings* cheats) (the-as uint (/ arg0 8)))
+      )
+  (logtest? (-> *pc-settings* cheats) (/ arg0 8))
+  )
+
 (defun debug-menu-context-make-default-menus ((arg0 debug-menu-context))
   (local-vars (sv-16 debug-menu-context))
   (let ((s5-0 (new 'debug 'debug-menu arg0 "Main menu")))
@@ -3205,6 +3212,43 @@
              )
            (function "Continue Start" #f ,(lambda () (start 'play (-> *game-info* current-continue))))
            (function "Kiosk Reset" #f ,(lambda () (auto-save-command 'restore 0 0 *default-pool* #f) (none)))
+           ;; og:preserve-this new menu option
+           (function "Give Ammo and Collectables" #f ,(lambda () (send-event *target* 'get-pickup (pickup-type ammo-yellow) 1000.0) (send-event *target* 'get-pickup (pickup-type ammo-red) 1000.0) (send-event *target* 'get-pickup (pickup-type ammo-blue) 1000.0) (send-event *target* 'get-pickup (pickup-type ammo-dark) 1000.0) (send-event *target* 'get-pickup (pickup-type eco-pill-dark) 1000.0) (send-event *target* 'get-pickup (pickup-type skill) 1000.0) (send-event *target* 'get-pickup (pickup-type gem) 5000.0)))
+           ;; og:preserve-this new menu option
+           (function "Unlock Everything" #f ,(lambda () (logior! (-> *game-info* features) (game-feature gun gun-yellow gun-red gun-blue gun-dark gun-upgrade-speed gun-upgrade-ammo gun-upgrade-damage pass-red pass-green pass-yellow pass-blue board darkjak darkjak-bomb0 darkjak-bomb1 darkjak-invinc darkjak-giant))))
+           ;; og:preserve-this new menu option
+           (function "Finish Story" #f ,(lambda () (task-node-close! (game-task-node city-win-resolution))))
+           ;; og:preserve-this new menu option
+           (function "Finish Optional Missions"
+                     #f
+                     ,(lambda ()
+                        (task-node-close! (game-task-node city-oracle-level3-training))
+                        (task-node-close! (game-task-node city-burning-bush-ring-1-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-1-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-2-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-3-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-4-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-collection-1-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-racepoint-1-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-ring-2-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-5-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-6-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-shuttle-1-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-7-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-8-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-9-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-collection-2-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-10-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-11-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-ring-3-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-12-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-bombbot-1-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-13-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-14-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-get-to-15-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-collection-3-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-race-errol-resolution))
+                        (task-node-close! (game-task-node city-burning-bush-race-port-resolution))))
            (menu
              "Secrets"
              (flag "toggle-beard" 1 dm-game-secret-toggle-pick-func)
@@ -3218,7 +3262,7 @@
              (flag "level-select" 256 dm-game-secret-toggle-pick-func)
              (flag "scrap-book-1" 512 dm-game-secret-toggle-pick-func)
              (flag "scrap-book-2" 1024 dm-game-secret-toggle-pick-func)
-             ;; ;; og:preserve-this they missed one!
+             ;; og:preserve-this they missed one!
              (flag "scrap-book-3" 2048 dm-game-secret-toggle-pick-func)
              (flag "gungame-blue" 4096 dm-game-secret-toggle-pick-func)
              (flag "gungame-dark" 8192 dm-game-secret-toggle-pick-func)
@@ -3226,6 +3270,30 @@
              (flag "hero-mode" 32768 dm-game-secret-toggle-pick-func)
              (flag "big-head" 65536 dm-game-secret-toggle-pick-func)
              (flag "little-head" 131072 dm-game-secret-toggle-pick-func)
+             )
+           ;; og:preserve-this new menu
+           (menu
+             "OpenGOAL Cheats"
+             (flag "turbo-board" 1 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "health-bars" 2 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "vehicle-health-bars" 4 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "vehicle-invuln" 8 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "statistics" 16 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "suck-in-all" 32 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "music-player" 64 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "no-textures" 128 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "fast-movies" 256 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "slow-movies" 512 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "fast-speed" 1024 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "slow-speed" 2048 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "fast-travel" 4096 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "orb-tracker" 8192 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "real-time-of-day" 16384 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "city-peace" 32768 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "board-tricks" 65536 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "weather-bad" 131072 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "weather-good" 262144 dm-game-opengoal-cheat-toggle-pick-func)
+             (flag "hijack-lines" 524288 dm-game-opengoal-cheat-toggle-pick-func)
              )
            (menu "Continue")
            (menu


### PR DESCRIPTION
Adds some debug options that make it easier to quickly complete the game, get orbs, unlock cheats, etc.

![image](https://github.com/open-goal/jak-project/assets/13153231/8854dc42-084a-457e-ae9b-e9ba2dd7917c)
