### PR TITLE
[jak1] Enforce certain pc-settings in speedrunner mode

### DIFF
--- a/goal_src/jak1/pc/features/speedruns.gc
+++ b/goal_src/jak1/pc/features/speedruns.gc
@@ -228,7 +228,6 @@
      (initialize! *game-info* 'game (the-as game-save #f) "intro-start"))
     (else
      (format 0 "start-speedrun: unrecognized category ~S~%" (enum->string speedrun-category (-> *speedrun-info* category)))))
-  
   (enforce-speedrun-pc-settings)
   ;; enable auto saving by default
   (set! (-> *setting-control* default auto-save) #t)

--- a/goal_src/jak1/pc/features/speedruns.gc
+++ b/goal_src/jak1/pc/features/speedruns.gc
@@ -133,6 +133,18 @@
   (and (-> *pc-settings* speedrunner-mode?)
        (name= category (enum->string speedrun-category (-> *speedrun-info* category)))))
 
+(defun enforce-speedrun-pc-settings ()
+  ;; Disable any active cheats
+  (set! (-> *pc-settings* cheats) (the-as pc-cheats #x0))
+  ;; ensure PS2 actor vis is enabled
+  (set! (-> *pc-settings* ps2-actor-vis?) #t)
+  ;; ensure FPS set to `60`
+  (when (!= (-> *pc-settings* target-fps) 60)
+    (set-frame-rate! *pc-settings* 60 #t)
+    )
+  (none)
+  )
+
 (defun start-speedrun ((category speedrun-category))
   ;; randomize game id so the autosplitter knows to restart
   (update-autosplit-jak1-new-game)
@@ -216,10 +228,8 @@
      (initialize! *game-info* 'game (the-as game-save #f) "intro-start"))
     (else
      (format 0 "start-speedrun: unrecognized category ~S~%" (enum->string speedrun-category (-> *speedrun-info* category)))))
-  ;; ensure actor vis is enabled
-  (set! (-> *pc-settings* ps2-actor-vis?) #t)
-  ;; force FPS to `60`
-  (set-frame-rate! *pc-settings* 60 #t)
+  
+  (enforce-speedrun-pc-settings)
   ;; enable auto saving by default
   (set! (-> *setting-control* default auto-save) #t)
   (none))
@@ -384,8 +394,7 @@
     (update-autosplit-info-jak1)
     ;; Draw info to the screen
     (speedrun-draw-settings)
-    ;;Disable any active cheats
-    (set! (-> *pc-settings* cheats) (the-as pc-cheats #x0))
+    (enforce-speedrun-pc-settings)
     ;; Run after-blackout speedrun setup (if needed)
     (setup-speedrun-post-blackout))
   (none))

--- a/goal_src/jak1/pc/progress-pc.gc
+++ b/goal_src/jak1/pc/progress-pc.gc
@@ -631,7 +631,10 @@
        (new 'static 'game-option :option-type (game-option-type lod-fg) :name (text-id lod-fg) :scale #t)
        (new 'static 'game-option :option-type (game-option-type on-off) :name (text-id ps2-parts) :scale #t)
        (new 'static 'game-option :option-type (game-option-type on-off) :name (text-id force-envmap) :scale #t)
-       (new 'static 'game-option :option-type (game-option-type on-off) :name (text-id force-actors) :scale #t)
+       (new 'static 'game-option :option-type (game-option-type on-off) :name (text-id force-actors) :scale #t 
+          :option-disabled-func
+            (lambda ()
+              (-> *pc-settings* speedrunner-mode?)))
        (new 'static 'game-option :option-type (game-option-type button) :name (text-id back) :scale #t)))
 
 ;; TODO - aspect ratios are hard-coded

--- a/goal_src/jak1/pc/progress-pc.gc
+++ b/goal_src/jak1/pc/progress-pc.gc
@@ -631,7 +631,7 @@
        (new 'static 'game-option :option-type (game-option-type lod-fg) :name (text-id lod-fg) :scale #t)
        (new 'static 'game-option :option-type (game-option-type on-off) :name (text-id ps2-parts) :scale #t)
        (new 'static 'game-option :option-type (game-option-type on-off) :name (text-id force-envmap) :scale #t)
-       (new 'static 'game-option :option-type (game-option-type on-off) :name (text-id force-actors) :scale #t 
+       (new 'static 'game-option :option-type (game-option-type on-off) :name (text-id force-actors) :scale #t
           :option-disabled-func
             (lambda ()
               (-> *pc-settings* speedrunner-mode?)))


### PR DESCRIPTION
Currently PS2 Actor Vis and FPS are only enforced when starting a run - this enforces them on every frame similar to cheats.
In the progress menu, FPS is already disabled in speedrunner mode - this adds the same restriction for PS2 Actor Vis.

Jak 2 already does this properly, no change needed there