### PR TITLE
ci: fix broken windows builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 > Our repositories on GitHub are primarily for development of the project and tracking active issues. Most of the information you will find here pertains to setting up the project for development purposes and is not relevant to the end-user.
 
 For a setup guide on how to install and play the game there is the following video that you can check out: https://youtu.be/K84UUMnkJc4
-
+ 
 For questions or additional information pertaining to the project, we have a Discord for discussion here: https://discord.gg/VZbXMHXzWv
 
 Additionally, you can find further documentation and answers to **frequently asked questions** on the project's main website: https://opengoal.dev


### PR DESCRIPTION
A recent windows image rolled out which has multiple problems:
- https://github.com/actions/runner-images/issues/10001
  - VS was updated, this new toolchain requires atleast Clang17
  - This is fine for us, but by default the image chooses to use the system installed clang (which is still clang16)
- https://github.com/actions/runner-images/issues/10004
  - If you work around that, your binaries will crash upon launching.  This is allegedly because for whatever reason, an old `msvcp140.dll` is being used.  There is a potential workaround for this but hopefully we can just wait for a fixed image.