### PR TITLE
jak3: fix some nan bugs

### DIFF
--- a/goal_src/jak3/engine/target/flut/flut.gc
+++ b/goal_src/jak3/engine/target/flut/flut.gc
@@ -603,6 +603,10 @@
   (set! (-> self draw light-index) (the-as uint 30))
   (logior! (-> self mask) (process-mask crate))
   (cond
+    ;; og:preserve-this hack to prevent NaNs
+    ((= (-> self level name) 'desliz)
+     (go-virtual idle)
+     )
     ((logtest? arg3 (flut-flag ff2))
      (go-virtual die)
      )

--- a/goal_src/jak3/engine/target/pilot-states.gc
+++ b/goal_src/jak3/engine/target/pilot-states.gc
@@ -557,6 +557,8 @@
               )
             )
           )
+        ;; og:preserve-this
+        (init-vf0-vector)
         (.svf (&-> (-> gp-0 accel-array) 0 quad) vf0)
         )
       (go target-pilot-stance)

--- a/goal_src/jak3/levels/desert/boss/terraformer-setup.gc
+++ b/goal_src/jak3/levels/desert/boss/terraformer-setup.gc
@@ -2329,6 +2329,8 @@
     (terraformer-always)
     )
   :code sleep-code
+  ;; og:preserve-this added post to prevent NaNs
+  :post ja-post
   )
 
 (defstate frozen (terraformer)

--- a/goal_src/jak3/levels/desert/chase/marauder.gc
+++ b/goal_src/jak3/levels/desert/chase/marauder.gc
@@ -1609,7 +1609,8 @@
         (set! (-> gp-0 r) 81920.0)
         (when (not (and (-> self skip-jump) (not (sphere-in-view-frustum? gp-0))))
           )
-        (suspend)
+        ;; og:preserve-this prevent vf0 clobbering
+        ; (suspend)
         (when (and (-> self skip-jump) (not (sphere-in-view-frustum? gp-0)))
           (let ((gp-1 (new 'stack-no-clear 'vector)))
             (set! (-> gp-1 quad) (-> self root trans quad))
@@ -1679,6 +1680,8 @@
               (set! f28-0 1.0)
               )
           (suspend)
+          ;; og:preserve-this fix vf0 clobbering after suspend
+          (init-vf0-vector)
           (ja :num! (seek! max f30-0))
           )
         )


### PR DESCRIPTION
Fixes a couple of NaN bugs, making the Arena and Marauder Stronghold missions, the leaper corralling mission and final boss playable:

- Fixes #3579:
  - After catching a leaper, the `flut` that spawns would have a NaN `world-sphere`
- Fixes #3580:
  - `vf0` was being clobbered after a `suspend`, causing them to spawn at the origin.
- The Terraformer's `world-sphere` would be NaN until an animation started playing.