### PR TITLE
[jak3] A few bug fixes

### DIFF
--- a/game/graphics/opengl_renderer/TextureUploadHandler.cpp
+++ b/game/graphics/opengl_renderer/TextureUploadHandler.cpp
@@ -119,3 +119,7 @@ void TextureUploadHandler::draw_debug_window() {
     m_direct->draw_debug_window();
   }
 }
+
+bool TextureUploadHandler::empty() const {
+  return m_upload_count == 0;
+}

--- a/game/graphics/opengl_renderer/TextureUploadHandler.h
+++ b/game/graphics/opengl_renderer/TextureUploadHandler.h
@@ -18,6 +18,7 @@ class TextureUploadHandler : public BucketRenderer {
                        bool add_direct = false);
   void render(DmaFollower& dma, SharedRenderState* render_state, ScopedProfilerNode& prof) override;
   void draw_debug_window() override;
+  bool empty() const override;
 
  private:
   struct TextureUpload {

--- a/game/graphics/opengl_renderer/foreground/Generic2.cpp
+++ b/game/graphics/opengl_renderer/foreground/Generic2.cpp
@@ -75,6 +75,8 @@ void Generic2::render_in_mode(DmaFollower& dma,
     }
   }
 
+  m_empty = m_next_free_vert == 0;
+
   {
     // the next pass is to look at all of that data, and figure out the best order to draw it
     // using OpenGL

--- a/game/graphics/opengl_renderer/foreground/Generic2.h
+++ b/game/graphics/opengl_renderer/foreground/Generic2.h
@@ -19,6 +19,7 @@ class Generic2 {
                       Mode mode);
 
   void draw_debug_window();
+  bool empty() { return m_empty; }
 
   struct Vertex {
     math::Vector<float, 3> xyz;
@@ -202,4 +203,6 @@ class Generic2 {
     GLuint gfx_hack_no_tex;
     GLuint warp_sample_mode;
   } m_ogl;
+
+  bool m_empty = false;
 };

--- a/game/graphics/opengl_renderer/foreground/Generic2BucketRenderer.cpp
+++ b/game/graphics/opengl_renderer/foreground/Generic2BucketRenderer.cpp
@@ -22,4 +22,9 @@ void Generic2BucketRenderer::render(DmaFollower& dma,
     return;
   }
   m_generic->render_in_mode(dma, render_state, prof, m_mode);
+  m_empty = m_generic->empty();
+}
+
+bool Generic2BucketRenderer::empty() const {
+  return m_empty;
 }

--- a/game/graphics/opengl_renderer/foreground/Generic2BucketRenderer.h
+++ b/game/graphics/opengl_renderer/foreground/Generic2BucketRenderer.h
@@ -11,8 +11,10 @@ class Generic2BucketRenderer : public BucketRenderer {
                          Generic2::Mode mode);
   void render(DmaFollower& dma, SharedRenderState* render_state, ScopedProfilerNode& prof) override;
   void draw_debug_window() override;
+  bool empty() const override;
 
  private:
   std::shared_ptr<Generic2> m_generic;
   Generic2::Mode m_mode;
+  bool m_empty = false;
 };

--- a/game/graphics/opengl_renderer/foreground/Merc2.cpp
+++ b/game/graphics/opengl_renderer/foreground/Merc2.cpp
@@ -768,8 +768,12 @@ void Merc2::switch_to_emerc(SharedRenderState* render_state) {
 void Merc2::render(DmaFollower& dma,
                    SharedRenderState* render_state,
                    ScopedProfilerNode& prof,
-                   MercDebugStats* stats) {
+                   MercDebugStats* stats,
+                   bool debug) {
+  m_debug = true;
+  bool hack = stats->collect_debug_model_list;
   *stats = {};
+  stats->collect_debug_model_list = hack;
   if (stats->collect_debug_model_list) {
     stats->model_list.clear();
   }
@@ -1216,7 +1220,7 @@ void Merc2::do_draws(const Draw* draw_array,
                      bool set_fade,
                      SharedRenderState* render_state) {
   glBindVertexArray(m_vao);
-  int last_tex = -1;
+  s32 last_tex = INT32_MIN;
   int last_light = -1;
   bool normal_vtx_buffer_bound = true;
 

--- a/game/graphics/opengl_renderer/foreground/Merc2.h
+++ b/game/graphics/opengl_renderer/foreground/Merc2.h
@@ -46,7 +46,8 @@ class Merc2 {
   void render(DmaFollower& dma,
               SharedRenderState* render_state,
               ScopedProfilerNode& prof,
-              MercDebugStats* stats);
+              MercDebugStats* stats,
+              bool debug);
   static constexpr int kMaxBlerc = 40;
 
  private:
@@ -138,6 +139,7 @@ class Merc2 {
   };
 
   Uniforms m_merc_uniforms, m_emerc_uniforms;
+  bool m_debug = false;
 
   void init_shader_common(Shader& shader, Uniforms* uniforms, bool include_lights);
   void handle_setup_dma(DmaFollower& dma, SharedRenderState* render_state);

--- a/game/graphics/opengl_renderer/foreground/Merc2BucketRenderer.cpp
+++ b/game/graphics/opengl_renderer/foreground/Merc2BucketRenderer.cpp
@@ -16,9 +16,15 @@ void Merc2BucketRenderer::render(DmaFollower& dma,
     return;
   }
 
-  m_renderer->render(dma, render_state, prof, &m_debug_stats);
+  m_renderer->render(dma, render_state, prof, &m_debug_stats, m_my_id == 362);
+
+  m_empty = m_debug_stats.num_predicted_draws == 0;
 }
 
 void Merc2BucketRenderer::draw_debug_window() {
   m_renderer->draw_debug_window(&m_debug_stats);
+}
+
+bool Merc2BucketRenderer::empty() const {
+  return m_empty;
 }

--- a/game/graphics/opengl_renderer/foreground/Merc2BucketRenderer.h
+++ b/game/graphics/opengl_renderer/foreground/Merc2BucketRenderer.h
@@ -8,8 +8,10 @@ class Merc2BucketRenderer : public BucketRenderer {
   Merc2BucketRenderer(const std::string& name, int my_id, std::shared_ptr<Merc2> merc);
   void draw_debug_window() override;
   void render(DmaFollower& dma, SharedRenderState* render_state, ScopedProfilerNode& prof) override;
+  bool empty() const override;
 
  private:
+  bool m_empty = false;
   std::shared_ptr<Merc2> m_renderer;
   MercDebugStats m_debug_stats;
 };

--- a/game/overlord/jak3/dvd_driver.cpp
+++ b/game/overlord/jak3/dvd_driver.cpp
@@ -305,8 +305,9 @@ s32 CDvdDriver::ValidateBlockParams(jak3::BlockParams* params, int num_params) {
       lg::die("Invalid BlockParams: {} had nullptr dest", i);
       return 0;
     }
-    int kMaxFileSize = 1024 * 1024 * 1024;
-    if (p.sector_num > kMaxFileSize / 0x800) {
+    int kMaxSector = 1000000;
+    if (p.sector_num > kMaxSector) {
+      // this is just a sanity check - if we ever have larger files this is okay to increase.
       lg::die("Invalid BlockParams: {} had sector num {}", i, p.sector_num);
       return 0;
     }

--- a/goal_src/jak3/engine/common-obs/scene-actor.gc
+++ b/goal_src/jak3/engine/common-obs/scene-actor.gc
@@ -16,15 +16,15 @@
 (defskelgroup skel-particleman particleman particleman-lod0-jg -1
               ((particleman-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 10)
-              :shadow-joint-index 3
+              :origin-joint-index 3
               )
 
 (defskelgroup skel-darkjak-highres darkjak-highres darkjak-highres-lod0-jg -1
               ((darkjak-highres-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 3.2)
               :longest-edge (meters 1)
-              :shadow-joint-index 3
-              :light-index 1
+              :sort 1
+              :origin-joint-index 3
               :clothing (((mesh darkjak-highres-jakcfma0-skirt-cg)
                 (gravity-constant (meters 16))
                 (wind-constant 0.5)
@@ -308,7 +308,7 @@
               ((crimson-guard-highres-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 3)
               :shadow crimson-guard-highres-shadow-mg
-              :shadow-joint-index 3
+              :origin-joint-index 3
               )
 
 (defskelgroup skel-torn-highres torn-highres torn-highres-lod0-jg torn-highres-idle-ja
@@ -406,21 +406,21 @@
 (defskelgroup skel-palmpilot palmpilot palmpilot-lod0-jg -1
               ((palmpilot-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 1.5)
-              :shadow-joint-index 3
+              :origin-joint-index 3
               )
 
 (defskelgroup skel-palmpilot-b palmpilot-b palmpilot-b-lod0-jg -1
               ((palmpilot-b-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 1.5)
-              :shadow-joint-index 3
+              :origin-joint-index 3
               )
 
 (defskelgroup skel-sig-highres sig-highres sig-highres-lod0-jg sig-highres-idle-ja
               ((sig-highres-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 5)
               :shadow sig-highres-shadow-mg
-              :origin-joint-index 3
-              :shadow-joint-index 17
+              :origin-joint-index 17
+              :shadow-joint-index 3
               )
 
 (deftype sig-npc (process-taskable)
@@ -778,7 +778,7 @@
 (defskelgroup skel-jinx-highres jinx-highres jinx-highres-lod0-jg jinx-highres-idle-ja
               ((jinx-highres-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 2.5)
-              :shadow-joint-index 3
+              :origin-joint-index 3
               )
 
 (deftype jinx-npc (process-taskable)
@@ -812,7 +812,7 @@
               ((gun-npc-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 1.5)
               :shadow gun-npc-shadow-mg
-              :shadow-joint-index 3
+              :origin-joint-index 3
               )
 
 (deftype gun-npc (process-taskable)
@@ -856,7 +856,7 @@
               ((tess-highres-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 3)
               :shadow tess-highres-shadow-mg
-              :shadow-joint-index 3
+              :origin-joint-index 3
               )
 
 (deftype tess-npc (process-taskable)
@@ -909,7 +909,7 @@
               ((wlander-male-lod0-mg (meters 20)) (wlander-male-lod2-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 3)
               :shadow wlander-male-shadow-mg
-              :shadow-joint-index 3
+              :origin-joint-index 3
               )
 
 (deftype vin-npc (process-taskable)
@@ -935,15 +935,15 @@
 (defskelgroup skel-eco-crystal-dark eco-crystal-dark eco-crystal-dark-lod0-jg eco-crystal-dark-idle-ja
               ((eco-crystal-dark-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 0.5)
-              :shadow-joint-index 3
+              :origin-joint-index 3
               )
 
 (defskelgroup skel-keira-highres keira-highres keira-highres-lod0-jg keira-highres-idle-ja
               ((keira-highres-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 3)
               :shadow keira-highres-shadow-mg
-              :origin-joint-index 4
-              :shadow-joint-index 3
+              :origin-joint-index 3
+              :shadow-joint-index 4
               )
 
 (deftype keira-npc (process-taskable)
@@ -980,13 +980,13 @@
               ((hellcat-lod0-mg (meters 20)) (hellcat-lod0-mg (meters 40)) (hellcat-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 6.8)
               :shadow hellcat-shadow-mg
-              :shadow-joint-index 3
+              :origin-joint-index 3
               )
 
 (defskelgroup skel-kidmedallion kidmedallion kidmedallion-lod0-jg kidmedallion-idle-ja
               ((kidmedallion-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 1)
-              :shadow-joint-index 3
+              :origin-joint-index 3
               )
 
 (defun pre-intro-play ()
@@ -1027,16 +1027,33 @@
   (none)
   )
 
-;; og:preserve-this
-;; for some inexplicable reason, there is a lambda at the top level with skelgroups and a type definition
-;; we just get rid of that and move everything to the top level
-(defskelgroup skel-flut-wild flut-wild flut-wild-lod0-jg flut-wild-idle-ja
-              ((flut-wild-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 2 0 4)
-              :shadow flut-wild-shadow-mg
-              :shadow-joint-index 3
-              :light-index 1
-              )
+((lambda ()
+   (let ((a0-0
+           (new 'static 'skeleton-group
+             :name "skel-flut-wild"
+             :extra #f
+             :info #f
+             :art-group-name "flut-wild"
+             :bounds (new 'static 'vector :y 8192.0 :w 16384.0)
+             :version 8
+             :shadow 2
+             :origin-joint-index 3
+             :sort 1
+             :clothing #f
+             )
+           )
+         )
+     (when #f
+       (set! (-> a0-0 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-0 clothing length) (-> a0-0 clothing allocated-length))
+       )
+     (set! (-> a0-0 jgeo) 0)
+     (set! (-> a0-0 janim) 3)
+     (set! (-> a0-0 mgeo 0) 1)
+     (set! (-> a0-0 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-0)
+     )
+
 
 (deftype flut-npc (process-taskable)
   ()
@@ -1057,11 +1074,47 @@
      (-> this draw art-group data 12)
      )
     (else
-     (-> this draw art-group data 3)
-     )
+      (-> this draw art-group data 3)
+      )
     )
   )
-
+   ; (type-new 'flut-npc process-taskable (the-as int (the-as uint #x2800a00118)))
+   ; (method-set! flut-npc 3 (lambda ((arg0 flut-npc))
+   ;                           (when (not arg0)
+   ;                             (set! arg0 arg0)
+   ;                             (goto cfg-4)
+   ;                             )
+   ;                           (let ((t9-0 (method-of-type process-taskable inspect)))
+   ;                             (t9-0 arg0)
+   ;                             )
+   ;                           (label cfg-4)
+   ;                           arg0
+   ;                           )
+   ;              )
+   ; (method-set! flut-npc 37 (lambda ((arg0 flut-npc)) (case (-> arg0 task actor)
+   ;                                                      (((game-task-actor wascity-leaper))
+   ;                                                       (-> arg0 draw art-group data 12)
+   ;                                                       )
+   ;                                                      (else
+   ;                                                        (-> arg0 draw art-group data 3)
+   ;                                                        )
+   ;                                                      )
+   ;                                  )
+   ;              )
+   ; (method-set!
+   ;   flut-npc
+   ;   35
+   ;   (lambda ((arg0 flut-npc))
+   ;     (initialize-skeleton
+   ;       arg0
+   ;       (the-as skeleton-group (art-group-get-by-name *level* "skel-flut-wild" (the-as (pointer level) #f)))
+   ;       (the-as pair 0)
+   ;       )
+   ;     (set! (-> arg0 draw light-index) (the-as uint 30))
+   ;     0
+   ;     (none)
+   ;     )
+   ;   )
 (defmethod init-skeleton! ((this flut-npc))
   (initialize-skeleton
     this
@@ -1071,577 +1124,406 @@
   (set! (-> this draw light-index) (the uint 30))
   (none)
   )
-
-(defskelgroup skel-mhcity-de-tower-egg mhcity-de-tower-egg mhcity-de-tower-egg-lod0-jg mhcity-de-tower-egg-idle-ja
-              ((mhcity-de-tower-egg-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 10)
-              :shadow-joint-index 3
-              )
-(defskelgroup skel-errol-effect errol-effect errol-effect-lod0-jg errol-effect-idle-ja
-              ((errol-effect-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 8)
-              :shadow-joint-index 3
-              )
-(defskelgroup skel-errol errol errol-lod0-jg errol-idle-ja
-              ((errol-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 8)
-              :shadow-joint-index 6
-              )
-(defskelgroup skel-snake-wheel-fma snake-wheel-fma snake-wheel-fma-lod0-jg snake-wheel-fma-idle-ja
-              ((snake-wheel-fma-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 10)
-              :shadow snake-wheel-fma-shadow-mg
-              :origin-joint-index 3
-              :shadow-joint-index 3
-              )
-(defskelgroup skel-ottsel-veger ottsel-veger ottsel-veger-lod0-jg ottsel-veger-idle-ja
-              ((ottsel-veger-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 2.5)
-              :shadow ottsel-veger-shadow-mg
-              :shadow-joint-index 3
-              )
-(defskelgroup skel-ottsel-surfer ottsel-surfer ottsel-surfer-lod0-jg ottsel-surfer-idle-ja
-              ((ottsel-surfer-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 2.5)
-              :shadow ottsel-surfer-shadow-mg
-              :shadow-joint-index 3
-              )
-(defskelgroup skel-ottsel-leader ottsel-leader ottsel-leader-lod0-jg ottsel-leader-idle-ja
-              ((ottsel-leader-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 2.5)
-              :shadow ottsel-leader-shadow-mg
-              :shadow-joint-index 3
-              :clothing (((mesh ottsel-leader-leader-leaderskirt_fr-cg)
-                (gravity-constant (meters 12))
-                (wind-constant 1.0)
-                (cloth-width 13)
-                (flags (cloth-flag use-wind double-sided flip-normals autogen-uvs))
-                (tex-name "prec-leader-robe-01")
-                (tex-name2 "prec-leader-robe-01")
-                (tex-name3 "prec-leader-robe-01")
-                (cloth-thickness 1.0)
-                (initial-xform 3)
-                (drag 0.151)
-                (num-iterations 1)
-                (timestep-frequency 7)
+   (let ((a0-5 (new 'static 'skeleton-group
+                 :name "skel-mhcity-de-tower-egg"
+                 :extra #f
+                 :info #f
+                 :art-group-name "mhcity-de-tower-egg"
+                 :bounds (new 'static 'vector :w 40960.0)
+                 :version 8
+                 :origin-joint-index 3
+                 :clothing #f
+                 )
+               )
+         )
+     (when #f
+       (set! (-> a0-5 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-5 clothing length) (-> a0-5 clothing allocated-length))
+       )
+     (set! (-> a0-5 jgeo) 0)
+     (set! (-> a0-5 janim) 2)
+     (set! (-> a0-5 mgeo 0) 1)
+     (set! (-> a0-5 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-5)
+     )
+   (let ((a0-6 (new 'static 'skeleton-group
+                 :name "skel-errol-effect"
+                 :extra #f
+                 :info #f
+                 :art-group-name "errol-effect"
+                 :bounds (new 'static 'vector :w 32768.0)
+                 :version 8
+                 :origin-joint-index 3
+                 :clothing #f
+                 )
+               )
+         )
+     (when #f
+       (set! (-> a0-6 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-6 clothing length) (-> a0-6 clothing allocated-length))
+       )
+     (set! (-> a0-6 jgeo) 0)
+     (set! (-> a0-6 janim) 2)
+     (set! (-> a0-6 mgeo 0) 1)
+     (set! (-> a0-6 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-6)
+     )
+   (let ((a0-7 (new 'static 'skeleton-group
+                 :name "skel-errol"
+                 :extra #f
+                 :info #f
+                 :art-group-name "errol"
+                 :bounds (new 'static 'vector :w 32768.0)
+                 :version 8
+                 :origin-joint-index 6
+                 :clothing #f
+                 )
+               )
+         )
+     (when #f
+       (set! (-> a0-7 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-7 clothing length) (-> a0-7 clothing allocated-length))
+       )
+     (set! (-> a0-7 jgeo) 0)
+     (set! (-> a0-7 janim) 2)
+     (set! (-> a0-7 mgeo 0) 1)
+     (set! (-> a0-7 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-7)
+     )
+   (let ((a0-8 (new 'static 'skeleton-group
+                 :name "skel-snake-wheel-fma"
+                 :extra #f
+                 :info #f
+                 :art-group-name "snake-wheel-fma"
+                 :bounds (new 'static 'vector :w 40960.0)
+                 :version 8
+                 :shadow 2
+                 :shadow-joint-index 3
+                 :origin-joint-index 3
+                 :clothing #f
+                 )
+               )
+         )
+     (when #f
+       (set! (-> a0-8 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-8 clothing length) (-> a0-8 clothing allocated-length))
+       )
+     (set! (-> a0-8 jgeo) 0)
+     (set! (-> a0-8 janim) 3)
+     (set! (-> a0-8 mgeo 0) 1)
+     (set! (-> a0-8 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-8)
+     )
+   (let ((a0-9 (new 'static 'skeleton-group
+                 :name "skel-ottsel-veger"
+                 :extra #f
+                 :info #f
+                 :art-group-name "ottsel-veger"
+                 :bounds (new 'static 'vector :w 10240.0)
+                 :version 8
+                 :shadow 2
+                 :origin-joint-index 3
+                 :clothing #f
+                 )
+               )
+         )
+     (when #f
+       (set! (-> a0-9 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-9 clothing length) (-> a0-9 clothing allocated-length))
+       )
+     (set! (-> a0-9 jgeo) 0)
+     (set! (-> a0-9 janim) 3)
+     (set! (-> a0-9 mgeo 0) 1)
+     (set! (-> a0-9 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-9)
+     )
+   (let ((a0-10 (new 'static 'skeleton-group
+                  :name "skel-ottsel-surfer"
+                  :extra #f
+                  :info #f
+                  :art-group-name "ottsel-surfer"
+                  :bounds (new 'static 'vector :w 10240.0)
+                  :version 8
+                  :shadow 2
+                  :origin-joint-index 3
+                  :clothing #f
+                  )
                 )
+         )
+     (when #f
+       (set! (-> a0-10 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-10 clothing length) (-> a0-10 clothing allocated-length))
+       )
+     (set! (-> a0-10 jgeo) 0)
+     (set! (-> a0-10 janim) 3)
+     (set! (-> a0-10 mgeo 0) 1)
+     (set! (-> a0-10 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-10)
+     )
+   (let ((a0-11 (new 'static 'skeleton-group
+                  :name "skel-ottsel-leader"
+                  :extra #f
+                  :info #f
+                  :art-group-name "ottsel-leader"
+                  :bounds (new 'static 'vector :w 10240.0)
+                  :version 8
+                  :shadow 2
+                  :origin-joint-index 3
+                  :clothing #f
+                  )
                 )
-              )
-(defskelgroup skel-battle-amulet battle-amulet battle-amulet-lod0-jg battle-amulet-idle-ja
-              ((battle-amulet-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 2)
-              :shadow-joint-index 3
-              )
-(defskelgroup skel-precursor precursor precursor-lod0-jg precursor-idle-ja
-              ((precursor-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 8.5)
-              :shadow-joint-index 3
-              )
-(defskelgroup skel-comb-rail-rider-fma comb-rail-rider comb-rail-rider-lod0-jg comb-rail-rider-idle-ja
-              ((comb-rail-rider-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 10.5)
-              :shadow-joint-index 3
-              )
-(defskelgroup skel-monk monk monk-lod0-jg monk-idle-ja
-              ((monk-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 4)
-              :shadow monk-shadow-mg
-              :origin-joint-index 3
-              :shadow-joint-index 3
-              )
-(defskelgroup skel-terraformer-fma terraformer-fma 0 2
-              ((1 (meters 999999)))
-              :bounds (static-spherem 0 0 0 4)
-              :shadow-joint-index 3
-              )
-(defskelgroup skel-rhino-fma rhino rhino-lod0-jg rhino-idle-ja
-              ((rhino-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 100)
-              :shadow-joint-index 3
-              )
-(defskelgroup skel-neo-satellite-fma neo-satellite-fma neo-satellite-fma-lod0-jg neo-satellite-fma-idle-ja
-              ((neo-satellite-fma-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 10)
-              :shadow neo-satellite-fma-shadow-mg
-              :shadow-joint-index 3
-              :global-effects 32
-              )
-(defskelgroup skel-neo-satellite-break neo-satellite-break neo-satellite-break-lod0-jg neo-satellite-break-idle-ja
-              ((neo-satellite-break-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 500)
-              :shadow-joint-index 3
-              :global-effects 32
-              )
-(defskelgroup skel-talk-box talk-box talk-box-lod0-jg talk-box-idle-ja
-              ((talk-box-lod0-mg (meters 999999)))
-              :bounds (static-spherem 0 0 0 2)
-              :shadow-joint-index 3
-              )
-
-;; og:preserve-this
-;; ((lambda ()
-;;    (let ((a0-0
-;;            (new 'static 'skeleton-group
-;;              :name "skel-flut-wild"
-;;              :extra #f
-;;              :info #f
-;;              :art-group-name "flut-wild"
-;;              :bounds (new 'static 'vector :y 8192.0 :w 16384.0)
-;;              :version 8
-;;              :shadow 2
-;;              :origin-joint-index 3
-;;              :sort 1
-;;              :clothing #f
-;;              )
-;;            )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-0 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-0 clothing length) (-> a0-0 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-0 jgeo) 0)
-;;      (set! (-> a0-0 janim) 3)
-;;      (set! (-> a0-0 mgeo 0) 1)
-;;      (set! (-> a0-0 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-0)
-;;      )
-;;    (type-new 'flut-npc process-taskable (the-as int (the-as uint #x2800a00118)))
-;;    (method-set! flut-npc 3 (lambda ((arg0 flut-npc))
-;;                              (when (not arg0)
-;;                                (set! arg0 arg0)
-;;                                (goto cfg-4)
-;;                                )
-;;                              (let ((t9-0 (method-of-type process-taskable inspect)))
-;;                                (t9-0 arg0)
-;;                                )
-;;                              (label cfg-4)
-;;                              arg0
-;;                              )
-;;                 )
-;;    (method-set! flut-npc 37 (lambda ((arg0 flut-npc)) (case (-> arg0 task actor)
-;;                                                         (((game-task-actor wascity-leaper))
-;;                                                          (-> arg0 draw art-group data 12)
-;;                                                          )
-;;                                                         (else
-;;                                                           (-> arg0 draw art-group data 3)
-;;                                                           )
-;;                                                         )
-;;                                     )
-;;                 )
-;;    (method-set!
-;;      flut-npc
-;;      35
-;;      (lambda ((arg0 flut-npc))
-;;        (initialize-skeleton
-;;          arg0
-;;          (the-as skeleton-group (art-group-get-by-name *level* "skel-flut-wild" (the-as (pointer level) #f)))
-;;          (the-as pair 0)
-;;          )
-;;        (set! (-> arg0 draw light-index) (the-as uint 30))
-;;        0
-;;        (none)
-;;        )
-;;      )
-;;    (let ((a0-5 (new 'static 'skeleton-group
-;;                  :name "skel-mhcity-de-tower-egg"
-;;                  :extra #f
-;;                  :info #f
-;;                  :art-group-name "mhcity-de-tower-egg"
-;;                  :bounds (new 'static 'vector :w 40960.0)
-;;                  :version 8
-;;                  :origin-joint-index 3
-;;                  :clothing #f
-;;                  )
-;;                )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-5 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-5 clothing length) (-> a0-5 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-5 jgeo) 0)
-;;      (set! (-> a0-5 janim) 2)
-;;      (set! (-> a0-5 mgeo 0) 1)
-;;      (set! (-> a0-5 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-5)
-;;      )
-;;    (let ((a0-6 (new 'static 'skeleton-group
-;;                  :name "skel-errol-effect"
-;;                  :extra #f
-;;                  :info #f
-;;                  :art-group-name "errol-effect"
-;;                  :bounds (new 'static 'vector :w 32768.0)
-;;                  :version 8
-;;                  :origin-joint-index 3
-;;                  :clothing #f
-;;                  )
-;;                )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-6 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-6 clothing length) (-> a0-6 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-6 jgeo) 0)
-;;      (set! (-> a0-6 janim) 2)
-;;      (set! (-> a0-6 mgeo 0) 1)
-;;      (set! (-> a0-6 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-6)
-;;      )
-;;    (let ((a0-7 (new 'static 'skeleton-group
-;;                  :name "skel-errol"
-;;                  :extra #f
-;;                  :info #f
-;;                  :art-group-name "errol"
-;;                  :bounds (new 'static 'vector :w 32768.0)
-;;                  :version 8
-;;                  :origin-joint-index 6
-;;                  :clothing #f
-;;                  )
-;;                )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-7 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-7 clothing length) (-> a0-7 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-7 jgeo) 0)
-;;      (set! (-> a0-7 janim) 2)
-;;      (set! (-> a0-7 mgeo 0) 1)
-;;      (set! (-> a0-7 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-7)
-;;      )
-;;    (let ((a0-8 (new 'static 'skeleton-group
-;;                  :name "skel-snake-wheel-fma"
-;;                  :extra #f
-;;                  :info #f
-;;                  :art-group-name "snake-wheel-fma"
-;;                  :bounds (new 'static 'vector :w 40960.0)
-;;                  :version 8
-;;                  :shadow 2
-;;                  :shadow-joint-index 3
-;;                  :origin-joint-index 3
-;;                  :clothing #f
-;;                  )
-;;                )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-8 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-8 clothing length) (-> a0-8 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-8 jgeo) 0)
-;;      (set! (-> a0-8 janim) 3)
-;;      (set! (-> a0-8 mgeo 0) 1)
-;;      (set! (-> a0-8 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-8)
-;;      )
-;;    (let ((a0-9 (new 'static 'skeleton-group
-;;                  :name "skel-ottsel-veger"
-;;                  :extra #f
-;;                  :info #f
-;;                  :art-group-name "ottsel-veger"
-;;                  :bounds (new 'static 'vector :w 10240.0)
-;;                  :version 8
-;;                  :shadow 2
-;;                  :origin-joint-index 3
-;;                  :clothing #f
-;;                  )
-;;                )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-9 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-9 clothing length) (-> a0-9 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-9 jgeo) 0)
-;;      (set! (-> a0-9 janim) 3)
-;;      (set! (-> a0-9 mgeo 0) 1)
-;;      (set! (-> a0-9 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-9)
-;;      )
-;;    (let ((a0-10 (new 'static 'skeleton-group
-;;                   :name "skel-ottsel-surfer"
-;;                   :extra #f
-;;                   :info #f
-;;                   :art-group-name "ottsel-surfer"
-;;                   :bounds (new 'static 'vector :w 10240.0)
-;;                   :version 8
-;;                   :shadow 2
-;;                   :origin-joint-index 3
-;;                   :clothing #f
-;;                   )
-;;                 )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-10 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-10 clothing length) (-> a0-10 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-10 jgeo) 0)
-;;      (set! (-> a0-10 janim) 3)
-;;      (set! (-> a0-10 mgeo 0) 1)
-;;      (set! (-> a0-10 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-10)
-;;      )
-;;    (let ((a0-11 (new 'static 'skeleton-group
-;;                   :name "skel-ottsel-leader"
-;;                   :extra #f
-;;                   :info #f
-;;                   :art-group-name "ottsel-leader"
-;;                   :bounds (new 'static 'vector :w 10240.0)
-;;                   :version 8
-;;                   :shadow 2
-;;                   :origin-joint-index 3
-;;                   :clothing #f
-;;                   )
-;;                 )
-;;          )
-;;      (when #t
-;;        (set! (-> a0-11 clothing) (new 'static 'boxed-array :type cloth-params :length 0 :allocated-length 1))
-;;        (set! (-> a0-11 clothing 0) (new 'static 'cloth-params
-;;                                      :mesh 3
-;;                                      :gravity-constant (meters 12)
-;;                                      :wind-constant 1.0
-;;                                      :cloth-width #xd
-;;                                      :flags (cloth-flag use-wind double-sided flip-normals autogen-uvs)
-;;                                      :tex-name "prec-leader-robe-01"
-;;                                      :tex-name2 "prec-leader-robe-01"
-;;                                      :tex-name3 "prec-leader-robe-01"
-;;                                      :alt-tex-name #f
-;;                                      :alt-tex-name2 #f
-;;                                      :alt-tex-name3 #f
-;;                                      :cloth-thickness 1.0
-;;                                      :initial-xform 3
-;;                                      :drag 0.151
-;;                                      :num-iterations 1
-;;                                      :timestep-frequency 7
-;;                                      )
-;;              )
-;;        (set! (-> a0-11 clothing length) (-> a0-11 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-11 jgeo) 0)
-;;      (set! (-> a0-11 janim) 4)
-;;      (set! (-> a0-11 mgeo 0) 1)
-;;      (set! (-> a0-11 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-11)
-;;      )
-;;    (let ((a0-12 (new 'static 'skeleton-group
-;;                   :name "skel-battle-amulet"
-;;                   :extra #f
-;;                   :info #f
-;;                   :art-group-name "battle-amulet"
-;;                   :bounds (new 'static 'vector :w 8192.0)
-;;                   :version 8
-;;                   :origin-joint-index 3
-;;                   :clothing #f
-;;                   )
-;;                 )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-12 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-12 clothing length) (-> a0-12 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-12 jgeo) 0)
-;;      (set! (-> a0-12 janim) 2)
-;;      (set! (-> a0-12 mgeo 0) 1)
-;;      (set! (-> a0-12 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-12)
-;;      )
-;;    (let ((a0-13 (new 'static 'skeleton-group
-;;                   :name "skel-precursor"
-;;                   :extra #f
-;;                   :info #f
-;;                   :art-group-name "precursor"
-;;                   :bounds (new 'static 'vector :w 34816.0)
-;;                   :version 8
-;;                   :origin-joint-index 3
-;;                   :clothing #f
-;;                   )
-;;                 )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-13 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-13 clothing length) (-> a0-13 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-13 jgeo) 0)
-;;      (set! (-> a0-13 janim) 2)
-;;      (set! (-> a0-13 mgeo 0) 1)
-;;      (set! (-> a0-13 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-13)
-;;      )
-;;    (let ((a0-14 (new 'static 'skeleton-group
-;;                   :name "skel-comb-rail-rider-fma"
-;;                   :extra #f
-;;                   :info #f
-;;                   :art-group-name "comb-rail-rider"
-;;                   :bounds (new 'static 'vector :w 43008.0)
-;;                   :version 8
-;;                   :origin-joint-index 3
-;;                   :clothing #f
-;;                   )
-;;                 )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-14 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-14 clothing length) (-> a0-14 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-14 jgeo) 0)
-;;      (set! (-> a0-14 janim) 3)
-;;      (set! (-> a0-14 mgeo 0) 1)
-;;      (set! (-> a0-14 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-14)
-;;      )
-;;    (let ((a0-15 (new 'static 'skeleton-group
-;;                   :name "skel-monk"
-;;                   :extra #f
-;;                   :info #f
-;;                   :art-group-name "monk"
-;;                   :bounds (new 'static 'vector :w 16384.0)
-;;                   :version 8
-;;                   :shadow 2
-;;                   :shadow-joint-index 3
-;;                   :origin-joint-index 3
-;;                   :clothing #f
-;;                   )
-;;                 )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-15 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-15 clothing length) (-> a0-15 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-15 jgeo) 0)
-;;      (set! (-> a0-15 janim) 3)
-;;      (set! (-> a0-15 mgeo 0) 1)
-;;      (set! (-> a0-15 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-15)
-;;      )
-;;    (let ((a0-16 (new 'static 'skeleton-group
-;;                   :name "skel-terraformer-fma"
-;;                   :extra #f
-;;                   :info #f
-;;                   :art-group-name "terraformer-fma"
-;;                   :bounds (new 'static 'vector :w 16384.0)
-;;                   :version 8
-;;                   :origin-joint-index 3
-;;                   :clothing #f
-;;                   )
-;;                 )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-16 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-16 clothing length) (-> a0-16 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-16 jgeo) 0)
-;;      (set! (-> a0-16 janim) 2)
-;;      (set! (-> a0-16 mgeo 0) 1)
-;;      (set! (-> a0-16 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-16)
-;;      )
-;;    (let ((a0-17 (new 'static 'skeleton-group
-;;                   :name "skel-rhino-fma"
-;;                   :extra #f
-;;                   :info #f
-;;                   :art-group-name "rhino"
-;;                   :bounds (new 'static 'vector :w 409600.0)
-;;                   :version 8
-;;                   :origin-joint-index 3
-;;                   :clothing #f
-;;                   )
-;;                 )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-17 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-17 clothing length) (-> a0-17 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-17 jgeo) 4)
-;;      (set! (-> a0-17 janim) 7)
-;;      (set! (-> a0-17 mgeo 0) 5)
-;;      (set! (-> a0-17 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-17)
-;;      )
-;;    (let ((a0-18 (new 'static 'skeleton-group
-;;                   :name "skel-neo-satellite-fma"
-;;                   :extra #f
-;;                   :info #f
-;;                   :art-group-name "neo-satellite-fma"
-;;                   :bounds (new 'static 'vector :w 40960.0)
-;;                   :version 8
-;;                   :shadow 2
-;;                   :origin-joint-index 3
-;;                   :clothing #f
-;;                   :global-effects #x20
-;;                   )
-;;                 )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-18 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-18 clothing length) (-> a0-18 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-18 jgeo) 0)
-;;      (set! (-> a0-18 janim) 3)
-;;      (set! (-> a0-18 mgeo 0) 1)
-;;      (set! (-> a0-18 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-18)
-;;      )
-;;    (let ((a0-19 (new 'static 'skeleton-group
-;;                   :name "skel-neo-satellite-break"
-;;                   :extra #f
-;;                   :info #f
-;;                   :art-group-name "neo-satellite-break"
-;;                   :bounds (new 'static 'vector :w 2048000.0)
-;;                   :version 8
-;;                   :origin-joint-index 3
-;;                   :clothing #f
-;;                   :global-effects #x20
-;;                   )
-;;                 )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-19 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-19 clothing length) (-> a0-19 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-19 jgeo) 0)
-;;      (set! (-> a0-19 janim) 2)
-;;      (set! (-> a0-19 mgeo 0) 1)
-;;      (set! (-> a0-19 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-19)
-;;      )
-;;    (let ((a0-20 (new 'static 'skeleton-group
-;;                   :name "skel-talk-box"
-;;                   :extra #f
-;;                   :info #f
-;;                   :art-group-name "talk-box"
-;;                   :bounds (new 'static 'vector :w 8192.0)
-;;                   :version 8
-;;                   :origin-joint-index 3
-;;                   :clothing #f
-;;                   )
-;;                 )
-;;          )
-;;      (when #f
-;;        (set! (-> a0-20 clothing) (new 'static 'boxed-array :type cloth-params))
-;;        (set! (-> a0-20 clothing length) (-> a0-20 clothing allocated-length))
-;;        )
-;;      (set! (-> a0-20 jgeo) 0)
-;;      (set! (-> a0-20 janim) 2)
-;;      (set! (-> a0-20 mgeo 0) 1)
-;;      (set! (-> a0-20 lod-dist 0) 4095996000.0)
-;;      (add-to-loading-level a0-20)
-;;      )
-;;    (none)
-;;    )
-;;  )
+         )
+     (when #t
+       (set! (-> a0-11 clothing) (new 'static 'boxed-array :type cloth-params :length 0 :allocated-length 1))
+       (set! (-> a0-11 clothing 0) (new 'static 'cloth-params
+                                     :mesh 3
+                                     :gravity-constant (meters 12)
+                                     :wind-constant 1.0
+                                     :cloth-width #xd
+                                     :flags (cloth-flag use-wind double-sided flip-normals autogen-uvs)
+                                     :tex-name "prec-leader-robe-01"
+                                     :tex-name2 "prec-leader-robe-01"
+                                     :tex-name3 "prec-leader-robe-01"
+                                     :alt-tex-name #f
+                                     :alt-tex-name2 #f
+                                     :alt-tex-name3 #f
+                                     :cloth-thickness 1.0
+                                     :initial-xform 3
+                                     :drag 0.151
+                                     :num-iterations 1
+                                     :timestep-frequency 7
+                                     )
+             )
+       (set! (-> a0-11 clothing length) (-> a0-11 clothing allocated-length))
+       )
+     (set! (-> a0-11 jgeo) 0)
+     (set! (-> a0-11 janim) 4)
+     (set! (-> a0-11 mgeo 0) 1)
+     (set! (-> a0-11 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-11)
+     )
+   (let ((a0-12 (new 'static 'skeleton-group
+                  :name "skel-battle-amulet"
+                  :extra #f
+                  :info #f
+                  :art-group-name "battle-amulet"
+                  :bounds (new 'static 'vector :w 8192.0)
+                  :version 8
+                  :origin-joint-index 3
+                  :clothing #f
+                  )
+                )
+         )
+     (when #f
+       (set! (-> a0-12 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-12 clothing length) (-> a0-12 clothing allocated-length))
+       )
+     (set! (-> a0-12 jgeo) 0)
+     (set! (-> a0-12 janim) 2)
+     (set! (-> a0-12 mgeo 0) 1)
+     (set! (-> a0-12 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-12)
+     )
+   (let ((a0-13 (new 'static 'skeleton-group
+                  :name "skel-precursor"
+                  :extra #f
+                  :info #f
+                  :art-group-name "precursor"
+                  :bounds (new 'static 'vector :w 34816.0)
+                  :version 8
+                  :origin-joint-index 3
+                  :clothing #f
+                  )
+                )
+         )
+     (when #f
+       (set! (-> a0-13 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-13 clothing length) (-> a0-13 clothing allocated-length))
+       )
+     (set! (-> a0-13 jgeo) 0)
+     (set! (-> a0-13 janim) 2)
+     (set! (-> a0-13 mgeo 0) 1)
+     (set! (-> a0-13 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-13)
+     )
+   (let ((a0-14 (new 'static 'skeleton-group
+                  :name "skel-comb-rail-rider-fma"
+                  :extra #f
+                  :info #f
+                  :art-group-name "comb-rail-rider"
+                  :bounds (new 'static 'vector :w 43008.0)
+                  :version 8
+                  :origin-joint-index 3
+                  :clothing #f
+                  )
+                )
+         )
+     (when #f
+       (set! (-> a0-14 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-14 clothing length) (-> a0-14 clothing allocated-length))
+       )
+     (set! (-> a0-14 jgeo) 0)
+     (set! (-> a0-14 janim) 3)
+     (set! (-> a0-14 mgeo 0) 1)
+     (set! (-> a0-14 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-14)
+     )
+   (let ((a0-15 (new 'static 'skeleton-group
+                  :name "skel-monk"
+                  :extra #f
+                  :info #f
+                  :art-group-name "monk"
+                  :bounds (new 'static 'vector :w 16384.0)
+                  :version 8
+                  :shadow 2
+                  :shadow-joint-index 3
+                  :origin-joint-index 3
+                  :clothing #f
+                  )
+                )
+         )
+     (when #f
+       (set! (-> a0-15 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-15 clothing length) (-> a0-15 clothing allocated-length))
+       )
+     (set! (-> a0-15 jgeo) 0)
+     (set! (-> a0-15 janim) 3)
+     (set! (-> a0-15 mgeo 0) 1)
+     (set! (-> a0-15 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-15)
+     )
+   (let ((a0-16 (new 'static 'skeleton-group
+                  :name "skel-terraformer-fma"
+                  :extra #f
+                  :info #f
+                  :art-group-name "terraformer-fma"
+                  :bounds (new 'static 'vector :w 16384.0)
+                  :version 8
+                  :origin-joint-index 3
+                  :clothing #f
+                  )
+                )
+         )
+     (when #f
+       (set! (-> a0-16 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-16 clothing length) (-> a0-16 clothing allocated-length))
+       )
+     (set! (-> a0-16 jgeo) 0)
+     (set! (-> a0-16 janim) 2)
+     (set! (-> a0-16 mgeo 0) 1)
+     (set! (-> a0-16 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-16)
+     )
+   (let ((a0-17 (new 'static 'skeleton-group
+                  :name "skel-rhino-fma"
+                  :extra #f
+                  :info #f
+                  :art-group-name "rhino"
+                  :bounds (new 'static 'vector :w 409600.0)
+                  :version 8
+                  :origin-joint-index 3
+                  :clothing #f
+                  )
+                )
+         )
+     (when #f
+       (set! (-> a0-17 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-17 clothing length) (-> a0-17 clothing allocated-length))
+       )
+     (set! (-> a0-17 jgeo) 4)
+     (set! (-> a0-17 janim) 7)
+     (set! (-> a0-17 mgeo 0) 5)
+     (set! (-> a0-17 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-17)
+     )
+   (let ((a0-18 (new 'static 'skeleton-group
+                  :name "skel-neo-satellite-fma"
+                  :extra #f
+                  :info #f
+                  :art-group-name "neo-satellite-fma"
+                  :bounds (new 'static 'vector :w 40960.0)
+                  :version 8
+                  :shadow 2
+                  :origin-joint-index 3
+                  :clothing #f
+                  :global-effects #x20
+                  )
+                )
+         )
+     (when #f
+       (set! (-> a0-18 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-18 clothing length) (-> a0-18 clothing allocated-length))
+       )
+     (set! (-> a0-18 jgeo) 0)
+     (set! (-> a0-18 janim) 3)
+     (set! (-> a0-18 mgeo 0) 1)
+     (set! (-> a0-18 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-18)
+     )
+   (let ((a0-19 (new 'static 'skeleton-group
+                  :name "skel-neo-satellite-break"
+                  :extra #f
+                  :info #f
+                  :art-group-name "neo-satellite-break"
+                  :bounds (new 'static 'vector :w 2048000.0)
+                  :version 8
+                  :origin-joint-index 3
+                  :clothing #f
+                  :global-effects #x20
+                  )
+                )
+         )
+     (when #f
+       (set! (-> a0-19 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-19 clothing length) (-> a0-19 clothing allocated-length))
+       )
+     (set! (-> a0-19 jgeo) 0)
+     (set! (-> a0-19 janim) 2)
+     (set! (-> a0-19 mgeo 0) 1)
+     (set! (-> a0-19 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-19)
+     )
+   (let ((a0-20 (new 'static 'skeleton-group
+                  :name "skel-talk-box"
+                  :extra #f
+                  :info #f
+                  :art-group-name "talk-box"
+                  :bounds (new 'static 'vector :w 8192.0)
+                  :version 8
+                  :origin-joint-index 3
+                  :clothing #f
+                  )
+                )
+         )
+     (when #f
+       (set! (-> a0-20 clothing) (new 'static 'boxed-array :type cloth-params))
+       (set! (-> a0-20 clothing length) (-> a0-20 clothing allocated-length))
+       )
+     (set! (-> a0-20 jgeo) 0)
+     (set! (-> a0-20 janim) 2)
+     (set! (-> a0-20 mgeo 0) 1)
+     (set! (-> a0-20 lod-dist 0) 4095996000.0)
+     (add-to-loading-level a0-20)
+     )
+   (none)
+   )
+ )
 
 (defskelgroup skel-ottsel-daxpants ottsel-daxpants ottsel-daxpants-lod0-jg ottsel-daxpants-idle-ja
               ((ottsel-daxpants-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 2.5)
-              :shadow-joint-index 3
+              :origin-joint-index 3
               )
 
 (defskelgroup skel-ottsel-dummy ottsel-dummy ottsel-dummy-lod0-jg ottsel-dummy-idle-ja
               ((ottsel-dummy-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 2.5)
-              :shadow-joint-index 3
+              :origin-joint-index 3
               )
 
 (defskelgroup skel-ottsel-tess ottsel-tess ottsel-tess-lod0-jg ottsel-tess-idle-ja
               ((ottsel-tess-lod0-mg (meters 999999)))
               :bounds (static-spherem 0 0 0 2.5)
               :shadow ottsel-tess-shadow-mg
-              :shadow-joint-index 3
+              :origin-joint-index 3
               )


### PR DESCRIPTION
A few minor fixes:

- Fix crash in overlord3 during final boss https://github.com/open-goal/jak-project/issues/3605
- Update goal_src for `scene-actor.gc`, which was not updated after a bug fix for decompiling skelgroups, making some cutscene actors invisible due to using the wrong joint for culling checks.
- Stop using `-1` as an invalid value for texture id's in Merc.cpp. This could sometimes cause Merc2.cpp to accidentally skip updating the OpenGL texture. This fixes the bug where skull gems sometimes didn't have the animated textures.