### PR TITLE
decompiler: Apply docstring indentation fix to all game versions

### DIFF
--- a/decompiler/analysis/final_output.cpp
+++ b/decompiler/analysis/final_output.cpp
@@ -54,12 +54,8 @@ void append_body_to_function_definition(goos::Object* top_form,
   body_elements.insert(body_elements.end(), inline_body.begin(), inline_body.end());
   // If the first element in the body is a docstring, add it first
   if (body_elements.size() > 0 && body_elements.at(0).is_string()) {
-    if (version > GameVersion::Jak2) {
-      initial_top_level_forms.push_back(
-          goos::StringObject::make_new(fix_docstring_indent(inline_body.at(0).as_string()->data)));
-    } else {
-      initial_top_level_forms.push_back(inline_body.at(0));
-    }
+    initial_top_level_forms.push_back(
+        goos::StringObject::make_new(fix_docstring_indent(inline_body.at(0).as_string()->data)));
     body_elements.erase(body_elements.begin());
   }
 

--- a/test/decompiler/reference/jak2/engine/ai/enemy_REF.gc
+++ b/test/decompiler/reference/jak2/engine/ai/enemy_REF.gc
@@ -38,31 +38,31 @@
 ;; definition for method 118 of type enemy
 (defmethod rnd-float-range ((this enemy) (low float) (high float))
   "@param low The lower bound of the range (inclusive)
-@param high The upper bound of the range (exclusive)
-@returns A random float in the specified range"
+   @param high The upper bound of the range (exclusive)
+   @returns A random float in the specified range"
   (+ low (* (rand-vu) (- high low)))
   )
 
 ;; definition for method 119 of type enemy
 (defmethod rnd-int-count ((this enemy) (high int))
   "@param high The upper bound of the range (exclusive)
-@returns a random integer in the range 0 to `high`
-@see [[rand-vu]]"
+   @returns a random integer in the range 0 to `high`
+   @see [[rand-vu]]"
   (the int (* (rand-vu) (the float high)))
   )
 
 ;; definition for method 121 of type enemy
 (defmethod rnd-int-range ((this enemy) (low int) (high int))
   "@param low The lower bound of the range (inclusive)
-@param high The upper bound of the range (exclusive)
-@returns A random integer in the specified range"
+   @param high The upper bound of the range (exclusive)
+   @returns A random integer in the specified range"
   (+ low (the int (* (rand-vu) (the float (+ (- 1 low) high)))))
   )
 
 ;; definition for method 122 of type enemy
 (defmethod rnd-percent? ((this enemy) (chance float))
   "@param chance The value to compare ([[>=]]) with the result from [[rand-vu]].
-@returns If `chance` is greater than the random draw"
+   @returns If `chance` is greater than the random draw"
   (>= chance (rand-vu))
   )
 
@@ -202,7 +202,7 @@
 ;; definition for method 59 of type enemy
 (defmethod get-penetrate-info ((this enemy))
   "@returns the allowed way(s) this enemy can take damage
-@see [[penetrate]] and [[penetrated-by-all&hit-points->penetrated-by]]"
+   @see [[penetrate]] and [[penetrated-by-all&hit-points->penetrated-by]]"
   (penetrated-by-all&hit-points->penetrated-by (-> this penetrated-by-all) (-> this hit-points))
   )
 
@@ -303,9 +303,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod common-post ((self enemy))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (if (and (nonzero? (-> self draw)) (logtest? (-> self draw status) (draw-control-status on-screen)))
       (set-time! (-> self last-draw-time))
       )
@@ -803,7 +803,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod look-at-target! ((this enemy) (arg0 enemy-flag))
   "Logic for looking at the target that is locked on, sets some flags and adjusts the neck to look at the target if available
-@param flag Reacts to [[enemy-flag::death-start]] and [[enemy-flag::enable-on-active]], see implementation for details"
+   @param flag Reacts to [[enemy-flag::death-start]] and [[enemy-flag::enable-on-active]], see implementation for details"
   (case arg0
     (((enemy-flag look-at-focus))
      (logclear! (-> this enemy-flags) (enemy-flag look-at-move-dest))
@@ -846,7 +846,7 @@
 ;; definition for method 126 of type enemy
 (defmethod enemy-above-ground? ((this enemy) (arg0 collide-query) (arg1 vector) (arg2 collide-spec) (arg3 float) (arg4 float) (arg5 float))
   "@returns if the enemy is above the ground or not
-@see [[above-ground?]]"
+   @see [[above-ground?]]"
   (above-ground? (-> this root) arg0 arg1 arg2 arg3 arg4 arg5)
   )
 
@@ -1060,7 +1060,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod set-enemy-info! ((this enemy) (arg0 enemy-info))
   "In addition to setting the `enemy-info`, also init the `neck-joint` if applicable from it
-@param info Set `enemy-info` accordingly"
+   @param info Set `enemy-info` accordingly"
   (set! (-> this enemy-info) arg0)
   (when (and (!= (-> this enemy-info neck-joint) -1) (zero? (-> this neck)))
     (set! (-> this neck)
@@ -1291,11 +1291,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this enemy) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-enemy-collision! this)
   (process-drawable-from-entity! this arg0)
   (init-enemy! this)
@@ -1351,10 +1351,10 @@ This commonly includes things such as:
 ;; definition for method 98 of type enemy
 (defmethod in-aggro-range? ((this enemy) (arg0 process-focusable) (arg1 vector))
   "Should the enemy activate.
-- if `activate-distance` is `0.0`, always true
-- otherwise, check if the provided process is close enough
-@param proc The process used to distance check
-@returns true/false"
+   - if `activate-distance` is `0.0`, always true
+   - otherwise, check if the provided process is close enough
+   @param proc The process used to distance check
+   @returns true/false"
   #t
   )
 
@@ -1528,8 +1528,8 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs enemy-aware.
 (defmethod update-target-awareness! ((this enemy) (arg0 process-focusable) (arg1 enemy-best-focus))
   "Checks a variety of criteria to determine the level of awareness the enemy is of the target.  Sets `aware` and related fields as well!
-@TODO - flesh out docs
-@returns the value that sets `aware`"
+   @TODO - flesh out docs
+   @returns the value that sets `aware`"
   (let ((f30-0 (vector-vector-distance (get-trans arg0 0) (-> this root trans)))
         (s3-1 #f)
         (s2-0 #f)
@@ -1673,7 +1673,7 @@ This commonly includes things such as:
 ;; INFO: Used lq/sq
 (defmethod general-event-handler ((this enemy) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (local-vars (s5-5 rgbaf) (sv-432 process) (sv-448 event-message-block))
   (cond
     ((= arg2 'track)

--- a/test/decompiler/reference/jak2/engine/ambient/ambient_REF.gc
+++ b/test/decompiler/reference/jak2/engine/ambient/ambient_REF.gc
@@ -123,7 +123,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod play-communicator-speech! ((this talker-speech-class))
   "Plays the provided [[talker-speech-class]]
-@TODO - understand the array from [[game-info]] better"
+   @TODO - understand the array from [[game-info]] better"
   (set! (-> *game-info* unknown-pad6 (+ (* (-> this speech) 2) 1)) (the-as uint #xffff))
   0
   (none)

--- a/test/decompiler/reference/jak2/engine/anim/aligner_REF.gc
+++ b/test/decompiler/reference/jak2/engine/anim/aligner_REF.gc
@@ -141,10 +141,10 @@
 ;; definition for method 10 of type align-control
 (defmethod align! ((this align-control) (options align-opts) (x float) (y float) (z float))
   "As long as [[align-flags::0]] is not set call [[process-drawable::16]] on the process being controlled
-using the arguments passed to construct a [[vector]] - <`x`, `y`, `z`, 1.0>
-
-@returns the `root` of the [[process-drawable]] after the method returns
-@see [[process-drawable::16]]"
+   using the arguments passed to construct a [[vector]] - <`x`, `y`, `z`, 1.0>
+   
+   @returns the `root` of the [[process-drawable]] after the method returns
+   @see [[process-drawable::16]]"
   (when (not (logtest? (-> this flags) (align-flags disabled)))
     (let* ((process (-> this process))
            (method-call (method-of-object process apply-alignment))

--- a/test/decompiler/reference/jak2/engine/camera/cam-interface_REF.gc
+++ b/test/decompiler/reference/jak2/engine/camera/cam-interface_REF.gc
@@ -41,9 +41,9 @@
 ;; definition for function camera-pos
 (defun camera-pos ()
   "Returns the `trans` vector from whatever is first determined to exist:
-- [[*camera-combiner*]]
-- [[*math-camera*]]
-- else, [[*camera-dummy-vector*]]"
+   - [[*camera-combiner*]]
+   - [[*math-camera*]]
+   - else, [[*camera-dummy-vector*]]"
   (cond
     (*camera-combiner*
       (-> *camera-combiner* trans)

--- a/test/decompiler/reference/jak2/engine/common_objs/base-plat_REF.gc
+++ b/test/decompiler/reference/jak2/engine/common_objs/base-plat_REF.gc
@@ -43,7 +43,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-plat! ((this base-plat))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   0
   (none)
   )
@@ -64,8 +64,8 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; WARN: Return type mismatch int vs none.
 (defmethod start-bouncing! ((this base-plat))
   "Sets `bouncing` to [[#t]] and sets up the clock to periodically bounce
-and translate the platform via the `smush`
-@see [[smush-control]]"
+   and translate the platform via the `smush`
+   @see [[smush-control]]"
   (activate! (-> this smush) -1.0 60 150 1.0 1.0 (-> self clock))
   (set-time! (-> this bounce-time))
   (set! (-> this bouncing) #t)
@@ -81,8 +81,8 @@ and translate the platform via the `smush`
 ;; WARN: new jak 2 until loop case, check carefully
 (defbehavior plat-code base-plat ()
   "After calling [[transform-post]] for 2 consecutive frames, put the process to sleep if it's not bouncing
-otherwise, continue bouncing...forever!
-@see [[transform-post]]"
+   otherwise, continue bouncing...forever!
+   @see [[transform-post]]"
   (transform-post)
   (suspend)
   (transform-post)
@@ -105,9 +105,9 @@ otherwise, continue bouncing...forever!
 ;; INFO: Used lq/sq
 (defbehavior plat-trans base-plat ()
   "If the platform is `bouncing`, move the platform accordingly with the [[smush-control]]
-- If the amplitude of the `smush` has hit `0.0` then stop bouncing
-
-If we aren't bouncing however, TODO - CSHAPE"
+   - If the amplitude of the `smush` has hit `0.0` then stop bouncing
+   
+   If we aren't bouncing however, TODO - CSHAPE"
   (rider-trans)
   (cond
     ((-> self bouncing)
@@ -160,7 +160,7 @@ If we aren't bouncing however, TODO - CSHAPE"
 ;; WARN: Return type mismatch none vs object.
 (defbehavior plat-event base-plat ((proc process) (arg1 int) (event-type symbol) (event event-message-block))
   "Handles platform related events.  Presently all this does is:
-- if `event-type` is [['bonk]], then call [[base-plat:29]]"
+   - if `event-type` is [['bonk]], then call [[base-plat:29]]"
   (case event-type
     (('bonk)
      (start-bouncing! self)
@@ -226,9 +226,9 @@ If we aren't bouncing however, TODO - CSHAPE"
 ;; WARN: Return type mismatch symbol vs object.
 (defbehavior eco-door-event-handler eco-door ((proc process) (arg1 int) (event-type symbol) (event event-message-block))
   "If the `event-type` is `'trigger`, flip the `locked` flag on the door
-and play the respective sound
-
-@unused - likely a leftover from Jak 1"
+   and play the respective sound
+   
+   @unused - likely a leftover from Jak 1"
   (case event-type
     (('trigger)
      (set! (-> self locked) (not (-> self locked)))
@@ -380,7 +380,7 @@ eco-door-event-handler
 ;; WARN: Return type mismatch int vs none.
 (defmethod lock-according-to-task! ((this eco-door))
   "If the associated subtask is completed, lock the door if [[eco-door-flags:0]] is set
-otherwise, lock it if [[eco-door-flags:0]] is set"
+   otherwise, lock it if [[eco-door-flags:0]] is set"
   (when (-> this state-actor)
     (if (logtest? (-> this state-actor extra perm status) (entity-perm-status subtask-complete))
         (set! (-> this locked) (logtest? (-> this flags) (eco-door-flags ecdf01)))
@@ -427,11 +427,11 @@ otherwise, lock it if [[eco-door-flags:0]] is set"
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this eco-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (eco-door-method-25 this)
   (process-drawable-from-entity! this arg0)
   (let ((door-scale (res-lump-float (-> this entity) 'scale :default 1.0)))

--- a/test/decompiler/reference/jak2/engine/common_objs/basebutton_REF.gc
+++ b/test/decompiler/reference/jak2/engine/common_objs/basebutton_REF.gc
@@ -291,9 +291,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod send-event! ((this basebutton) (event-type symbol))
   "Prepares an [[event-message-block]] using the provided type to send an event to:
-- the `notify-actor`
-- every [[entity-actor]] in the `actor-group` array
-@see [[entity-actor]]"
+   - the `notify-actor`
+   - every [[entity-actor]] in the `actor-group` array
+   @see [[entity-actor]]"
   (when event-type
     (let ((event (new 'stack-no-clear 'event-message-block)))
       (set! (-> event from) (process->ppointer self))
@@ -427,11 +427,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this basebutton) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (reset! this)
   (set! (-> this button-id) -1)

--- a/test/decompiler/reference/jak2/engine/common_objs/blocking-plane_REF.gc
+++ b/test/decompiler/reference/jak2/engine/common_objs/blocking-plane_REF.gc
@@ -175,11 +175,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this blocking-plane) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'path-control this 'path 0.0 (the-as entity #f) #f))
         (f30-0 (res-lump-float (-> this entity) 'height :default 122880.0))
         )

--- a/test/decompiler/reference/jak2/engine/common_objs/collectables_REF.gc
+++ b/test/decompiler/reference/jak2/engine/common_objs/collectables_REF.gc
@@ -1345,11 +1345,11 @@
 ;; definition for method 11 of type eco-yellow
 (defmethod init-from-entity! ((this eco-yellow) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-common this arg0 (pickup-type eco-yellow) (-> *FACT-bank* eco-single-inc))
   (none)
   )
@@ -1375,11 +1375,11 @@ This commonly includes things such as:
 ;; definition for method 11 of type eco-red
 (defmethod init-from-entity! ((this eco-red) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-common this arg0 (pickup-type eco-red) (-> *FACT-bank* eco-single-inc))
   (none)
   )
@@ -1405,11 +1405,11 @@ This commonly includes things such as:
 ;; definition for method 11 of type eco-blue
 (defmethod init-from-entity! ((this eco-blue) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-common this arg0 (pickup-type eco-blue) (-> *FACT-bank* eco-single-inc))
   (none)
   )
@@ -1435,11 +1435,11 @@ This commonly includes things such as:
 ;; definition for method 11 of type eco-green
 (defmethod init-from-entity! ((this eco-green) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-common this arg0 (pickup-type eco-green) (-> *FACT-bank* eco-single-inc))
   (none)
   )
@@ -1465,11 +1465,11 @@ This commonly includes things such as:
 ;; definition for method 11 of type health
 (defmethod init-from-entity! ((this health) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-common this arg0 (pickup-type health) (-> *FACT-bank* health-default-inc))
   (none)
   )
@@ -1520,11 +1520,11 @@ This commonly includes things such as:
 ;; definition for method 11 of type eco-pill
 (defmethod init-from-entity! ((this eco-pill) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-common this arg0 (pickup-type eco-pill-green) (-> *FACT-bank* health-small-inc))
   (none)
   )
@@ -1749,11 +1749,11 @@ This commonly includes things such as:
 ;; definition for method 11 of type money
 (defmethod init-from-entity! ((this money) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (initialize-allocations this)
   (process-drawable-from-entity! this (-> this entity))
   (initialize-options this 0 1024.0 (the-as fact-info #f))
@@ -2393,11 +2393,11 @@ This commonly includes things such as:
 ;; definition for method 11 of type trick-point
 (defmethod init-from-entity! ((this trick-point) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (initialize-allocations this)
   (process-drawable-from-entity! this (-> this entity))
   (initialize-options this 0 1024.0 (the-as fact-info #f))
@@ -2713,11 +2713,11 @@ This commonly includes things such as:
 ;; definition for method 11 of type eco
 (defmethod init-from-entity! ((this eco) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((v1-1 (res-lump-value (-> this entity) 'eco-info uint128 :time -1000000000.0)))
     (set! (-> this type) (cond
                            ((= (the-as uint v1-1) 3)

--- a/test/decompiler/reference/jak2/engine/common_objs/conveyor_REF.gc
+++ b/test/decompiler/reference/jak2/engine/common_objs/conveyor_REF.gc
@@ -145,7 +145,7 @@
 ;; WARN: Return type mismatch object vs ambient-sound.
 (defmethod set-and-get-ambient-sound! ((this conveyor))
   "So long as [[actor-option::16]] is not set, fetch the [[ambient-sound]] for the [[conveyor]]
-and return it as well.  Otherwise, set it to `0`"
+   and return it as well.  Otherwise, set it to `0`"
   (let ((actor-options (res-lump-value (-> this entity) 'options actor-option :time -1000000000.0)))
     (the-as
       ambient-sound
@@ -429,11 +429,11 @@ and return it as well.  Otherwise, set it to `0`"
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this conveyor) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (reset-root! this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton this (the-as skeleton-group (get-art-group this)) (the-as pair 0))

--- a/test/decompiler/reference/jak2/engine/common_objs/crates_REF.gc
+++ b/test/decompiler/reference/jak2/engine/common_objs/crates_REF.gc
@@ -1168,11 +1168,11 @@
 ;; definition for method 11 of type crate
 (defmethod init-from-entity! ((this crate) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (crate-init! this arg0)
   (skel-init! this)
   (crate-method-38 this)
@@ -1471,7 +1471,3 @@ This commonly includes things such as:
     #f
     )
   )
-
-
-
-

--- a/test/decompiler/reference/jak2/engine/common_objs/elevator_REF.gc
+++ b/test/decompiler/reference/jak2/engine/common_objs/elevator_REF.gc
@@ -136,10 +136,10 @@
 ;; definition for method 43 of type elevator
 (defmethod move-between-points ((this elevator) (arg0 vector) (arg1 float) (arg2 float))
   "Move between two points on the elevator's path
-@param vec TODO not sure
-@param point-a The first point fetched from the elevator's path
-@param point-b The second point fetched from the path
-@see [[path-control]] and [[elevator]]"
+   @param vec TODO not sure
+   @param point-a The first point fetched from the elevator's path
+   @param point-b The second point fetched from the path
+   @see [[path-control]] and [[elevator]]"
   #f
   )
 
@@ -183,11 +183,11 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-defaults! ((this elevator))
   "Initializes default settings related to the [[elevator]]:
-- `elevator-xz-threshold`
-- `elevator-y-threshold`
-- `elevator-start-pos`
-- `elevator-move-rate`
-- `elevator-flags`"
+   - `elevator-xz-threshold`
+   - `elevator-y-threshold`
+   - `elevator-start-pos`
+   - `elevator-move-rate`
+   - `elevator-flags`"
   (let ((entity (-> this entity)))
     (set! (-> this params xz-threshold) ((method-of-object entity get-property-value-float)
                                          entity
@@ -252,8 +252,8 @@
 ;; definition for function ease-value-in-out
 (defun ease-value-in-out ((value float) (step-amount float))
   "TODO - the math in this function is full of duplication and isn't totally clear
-but if the name is to be believed, it's to slow a values grow at the beginning and end of it's range
-which is obviously useful for an elevator."
+   but if the name is to be believed, it's to slow a values grow at the beginning and end of it's range
+   which is obviously useful for an elevator."
   (let* ((step step-amount)
          (f4-0 (- 1.0 step-amount))
          (f3-0 (/ step (- 1.0 f4-0)))
@@ -421,13 +421,13 @@ which is obviously useful for an elevator."
 ;; INFO: Used lq/sq
 (defmethod find-closest-point-in-path! ((this elevator) (arg0 vector) (arg1 (pointer float)) (arg2 symbol) (arg3 symbol))
   "Finds and sets the provided [[path-step]]'s `next-pos` field to the vertex index in the path which is closest to
-the provided [[vector]]
-
-@param vec The point at which distance calculations are based off
-@param! next-step If a point is found, `next-pos` will be set to the correct point
-@param arg2 TODO
-@param arg3 TODO
-@returns [[#t]] if a point in the path was found"
+   the provided [[vector]]
+   
+   @param vec The point at which distance calculations are based off
+   @param! next-step If a point is found, `next-pos` will be set to the correct point
+   @param arg2 TODO
+   @param arg3 TODO
+   @returns [[#t]] if a point in the path was found"
   (local-vars (path-point vector))
   (let ((elev-params (-> this params))
         (smallest-dist 0.0)
@@ -494,8 +494,8 @@ the provided [[vector]]
 ;; WARN: Return type mismatch int vs none.
 (defmethod move-to-next-point! ((this elevator))
   "If the [[*target*]] is in a valid state and there is a point to transition to in the elevator's path
-do so.
-@see [[elevator::47]]"
+   do so.
+   @see [[elevator::47]]"
   (local-vars (zero float))
   (let ((target *target*))
     (when (and target
@@ -765,9 +765,9 @@ do so.
 ;; WARN: Return type mismatch int vs none.
 (defmethod calc-dist-between-points! ((this elevator) (path-point-x int) (path-point-y int))
   "Calculates the distance between two points in the elevator's path.
-
-@param path-point-x The index of the first point in the distance calculation, and where `next-pos` and `dist` are stored in the `path-seq` array
-@param path-point-y The second point in the distance calculation"
+   
+   @param path-point-x The index of the first point in the distance calculation, and where `next-pos` and `dist` are stored in the `path-seq` array
+   @param path-point-y The second point in the distance calculation"
   (set! (-> this path-seq data path-point-x next-pos) (the float path-point-y))
   (let ((point-x (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) (the float path-point-x) 'interp))
         (point-y (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) (the float path-point-y) 'interp))
@@ -791,7 +791,7 @@ do so.
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-plat! ((this elevator))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   0
   (none)
   )
@@ -832,11 +832,11 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this elevator) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-32 float) (sv-36 path-control) (sv-40 target))
   (init-plat-collision! this)
   (process-drawable-from-entity! this entity)

--- a/test/decompiler/reference/jak2/engine/common_objs/generic-obs_REF.gc
+++ b/test/decompiler/reference/jak2/engine/common_objs/generic-obs_REF.gc
@@ -242,11 +242,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this swingpole) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   "Copy defaults from the entity."
   (stack-size-set! (-> this main-thread) 128)
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
@@ -343,11 +343,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this process-hidden) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   "Copy defaults from the entity."
   (process-entity-status! this (entity-perm-status dead) #t)
   (go (method-of-object this die))
@@ -2050,11 +2050,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this med-res-level) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stack-size-set! (-> this main-thread) 128)
   (let ((s4-0 (res-lump-struct arg0 'art-name structure))
         (s3-0 (res-lump-struct (-> this entity) 'level structure))
@@ -2137,11 +2137,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this part-spawner) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 string))
   (stack-size-set! (-> this main-thread) 128)
   (logior! (-> this mask) (process-mask ambient))
@@ -2783,11 +2783,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this launcher) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stack-size-set! (-> this main-thread) 128)
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((v1-4 (new 'process 'collide-shape-prim-sphere s4-0 (the-as uint 0))))

--- a/test/decompiler/reference/jak2/engine/common_objs/plat_REF.gc
+++ b/test/decompiler/reference/jak2/engine/common_objs/plat_REF.gc
@@ -74,7 +74,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-plat! ((this plat))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   0
   (none)
   )
@@ -89,9 +89,9 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; definition for method 36 of type plat
 (defmethod plat-path-sync ((this plat))
   "If the `sync` period is greater than `0` then transition the state to [[plat::35]]
-otherwise, [[plat::34]]
-
-@see [[sync-eased]]"
+   otherwise, [[plat::34]]
+   
+   @see [[sync-eased]]"
   (cond
     ((logtest? (-> this path flags) (path-control-flag not-found))
      (go (method-of-object this plat-idle))
@@ -166,11 +166,11 @@ otherwise, [[plat::34]]
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this plat) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (logior! (-> this mask) (process-mask platform))
   (init-plat-collision! this)
   (process-drawable-from-entity! this entity)

--- a/test/decompiler/reference/jak2/engine/common_objs/projectile_REF.gc
+++ b/test/decompiler/reference/jak2/engine/common_objs/projectile_REF.gc
@@ -90,9 +90,9 @@
 ;; definition for method 36 of type projectile
 (defmethod handle-proj-hit! ((this projectile) (arg0 process) (arg1 event-message-block))
   "When a projectile hits something, first deal damage via [[projectile::37]]
-and increment the projectiles hit count.
-
-If we've met or exceeded the projectiles maximum allowed hits, switch to the [[projectile::impact]] state"
+   and increment the projectiles hit count.
+   
+   If we've met or exceeded the projectiles maximum allowed hits, switch to the [[projectile::impact]] state"
   (when (-> this attack-mode)
     (let ((a2-1 (-> arg1 param 0)))
       (when (deal-damage! this arg0 (the-as event-message-block a2-1))

--- a/test/decompiler/reference/jak2/engine/common_objs/rigid-body-plat_REF.gc
+++ b/test/decompiler/reference/jak2/engine/common_objs/rigid-body-plat_REF.gc
@@ -551,11 +551,11 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-from-entity! ((this rigid-body-platform) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (logior! (-> this mask) (process-mask platform))
   (allocate-and-init-cshape this)
   (process-drawable-from-entity! this arg0)

--- a/test/decompiler/reference/jak2/engine/common_objs/voicebox_REF.gc
+++ b/test/decompiler/reference/jak2/engine/common_objs/voicebox_REF.gc
@@ -608,11 +608,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this judge) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (setup-collision this)
   (init this)
   (process-drawable-from-entity! this arg0)

--- a/test/decompiler/reference/jak2/engine/common_objs/water-anim_REF.gc
+++ b/test/decompiler/reference/jak2/engine/common_objs/water-anim_REF.gc
@@ -682,11 +682,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this water-anim) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (water-anim-method-27 this)
   (reset-root! this)
   (water-anim-init! this)

--- a/test/decompiler/reference/jak2/engine/debug/history_REF.gc
+++ b/test/decompiler/reference/jak2/engine/debug/history_REF.gc
@@ -174,9 +174,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod clear-history-entries! ((this history))
   "Iterates through each [[history-elt]] in the `elt` dynamic array
-For each entry:
-- clear `timestamp`
-- clear `record-tag`"
+   For each entry:
+   - clear `timestamp`
+   - clear `record-tag`"
   (set! (-> this alloc-index) 0)
   (countdown (v1-0 (-> this allocated-length))
     (let ((a1-3 (-> this elts v1-0)))
@@ -199,10 +199,10 @@ For each entry:
 ;; WARN: new jak 2 until loop case, check carefully
 (defmethod clear-record-tags! ((this history) (arg0 history-channel) (arg1 uint) (arg2 uint))
   "First grab the latest [[history-elt]] at `alloc-index`
-1. update it's `channel`, `record-id` and `owner` from the provided args
-2. - if it's `record-tag` is zero -- return it
-- otherwise, iterate through all `elts` until one is found that does not match it's `timestamp`
-- if not `0` out the `record-tag` for that elt and continue iteration"
+   1. update it's `channel`, `record-id` and `owner` from the provided args
+   2. - if it's `record-tag` is zero -- return it
+   - otherwise, iterate through all `elts` until one is found that does not match it's `timestamp`
+   - if not `0` out the `record-tag` for that elt and continue iteration"
   (let* ((t1-0 (-> this alloc-index))
          (v1-0 (-> this elts))
          (v0-0 (-> v1-0 t1-0))
@@ -253,9 +253,9 @@ For each entry:
 ;; definition for method 10 of type history-iterator
 (defmethod update-entries! ((this history-iterator))
   "Iterate through each [[history-elt]] in [[*history*]]
-- If we hit the end set `done?` to true
-- If the `timestamp` on the elt, minus the current framecounter exceeds `max-age`, we are also done, return #f
-- However if we find an elt who's `owner` matches the iterator's, break out early returning that `elt`"
+   - If we hit the end set `done?` to true
+   - If the `timestamp` on the elt, minus the current framecounter exceeds `max-age`, we are also done, return #f
+   - However if we find an elt who's `owner` matches the iterator's, break out early returning that `elt`"
   (let ((v1-0 *history*)
         (a1-2 (-> *display* base-clock frame-counter))
         )

--- a/test/decompiler/reference/jak2/engine/debug/memory-usage_REF.gc
+++ b/test/decompiler/reference/jak2/engine/debug/memory-usage_REF.gc
@@ -64,9 +64,9 @@
 ;; definition for function mem-size
 (defun mem-size ((data basic) (inspect-usage? symbol) (arg2 int))
   "@param data The [[basic]] to call `mem-usage` on
-@param inspect-usage? Set to [[#t]] if `inspect` should be called on the resulting [[memory-usage-block]]
-@param arg2 TODO - unsure, some sort of bitfield
-@returns The total memory footprint of the provided [[basic]]"
+   @param inspect-usage? Set to [[#t]] if `inspect` should be called on the resulting [[memory-usage-block]]
+   @param arg2 TODO - unsure, some sort of bitfield
+   @returns The total memory footprint of the provided [[basic]]"
   (let ((block (new 'stack 'memory-usage-block)))
     (mem-usage data block arg2)
     (if inspect-usage?
@@ -79,11 +79,11 @@
 ;; definition for method 14 of type level
 (defmethod compute-memory-usage! ((this level) (force? symbol))
   "Calculates the memory usage of the level, returns and stores the [[memory-usage-block]]
-in `mem-usage-block` as well as the total size in `mem-usage`
-
-@param force? - Will re-compute the usage if set to [[#t]], even if `mem-usage` has been set to a non-zero value
-@returns The [[memory-usage-block]] representing the footprint of the level
-@see [[memory-usage-block::10]]"
+   in `mem-usage-block` as well as the total size in `mem-usage`
+   
+   @param force? - Will re-compute the usage if set to [[#t]], even if `mem-usage` has been set to a non-zero value
+   @returns The [[memory-usage-block]] representing the footprint of the level
+   @see [[memory-usage-block::10]]"
   (if (zero? (-> this mem-usage-block))
       (set! (-> this mem-usage-block) (new 'debug 'memory-usage-block))
       )

--- a/test/decompiler/reference/jak2/engine/debug/nav/mysql-nav-graph_REF.gc
+++ b/test/decompiler/reference/jak2/engine/debug/nav/mysql-nav-graph_REF.gc
@@ -311,7 +311,7 @@
 ;; definition for method 13 of type mysql-nav-graph
 (defmethod alloc-new-node! ((this mysql-nav-graph))
   "Allocates a new `[[mysql-nav-node]]`, if `node-array`'s `length` exceeds `3000` return `-1`
-otherwise, return the new size of the array"
+   otherwise, return the new size of the array"
   (cond
     ((>= (-> this node-array length) 3000)
      (format #t "mysql-nav-graph : nodes buffer too small, increase NAV_GRAPH_EDITOR_NODE_COUNT~%")
@@ -336,7 +336,7 @@ otherwise, return the new size of the array"
 ;; definition for method 14 of type mysql-nav-graph
 (defmethod alloc-new-edge! ((this mysql-nav-graph))
   "Allocates a new `[[mysql-nav-edge]]`, if `edge-array`'s `length` exceeds `5000` return `-1`
-otherwise, return the new size of the array"
+   otherwise, return the new size of the array"
   (cond
     ((>= (-> this edge-array length) 5000)
      (format #t "mysql-nav-graph : edges buffer too small, increase NAV_GRAPH_EDITOR_EDGE_COUNT~%")
@@ -361,7 +361,7 @@ otherwise, return the new size of the array"
 ;; definition for method 15 of type mysql-nav-graph
 (defmethod indexof-visnode ((this mysql-nav-graph) (edge-id int) (node-id int))
   "Returns the index in the `visnode-array` whom's [[mysql-nav-visnode]] has the provided `runtime-edge-id` and `runtime-node-id`
-if none exist, return `-1`"
+   if none exist, return `-1`"
   (dotimes (v1-0 (-> this visnode-array length))
     (let ((a3-2 (-> this visnode-array data v1-0)))
       (if (and (= (-> a3-2 runtime-edge-id) edge-id) (= (-> a3-2 runtime-node-id) node-id))
@@ -375,9 +375,9 @@ if none exist, return `-1`"
 ;; definition for method 16 of type mysql-nav-graph
 (defmethod alloc-new-visnode! ((this mysql-nav-graph) (edge-id int) (node-id int))
   "Potentially allocates a new `[[mysql-nav-visnode]]`:
-- if `visnode-array`'s `length` exceeds `3000` return `-1`
-- otherwise, if the node already exists, TODO
-- if the node does not already exist, create it!"
+   - if `visnode-array`'s `length` exceeds `3000` return `-1`
+   - otherwise, if the node already exists, TODO
+   - if the node does not already exist, create it!"
   (cond
     ((>= (-> this visnode-array length) 3000)
      (format #t "mysql-nav-graph : visnodes buffer too small, increase NAV_GRAPH_EDITOR_VISNODE_COUNT~%")
@@ -777,7 +777,7 @@ if none exist, return `-1`"
 ;; definition for method 11 of type mysql-nav-graph
 (defmethod indexof-nav-node ((this mysql-nav-graph) (node-id int))
   "Iterate through the `node-array` and return the index for the first [[mysql-nav-node]] whom's `nav_node_id` matches the provided id
-returns `-1` if none is found"
+   returns `-1` if none is found"
   (dotimes (v1-0 (-> this node-array length))
     (if (= node-id (-> (the-as mysql-nav-node (-> this node-array data v1-0)) nav_node_id))
         (return v1-0)
@@ -789,7 +789,7 @@ returns `-1` if none is found"
 ;; definition for method 12 of type mysql-nav-graph
 (defmethod indexof-nav-edge ((this mysql-nav-graph) (edge-id int))
   "Iterate through the `edge-array` and return the index for the first [[mysql-nav-edge]] whom's `nav_edge_id` matches the provided id
-returns `-1` if none is found"
+   returns `-1` if none is found"
   (dotimes (v1-0 (-> this edge-array length))
     (if (= edge-id (-> (the-as mysql-nav-edge (-> this edge-array data v1-0)) nav_edge_id))
         (return v1-0)

--- a/test/decompiler/reference/jak2/engine/debug/sampler_REF.gc
+++ b/test/decompiler/reference/jak2/engine/debug/sampler_REF.gc
@@ -30,8 +30,8 @@
 ;; WARN: Return type mismatch int vs none.
 (defun-debug sampler-start ()
   "Reset the [[timer-bank]] EE registers.
-- If [[*sampler-mem*]] is undefined, allocate 16.7MB in the debug segment
-- and when [[*sampler-mem*]] is defined, initialize the [[timer-bank]] fully.  Reset [[*sampler-count*]] to 0 as well"
+   - If [[*sampler-mem*]] is undefined, allocate 16.7MB in the debug segment
+   - and when [[*sampler-mem*]] is defined, initialize the [[timer-bank]] fully.  Reset [[*sampler-count*]] to 0 as well"
   (set! (-> (the-as timer-bank #x10000000) mode) (new 'static 'timer-mode))
   (set! (-> (the-as timer-bank #x10000000) count) (the-as uint 0))
   (set! (-> (the-as timer-bank #x10000000) comp) *sampler-compare*)

--- a/test/decompiler/reference/jak2/engine/debug/viewer_REF.gc
+++ b/test/decompiler/reference/jak2/engine/debug/viewer_REF.gc
@@ -218,11 +218,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this viewer) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! *viewer* this)
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)

--- a/test/decompiler/reference/jak2/engine/dma/dma-disasm_REF.gc
+++ b/test/decompiler/reference/jak2/engine/dma/dma-disasm_REF.gc
@@ -513,9 +513,9 @@
 ;; INFO: Used lq/sq
 (defun disasm-dma-list ((arg0 dma-packet) (arg1 symbol) (arg2 symbol) (arg3 symbol) (arg4 int))
   "Print out an entire DMA list.
-If mode is #t, print vif tags too. If mode is 'details, also print data unpacked by vif-tags.
-If verbose is #t, print out the addresses of each tag, and total size statistics.
-If expected size is negative, it is ignored. Otherwise, only disassemble this much dma data."
+   If mode is #t, print vif tags too. If mode is 'details, also print data unpacked by vif-tags.
+   If verbose is #t, print out the addresses of each tag, and total size statistics.
+   If expected size is negative, it is ignored. Otherwise, only disassemble this much dma data."
   (local-vars
     (sv-16 object)
     (sv-32 dma-packet)

--- a/test/decompiler/reference/jak2/engine/draw/drawable_REF.gc
+++ b/test/decompiler/reference/jak2/engine/draw/drawable_REF.gc
@@ -218,10 +218,10 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod collect-regions ((this drawable) (arg0 sphere) (arg1 int) (arg2 region-prim-list))
   "Determines the number of [[drawable]]s in the `obj` that overlap the given `area-of-interest` this number is stored in the `region-list`'s item count
-@param area-of-interest The area defined by a sphere that we care about overlaps
-@param _count The amount of [[drawable]]s in the object to enumerate through
-@param! region-list Stores the overlapping regions and a count for how many were found
-@returns none"
+   @param area-of-interest The area defined by a sphere that we care about overlaps
+   @param _count The amount of [[drawable]]s in the object to enumerate through
+   @param! region-list Stores the overlapping regions and a count for how many were found
+   @returns none"
   0
   (none)
   )

--- a/test/decompiler/reference/jak2/engine/entity/actor-link-h_REF.gc
+++ b/test/decompiler/reference/jak2/engine/entity/actor-link-h_REF.gc
@@ -26,7 +26,7 @@
 ;; INFO: Used lq/sq
 (defun entity-actor-count ((arg0 res-lump) (arg1 symbol))
   "Get the number of entities that this res references under the name.
-This works on more than just next/prev."
+   This works on more than just next/prev."
   (local-vars (sv-16 res-tag))
   (set! sv-16 (new 'static 'res-tag))
   (if (res-lump-data arg0 arg1 pointer :tag-ptr (& sv-16))
@@ -95,8 +95,8 @@ and use it for entity lookups."
 ;; definition for method 0 of type actor-link-info
 (defmethod new actor-link-info ((allocation symbol) (type-to-make type) (arg0 process) (arg1 symbol))
   "Set up an actor-link-info for the given process.
-The entity of this process should be the entity-actor
-that will get this actor-link-info."
+   The entity of this process should be the entity-actor
+   that will get this actor-link-info."
   (let* ((a0-1 (-> arg0 entity))
          (s4-0 (entity-actor-lookup a0-1 'next-actor 0))
          (a0-2 (-> arg0 entity))
@@ -152,7 +152,7 @@ that will get this actor-link-info."
 ;; definition for method 16 of type actor-link-info
 (defmethod apply-function-forward ((this actor-link-info) (arg0 (function entity-actor object object)) (arg1 object))
   "Iterate forward through actors, and apply this function. Starts at (-> this next)
-If the function returns truthy, stop iterating."
+   If the function returns truthy, stop iterating."
   (let ((s3-0 (-> this next)))
     (while s3-0
       (if (arg0 s3-0 arg1)
@@ -167,7 +167,7 @@ If the function returns truthy, stop iterating."
 ;; definition for method 17 of type actor-link-info
 (defmethod apply-function-reverse ((this actor-link-info) (arg0 (function entity-actor object object)) (arg1 object))
   "Iterate backward through actors and apply function.
-If the function returns truth, stop iterating."
+   If the function returns truth, stop iterating."
   (let ((s3-0 (-> this prev)))
     (while s3-0
       (if (arg0 s3-0 arg1)
@@ -323,7 +323,7 @@ If the function returns truth, stop iterating."
 ;; definition for method 9 of type actor-link-info
 (defmethod get-matching-actor-type-mask ((this actor-link-info) (arg0 type))
   "Iterate through _all_ actors that are part of this actor list.
-If the nth actor is type matching-type, then set the nth bit of the result."
+   If the nth actor is type matching-type, then set the nth bit of the result."
   (let ((s3-0 (-> this process entity))
         (s5-0 0)
         )

--- a/test/decompiler/reference/jak2/engine/entity/entity-table_REF.gc
+++ b/test/decompiler/reference/jak2/engine/entity/entity-table_REF.gc
@@ -192,10 +192,10 @@
 ;; WARN: Return type mismatch basic vs entity-info.
 (defun entity-info-lookup ((arg0 type))
   "Given a type, return the [[entity-info]] from [[*entity-info*]] whos type
-matches the `ptype` field.  Set's `method 13` on said type that returns the `length`
-off the [[entity-info]]
-
-If nothing matches, set `method 13` to `#f` and return `#f`"
+   matches the `ptype` field.  Set's `method 13` on said type that returns the `length`
+   off the [[entity-info]]
+   
+   If nothing matches, set `method 13` to `#f` and return `#f`"
   (the-as entity-info (cond
                         ((nonzero? (-> arg0 method-table 13))
                          (-> arg0 method-table 13)

--- a/test/decompiler/reference/jak2/engine/entity/res_REF.gc
+++ b/test/decompiler/reference/jak2/engine/entity/res_REF.gc
@@ -116,16 +116,16 @@
 ;; WARN: Return type mismatch int vs res-tag-pair.
 (defmethod lookup-tag-idx ((this res-lump) (arg0 symbol) (arg1 symbol) (arg2 float))
   "Look up the index of the tag containing with the given name and timestamp.
-Correct lookups return a res-tag-pair, which contains one tag index in the lower 32 bits and one in the upper 32 bits.
-Depending on the mode, they may be the same, or they may be two tags that you should interpolate
-between, if the exact time was not found.
-
-@param name-sym should be the name of the thing you want.
-@param time is for the timestamp you want.
-If mode = 'base, then both the indices are the same and the timestamp is ignored.
-If mode = 'interp, then it tries to get closest below/closest above (or both the same, if exact match found).
-If mode = 'exact, then it requires an exact timestamp match and both indices are the same.
-If things go wrong, returns a negative number."
+   Correct lookups return a res-tag-pair, which contains one tag index in the lower 32 bits and one in the upper 32 bits.
+   Depending on the mode, they may be the same, or they may be two tags that you should interpolate
+   between, if the exact time was not found.
+   
+   @param name-sym should be the name of the thing you want.
+   @param time is for the timestamp you want.
+   If mode = 'base, then both the indices are the same and the timestamp is ignored.
+   If mode = 'interp, then it tries to get closest below/closest above (or both the same, if exact match found).
+   If mode = 'exact, then it requires an exact timestamp match and both indices are the same.
+   If things go wrong, returns a negative number."
   (local-vars (t4-1 int))
   (when (or (= arg0 'id)
             (= arg0 'aid)
@@ -227,9 +227,9 @@ If things go wrong, returns a negative number."
 ;; INFO: Used lq/sq
 (defmethod make-property-data ((this res-lump) (arg1 float) (tag-pair res-tag-pair) (arg3 pointer))
   "Returns (a pointer to) the value data of a property with the tag-pair.
-If tag-pair does not represent an exact point in the timeline, then the data is interpolated based on time
-with the result written into buf. buf must have enough space to copy all of the data.
-Otherwise, simply returns an address to the resource binary."
+   If tag-pair does not represent an exact point in the timeline, then the data is interpolated based on time
+   with the result written into buf. buf must have enough space to copy all of the data.
+   Otherwise, simply returns an address to the resource binary."
   (rlet ((vf1 :class vf)
          (vf2 :class vf)
          (vf3 :class vf)
@@ -420,10 +420,10 @@ Otherwise, simply returns an address to the resource binary."
                              (arg5 pointer)
                              )
   "Returns an address to a given property's data at a specific time stamp, or default on error.
-@param name is the name of the property you want, mode is its lookup mode ('interp 'base 'exact), time is the timestamp.
-@param default is the default result returned in the case of an error.
-@param tag-addr is an address to a res-tag. The current base tag is written to this. Ignored if tag-addr is #f
-@param buf-addr is an address to the data buffer used to write interpolated data to. It must have enough space! Only necessary for 'interp mode."
+   @param name is the name of the property you want, mode is its lookup mode ('interp 'base 'exact), time is the timestamp.
+   @param default is the default result returned in the case of an error.
+   @param tag-addr is an address to a res-tag. The current base tag is written to this. Ignored if tag-addr is #f
+   @param buf-addr is an address to the data buffer used to write interpolated data to. It must have enough space! Only necessary for 'interp mode."
   (let ((s3-0 (lookup-tag-idx this arg0 arg1 arg2)))
     (cond
       ((< (the-as int s3-0) 0)
@@ -452,11 +452,11 @@ Otherwise, simply returns an address to the resource binary."
                                (arg5 pointer)
                                )
   "Returns a given struct property's value at a specific time stamp, or default on error.
-@param name is the name of the property you want, `mode` is its lookup mode ('interp 'base 'exact), `time` is the timestamp.
-@param default is the default result returned in the case of an error.
-@param tag-addr is an address to a [[res-tag]]. The current base tag is written to this. Ignored if tag-addr is #f.
-@param buf-addr is an address to the data buffer used to write interpolated data to.
-It must have enough space! Only necessary for 'interp mode."
+   @param name is the name of the property you want, `mode` is its lookup mode ('interp 'base 'exact), `time` is the timestamp.
+   @param default is the default result returned in the case of an error.
+   @param tag-addr is an address to a [[res-tag]]. The current base tag is written to this. Ignored if tag-addr is #f.
+   @param buf-addr is an address to the data buffer used to write interpolated data to.
+   It must have enough space! Only necessary for 'interp mode."
   (let ((s3-0 (lookup-tag-idx this arg0 arg1 arg2)))
     (cond
       ((< (the-as int s3-0) 0)
@@ -491,11 +491,11 @@ It must have enough space! Only necessary for 'interp mode."
                               (arg5 pointer)
                               )
   "Returns a given value property's value at a specific time stamp, or default on error.
-@param name is the name of the property you want, `mode` is its lookup mode ('interp 'base 'exact), `time` is the timestamp.
-@param default is the default result returned in the case of an error.
-@param tag-addr is an address to a res-tag. The current base tag is written to this. Ignored if `tag-addr` is #f.
-@param buf-addr is an address to the data buffer used to write interpolated data to.
-It must have enough space! Only necessary for 'interp mode."
+   @param name is the name of the property you want, `mode` is its lookup mode ('interp 'base 'exact), `time` is the timestamp.
+   @param default is the default result returned in the case of an error.
+   @param tag-addr is an address to a res-tag. The current base tag is written to this. Ignored if `tag-addr` is #f.
+   @param buf-addr is an address to the data buffer used to write interpolated data to.
+   It must have enough space! Only necessary for 'interp mode."
   (let ((a2-1 (lookup-tag-idx this arg0 arg1 arg2)))
     (cond
       ((< (the-as int a2-1) 0)
@@ -677,10 +677,10 @@ It must have enough space! Only necessary for 'interp mode."
 ;; INFO: Used lq/sq
 (defmethod allocate-data-memory-for-tag! ((this res-lump) (arg0 res-tag))
   "Find space for the data described by arg0 in this.
-Returns a tag with data-offset set correctly for this res-lump.
-If the lump already contains memory for the given tag, and it is big enough,
-it will be reused. Alignment will be at least 8 bytes.
-If the input tag has elt-count = 0, it will return a tag for elt-count = 1."
+   Returns a tag with data-offset set correctly for this res-lump.
+   If the lump already contains memory for the given tag, and it is big enough,
+   it will be reused. Alignment will be at least 8 bytes.
+   If the input tag has elt-count = 0, it will return a tag for elt-count = 1."
   (local-vars (resource-mem pointer))
   (let* ((tag-pair (lookup-tag-idx this (-> arg0 name) 'exact (-> arg0 key-frame)))
          (existing-tag (-> this tag (-> tag-pair lo)))
@@ -746,8 +746,8 @@ If the input tag has elt-count = 0, it will return a tag for elt-count = 1."
 ;; definition for method 17 of type res-lump
 (defmethod add-data! ((this res-lump) (tag res-tag) (arg2 pointer))
   "Given a tag and a pointer to its data, copy it to this res-lump.
-This doesn't seem to do the right thing if the given tag is a non-inline tag
-with > 1 element."
+   This doesn't seem to do the right thing if the given tag is a non-inline tag
+   with > 1 element."
   (let ((a0-2 (allocate-data-memory-for-tag! this tag)))
     (when a0-2
       (let* ((v1-2 this)
@@ -787,7 +787,7 @@ with > 1 element."
 ;; INFO: Used lq/sq
 (defmethod get-curve-data! ((this res-lump) (arg0 curve) (arg1 symbol) (arg2 symbol) (arg3 float))
   "Read curve data and write it to curve-target. Return #t if both
-control points and knots data was succesfully read, #f otherwise."
+   control points and knots data was succesfully read, #f otherwise."
   (local-vars (sv-16 res-tag) (sv-32 res-tag))
   (let ((s5-0 #f))
     (set! sv-16 (new 'static 'res-tag))

--- a/test/decompiler/reference/jak2/engine/geometry/bounding-box_REF.gc
+++ b/test/decompiler/reference/jak2/engine/geometry/bounding-box_REF.gc
@@ -249,7 +249,7 @@
 ;; WARN: disable def twice: 23. This may happen when a cond (no else) is nested inside of another conditional, but it should be rare.
 (defmethod intersects-line-segment? ((this bounding-box) (arg0 vector) (arg1 vector))
   "Check intersection in xz plane, using liang-barsky. Not sure if this actually
-a useful check or not..."
+   a useful check or not..."
   (let ((f28-0 (- (-> arg1 x) (-> arg0 x)))
         (f30-0 (- (-> arg1 z) (-> arg0 z)))
         )

--- a/test/decompiler/reference/jak2/engine/geometry/geometry_REF.gc
+++ b/test/decompiler/reference/jak2/engine/geometry/geometry_REF.gc
@@ -4,7 +4,7 @@
 ;; definition for function vector-flatten!
 (defun vector-flatten! ((arg0 vector) (arg1 vector) (arg2 vector))
   "Get the projection of src onto a plane with the given normal
-The normal should have magnitude 1.0."
+   The normal should have magnitude 1.0."
   (rlet ((acc :class vf)
          (vf0 :class vf)
          (vf1 :class vf)
@@ -51,11 +51,11 @@ The normal should have magnitude 1.0."
 ;; definition for function vector-reflect-flat!
 (defun vector-reflect-flat! ((arg0 vector) (arg1 vector) (arg2 vector))
   "This is a weird one. It doesn't care about the value of src dot normal
-and it effectively replaces the component of src normal to the plane with
-the plane's normal.  I think this requires src/normal to both be unit vectors
-in order to make sense.
-NOTE: src should point from positive halfspace to negative otherwise it
-doesn't work."
+   and it effectively replaces the component of src normal to the plane with
+   the plane's normal.  I think this requires src/normal to both be unit vectors
+   in order to make sense.
+   NOTE: src should point from positive halfspace to negative otherwise it
+   doesn't work."
   (rlet ((acc :class vf)
          (vf0 :class vf)
          (vf1 :class vf)
@@ -130,8 +130,8 @@ doesn't work."
 ;; definition for function vector-segment-distance-point!
 (defun vector-segment-distance-point! ((arg0 vector) (arg1 vector) (arg2 vector) (arg3 vector))
   "Compute the distance from a point to the closest point on the line segment.
-arg0 is the point. arg1/arg2 are the endpoints of the line segment.
-arg3 is an optional output closest point."
+   arg0 is the point. arg1/arg2 are the endpoints of the line segment.
+   arg3 is an optional output closest point."
   (local-vars (v0-0 float) (v1-0 float) (v1-1 float))
   (rlet ((acc :class vf)
          (Q :class vf)
@@ -204,7 +204,7 @@ arg3 is an optional output closest point."
 ;; INFO: Used lq/sq
 (defun vector-line-distance ((arg0 vector) (arg1 vector) (arg2 vector))
   "Weird function: given a point arg1, and an infinite line connecting arg2 and arg1, compute the distance
-from arg0 to that line."
+   from arg0 to that line."
   (let* ((a1-3 (vector-normalize! (vector-! (new-stack-vector0) arg2 arg1) 1.0))
          (gp-1 (vector-! (new-stack-vector0) arg0 arg1))
          (f0-1 (vector-dot a1-3 gp-1))
@@ -405,7 +405,7 @@ from arg0 to that line."
 ;; definition for function forward-up->inv-matrix
 (defun forward-up->inv-matrix ((arg0 matrix) (arg1 vector) (arg2 vector))
   "Create a matrix representing an inverse transform where arg1 is forward (+z)
-and arg2 is up (+y). Will use the pitch of forward."
+   and arg2 is up (+y). Will use the pitch of forward."
   (forward-down->inv-matrix arg0 arg1 (vector-negate! (new 'stack-no-clear 'vector) arg2))
   )
 
@@ -413,7 +413,7 @@ and arg2 is up (+y). Will use the pitch of forward."
 ;; INFO: Used lq/sq
 (defun forward-up-nopitch->inv-matrix ((arg0 matrix) (arg1 vector) (arg2 vector))
   "Create a matrix representing an inverse transform where arg1 is forward (+z)
-and arg2 is up (+y). Will not use the pitch of forward."
+   and arg2 is up (+y). Will not use the pitch of forward."
   (forward-down-nopitch->inv-matrix arg0 arg1 (vector-negate! (new-stack-vector0) arg2))
   )
 
@@ -454,7 +454,7 @@ and arg2 is up (+y). Will not use the pitch of forward."
 ;; INFO: Used lq/sq
 (defun quaternion-from-two-vectors-partial! ((arg0 quaternion) (arg1 vector) (arg2 vector) (arg3 float))
   "Create a quaternion representing the rotation between two vectors,
-doing arg3 fraction of the total rotation."
+   doing arg3 fraction of the total rotation."
   (let* ((s5-0 (vector-cross! (new-stack-vector0) arg1 arg2))
          (f0-0 (vector-length s5-0))
          (f1-1 (+ 1.0 (* arg3 (+ -1.0 (vector-dot arg1 arg2)))))
@@ -543,7 +543,7 @@ doing arg3 fraction of the total rotation."
 ;; INFO: Used lq/sq
 (defun matrix-from-two-vectors-max-angle! ((arg0 matrix) (arg1 vector) (arg2 vector) (arg3 float))
   "Create a rotation matrix representing the rotation between two vectors,
-allowing at most a rotation of arg3 degrees."
+   allowing at most a rotation of arg3 degrees."
   (let ((s4-1 (vector-normalize! (vector-cross! (new-stack-vector0) arg2 arg1) 1.0))
         (f30-0 (vector-dot arg1 arg2))
         (f28-0 (cos arg3))
@@ -569,10 +569,10 @@ allowing at most a rotation of arg3 degrees."
 ;; definition for function matrix-from-two-vectors-smooth!
 (defun matrix-from-two-vectors-smooth! ((arg0 matrix) (arg1 vector) (arg2 vector) (arg3 float) (arg4 int))
   "This function can help smoothly rotate from a current heading vector to a target one.
-It returns a rotation to move arg1 closer to arg2, subject to two different speed limits.
-arg3 is a rotations-per-frame rate. This limit takes frame rate into account (when lagging, the rotation is larger)
-arg4 is a 'slow down when getting close to the end' limit.
-This is used in rotate-toward-orientation, which is much improved from jak 1."
+   It returns a rotation to move arg1 closer to arg2, subject to two different speed limits.
+   arg3 is a rotations-per-frame rate. This limit takes frame rate into account (when lagging, the rotation is larger)
+   arg4 is a 'slow down when getting close to the end' limit.
+   This is used in rotate-toward-orientation, which is much improved from jak 1."
   (let* ((s5-1 (vector-normalize! (vector-cross! (new 'stack-no-clear 'vector) arg2 arg1) 1.0))
          (f0-1 (vector-dot arg1 arg2))
          (f0-2 (acos f0-1))
@@ -587,7 +587,7 @@ This is used in rotate-toward-orientation, which is much improved from jak 1."
 ;; definition for function matrix-from-two-vectors-the-long-way-smooth!
 (defun matrix-from-two-vectors-the-long-way-smooth! ((arg0 matrix) (arg1 vector) (arg2 vector) (arg3 float) (arg4 int))
   "Same as above, but rotates you away from the target.
-Note that the 'near the end' smoothing will apply when you're near the target."
+   Note that the 'near the end' smoothing will apply when you're near the target."
   (let* ((s5-1 (vector-normalize! (vector-cross! (new 'stack-no-clear 'vector) arg2 arg1) 1.0))
          (f0-1 (vector-dot arg1 arg2))
          (f0-3 (- (acos f0-1)))
@@ -610,7 +610,7 @@ Note that the 'near the end' smoothing will apply when you're near the target."
 ;; definition for function matrix-from-two-vectors-max-angle-partial!
 (defun matrix-from-two-vectors-max-angle-partial! ((arg0 matrix) (arg1 vector) (arg2 vector) (arg3 float) (arg4 float))
   "Create a rotation matrix representing the given fraction of the rotation between two heading vectors,
-rotating by at most the given angle."
+   rotating by at most the given angle."
   (let* ((s4-1 (vector-normalize! (vector-cross! (new 'stack-no-clear 'vector) arg2 arg1) 1.0))
          (f28-0 (vector-dot arg1 arg2))
          (f30-0 (cos arg3))
@@ -1049,8 +1049,8 @@ rotating by at most the given angle."
 ;; definition for function point-in-plane-<-point+normal!
 (defun point-in-plane-<-point+normal! ((arg0 vector) (arg1 vector) (arg2 vector))
   "Very strange function. Takes a plane, in point-normal form, then returns some other point on that plane.
-It will move 1m in two of {x, y, z} directions. The direction not moved in is the one which is closest to point-in-triangle-cross
-in the same direction of the normal (this prevent moving huge distances for nearly vertical planes for example)."
+   It will move 1m in two of {x, y, z} directions. The direction not moved in is the one which is closest to point-in-triangle-cross
+   in the same direction of the normal (this prevent moving huge distances for nearly vertical planes for example)."
   (let ((f0-3 (+ (* (-> arg2 x) (-> arg1 x)) (* (-> arg2 y) (-> arg1 y)) (* (-> arg2 z) (-> arg1 z)))))
     (set! (-> arg0 w) 1.0)
     (let ((f1-7 (fabs (-> arg2 x)))
@@ -1509,12 +1509,12 @@ in the same direction of the normal (this prevent moving huge distances for near
 ;; ERROR: Unsupported inline assembly instruction kind - [sll v1, v1, 4]
 (defun curve-evaluate! ((arg0 vector) (arg1 float) (arg2 (inline-array vector)) (arg3 int) (arg4 (pointer float)) (arg5 int))
   "Evaluate a curve.
-arg0 is the output
-arg1 is the input.
-arg2 is control vertices.
-arg3 is the number of control vertices.
-arg4 is the knot points.
-arg5 is the number of knots."
+   arg0 is the output
+   arg1 is the input.
+   arg2 is control vertices.
+   arg3 is the number of control vertices.
+   arg4 is the knot points.
+   arg5 is the number of knots."
   (local-vars (v1-7 int) (v1-8 int) (v1-10 float) (s3-0 int))
   (rlet ((acc :class vf)
          (vf0 :class vf)

--- a/test/decompiler/reference/jak2/engine/geometry/path_REF.gc
+++ b/test/decompiler/reference/jak2/engine/geometry/path_REF.gc
@@ -73,8 +73,8 @@
 ;; definition for method 18 of type curve-control
 (defmethod total-distance ((this curve-control))
   "Will lazily calculate and set the [[curve]]'s `length`
-@returns total path length of the [[curve]]
-@see [[curve-length]]"
+   @returns total path length of the [[curve]]
+   @see [[curve-length]]"
   (let ((f0-0 (-> this curve length)))
     (when (= f0-0 0.0)
       (set! f0-0 (curve-length (-> this curve)))
@@ -88,16 +88,16 @@
 ;; INFO: Used lq/sq
 (defmethod get-point-in-path! ((this path-control) (ret vector) (idx float) (search-type symbol))
   "Depending on the value of `idx`, the result can be quite different:
-- if `idx` is less than `0.0` - return the first vertex in the path
-- if `idx` is greater than the number of vertices in the path, return the last vertex
-- if `search-type` is equal to `exact` OR `idx` is an integral number (ex 1.0), return that vertex
-- otherwise, do a linear interpolation between the vertex at `idx` (truncated) and the next vertex
-using the fractional component of `idx` as the interpolant, return this result
-
-@param! ret The [[vector]] that is used to hold the return value
-@param idx Either the vertex index or also partially the interpolant in a LERP
-@param search-type The only recognized value is `exact`
-@returns Either a distinct vertex along the path, or some fractional point between two vertices"
+   - if `idx` is less than `0.0` - return the first vertex in the path
+   - if `idx` is greater than the number of vertices in the path, return the last vertex
+   - if `search-type` is equal to `exact` OR `idx` is an integral number (ex 1.0), return that vertex
+   - otherwise, do a linear interpolation between the vertex at `idx` (truncated) and the next vertex
+   using the fractional component of `idx` as the interpolant, return this result
+   
+   @param! ret The [[vector]] that is used to hold the return value
+   @param idx Either the vertex index or also partially the interpolant in a LERP
+   @param search-type The only recognized value is `exact`
+   @returns Either a distinct vertex along the path, or some fractional point between two vertices"
   (let ((num-vertices (-> this curve num-cverts))
         (vert-idx (the float (the int idx)))
         )
@@ -148,20 +148,20 @@ using the fractional component of `idx` as the interpolant, return this result
 ;; definition for method 14 of type path-control
 (defmethod get-point-at-percent-along-path! ((this path-control) (ret vector) (percent float) (search-type symbol))
   "@param! ret The [[vector]] that is used to hold the return value
-@param percent The percentage along the path
-@param search-type The only recognized value is `exact`
-@returns the point closest to some arbitrary percentage along the path
-@see [[path-control::10]]"
+   @param percent The percentage along the path
+   @param search-type The only recognized value is `exact`
+   @returns the point closest to some arbitrary percentage along the path
+   @see [[path-control::10]]"
   (get-point-in-path! this ret (* percent (the float (+ (-> this curve num-cverts) -1))) search-type)
   )
 
 ;; definition for method 14 of type curve-control
 (defmethod get-point-at-percent-along-path! ((this curve-control) (arg0 vector) (arg1 float) (arg2 symbol))
   "@param! ret The [[vector]] that is used to hold the return value
-@param percent The percentage along the path
-@param search-type The only recognized value is `exact`
-@returns the point closest to some arbitrary percentage along the path
-@see [[path-control::10]]"
+   @param percent The percentage along the path
+   @param search-type The only recognized value is `exact`
+   @returns the point closest to some arbitrary percentage along the path
+   @see [[path-control::10]]"
   (if (not (logtest? (-> this flags) (path-control-flag not-found)))
       (curve-evaluate!
         arg0
@@ -178,16 +178,16 @@ using the fractional component of `idx` as the interpolant, return this result
 ;; definition for method 10 of type curve-control
 (defmethod get-point-in-path! ((this curve-control) (arg0 vector) (arg1 float) (arg2 symbol))
   "Depending on the value of `idx`, the result can be quite different:
-- if `idx` is less than `0.0` - return the first vertex in the path
-- if `idx` is greater than the number of vertices in the path, return the last vertex
-- if `search-type` is equal to `exact` OR `idx` is an integral number (ex 1.0), return that vertex
-- otherwise, do a linear interpolation between the vertex at `idx` (truncated) and the next vertex
-using the fractional component of `idx` as the interpolant, return this result
-
-@param! ret The [[vector]] that is used to hold the return value
-@param idx Either the vertex index or also partially the interpolant in a LERP
-@param search-type The only recognized value is `exact`
-@returns Either a distinct vertex along the path, or some fractional point between two vertices"
+   - if `idx` is less than `0.0` - return the first vertex in the path
+   - if `idx` is greater than the number of vertices in the path, return the last vertex
+   - if `search-type` is equal to `exact` OR `idx` is an integral number (ex 1.0), return that vertex
+   - otherwise, do a linear interpolation between the vertex at `idx` (truncated) and the next vertex
+   using the fractional component of `idx` as the interpolant, return this result
+   
+   @param! ret The [[vector]] that is used to hold the return value
+   @param idx Either the vertex index or also partially the interpolant in a LERP
+   @param search-type The only recognized value is `exact`
+   @returns Either a distinct vertex along the path, or some fractional point between two vertices"
   (if (not (logtest? (-> this flags) (path-control-flag not-found)))
       (curve-evaluate!
         arg0
@@ -204,15 +204,15 @@ using the fractional component of `idx` as the interpolant, return this result
 ;; definition for method 26 of type path-control
 (defmethod displacement-between-two-points! ((this path-control) (ret vector) (idx float) (mag float))
   "Return value can differ quite a bit:
-- If [[path-control-flag::4]] is set OR there are less than 2 vertices OR `idx` is less than `0.0` - return [[*null-vector*]]
-- Otherwise, find the scaled (by `mag`) displacement vector between two points in the path:
-- If `idx` is not beyond the second last vertex, the result is between vertex `idx` and `idx+1`
-- else, the result is between the second last vertex and the last
-
-@param! ret The [[vector]] that is used to hold the return value
-@param idx The vertex index
-@param mag The magnitude to scale the resulting displacement vector by
-@returns The displacement [[vector]] between two points in the path, the last 2, or the [[*null-vector*]]"
+   - If [[path-control-flag::4]] is set OR there are less than 2 vertices OR `idx` is less than `0.0` - return [[*null-vector*]]
+   - Otherwise, find the scaled (by `mag`) displacement vector between two points in the path:
+   - If `idx` is not beyond the second last vertex, the result is between vertex `idx` and `idx+1`
+   - else, the result is between the second last vertex and the last
+   
+   @param! ret The [[vector]] that is used to hold the return value
+   @param idx The vertex index
+   @param mag The magnitude to scale the resulting displacement vector by
+   @returns The displacement [[vector]] between two points in the path, the last 2, or the [[*null-vector*]]"
   (let ((num-vertices (-> this curve num-cverts))
         (vert-idx (the float (the int idx)))
         )
@@ -234,17 +234,17 @@ using the fractional component of `idx` as the interpolant, return this result
 ;; definition for method 12 of type path-control
 (defmethod displacement-between-two-points-copy! ((this path-control) (ret vector) (idx float) (mag float))
   "Calls [[path-control::26]] with the provided args
-@see [[path-control::26]]"
+   @see [[path-control::26]]"
   (displacement-between-two-points! this ret idx mag)
   )
 
 ;; definition for method 15 of type path-control
 (defmethod displacement-between-points-at-percent-scaled! ((this path-control) (ret vector) (percent float) (mag float))
   "Calls [[path-control::12], with the `idx` at a given percent along the path
-@param ret The [[vector]] that is used to hold the return value
-@param percent The percentage along the path to find the first index
-@param mag Multiplied by the number of points in the path and scales the resulting vector
-@returns The displacement between the last two points of the path scaled to the magnitude equal to the number of points in the path"
+   @param ret The [[vector]] that is used to hold the return value
+   @param percent The percentage along the path to find the first index
+   @param mag Multiplied by the number of points in the path and scales the resulting vector
+   @returns The displacement between the last two points of the path scaled to the magnitude equal to the number of points in the path"
   (displacement-between-two-points-copy!
     this
     ret
@@ -256,10 +256,10 @@ using the fractional component of `idx` as the interpolant, return this result
 ;; definition for method 13 of type path-control
 (defmethod displacement-between-two-points-normalized! ((this path-control) (ret vector) (idx float))
   "Calls [[path-control::26], with the provided `idx`
-@param! ret The [[vector]] the result is stored within
-@param  idx The vertex index
-@returns The resulting displacement vector, normalized
-@see [[path-control::26]]"
+   @param! ret The [[vector]] the result is stored within
+   @param  idx The vertex index
+   @returns The resulting displacement vector, normalized
+   @see [[path-control::26]]"
   (displacement-between-two-points! this ret idx 1.0)
   (vector-normalize! ret 1.0)
   )
@@ -267,11 +267,11 @@ using the fractional component of `idx` as the interpolant, return this result
 ;; definition for method 16 of type path-control
 (defmethod displacement-between-points-at-percent-normalized! ((this path-control) (ret vector) (percent float))
   "Calls [[path-control::13], with the `idx` at a given percent along the path
-@param! ret The [[vector]] the result is stored within
-@param  percent The percentage along the path
-@returns The resulting displacement vector, normalized
-@see [[path-control::13]]
-@see [[path-control::14]]"
+   @param! ret The [[vector]] the result is stored within
+   @param  percent The percentage along the path
+   @returns The resulting displacement vector, normalized
+   @see [[path-control::13]]
+   @see [[path-control::14]]"
   (displacement-between-two-points-normalized!
     this
     ret
@@ -282,15 +282,15 @@ using the fractional component of `idx` as the interpolant, return this result
 ;; definition for method 26 of type curve-control
 (defmethod displacement-between-two-points! ((this curve-control) (arg0 vector) (arg1 float) (arg2 float))
   "Return value can differ quite a bit:
-- If [[path-control-flag::4]] is set OR there are less than 2 vertices OR `idx` is less than `0.0` - return [[*null-vector*]]
-- Otherwise, find the scaled (by `mag`) displacement vector between two points in the path:
-- If `idx` is not beyond the second last vertex, the result is between vertex `idx` and `idx+1`
-- else, the result is between the second last vertex and the last
-
-@param! ret The [[vector]] that is used to hold the return value
-@param idx The vertex index
-@param mag The magnitude to scale the resulting displacement vector by
-@returns The displacement [[vector]] between two points in the path, the last 2, or the [[*null-vector*]]"
+   - If [[path-control-flag::4]] is set OR there are less than 2 vertices OR `idx` is less than `0.0` - return [[*null-vector*]]
+   - Otherwise, find the scaled (by `mag`) displacement vector between two points in the path:
+   - If `idx` is not beyond the second last vertex, the result is between vertex `idx` and `idx+1`
+   - else, the result is between the second last vertex and the last
+   
+   @param! ret The [[vector]] that is used to hold the return value
+   @param idx The vertex index
+   @param mag The magnitude to scale the resulting displacement vector by
+   @returns The displacement [[vector]] between two points in the path, the last 2, or the [[*null-vector*]]"
   (when (not (logtest? (-> this flags) (path-control-flag not-found)))
     (let ((s4-0 (new 'stack-no-clear 'vector)))
       (curve-evaluate!
@@ -338,21 +338,21 @@ using the fractional component of `idx` as the interpolant, return this result
 ;; definition for method 15 of type curve-control
 (defmethod displacement-between-points-at-percent-scaled! ((this curve-control) (ret vector) (idx float) (mag float))
   "Calls [[path-control::12], with the `idx` at a given percent along the path
-@param ret The [[vector]] that is used to hold the return value
-@param percent The percentage along the path to find the first index
-@param mag Multiplied by the number of points in the path and scales the resulting vector
-@returns The displacement between the last two points of the path scaled to the magnitude equal to the number of points in the path"
+   @param ret The [[vector]] that is used to hold the return value
+   @param percent The percentage along the path to find the first index
+   @param mag Multiplied by the number of points in the path and scales the resulting vector
+   @returns The displacement between the last two points of the path scaled to the magnitude equal to the number of points in the path"
   (displacement-between-two-points! this ret idx mag)
   )
 
 ;; definition for method 16 of type curve-control
 (defmethod displacement-between-points-at-percent-normalized! ((this curve-control) (ret vector) (percent float))
   "Calls [[path-control::13], with the `idx` at a given percent along the path
-@param! ret The [[vector]] the result is stored within
-@param  percent The percentage along the path
-@returns The resulting displacement vector, normalized
-@see [[path-control::13]]
-@see [[path-control::14]]"
+   @param! ret The [[vector]] the result is stored within
+   @param  percent The percentage along the path
+   @returns The resulting displacement vector, normalized
+   @see [[path-control::13]]
+   @see [[path-control::14]]"
   (displacement-between-two-points! this ret percent 0.01)
   (vector-normalize! ret 1.0)
   )
@@ -371,8 +371,8 @@ using the fractional component of `idx` as the interpolant, return this result
 ;; INFO: Used lq/sq
 (defmethod get-furthest-point-on-path ((this path-control) (point vector))
   "@param point The point to calculate distance from
-@returns the `vertex-idx.interpolant` value to the point on the path furthest away from the `point`
-@see [[path-control::10]]"
+   @returns the `vertex-idx.interpolant` value to the point on the path furthest away from the `point`
+   @see [[path-control::10]]"
   (let ((curr-point (new 'stack-no-clear 'vector))
         (next-point (new 'stack-no-clear 'vector))
         (given-point (new 'stack-no-clear 'vector))
@@ -407,8 +407,8 @@ using the fractional component of `idx` as the interpolant, return this result
 ;; definition for method 23 of type path-control
 (defmethod get-path-percentage-at-furthest-point ((this path-control) (point vector))
   "@param point The point to calculate distance from
-@returns the percentage of path completion from the point on the path furthest away from the `point`
-@see [[path-control::14]]"
+   @returns the percentage of path completion from the point on the path furthest away from the `point`
+   @see [[path-control::14]]"
   (/ (get-furthest-point-on-path this point) (the float (+ (-> this curve num-cverts) -1)))
   )
 

--- a/test/decompiler/reference/jak2/engine/gfx/foreground/lights_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/foreground/lights_REF.gc
@@ -7,11 +7,11 @@
 ;; definition for function light-slerp
 (defun light-slerp ((light-out light) (light-a light) (light-b light) (alpha float))
   "Linearly interpolate between two [[light]]s
-@param! light-out The resultant
-@param light-a One of the two lights
-@param light-b One of the two lights
-@param alpha Clamped to between `0.0` and `1.0`
-@returns The interpolated [[light]]"
+   @param! light-out The resultant
+   @param light-a One of the two lights
+   @param light-b One of the two lights
+   @param alpha Clamped to between `0.0` and `1.0`
+   @returns The interpolated [[light]]"
   (let ((clamped-alpha (fmax 0.0 (fmin 1.0 alpha))))
     (vector-lerp! (-> light-out color) (-> light-a color) (-> light-b color) clamped-alpha)
     (vector-deg-slerp (-> light-out direction) (-> light-a direction) (-> light-b direction) clamped-alpha)
@@ -27,11 +27,11 @@
 ;; definition for function light-group-slerp
 (defun light-group-slerp ((light-group-out light-group) (light-group-a light-group) (light-group-b light-group) (alpha float))
   "Linearly interpolate between two [[light-groups]]s by calling [[light-slerp]] on each respective collection of lights
-@param light-group-out The resultant
-@param light-group-a One of the two [[light-group]]s
-@param light-group-b One of the two [[light-group]]s
-@param alpha
-@returns The linearly interpolated [[light-group]]"
+   @param light-group-out The resultant
+   @param light-group-a One of the two [[light-group]]s
+   @param light-group-b One of the two [[light-group]]s
+   @param alpha
+   @returns The linearly interpolated [[light-group]]"
   (dotimes (group-idx 4)
     (light-slerp
       (-> light-group-out lights group-idx)
@@ -46,11 +46,11 @@
 ;; definition for function light-group-process!
 (defun light-group-process! ((vu-lights vu-lights) (light-group light-group) (vec1 vector) (vec2 vector))
   "Unused, needlessly calls [[rotate-y<-vector+vector]] on the two [[vector]]s and calls [[vu-lights<-light-group!]]
-@param vu-lights
-@param light-group
-@param vec1
-@param vec2
-@returns [[none]]"
+   @param vu-lights
+   @param light-group
+   @param vec1
+   @param vec2
+   @returns [[none]]"
   (rotate-y<-vector+vector vec2 vec1)
   (vu-lights<-light-group! vu-lights light-group)
   (none)
@@ -62,8 +62,8 @@
 ;; definition for function vu-lights-default!
 (defun vu-lights-default! ((lights vu-lights))
   "Setups up a default [[vu-lights]] instance
-@param! lights
-@returns [[vu-lights]]"
+   @param! lights
+   @returns [[vu-lights]]"
   (set-vector! (-> lights ambient) 0.3 0.3 0.3 1.0)
   (set-vector! (-> lights color 0) 1.0 1.0 1.0 1.0)
   (set-vector! (-> lights color 1) 0.2 0.2 0.2 1.0)
@@ -78,10 +78,10 @@
 ;; WARN: Return type mismatch pointer vs none.
 (defun-debug init-light-hash ()
   "Initializes the global [[*light-hash*]].
-- Bucket array allocates `4096` bytes. (enough for 16,384 entries)
-- Index array allocates `65536` bytes.
-- Light sphere array allocates `16384` bytes. (enough for 256 light spheres)
-@returns [[light-hash]]"
+   - Bucket array allocates `4096` bytes. (enough for 16,384 entries)
+   - Index array allocates `65536` bytes.
+   - Light sphere array allocates `16384` bytes. (enough for 256 light spheres)
+   @returns [[light-hash]]"
   (when (not *light-hash*)
     (set! *light-hash* (new 'loading-level 'light-hash))
     (set! (-> *light-hash* num-lights) (the-as uint 0))
@@ -111,7 +111,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defun-debug reset-light-hash ((arg0 light-hash))
   "Resets the global [[*light-hash*]] back to having `0` lights, indicies, and buckets.
-@returns [[none]]"
+   @returns [[none]]"
   (set! (-> *light-hash* num-lights) (the-as uint 0))
   (set! (-> *light-hash* num-indices) (the-as uint 0))
   (set! (-> *light-hash* num-buckets) (the-as uint 0))
@@ -201,9 +201,9 @@
 ;; definition for function lookup-light-sphere-by-name
 (defun lookup-light-sphere-by-name ((name string) (hash light-hash))
   "Search through a given [[light-hash]]'s lights to find the one that matches the given name
-@param name The name to look for
-@param hash The hash to search through
-@returns Either the [[light]] or [[#f]]"
+   @param name The name to look for
+   @param hash The hash to search through
+   @returns Either the [[light]] or [[#f]]"
   (when (and hash (nonzero? hash))
     (dotimes (num-lights (the-as int (-> hash num-lights)))
       (let ((light (-> hash light-sphere-array num-lights)))

--- a/test/decompiler/reference/jak2/engine/gfx/foreground/ripple_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/foreground/ripple_REF.gc
@@ -49,9 +49,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defun ripple-make-request ((waveform ripple-wave) (effect merc-effect))
   "Iterate through [[*ripple-globals*]] `requests` looking for the one that matches the provided `effect`
-If NOT found, append a new [[ripple-request]] with the providded `effect` and `waveform` to the end of the `requests`.
-
-NOTE: There can only be 16 effects at a given time, NOOP if already at that limit!"
+   If NOT found, append a new [[ripple-request]] with the providded `effect` and `waveform` to the end of the `requests`.
+   
+   NOTE: There can only be 16 effects at a given time, NOOP if already at that limit!"
   (let ((v1-1 (-> *ripple-globals* count))
         (a2-1 (-> *ripple-globals* requests))
         (a3-0 0)
@@ -107,10 +107,10 @@ NOTE: There can only be 16 effects at a given time, NOOP if already at that limi
 ;; WARN: Return type mismatch int vs none.
 (defun ripple-execute ()
   "Iterate through [[*ripple-globals*]] requests, from the end to index `0`
-For each request, if it has a `waveform` create the wave-table via `ripple-create-wave-table`
-Then for each `waveform` apply the `effect` using `ripple-apply-wave-table`
-
-Once completed, all `requests` have been processed and the `count` is reset to `0`"
+   For each request, if it has a `waveform` create the wave-table via `ripple-create-wave-table`
+   Then for each `waveform` apply the `effect` using `ripple-apply-wave-table`
+   
+   Once completed, all `requests` have been processed and the `count` is reset to `0`"
   (when (-> *ripple-globals* count)
     (ripple-execute-init)
     (let ((gp-0 0)

--- a/test/decompiler/reference/jak2/engine/gfx/hw/video_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/hw/video_REF.gc
@@ -5,11 +5,11 @@
 ;; WARN: Return type mismatch int vs none.
 (defun set-video-mode ((tv-format symbol))
   "Set related settings to the video mode in the settings, [[*video-params*]] and the [[*video-mode*]]
-`ntsc` has a [[*video-mode*]] value of `0`, where as `pal` has a value of `1`
-
-Will also set a bunch of common settings related to profiling and the camera to finalize the switch
-
-@param tv-format Recognizes `ntsc` and `pal`"
+   `ntsc` has a [[*video-mode*]] value of `0`, where as `pal` has a value of `1`
+   
+   Will also set a bunch of common settings related to profiling and the camera to finalize the switch
+   
+   @param tv-format Recognizes `ntsc` and `pal`"
   (case tv-format
     (('ntsc)
      (set! (-> *setting-control* user-default display-dx) 0)
@@ -49,7 +49,7 @@ Will also set a bunch of common settings related to profiling and the camera to 
 ;; WARN: Return type mismatch int vs none.
 (defun set-aspect-ratio ((aspect symbol))
   "Set [[*video-params*]] aspect-ratio related settings based on the mode provided.
-@param aspect Recognizes `aspect4x3` and `aspect16x9`"
+   @param aspect Recognizes `aspect4x3` and `aspect16x9`"
   (case aspect
     (('aspect4x3)
      (set! (-> *video-params* relative-x-scale) 1.0)
@@ -74,7 +74,7 @@ Will also set a bunch of common settings related to profiling and the camera to 
 ;; WARN: Return type mismatch int vs none.
 (defun set-progressive-scan ((val symbol))
   "Flip the progressive scan setting flag depending on the value provided
-@param val The value to set the progressive scan flag to"
+   @param val The value to set the progressive scan flag to"
   (set! (-> *setting-control* user-default use-progressive-scan) val)
   0
   (none)

--- a/test/decompiler/reference/jak2/engine/gfx/math-camera_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/math-camera_REF.gc
@@ -53,7 +53,7 @@ Without this corrector, the fogginess of the world would change as the FOV chang
 ;; ERROR: Failed store: (s.w! (+ a0-43 12) a1-11) at op 465
 (defun update-math-camera ((arg0 math-camera) (arg1 symbol) (arg2 symbol) (arg3 float))
   "Compute some one-time camera constants.
-These should only change when changing aspect ratio."
+   These should only change when changing aspect ratio."
   (local-vars (sv-16 float))
   (set! (-> arg0 x-ratio) (tan (* 0.5 arg3)))
   (if (= arg2 'aspect4x3)
@@ -285,8 +285,8 @@ These should only change when changing aspect ratio."
 ;; INFO: Used lq/sq
 (defun move-target-from-pad ((arg0 transform) (arg1 int))
   "Unused function to adjust trans based on inputs from the pad.
-This function must be extremely old because it takes a non-quaternion transform,
-and all [[target]] stuff uses quaternions."
+   This function must be extremely old because it takes a non-quaternion transform,
+   and all [[target]] stuff uses quaternions."
   (let ((s4-0 (new-stack-vector0)))
     (set! (-> s4-0 x) (cond
                         ((cpad-hold? arg1 circle)
@@ -350,8 +350,8 @@ and all [[target]] stuff uses quaternions."
 ;; ERROR: Unsupported inline assembly instruction kind - [cfc2.i v1, Clipping]
 (defun transform-point-vector! ((arg0 vector) (arg1 vector))
   "Apply camera transformation to a point. Return true if it is visible or not.
-This returns the point in GS coords, but as float instead of int, so it's
-not really useful. See [[transform-point-qword!]] for more details."
+   This returns the point in GS coords, but as float instead of int, so it's
+   not really useful. See [[transform-point-qword!]] for more details."
   (local-vars (v1-2 int))
   (rlet ((acc :class vf)
          (Q :class vf)
@@ -401,7 +401,7 @@ not really useful. See [[transform-point-qword!]] for more details."
 ;; ERROR: Unsupported inline assembly instruction kind - [cfc2.i v1, Clipping]
 (defun transform-point-qword! ((arg0 vector4w) (arg1 vector))
   "Apply camera transformation to point, returning fixed point 28.4 position
-that can be given to the GS directly."
+   that can be given to the GS directly."
   (local-vars (v1-2 int))
   (rlet ((acc :class vf)
          (Q :class vf)
@@ -532,8 +532,8 @@ that can be given to the GS directly."
 ;; WARN: Return type mismatch symbol vs none.
 (defun init-for-transform ((arg0 matrix))
   "Sets up VU0 registers with camera info.
-This is probably a very old function and it's only used by camera debug.
-It stashes some data in vector float registers that must be there before calling transform-float-point."
+   This is probably a very old function and it's only used by camera debug.
+   It stashes some data in vector float registers that must be there before calling transform-float-point."
   (local-vars (v1-14 float))
   (rlet ((vf1 :class vf)
          (vf17 :class vf)

--- a/test/decompiler/reference/jak2/engine/gfx/mood/mood-tables2_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/mood/mood-tables2_REF.gc
@@ -94,8 +94,8 @@
 ;; WARN: Return type mismatch pointer vs none.
 (defun init-overide-table ((table mood-table))
   "Similar to [[init-mood-table]], does the bare minimum to setup the given [[mood-table]]
-@param! table The table to initialize
-@returns [[none]]"
+   @param! table The table to initialize
+   @returns [[none]]"
   (set! (-> table mood-fog-table) (new 'debug 'mood-fog-table))
   (set! (-> table mood-color-table) (new 'debug 'mood-color-table))
   (set! (-> table mood-channel-group) *no-cloud-mood-channel-group*)
@@ -260,7 +260,7 @@
 ;; WARN: Return type mismatch object vs none.
 (defun desaturate-mood-colors ((arg0 float) (arg1 float) (arg2 float))
   "Unused - Generate GOAL code for a new [[*overide-mood-color-table*]] definition that desaturates the color
-Apply said overrides to the [[*overide-table*]]"
+   Apply said overrides to the [[*overide-table*]]"
   (mem-copy!
     (the-as pointer (-> *overide-table* mood-color-table))
     (the-as pointer *no-cloud-mood-color-table*)
@@ -366,7 +366,7 @@ Apply said overrides to the [[*overide-table*]]"
 ;; WARN: Return type mismatch object vs none.
 (defun desaturate-mood-fog ((arg0 (pointer mood-fog-table)) (arg1 float) (arg2 float))
   "Unused - Generate GOAL code for a new [[*overide-mood-fog-table*]] definition that desaturates the fog color
-Apply said overrides to the [[*overide-table*]]"
+   Apply said overrides to the [[*overide-table*]]"
   (mem-copy! (the-as pointer (-> *overide-table* mood-fog-table)) arg0 384)
   (dotimes (data-idx 8)
     (let ((fog-data (-> *overide-table* mood-fog-table data data-idx)))

--- a/test/decompiler/reference/jak2/engine/gfx/mood/mood-tables_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/mood/mood-tables_REF.gc
@@ -827,8 +827,8 @@
 ;; WARN: Return type mismatch symbol vs none.
 (defun init-mood-control ((ctrl mood-control))
   "Given a [[mood-control]] initialize and set it up with default settings
-@param! ctrl The [[mood-control]]
-@returns [[none]]"
+   @param! ctrl The [[mood-control]]
+   @returns [[none]]"
   (set! (-> ctrl mood-fog-table) (new 'global 'mood-fog-table))
   (set! (-> ctrl mood-color-table) (new 'global 'mood-color-table))
   (set! (-> ctrl mood-channel-group) (new 'global 'mood-channel-group))

--- a/test/decompiler/reference/jak2/engine/gfx/mood/mood_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/mood/mood_REF.gc
@@ -1269,9 +1269,9 @@
 ;; WARN: Return type mismatch int vs sound-id.
 (defmethod play-or-stop-lightning! ((this mood-control) (arg0 sound-spec) (arg1 vector))
   "Handles playing/stopping of the lightning sound
-- Plays the lightning sound if we are not loading and `lightning-id` is zero
-- Stops the lightning sound first if `lightning-id` is non-zero
-Returns the current value of `lightning-id`"
+   - Plays the lightning sound if we are not loading and `lightning-id` is zero
+   - Stops the lightning sound first if `lightning-id` is non-zero
+   Returns the current value of `lightning-id`"
   (vector+! (new 'stack-no-clear 'vector) arg1 (math-camera-pos))
   (the-as sound-id (cond
                      ((or (load-in-progress? *level*) (movie?))
@@ -1684,8 +1684,8 @@ Returns the current value of `lightning-id`"
 ;; WARN: Return type mismatch int vs none.
 (defmethod update-mood-weather! ((this mood-control) (cloud-target float) (fog-target float) (cloud-speed float) (fog-speed float))
   "Set the `target-interp` and `speed-interp` for the clouds and fog
-If `*-speed` is 0.0, use the `*-target` args to set `current-interp`
-See [[mood-weather]]"
+   If `*-speed` is 0.0, use the `*-target` args to set `current-interp`
+   See [[mood-weather]]"
   (set! (-> this target-interp cloud) cloud-target)
   (set! (-> this target-interp fog) fog-target)
   (set! (-> this speed-interp cloud) cloud-speed)
@@ -1704,7 +1704,7 @@ See [[mood-weather]]"
 ;; WARN: Return type mismatch int vs none.
 (defmethod update-mood-range! ((this mood-control) (min-cloud float) (max-cloud float) (min-fog float) (max-fog float))
   "Set the minimum and maximum ranges of clouds and fog
-See [[mood-range]]"
+   See [[mood-range]]"
   (set! (-> this range min-cloud) min-cloud)
   (set! (-> this range max-cloud) max-cloud)
   (set! (-> this range min-fog) min-fog)
@@ -1717,7 +1717,7 @@ See [[mood-range]]"
 ;; WARN: Return type mismatch int vs none.
 (defmethod set-time-for-random-weather! ((this mood-control) (arg0 float) (arg1 float))
   "Set the `time-until-random`'s cloud and fog values
-See [[mood-weather]]"
+   See [[mood-weather]]"
   (set! (-> this time-until-random cloud) arg0)
   (set! (-> this time-until-random fog) arg1)
   0

--- a/test/decompiler/reference/jak2/engine/gfx/texture/texture-h_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/texture/texture-h_REF.gc
@@ -265,8 +265,8 @@ Each texture page has 3 segments - smaller number segments have higher detail mi
 ;; definition for function texture-mip->segment
 (defun texture-mip->segment ((arg0 int) (arg1 int))
   "Figure out which segment of a tpage a given mip level of a texture will be in.
-arg0 is the mip level, arg1 is the total number of mips.
-Higher mip level is lower detail."
+   arg0 is the mip level, arg1 is the total number of mips.
+   Higher mip level is lower detail."
   (if (>= 2 arg1)
       (+ (- -1 arg0) arg1)
       (max 0 (- 2 arg0))

--- a/test/decompiler/reference/jak2/engine/gfx/texture/texture_REF.gc
+++ b/test/decompiler/reference/jak2/engine/gfx/texture/texture_REF.gc
@@ -65,7 +65,7 @@
 ;; definition for function texture-qwc
 (defun texture-qwc ((w int) (h int) (tex-format gs-psm))
   "Get the number of quadwords needed for a given texture size and format.
-Does not consider weird PS2 memory layout stuff."
+   Does not consider weird PS2 memory layout stuff."
   (let ((v1-0 (texture-bpp tex-format)))
     (/ (+ (* (* w h) v1-0) 127) 128)
     )
@@ -74,7 +74,7 @@ Does not consider weird PS2 memory layout stuff."
 ;; definition for function physical-address
 (defun physical-address ((addr pointer))
   "Strip off high 8-bits of a pointer, to bypass the uncached memory mappings.
-This gives an address suitable for DMAing from main memory."
+   This gives an address suitable for DMAing from main memory."
   (logand #xfffffff addr)
   )
 
@@ -82,8 +82,8 @@ This gives an address suitable for DMAing from main memory."
 ;; WARN: Return type mismatch symbol vs none.
 (defun dma-buffer-add-ref-texture ((dma-buf dma-buffer) (tex-data-ptr pointer) (width int) (height int) (tex-fmt gs-psm))
   "Upload a texture, by reference. Doesn't copy the texture into the DMA buffer - just a reference,
-so it is up to the user to make sure the texture is valid during DMA time.
-Doesn't set up GIF for receiving textures."
+   so it is up to the user to make sure the texture is valid during DMA time.
+   Doesn't set up GIF for receiving textures."
   (let ((padr (physical-address tex-data-ptr))
         (qwc-remaining (texture-qwc width height tex-fmt))
         )
@@ -295,9 +295,9 @@ Doesn't set up GIF for receiving textures."
 ;; definition for function gs-blocks-used
 (defun gs-blocks-used ((w int) (h int) (tex-format gs-psm))
   "Get the number of blocks used by a texture.
-If the texture isn't an even number of pages, the partially completed
-page will be counted as the largest used block.
-(gaps in this page are counted as used)"
+   If the texture isn't an even number of pages, the partially completed
+   page will be counted as the largest used block.
+   (gaps in this page are counted as used)"
   (let* ((s4-0 (gs-page-width tex-format))
          (v1-0 (gs-page-height tex-format))
          (a0-6 (* (/ (+ s4-0 -1 w) s4-0) s4-0))
@@ -435,7 +435,7 @@ page will be counted as the largest used block.
 ;; definition for method 9 of type texture-page
 (defmethod remove-data-from-heap ((this texture-page) (heap kheap))
   "Bump the kheap pointer to discard this texture data. All metadata is kept.
-This is only safe to use if the last thing on the kheap is this texture."
+   This is only safe to use if the last thing on the kheap is this texture."
   (set! (-> heap current) (-> this segment 0 block-data))
   this
   )
@@ -443,8 +443,8 @@ This is only safe to use if the last thing on the kheap is this texture."
 ;; definition for function texture-page-default-allocate
 (defun texture-page-default-allocate ((pool texture-pool) (tpage texture-page) (heap kheap) (tpage-id int))
   "Texture allocation function for textures that permanently live in VRAM.
-The texture data is immediately uploaded, then discarded from the heap.
-This should only be called during startup."
+   The texture data is immediately uploaded, then discarded from the heap.
+   This should only be called during startup."
   (dotimes (seg 3)
     (let ((vram-loc (allocate-vram-words! pool (the-as int (-> tpage segment seg size)))))
       (relocate-dests! tpage vram-loc seg)
@@ -470,8 +470,8 @@ This should only be called during startup."
 ;; definition for function texture-page-common-allocate
 (defun texture-page-common-allocate ((pool texture-pool) (page texture-page) (heap kheap) (page-id int))
   "Texture allocation function for textures that share the common segment.
-The texture remains in RAM, and is uploaded to VRAM as needed as part
-of the main drawing DMA chain."
+   The texture remains in RAM, and is uploaded to VRAM as needed as part
+   of the main drawing DMA chain."
   (let ((s5-0 (-> pool segment-common dest)))
     (dotimes (s4-0 3)
       (relocate-dests! page (the-as int s5-0) s4-0)
@@ -485,8 +485,8 @@ of the main drawing DMA chain."
 ;; definition for function texture-page-font-allocate
 (defun texture-page-font-allocate ((pool texture-pool) (tpage texture-page) (heap kheap) (tpage-id int))
   "Texture allocation function for font. This temporarily stores them in the common segment,
-removes them from RAM. This is a bit of hack. Later font setup code expects the font texture
-to be in common, and they will eventually be moved into the upper 8-bits of the depth buffer."
+   removes them from RAM. This is a bit of hack. Later font setup code expects the font texture
+   to be in common, and they will eventually be moved into the upper 8-bits of the depth buffer."
   (texture-page-common-allocate pool tpage heap tpage-id)
   (upload-now! tpage (tex-upload-mode seg0-1-2))
   (remove-data-from-heap tpage heap)
@@ -668,7 +668,7 @@ to be in common, and they will eventually be moved into the upper 8-bits of the 
 ;; definition for function texture-page-common-boot-allocate
 (defun texture-page-common-boot-allocate ((pool texture-pool) (tpage texture-page) (heap kheap) (tpage-id int))
   "Allocator function for texture loaded at startup time.
-For jak 3, this seems to always do default-allocate (permanently in vram?)"
+   For jak 3, this seems to always do default-allocate (permanently in vram?)"
   (let ((common-page-slot-id (get-common-page-slot-by-id pool tpage-id)))
     (cond
       ((>= common-page-slot-id 0)
@@ -753,9 +753,9 @@ For jak 3, this seems to always do default-allocate (permanently in vram?)"
                  (bucket bucket-id)
                  )
   "Add DMA to upload a texture page. Will only upload the portion of data that is not already present in VRAM.
-This is the old Jak 1 background texture uploading system, which had this near/far concept
-for different mip levels. By jak 2, the background system switched to masks and uses
-the -pris variant of this function."
+   This is the old Jak 1 background texture uploading system, which had this near/far concept
+   for different mip levels. By jak 2, the background system switched to masks and uses
+   the -pris variant of this function."
   (local-vars
     (data-ptr pointer)
     (vram-ptr uint)
@@ -903,10 +903,10 @@ the -pris variant of this function."
                       (arg4 (pointer int32))
                       )
   "Similar to upload-vram-pages, but skips the near/far mode and instead uses masks.
-The foreground/background renderers will generate masks telling us which textures are used.
-This lets us skip uploading entire textures, or mip levels that won't need.
-(side note: this optimization is what causes many of the texturing issues in pcsx2,
-where the ps2 and pcsx2 disagree on the mip level to use.)"
+   The foreground/background renderers will generate masks telling us which textures are used.
+   This lets us skip uploading entire textures, or mip levels that won't need.
+   (side note: this optimization is what causes many of the texturing issues in pcsx2,
+   where the ps2 and pcsx2 disagree on the mip level to use.)"
   (local-vars
     (data-ptr pointer)
     (vram-ptr uint)
@@ -1614,8 +1614,8 @@ where the ps2 and pcsx2 disagree on the mip level to use.)"
 ;; WARN: Return type mismatch int vs none.
 (defmethod setup-font-texture ((this texture-pool))
   "Set up the font texture. In normal use, the font texture is allocated, and currently uploaded to, the common segment.
-This function copies that to the unused upper 8-bits of the depth buffer, and sets up the font
-renderer to point to that address."
+   This function copies that to the unused upper 8-bits of the depth buffer, and sets up the font
+   renderer to point to that address."
   (local-vars (sv-16 int) (sv-20 int))
   (let ((s3-0 (-> this font-palette)))
     (set! sv-16 (-> this cur))
@@ -1762,9 +1762,9 @@ renderer to point to that address."
 ;; definition for method 7 of type texture-page
 (defmethod relocate ((this texture-page) (loading-heap kheap) (name (pointer uint8)))
   "Handle a texture page that has been loaded by the linker.
-This must run in the linker, since we sometimes kick out textures from the loading heap, which
-requires no more allocations made after the texture, and the only time is right after the linker
-does the allocation for this GOAL object file."
+   This must run in the linker, since we sometimes kick out textures from the loading heap, which
+   requires no more allocations made after the texture, and the only time is right after the linker
+   does the allocation for this GOAL object file."
   (cond
     ((or (not this) (not (file-info-correct-version? (-> this info) (file-kind tpage) 0)))
      (the-as texture-page #f)
@@ -1811,9 +1811,9 @@ does the allocation for this GOAL object file."
 ;; definition for function relocate-later
 (defun relocate-later ()
   "Unused in jak 2 and likely unsed in jak 3. Feature to postpone some texture copying until
-a later frame. This is only used in cases when texture data must be memcpy'd in RAM, to patch up a hole left
-by some data that is now permanently in VRAM, and no longer needed.
-Note that Jak2/Jak3 don't have this problem since level textures are now never permanent"
+   a later frame. This is only used in cases when texture data must be memcpy'd in RAM, to patch up a hole left
+   by some data that is now permanently in VRAM, and no longer needed.
+   Note that Jak2/Jak3 don't have this problem since level textures are now never permanent"
   (let ((gp-0 *texture-relocate-later*))
     (let ((s5-0 (-> gp-0 entry))
           (s4-0 (-> gp-0 page))
@@ -1834,9 +1834,9 @@ Note that Jak2/Jak3 don't have this problem since level textures are now never p
 ;; definition for function texture-page-login
 (defun texture-page-login ((id texture-id) (alloc-func (function texture-pool texture-page kheap int texture-page)) (heap kheap))
   "'Login' (initialize) a texture page with the pool.
-This has a trick - it doesn't actually require you to pass a texture-page object - instead you pass an ID.
-If the texture was loaded at all, it will already be known to the texture pool, and this function will do nothing.
-However, if the texture is not present, it will be loaded through a call to `loado`, for use in development."
+   This has a trick - it doesn't actually require you to pass a texture-page object - instead you pass an ID.
+   If the texture was loaded at all, it will already be known to the texture pool, and this function will do nothing.
+   However, if the texture is not present, it will be loaded through a call to `loado`, for use in development."
   (when (and (nonzero? (-> id page)) (< (-> id page) (the-as uint (-> *texture-page-dir* length))))
     (let ((s5-0 (-> *texture-page-dir* entries (-> id page))))
       (when (not (-> s5-0 page))
@@ -1984,7 +1984,7 @@ However, if the texture is not present, it will be loaded through a call to `loa
 ;; definition for function link-texture-by-id
 (defun link-texture-by-id ((id texture-id) (shader adgif-shader))
   "Add this adgif shader to the linked list of shaders associated with the given texture ID.
-Will allocate the link array if it's not already."
+   Will allocate the link array if it's not already."
   (when (not (or (zero? (-> id page)) (>= (-> id page) (the-as uint (-> *texture-page-dir* length)))))
     (let ((s4-0 (-> *texture-page-dir* entries (-> id page))))
       (if (not (-> s4-0 link))
@@ -2082,8 +2082,8 @@ Will allocate the link array if it's not already."
 ;; definition for function adgif-shader-login
 (defun adgif-shader-login ((shader adgif-shader))
   "set up an adgif shader with the texture-pool, so it points to the right vram address.
-Will remap textures through the level remap table.
-If texture is missing, will load it on debug hardware."
+   Will remap textures through the level remap table.
+   If texture is missing, will load it on debug hardware."
   (when (logtest? (-> shader link-test) (link-test-flags needs-log-in))
     (logclear! (-> shader link-test) (link-test-flags needs-log-in bit-9))
     (set! (-> shader texture-id) (level-remap-texture (-> shader texture-id)))
@@ -2119,7 +2119,7 @@ If texture is missing, will load it on debug hardware."
 ;; definition for function adgif-shader-login-no-remap
 (defun adgif-shader-login-no-remap ((shader adgif-shader))
   "Set up an adgif shader with the texture-pool, so it points to the right vram adress.
-This does not do level tpage remapping, so the texture should be one that's not loaded in a combine level tpage."
+   This does not do level tpage remapping, so the texture should be one that's not loaded in a combine level tpage."
   (when (logtest? (-> shader link-test) (link-test-flags needs-log-in))
     (logclear! (-> shader link-test) (link-test-flags needs-log-in bit-9))
     (link-texture-by-id (-> shader texture-id) shader)
@@ -2149,9 +2149,9 @@ This does not do level tpage remapping, so the texture should be one that's not 
 ;; definition for function adgif-shader-login-fast
 (defun adgif-shader-login-fast ((shader adgif-shader))
   "Set up an adgif shader with the texture-pool, so it points to the right vram address.
-Will remap through the level table, so can be used to refer to textures inside 'squashed'
-level tpages.
-Will not load texture if it is missing."
+   Will remap through the level table, so can be used to refer to textures inside 'squashed'
+   level tpages.
+   Will not load texture if it is missing."
   (when (logtest? (-> shader link-test) (link-test-flags needs-log-in))
     (logclear! (-> shader link-test) (link-test-flags needs-log-in bit-9))
     (set! (-> shader texture-id) (level-remap-texture (-> shader texture-id)))
@@ -2182,8 +2182,8 @@ Will not load texture if it is missing."
 ;; definition for function adgif-shader-login-no-remap-fast
 (defun adgif-shader-login-no-remap-fast ((shader adgif-shader))
   "Set up an adgif shader with the texture-pool, so it points to the right vram address.
-Will not remap through the level tpage table.
-Will not load texture if it is missing."
+   Will not remap through the level tpage table.
+   Will not load texture if it is missing."
   (when (logtest? (-> shader link-test) (link-test-flags needs-log-in))
     (logclear! (-> shader link-test) (link-test-flags needs-log-in bit-9))
     (let ((v1-4 (-> shader texture-id)))
@@ -2219,7 +2219,7 @@ Will not load texture if it is missing."
 ;; definition for function adgif-shader<-texture-simple!
 (defun adgif-shader<-texture-simple! ((shader adgif-shader) (tex texture))
   "Simple adgif-shader to texture, just sets vram address and format stuff.
-Intended for use with fancy texture stuff that will later set the other regs."
+   Intended for use with fancy texture stuff that will later set the other regs."
   (set! (-> shader tex1) (new 'static 'gs-tex1 :mmag #x1 :mmin #x1))
   (set! (-> shader tex0 tfx) 0)
   (if tex

--- a/test/decompiler/reference/jak2/engine/level/bsp_REF.gc
+++ b/test/decompiler/reference/jak2/engine/level/bsp_REF.gc
@@ -496,10 +496,10 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod collect-regions ((this bsp-header) (arg0 sphere) (arg1 int) (arg2 region-prim-list))
   "Determines the number of [[drawable]]s in the `obj` that overlap the given `area-of-interest` this number is stored in the `region-list`'s item count
-@param area-of-interest The area defined by a sphere that we care about overlaps
-@param _count The amount of [[drawable]]s in the object to enumerate through
-@param! region-list Stores the overlapping regions and a count for how many were found
-@returns none"
+   @param area-of-interest The area defined by a sphere that we care about overlaps
+   @param _count The amount of [[drawable]]s in the object to enumerate through
+   @param! region-list Stores the overlapping regions and a count for how many were found
+   @returns none"
   (let ((s3-0 (-> this region-trees)))
     (dotimes (s2-0 (-> s3-0 length))
       (collect-regions (-> s3-0 s2-0) arg0 arg1 arg2)

--- a/test/decompiler/reference/jak2/engine/level/region_REF.gc
+++ b/test/decompiler/reference/jak2/engine/level/region_REF.gc
@@ -47,10 +47,10 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod collect-regions ((this drawable-region-prim) (area-of-interest sphere) (_count int) (region-list region-prim-list))
   "Determines the number of [[drawable]]s in the `obj` that overlap the given `area-of-interest` this number is stored in the `region-list`'s item count
-@param area-of-interest The area defined by a sphere that we care about overlaps
-@param _count The amount of [[drawable]]s in the object to enumerate through
-@param! region-list Stores the overlapping regions and a count for how many were found
-@returns none"
+   @param area-of-interest The area defined by a sphere that we care about overlaps
+   @param _count The amount of [[drawable]]s in the object to enumerate through
+   @param! region-list Stores the overlapping regions and a count for how many were found
+   @returns none"
   (dotimes (count _count)
     (when (spheres-overlap? area-of-interest (the-as sphere (-> this bsphere)))
       (set! (-> region-list items (-> region-list num-items)) this)
@@ -66,10 +66,10 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod collect-regions ((this drawable-inline-array-region-prim) (arg0 sphere) (arg1 int) (arg2 region-prim-list))
   "Determines the number of [[drawable]]s in the `obj` that overlap the given `area-of-interest` this number is stored in the `region-list`'s item count
-@param area-of-interest The area defined by a sphere that we care about overlaps
-@param _count The amount of [[drawable]]s in the object to enumerate through
-@param! region-list Stores the overlapping regions and a count for how many were found
-@returns none"
+   @param area-of-interest The area defined by a sphere that we care about overlaps
+   @param _count The amount of [[drawable]]s in the object to enumerate through
+   @param! region-list Stores the overlapping regions and a count for how many were found
+   @returns none"
   (collect-regions (the-as drawable-region-prim (-> this data)) arg0 (-> this length) arg2)
   0
   (none)
@@ -79,10 +79,10 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod collect-regions ((this drawable-tree-region-prim) (arg0 sphere) (arg1 int) (arg2 region-prim-list))
   "Determines the number of [[drawable]]s in the `obj` that overlap the given `area-of-interest` this number is stored in the `region-list`'s item count
-@param area-of-interest The area defined by a sphere that we care about overlaps
-@param _count The amount of [[drawable]]s in the object to enumerate through
-@param! region-list Stores the overlapping regions and a count for how many were found
-@returns none"
+   @param area-of-interest The area defined by a sphere that we care about overlaps
+   @param _count The amount of [[drawable]]s in the object to enumerate through
+   @param! region-list Stores the overlapping regions and a count for how many were found
+   @returns none"
   (collect-regions (-> this data2 0) arg0 (-> this length) arg2)
   0
   (none)
@@ -162,10 +162,10 @@
 ;; WARN: Function (method 9 region-prim-area) has a return type of none, but the expression builder found a return statement.
 (defmethod track-entered-region! ((this region-prim-area) (region-sphere drawable-region-sphere))
   "Enumerates through the objects `region-enter-list`, if we find the provided `region`, do nothing and exit
-otherwise, add the [[drawable-region-sphere]] to `region-enter-prim-list` and increment `region-enter-count`
-
-@param region-sphere Defines the region in question
-@returns nothing"
+   otherwise, add the [[drawable-region-sphere]] to `region-enter-prim-list` and increment `region-enter-count`
+   
+   @param region-sphere Defines the region in question
+   @returns nothing"
   (let ((regions-entered (-> this region-enter-count)))
     (let ((region (-> region-sphere region)))
       (countdown (idx regions-entered)
@@ -187,10 +187,10 @@ otherwise, add the [[drawable-region-sphere]] to `region-enter-prim-list` and in
 ;; WARN: Function (method 10 region-prim-area) has a return type of none, but the expression builder found a return statement.
 (defmethod track-exited-region! ((this region-prim-area) (arg0 drawable-region-sphere))
   "Enumerates through the objects `region-exit-list`, if we find the provided `region`, do nothing and exit
-otherwise, add the [[drawable-region-sphere]] to `region-exit-prim-list` and increment `region-exit-count`
-
-@param region-sphere Defines the region in question
-@returns nothing"
+   otherwise, add the [[drawable-region-sphere]] to `region-exit-prim-list` and increment `region-exit-count`
+   
+   @param region-sphere Defines the region in question
+   @returns nothing"
   (let ((regions-exited (-> this region-exit-count)))
     (let ((region (-> arg0 region)))
       (countdown (idx regions-exited)
@@ -212,10 +212,10 @@ otherwise, add the [[drawable-region-sphere]] to `region-exit-prim-list` and inc
 ;; WARN: Function (method 11 region-prim-area) has a return type of none, but the expression builder found a return statement.
 (defmethod track-inside-region! ((this region-prim-area) (arg0 drawable-region-sphere))
   "Enumerates through the objects `region-inside-list`, if we find the provided `region`, do nothing and exit
-otherwise, add the [[drawable-region-sphere]] to `region-inside-prim-list` and increment `region-inside-count`
-
-@param region-sphere Defines the region in question
-@returns nothing"
+   otherwise, add the [[drawable-region-sphere]] to `region-inside-prim-list` and increment `region-inside-count`
+   
+   @param region-sphere Defines the region in question
+   @returns nothing"
   (let ((regions-inside (-> this region-inside-count)))
     (let ((region (-> arg0 region)))
       (countdown (idx regions-inside)
@@ -237,10 +237,10 @@ otherwise, add the [[drawable-region-sphere]] to `region-inside-prim-list` and i
 ;; WARN: Function (method 12 region-prim-area) has a return type of none, but the expression builder found a return statement.
 (defmethod track-start-region! ((this region-prim-area) (arg0 drawable-region-sphere))
   "Enumerates through the objects `region-start-list`, if we find the provided `region`, do nothing and exit
-otherwise, add the [[drawable-region-sphere]] to `region-start-prim-list` and increment `region-start-count`
-
-@param region-sphere Defines the region in question
-@returns nothing"
+   otherwise, add the [[drawable-region-sphere]] to `region-start-prim-list` and increment `region-start-count`
+   
+   @param region-sphere Defines the region in question
+   @returns nothing"
   (let ((regions-started (-> this region-start-count)))
     (let ((region (-> arg0 region)))
       (countdown (idx regions-started)

--- a/test/decompiler/reference/jak2/engine/load/file-io_REF.gc
+++ b/test/decompiler/reference/jak2/engine/load/file-io_REF.gc
@@ -41,7 +41,7 @@
 ;; definition for function file-stream-read-string
 (defun file-stream-read-string ((fs file-stream) (str string))
   "Fill a string with data from a file stream.
-Note: this function does not work."
+   Note: this function does not work."
   (clear str)
   (file-stream-read fs (-> str data) (length fs))
   str
@@ -97,13 +97,13 @@ Note: this function does not work."
 ;; definition for function make-file-name
 (defun make-file-name ((arg0 file-kind) (arg1 string) (arg2 int) (arg3 symbol))
   "Get a file name to open a file with the given kind and name.
-The art-group-version argument can be used to override the version
-of the art-group. Set it to 0 or less to use the default version.
-Similar to MakeFileName in C.
-Note: file type enum is different between C and GOAL.
-File versions should match those in versions.h.
-Uses a single *file-temp-string* buffer, shared with make-vfile-name.
-arg3 is unused."
+   The art-group-version argument can be used to override the version
+   of the art-group. Set it to 0 or less to use the default version.
+   Similar to MakeFileName in C.
+   Note: file type enum is different between C and GOAL.
+   File versions should match those in versions.h.
+   Uses a single *file-temp-string* buffer, shared with make-vfile-name.
+   arg3 is unused."
   (clear *file-temp-string*)
   (cond
     ((= arg0 (file-kind dir-tpage))
@@ -150,7 +150,7 @@ arg3 is unused."
 ;; definition for function make-vfile-name
 (defun make-vfile-name ((kind file-kind) (name string))
   "Make virtual? file name. This makes a name that the kernel knows how to
-handle in a specific way. This function is not used."
+   handle in a specific way. This function is not used."
   (clear *file-temp-string*)
   (cond
     ((= kind (file-kind level-bt))
@@ -166,7 +166,7 @@ handle in a specific way. This function is not used."
 ;; definition for function file-info-correct-version?
 (defun file-info-correct-version? ((arg0 file-info) (arg1 file-kind) (arg2 int))
   "Check if the version and kind in the info is valid. The `version-override` can specify a
-non-default version, or set to 0 for the default version."
+   non-default version, or set to 0 for the default version."
   (let* ((s5-0 (cond
                  ((zero? arg2)
                   (case arg1

--- a/test/decompiler/reference/jak2/engine/load/load-dgo_REF.gc
+++ b/test/decompiler/reference/jak2/engine/load/load-dgo_REF.gc
@@ -147,8 +147,8 @@
 ;; definition for function str-load-status
 (defun str-load-status ((maxlen-out (pointer int32)))
   "Get the status of the most recent load.
-Return 'busy if in progress, 'error if failed, or 'complete.
-If 'complete, returns the maxlen value from the IOP."
+   Return 'busy if in progress, 'error if failed, or 'complete.
+   If 'complete, returns the maxlen value from the IOP."
   (if (check-busy *load-str-rpc*)
       (return 'busy)
       )
@@ -372,7 +372,7 @@ If 'complete, returns the maxlen value from the IOP."
 ;; definition for function find-temp-buffer
 (defun find-temp-buffer ((size int))
   "Unused function to find some temporary leftover space in DMA buffer.
-Unused since jak 1, and checks the same buffer twice??"
+   Unused since jak 1, and checks the same buffer twice??"
   (let ((gp-0 (+ (/ size 16) 2)))
     (cond
       ((< (the-as uint gp-0)

--- a/test/decompiler/reference/jak2/engine/math/euler_REF.gc
+++ b/test/decompiler/reference/jak2/engine/math/euler_REF.gc
@@ -97,7 +97,7 @@
 ;; definition for function matrix->eul
 (defun matrix->eul ((arg0 euler-angles) (arg1 matrix) (arg2 int))
   "Convert matrix to euler angles with given order flag.
-Not clear how this works if the matrix has more than just a rotation."
+   Not clear how this works if the matrix has more than just a rotation."
   0
   0
   0

--- a/test/decompiler/reference/jak2/engine/math/math_REF.gc
+++ b/test/decompiler/reference/jak2/engine/math/math_REF.gc
@@ -4,7 +4,7 @@
 ;; definition for function truncate
 (defun truncate ((arg0 float))
   "Round (toward zero) to an integer.
-@param arg0 float to truncate"
+   @param arg0 float to truncate"
   (the float (the int arg0))
   )
 
@@ -324,8 +324,8 @@
 ;; definition for function seek-ease
 (defun seek-ease ((arg0 float) (arg1 float) (arg2 float) (arg3 float) (arg4 float))
   "Move arg0 toward arg1, and slow down before reaching the end.
-When farther than arg3 away, move by at most arg2.
-When closer than arg3, linearly ramp down the movement amount from arg2 to 0 but no lower than arg4."
+   When farther than arg3 away, move by at most arg2.
+   When closer than arg3, linearly ramp down the movement amount from arg2 to 0 but no lower than arg4."
   (let ((f2-0 (- arg1 arg0)))
     (when (>= arg3 (fabs f2-0))
       (set! arg2 (* arg2 (- 1.0 (/ (- arg3 (fabs f2-0)) arg3))))
@@ -350,9 +350,9 @@ When closer than arg3, linearly ramp down the movement amount from arg2 to 0 but
 ;; definition for function seek-ease-in-out
 (defun seek-ease-in-out ((arg0 float) (arg1 float) (arg2 float) (arg3 float) (arg4 float) (arg5 float) (arg6 float))
   "Move arg0 toward arg2, and slow down at the start and end.
-When within arg4 of arg1 (at the beginning of movement), ramp up speed, with a minimum speed of arg6
-When within arg5 of arg2 (at the end of movement), ramp down speed, with a minimum speed of arg5
-Normally, move at most arg3"
+   When within arg4 of arg1 (at the beginning of movement), ramp up speed, with a minimum speed of arg6
+   When within arg5 of arg2 (at the end of movement), ramp down speed, with a minimum speed of arg5
+   Normally, move at most arg3"
   (let ((f2-0 (- arg2 arg0)))
     (let ((f4-1 (- arg0 arg1)))
       (when (>= arg4 (fabs f4-1))
@@ -391,7 +391,7 @@ Normally, move at most arg3"
 ;; definition (debug) for function lerp-scale-old
 (defun-debug lerp-scale-old ((arg0 float) (arg1 float) (arg2 float) (arg3 float) (arg4 float))
   "Linearly remap arg2 in [arg3, arg4] to [arg0, arg1].
-This is the jak 1 implementation, which I claimed was a bad implementation..."
+   This is the jak 1 implementation, which I claimed was a bad implementation..."
   (let ((f0-1 (fmax 0.0 (fmin 1.0 (/ (- arg2 arg3) (- arg4 arg3))))))
     (+ (* (- 1.0 f0-1) arg0) (* f0-1 arg1))
     )
@@ -497,8 +497,8 @@ This is the jak 1 implementation, which I claimed was a bad implementation..."
 ;; ERROR: Inline assembly instruction marked with TODO - [TODO.VRGET]
 (defun rand-vu-nostep ()
   "Get the number currently in the random generator.
-This will be equal to the last call of (rand-vu).
-This will not update the random generator."
+   This will be equal to the last call of (rand-vu).
+   This will not update the random generator."
   (local-vars (v0-0 float))
   (rlet ((vf0 :class vf)
          (vf1 :class vf)
@@ -548,7 +548,7 @@ This will not update the random generator."
 ;; WARN: new jak 2 until loop case, check carefully
 (defun rand-vu-int-count-excluding ((arg0 int) (arg1 int))
   "Get an integer in the range [0, arg0).
-If bit n is set in arg1, exclude this value from being returned."
+   If bit n is set in arg1, exclude this value from being returned."
   (let ((s4-0 0)
         (s5-0 0)
         )
@@ -591,7 +591,7 @@ If bit n is set in arg1, exclude this value from being returned."
 ;; WARN: new jak 2 until loop case, check carefully
 (defun rand-vu-int-range-exclude ((arg0 int) (arg1 int) (arg2 int))
   "Get an integer in the range [0, arg0), excluding arg2.
-Note that this doesn't use bits like rand-vu-int-count-excluding."
+   Note that this doesn't use bits like rand-vu-int-count-excluding."
   (until #f
     (let ((v1-0 (rand-vu-int-range arg0 arg1)))
       (if (!= v1-0 arg2)
@@ -676,7 +676,7 @@ Note that this doesn't use bits like rand-vu-int-count-excluding."
 ;; definition for function smooth-step
 (defun smooth-step ((arg0 float))
   "Interpolate between 0, 1 with a cubic polynomial.
-These are picked so f(0) = 0, f(1) = 1, f'(0) = f'(1) = 0."
+   These are picked so f(0) = 0, f(1) = 1, f'(0) = f'(1) = 0."
   (cond
     ((>= 0.0 arg0)
      0.0
@@ -693,9 +693,9 @@ These are picked so f(0) = 0, f(1) = 1, f'(0) = f'(1) = 0."
 ;; definition for function smooth-interp
 (defun smooth-interp ((arg0 float) (arg1 float) (arg2 float) (arg3 float) (arg4 float))
   "Remap arg2 from (arg3, arg4) to (arg0, arg1), using cubic interpolation.
-Satisfies:
-- f(arg3) = arg0
-- f(arg4) = arg1
-- f'(arg3) = f'(arg4) = 0"
+   Satisfies:
+   - f(arg3) = arg0
+   - f(arg4) = arg1
+   - f'(arg3) = f'(arg4) = 0"
   (+ arg0 (* (- arg1 arg0) (smooth-step (/ (- arg2 arg3) (- arg4 arg3)))))
   )

--- a/test/decompiler/reference/jak2/engine/math/matrix_REF.gc
+++ b/test/decompiler/reference/jak2/engine/math/matrix_REF.gc
@@ -2,7 +2,6 @@
 (in-package goal)
 
 ;; definition for method 3 of type matrix
-;; INFO: this function exists in multiple non-identical object files
 (defmethod inspect ((this matrix))
   (format #t "[~8x] matrix~%" this)
   (format
@@ -34,7 +33,6 @@
   )
 
 ;; definition for method 3 of type matrix3
-;; INFO: this function exists in multiple non-identical object files
 (defmethod inspect ((this matrix3))
   (format #t "[~8x] matrix3~%" this)
   (format #t "~T[~F] [~F] [~F]~%" (-> this vector 0 x) (-> this vector 0 y) (-> this vector 0 z))
@@ -76,7 +74,7 @@
 ;; definition for function matrix+!
 (defun matrix+! ((arg0 matrix) (arg1 matrix) (arg2 matrix))
   "Set dst = src1 + src2. It is okay for any arguments to be the same data.
-This is not an efficient implementation."
+   This is not an efficient implementation."
   (dotimes (v1-0 16)
     (set! (-> arg0 data v1-0) (+ (-> arg1 data v1-0) (-> arg2 data v1-0)))
     )
@@ -86,7 +84,7 @@ This is not an efficient implementation."
 ;; definition for function matrix-!
 (defun matrix-! ((arg0 matrix) (arg1 matrix) (arg2 matrix))
   "Set dst = src1 - src1. It is okay for any arugments to be the same data.
-This is not an efficient implementation."
+   This is not an efficient implementation."
   (dotimes (v1-0 16)
     (set! (-> arg0 data v1-0) (- (-> arg1 data v1-0) (-> arg2 data v1-0)))
     )
@@ -96,7 +94,7 @@ This is not an efficient implementation."
 ;; definition for function matrix*!
 (defun matrix*! ((arg0 matrix) (arg1 matrix) (arg2 matrix))
   "Set dst = src1 * src2. It is okay for any arguments to be the same data.
-This is a moderately efficient implementation."
+   This is a moderately efficient implementation."
   (rlet ((acc :class vf)
          (vf10 :class vf)
          (vf11 :class vf)
@@ -147,8 +145,8 @@ This is a moderately efficient implementation."
 ;; INFO: Used lq/sq
 (defun matrixp*! ((arg0 matrix) (arg1 matrix) (arg2 matrix))
   "Set dst = src1 * src2. NOTE: this function is a wrapper around matrix*!
-that adds no additional functionality. It seems to be a leftover from
-a time when matrix*! wasn't safe to use in place. This is unused."
+   that adds no additional functionality. It seems to be a leftover from
+   a time when matrix*! wasn't safe to use in place. This is unused."
   (let ((s5-0 (new-stack-matrix0)))
     (matrix*! s5-0 arg1 arg2)
     (set! (-> arg0 quad 0) (-> s5-0 quad 0))
@@ -215,7 +213,7 @@ a time when matrix*! wasn't safe to use in place. This is unused."
 ;; INFO: Used lq/sq
 (defun vector3s-matrix*! ((arg0 vector3s) (arg1 vector3s) (arg2 matrix))
   "Set dst to be ([src 1.0] * mat).xyz.  Doesn't touch the w of dst.
-dst and vec can be the same memory"
+   dst and vec can be the same memory"
   (let ((s5-0 (new-stack-vector0)))
     (set-vector! s5-0 (-> arg1 x) (-> arg1 y) (-> arg1 z) 1.0)
     (vector-matrix*! s5-0 s5-0 arg2)
@@ -230,7 +228,7 @@ dst and vec can be the same memory"
 ;; INFO: Used lq/sq
 (defun vector3s-rotate*! ((arg0 vector3s) (arg1 vector3s) (arg2 matrix))
   "Set dst to vec rotated by the rotation in the homogeneous transform mat.
-mat should not have a scale/shear (the upper 3x3 should be a pure rotation)."
+   mat should not have a scale/shear (the upper 3x3 should be a pure rotation)."
   (let ((s5-0 (new-stack-vector0)))
     (set-vector! s5-0 (-> arg1 x) (-> arg1 y) (-> arg1 z) 1.0)
     (vector-rotate*! s5-0 s5-0 arg2)
@@ -283,7 +281,7 @@ mat should not have a scale/shear (the upper 3x3 should be a pure rotation)."
 ;; definition for function matrix-inverse-of-rot-trans!
 (defun matrix-inverse-of-rot-trans! ((arg0 matrix) (arg1 matrix))
   "Set dst = src^-1, assuming src is a homogeneous tranform with only rotation/translation.
-NOTE: THIS FUNCTION REQUIRES dst != src"
+   NOTE: THIS FUNCTION REQUIRES dst != src"
   (rlet ((acc :class vf)
          (vf0 :class vf)
          (vf1 :class vf)
@@ -320,7 +318,7 @@ NOTE: THIS FUNCTION REQUIRES dst != src"
 ;; ERROR: Bad vector register dependency: vf5
 (defun matrix-4x4-inverse! ((arg0 matrix) (arg1 matrix))
   "Invert a 4x4 matrix. This assumes that the input is a homogeneous transform.
-Src and dst can be the same."
+   Src and dst can be the same."
   (rlet ((acc :class vf)
          (Q :class vf)
          (vf0 :class vf)
@@ -484,7 +482,7 @@ Src and dst can be the same."
 ;; INFO: Used lq/sq
 (defun matrix-translate+! ((arg0 matrix) (arg1 matrix) (arg2 vector))
   "Add the given translation to the translation of homogenous transform mat src
-and store in dst.  It is okay for dst = src."
+   and store in dst.  It is okay for dst = src."
   (set! (-> arg0 trans x) (+ (-> arg1 trans x) (-> arg2 x)))
   (set! (-> arg0 trans y) (+ (-> arg1 trans y) (-> arg2 y)))
   (set! (-> arg0 trans z) (+ (-> arg1 trans z) (-> arg2 z)))
@@ -500,7 +498,7 @@ and store in dst.  It is okay for dst = src."
 ;; INFO: Used lq/sq
 (defun matrix-scale! ((arg0 matrix) (arg1 vector))
   "Set dst to a homogenous transform with only a scale. The x,y,z components
-of scale become the x,y,z scaling factors"
+   of scale become the x,y,z scaling factors"
   (set! (-> arg0 quad 0) (the-as uint128 0))
   (set! (-> arg0 quad 1) (the-as uint128 0))
   (set! (-> arg0 quad 2) (the-as uint128 0))
@@ -515,8 +513,8 @@ of scale become the x,y,z scaling factors"
 ;; definition for function scale-matrix!
 (defun scale-matrix! ((arg0 matrix) (arg1 vector) (arg2 matrix))
   "Scale an existing matrix. Okay for dst = src. The scaling is applied per row.
-This means the x component of scale is used to scale the first row of src.
-The w component of scale is used."
+   This means the x component of scale is used to scale the first row of src.
+   The w component of scale is used."
   (rlet ((vf4 :class vf)
          (vf5 :class vf)
          (vf6 :class vf)
@@ -544,7 +542,7 @@ The w component of scale is used."
 ;; INFO: Used lq/sq
 (defun matrix-inv-scale! ((arg0 matrix) (arg1 vector))
   "Set dst to a homogeneous transform with only a scale.
-The x,y,z components of scale are inverted and used as the x,y,z scaling factors"
+   The x,y,z components of scale are inverted and used as the x,y,z scaling factors"
   (set! (-> arg0 quad 0) (the-as uint128 0))
   (set! (-> arg0 quad 1) (the-as uint128 0))
   (set! (-> arg0 quad 2) (the-as uint128 0))
@@ -559,7 +557,7 @@ The x,y,z components of scale are inverted and used as the x,y,z scaling factors
 ;; definition for function column-scale-matrix!
 (defun column-scale-matrix! ((arg0 matrix) (arg1 vector) (arg2 matrix))
   "Scale an existing matrix. Okay for dst = src. The scaling is applied column-wise.
-Meaning the x component of scale will scale the first column of src."
+   Meaning the x component of scale will scale the first column of src."
   (rlet ((vf4 :class vf)
          (vf5 :class vf)
          (vf6 :class vf)
@@ -768,7 +766,7 @@ Meaning the x component of scale will scale the first column of src."
 ;; definition for function matrix-rotate-yxy!
 (defun matrix-rotate-yxy! ((arg0 matrix) (arg1 vector))
   "Rotate. I believe in yxy order? Compared to the other rotations, this one
-is quite a bit more optimized and avoid repeated trig operations."
+   is quite a bit more optimized and avoid repeated trig operations."
   (let ((a2-0 (new 'stack-no-clear 'vector))
         (s5-0 (new 'stack-no-clear 'vector))
         (s4-0 (new 'stack-no-clear 'vector))
@@ -1139,7 +1137,7 @@ is quite a bit more optimized and avoid repeated trig operations."
 ;; definition for function matrix-3x3-inverse!
 (defun matrix-3x3-inverse! ((arg0 matrix) (arg1 matrix))
   "Compute the inverse of a 3x3 matrix. Not very efficient.
-Requires src != dst."
+   Requires src != dst."
   (let ((f0-0 (matrix-3x3-determinant arg1)))
     (set! (-> arg0 vector 0 x)
           (/ (- (* (-> arg1 vector 1 y) (-> arg1 vector 2 z)) (* (-> arg1 vector 1 z) (-> arg1 vector 2 y))) f0-0)
@@ -1175,7 +1173,7 @@ Requires src != dst."
 ;; definition for function matrix-3x3-inverse-transpose!
 (defun matrix-3x3-inverse-transpose! ((arg0 matrix) (arg1 matrix))
   "Invert and transpose.
-Requires dst != src."
+   Requires dst != src."
   (let ((f0-0 (matrix-3x3-determinant arg1)))
     (set! (-> arg0 vector 0 x)
           (/ (- (* (-> arg1 vector 1 y) (-> arg1 vector 2 z)) (* (-> arg1 vector 1 z) (-> arg1 vector 2 y))) f0-0)
@@ -1371,7 +1369,7 @@ Requires dst != src."
 ;; definition for function matrix-4x4-inverse-transpose!
 (defun matrix-4x4-inverse-transpose! ((arg0 matrix) (arg1 matrix))
   "Invert and transpose an entire 4x4. I think has no restrictions, other than dst != src. Unused.
-The answer is wrong. The determinant function is wrong."
+   The answer is wrong. The determinant function is wrong."
   (let ((f0-0 (matrix-4x4-determinant arg1)))
     (let ((f9-0 (-> arg1 vector 1 y))
           (f2-0 (-> arg1 vector 1 z))
@@ -1716,7 +1714,7 @@ The answer is wrong. The determinant function is wrong."
 ;; INFO: Used lq/sq
 (defun matrix->quat ((arg0 matrix) (arg1 quaternion))
   "Convert matrix to quaternion, works for matrix with scale.
-unlike matrix->quaternion."
+   unlike matrix->quaternion."
   (let ((s5-0 (new 'stack-no-clear 'matrix)))
     (let* ((a2-0 arg0)
            (v1-0 (-> a2-0 quad 0))

--- a/test/decompiler/reference/jak2/engine/math/quaternion_REF.gc
+++ b/test/decompiler/reference/jak2/engine/math/quaternion_REF.gc
@@ -2,7 +2,6 @@
 (in-package goal)
 
 ;; definition for method 3 of type quaternion
-;; INFO: this function exists in multiple non-identical object files
 (defmethod inspect ((this quaternion))
   (format #t "[~8x] quaternion~%" this)
   (format #t "~T[~F] [~F] [~F] [~F]~%" (-> this x) (-> this y) (-> this z) (-> this w))
@@ -184,8 +183,8 @@
 ;; ERROR: Bad vector register dependency: vf2
 (defun quaternion-conjugate! ((arg0 quaternion) (arg1 quaternion))
   "Set arg0 to the conjugate of arg1 (negate only ijk).
-If arg1 is normalized, this is equivalent to the inverse
-NOTE: this gives you the inverse rotation."
+   If arg1 is normalized, this is equivalent to the inverse
+   NOTE: this gives you the inverse rotation."
   (rlet ((vf1 :class vf)
          (vf2 :class vf)
          )
@@ -290,7 +289,7 @@ NOTE: this gives you the inverse rotation."
 ;; ERROR: Bad vector register dependency: vf3
 (defun quaternion-inverse! ((arg0 quaternion) (arg1 quaternion))
   "Invert a quaternion. The inverse will satisfy q * q^-1 = identity, even if q is not normalized.
-If your quaternion is normalized, it is faster/more accurate to do quaternion-conjugate!"
+   If your quaternion is normalized, it is faster/more accurate to do quaternion-conjugate!"
   (rlet ((acc :class vf)
          (Q :class vf)
          (vf0 :class vf)
@@ -371,9 +370,9 @@ If your quaternion is normalized, it is faster/more accurate to do quaternion-co
 ;; definition for function quaternion-right-mult-matrix!
 (defun quaternion-right-mult-matrix! ((arg0 matrix) (arg1 quaternion))
   "Place quaternion coefficients into a matrix.
-You can convert a quaternion to a matrix by taking the product of this
-right-mult and left-mult matrix, but this method is not used.
-Instead, quaternion->matrix is a more efficient implementation."
+   You can convert a quaternion to a matrix by taking the product of this
+   right-mult and left-mult matrix, but this method is not used.
+   Instead, quaternion->matrix is a more efficient implementation."
   (let ((f3-0 (-> arg1 x))
         (f2-0 (-> arg1 y))
         (f1-0 (-> arg1 z))
@@ -659,7 +658,7 @@ Instead, quaternion->matrix is a more efficient implementation."
 ;; definition for function quaternion-slerp!
 (defun quaternion-slerp! ((arg0 quaternion) (arg1 quaternion) (arg2 quaternion) (arg3 float))
   "Real quaternion slerp. Spherical-linear interpolation is a nice way to interpolate
-between quaternions."
+   between quaternions."
   (local-vars (v1-15 float))
   (rlet ((acc :class vf)
          (vf1 :class vf)
@@ -725,8 +724,8 @@ between quaternions."
 ;; definition for function quaternion-pseudo-slerp!
 (defun quaternion-pseudo-slerp! ((arg0 quaternion) (arg1 quaternion) (arg2 quaternion) (arg3 float))
   "This is a bad interpolation between quaternions. It lerps then normalizes.
-It will behave extremely poorly for 180 rotations.
-It is unused."
+   It will behave extremely poorly for 180 rotations.
+   It is unused."
   (rlet ((acc :class vf)
          (vf1 :class vf)
          (vf2 :class vf)
@@ -760,7 +759,7 @@ It is unused."
 ;; definition for function quaternion-pseudo-seek
 (defun quaternion-pseudo-seek ((arg0 quaternion) (arg1 quaternion) (arg2 quaternion) (arg3 float))
   "Seek one quaternion toward another. Not using real slerp, so this is only good if the quaternions
-are pretty similar."
+   are pretty similar."
   (let ((s3-0 (new 'stack-no-clear 'quaternion)))
     (let ((s5-0 (new 'stack-no-clear 'quaternion)))
       (quaternion-copy! s3-0 arg2)

--- a/test/decompiler/reference/jak2/engine/math/transformq-h_REF.gc
+++ b/test/decompiler/reference/jak2/engine/math/transformq-h_REF.gc
@@ -112,14 +112,14 @@ As a result, this type has a lot of weird methods and extra stuff hidden in it."
 ;; definition for method 23 of type trsqv
 (defmethod global-y-angle-to-point ((this trsqv) (arg0 vector))
   "Get the angle in the xz plane from the position of this trsqv to the point arg0
-(ignores our current yaw)."
+   (ignores our current yaw)."
   (vector-y-angle (vector-! (new 'stack-no-clear 'vector) arg0 (-> this trans)))
   )
 
 ;; definition for method 24 of type trsqv
 (defmethod relative-y-angle-to-point ((this trsqv) (arg0 vector))
   "Get the y angle between the current orientation and arg0
-(how much we'd have to yaw to point at arg0)."
+   (how much we'd have to yaw to point at arg0)."
   (deg-diff (y-angle this) (vector-y-angle (vector-! (new 'stack-no-clear 'vector) arg0 (-> this trans))))
   )
 

--- a/test/decompiler/reference/jak2/engine/math/trigonometry_REF.gc
+++ b/test/decompiler/reference/jak2/engine/math/trigonometry_REF.gc
@@ -15,7 +15,7 @@
 ;; definition for function deg-
 (defun deg- ((arg0 float) (arg1 float))
   "Compute arg0-arg1, unwrapped, using rotation units.
-Result should be in the range (-180, 180)"
+   Result should be in the range (-180, 180)"
   (the float (sar (- (shl (the int arg0) 48) (shl (the int arg1) 48)) 48))
   )
 
@@ -195,9 +195,9 @@ Result should be in the range (-180, 180)"
 ;; definition for function vector-sin-rad!
 (defun vector-sin-rad! ((arg0 vector) (arg1 vector))
   "Taylor series approximation of sine on all 4 elements in a vector.
-Inputs should be in radians, in -pi to pi.
-Somehow their coefficients are a little bit off.
-Like the first coefficient, which should obviously be 1, is not quite 1."
+   Inputs should be in radians, in -pi to pi.
+   Somehow their coefficients are a little bit off.
+   Like the first coefficient, which should obviously be 1, is not quite 1."
   (rlet ((acc :class vf)
          (vf1 :class vf)
          (vf10 :class vf)
@@ -239,7 +239,7 @@ Like the first coefficient, which should obviously be 1, is not quite 1."
 ;; ERROR: Bad vector register dependency: vf2
 (defun vector-cos-rad! ((arg0 vector) (arg1 vector))
   "Compute the cosine of all 4 vector elements.
-Radians, with no wrapping. Uses taylor series with 4 coefficients."
+   Radians, with no wrapping. Uses taylor series with 4 coefficients."
   (rlet ((acc :class vf)
          (vf0 :class vf)
          (vf1 :class vf)
@@ -272,8 +272,8 @@ Radians, with no wrapping. Uses taylor series with 4 coefficients."
 ;; ERROR: Bad vector register dependency: vf14
 (defun vector-sincos-rad! ((arg0 vector) (arg1 vector) (arg2 vector))
   "Compute the sine and cosine of each element of src, storing it in dst-sin and dst-cos.
-This is more efficient than separate calls to sin and cos.
-Inputs should be radians in -pi to pi."
+   This is more efficient than separate calls to sin and cos.
+   Inputs should be radians in -pi to pi."
   (rlet ((acc :class vf)
          (vf0 :class vf)
          (vf1 :class vf)
@@ -331,7 +331,7 @@ Inputs should be radians in -pi to pi."
 ;; WARN: Return type mismatch float vs none.
 (defun vector-rad<-vector-deg! ((out vector) (in vector))
   "Convert a vector in rotation units to radians, and unwrap.
-Input can be anything, output will be -2pi to pi."
+   Input can be anything, output will be -2pi to pi."
   (local-vars (v0-0 float) (v1-1 uint128) (v1-2 uint128) (v1-3 uint128))
   (rlet ((vf1 :class vf)
          (vf2 :class vf)
@@ -357,7 +357,7 @@ Input can be anything, output will be -2pi to pi."
 ;; WARN: Return type mismatch float vs int.
 (defun vector-rad<-vector-deg/2! ((out vector) (in vector))
   "Divide the input by two, and then convert from rotation units to radians, unwrapping.
-Not sure why this really needs to be separate the from previous function..."
+   Not sure why this really needs to be separate the from previous function..."
   (local-vars (v0-0 float) (v1-1 uint128) (v1-2 uint128) (v1-3 uint128))
   (rlet ((vf1 :class vf)
          (vf2 :class vf)
@@ -438,7 +438,7 @@ Not sure why this really needs to be separate the from previous function..."
 ;; definition for function sign
 (defun sign ((arg0 float))
   "Similar to above, but returns 0 if input is 0.
-But is more complicated."
+   But is more complicated."
   (cond
     ((< 0.0 arg0)
      1.0

--- a/test/decompiler/reference/jak2/engine/math/vector-h_REF.gc
+++ b/test/decompiler/reference/jak2/engine/math/vector-h_REF.gc
@@ -978,8 +978,8 @@
 ;; definition for function vector-dot
 (defun vector-dot ((arg0 vector) (arg1 vector))
   "Take the dot product of two vectors.
-Only does the x, y, z compoments.
-Originally handwritten assembly to space out loads and use FPU accumulator"
+   Only does the x, y, z compoments.
+   Originally handwritten assembly to space out loads and use FPU accumulator"
   (vector-dot arg0 arg1)
   )
 
@@ -1003,7 +1003,7 @@ Originally handwritten assembly to space out loads and use FPU accumulator"
 ;; definition for function vector4-dot
 (defun vector4-dot ((arg0 vector) (arg1 vector))
   "Take the dot product of two vectors.
-Does the x, y, z, and w compoments"
+   Does the x, y, z, and w compoments"
   (vector4-dot arg0 arg1)
   )
 

--- a/test/decompiler/reference/jak2/engine/math/vector_REF.gc
+++ b/test/decompiler/reference/jak2/engine/math/vector_REF.gc
@@ -111,7 +111,7 @@
 ;; definition for function vector/!
 (defun vector/! ((arg0 vector) (arg1 vector) (arg2 vector))
   "Set arg0 = arg1 / arg2. The w component will be set to 1.
-The implementation is kind of crazy."
+   The implementation is kind of crazy."
   (rlet ((Q :class vf)
          (vf0 :class vf)
          (vf4 :class vf)
@@ -208,7 +208,7 @@ The implementation is kind of crazy."
 ;; definition for function vector--float*!
 (defun vector--float*! ((arg0 vector) (arg1 vector) (arg2 vector) (arg3 float))
   "Set arg0 = arg1 - (arg2 * arg3). The w component will be set to 1.
-Is this different from vector-*!"
+   Is this different from vector-*!"
   (rlet ((acc :class vf)
          (vf0 :class vf)
          (vf1 :class vf)
@@ -311,7 +311,7 @@ Is this different from vector-*!"
 ;; definition for function vector-seek!
 (defun vector-seek! ((arg0 vector) (arg1 vector) (arg2 float))
   "Seek arg0 toward arg1. The arg0 is both read and written.
-arg2 is saturated to (0, 1)"
+   arg2 is saturated to (0, 1)"
   (rlet ((vf0 :class vf)
          (vf1 :class vf)
          (vf2 :class vf)
@@ -337,9 +337,9 @@ arg2 is saturated to (0, 1)"
 ;; definition for function vector-smooth-seek!
 (defun vector-smooth-seek! ((arg0 vector) (arg1 vector) (arg2 float))
   "Smoothly seek vec toward target.
-The step always points toward the target and has length (dist * alpha).
-If the step is longer than max-step, the step is projected onto a _square_ with side length arg2.
-Note that this doesn't project to a circle like the function below..."
+   The step always points toward the target and has length (dist * alpha).
+   If the step is longer than max-step, the step is projected onto a _square_ with side length arg2.
+   Note that this doesn't project to a circle like the function below..."
   (rlet ((acc :class vf)
          (vf0 :class vf)
          (vf4 :class vf)
@@ -369,9 +369,9 @@ Note that this doesn't project to a circle like the function below..."
 ;; definition for function vector-seek-2d-xz-smooth!
 (defun vector-seek-2d-xz-smooth! ((arg0 vector) (arg1 vector) (arg2 float) (arg3 float))
   "Smoothly seek vec's x and z components toward target.
-The step always points toward the target and has length (dist * alpha).
-If the step is longer than max-step, the step is projected onto a circle of radius max-step.
-Doesn't touch y or w."
+   The step always points toward the target and has length (dist * alpha).
+   If the step is longer than max-step, the step is projected onto a circle of radius max-step.
+   Doesn't touch y or w."
   (let ((f0-1 (- (-> arg1 x) (-> arg0 x)))
         (f2-1 (- (-> arg1 z) (-> arg0 z)))
         )
@@ -401,9 +401,9 @@ Doesn't touch y or w."
 ;; definition for function vector-seek-2d-yz-smooth!
 (defun vector-seek-2d-yz-smooth! ((arg0 vector) (arg1 vector) (arg2 float) (arg3 float))
   "Smoothly seek vec's y and z components toward target.
-The step always points toward the target and has length (dist * alpha).
-If the step is longer than max-step, the step is projected onto a circle of radius max-step.
-Doesn't touch x or w."
+   The step always points toward the target and has length (dist * alpha).
+   If the step is longer than max-step, the step is projected onto a circle of radius max-step.
+   Doesn't touch x or w."
   (let ((f0-1 (- (-> arg1 y) (-> arg0 y)))
         (f2-1 (- (-> arg1 z) (-> arg0 z)))
         )
@@ -433,9 +433,9 @@ Doesn't touch x or w."
 ;; definition for function vector-seek-3d-smooth!
 (defun vector-seek-3d-smooth! ((arg0 vector) (arg1 vector) (arg2 float) (arg3 float))
   "Smoothly seek vec's x, y, and z components toward target.
-The step always points toward the target and has length (dist * alpha).
-If the step is longer than max-step, the step is projected onto a circle of radius max-step.
-Doesn't touch w."
+   The step always points toward the target and has length (dist * alpha).
+   If the step is longer than max-step, the step is projected onto a circle of radius max-step.
+   Doesn't touch w."
   (let ((f0-1 (- (-> arg1 x) (-> arg0 x)))
         (f1-2 (- (-> arg1 y) (-> arg0 y)))
         (f3-1 (- (-> arg1 z) (-> arg0 z)))
@@ -469,8 +469,8 @@ Doesn't touch w."
 ;; definition for function seek-with-smooth
 (defun seek-with-smooth ((arg0 float) (arg1 float) (arg2 float) (arg3 float) (arg4 float))
   "Move value closer to target.
-If we are within deadband, just go straight to target.
-If not, try to go alpha*err. If that is a larger step than max-step, limit to max-step"
+   If we are within deadband, just go straight to target.
+   If not, try to go alpha*err. If that is a larger step than max-step, limit to max-step"
   (let ((f0-1 (- arg1 arg0)))
     (cond
       ((>= arg4 (fabs f0-1))
@@ -526,7 +526,7 @@ If not, try to go alpha*err. If that is a larger step than max-step, limit to ma
 ;; definition for function vector-v!
 (defun vector-v! ((arg0 vector))
   "Convert a velocity to a displacement per frame. The velocity should be in X/actual_second.
-Uses the current process clock."
+   Uses the current process clock."
   (vector-float*! arg0 arg0 (seconds-per-frame))
   arg0
   )
@@ -806,7 +806,7 @@ Uses the current process clock."
 ;; definition for function vector-normalize-ret-len!
 (defun vector-normalize-ret-len! ((arg0 vector) (arg1 float))
   "Modify arg0 in place to have length arg1 for its xyz components.
-The w part isn't changed and the _original_ length is returned."
+   The w part isn't changed and the _original_ length is returned."
   (local-vars (v1-1 float))
   (rlet ((acc :class vf)
          (Q :class vf)
@@ -843,8 +843,8 @@ The w part isn't changed and the _original_ length is returned."
 ;; INFO: Used lq/sq
 (defun vector-normalize-copy! ((arg0 vector) (arg1 vector) (arg2 float))
   "Normalize, but not in place.
-This implementation is very good compared to the vector-normalize! one.
-The w component is set to 1."
+   This implementation is very good compared to the vector-normalize! one.
+   The w component is set to 1."
   (let ((f0-0 (vector-length arg1)))
     (cond
       ((= f0-0 0.0)
@@ -906,8 +906,8 @@ The w component is set to 1."
 ;; definition for function vector-length-max!
 (defun vector-length-max! ((arg0 vector) (arg1 float))
   "Make vector at most arg1 length (xyz only).
-If it is larger, project onto sphere.
-Doesn't touch w"
+   If it is larger, project onto sphere.
+   Doesn't touch w"
   (let ((f0-0 (vector-length arg0)))
     (when (not (or (= f0-0 0.0) (< f0-0 arg1)))
       (let ((f0-1 (/ f0-0 arg1)))
@@ -925,8 +925,8 @@ Doesn't touch w"
 ;; definition for function vector-xz-length-max!
 (defun vector-xz-length-max! ((arg0 vector) (arg1 float))
   "Make vector at most arg1 length (xz only).
-It it is larger, project onto circle.
-Doesn't touch w or y."
+   It it is larger, project onto circle.
+   Doesn't touch w or y."
   (let* ((v1-0 arg0)
          (f0-4 (sqrtf (+ (* (-> v1-0 x) (-> v1-0 x)) (* (-> v1-0 z) (-> v1-0 z)))))
          )
@@ -1046,7 +1046,7 @@ Doesn't touch w or y."
 ;; definition for function rot-zxy-from-vector!
 (defun rot-zxy-from-vector! ((arg0 vector) (arg1 vector))
   "I think this gives you a vector of euler angles to rotate some unit vector
-to arg1."
+   to arg1."
   (let* ((f28-0 (-> arg1 z))
          (f30-0 (-> arg1 x))
          (f0-0 (atan f30-0 f28-0))
@@ -1065,7 +1065,7 @@ to arg1."
 ;; definition for function rot-zyx-from-vector!
 (defun rot-zyx-from-vector! ((arg0 vector) (arg1 vector))
   "I think this gives you a vector of euler angles to rotate some unit vector
-to arg1."
+   to arg1."
   (let* ((f28-0 (-> arg1 z))
          (f30-0 (- (-> arg1 y)))
          (f0-1 (atan f30-0 f28-0))
@@ -1084,7 +1084,7 @@ to arg1."
 ;; definition for function vector-lerp!
 (defun vector-lerp! ((arg0 vector) (arg1 vector) (arg2 vector) (arg3 float))
   "Linearly interpolate between two vectors. Alpha isn't clamped.
-w will be set to 1."
+   w will be set to 1."
   (rlet ((vf0 :class vf)
          (vf1 :class vf)
          (vf2 :class vf)
@@ -1108,7 +1108,7 @@ w will be set to 1."
 ;; INFO: Used lq/sq
 (defun vector-lerp-clamp! ((arg0 vector) (arg1 vector) (arg2 vector) (arg3 float))
   "Linearly interpolate between two vectors, clamping alpha to 0, 1.
-w will be set to 1."
+   w will be set to 1."
   (rlet ((vf0 :class vf)
          (vf1 :class vf)
          (vf2 :class vf)
@@ -1203,9 +1203,9 @@ w will be set to 1."
 ;; INFO: Used lq/sq
 (defun vector-degi ((arg0 vector) (arg1 vector))
   "Convert a vector (in _rotations_) to degrees units, stored in an int.
-Truncates to the nearest _rotation_.
-Neither the input or output is a commonly used form.
-Unsurprisingly, this strange function is never used."
+   Truncates to the nearest _rotation_.
+   Neither the input or output is a commonly used form.
+   Unsurprisingly, this strange function is never used."
   (local-vars (v1-0 uint128) (v1-1 uint128))
   (rlet ((vf1 :class vf))
     (.lvf vf1 (&-> arg1 quad))
@@ -1221,8 +1221,8 @@ Unsurprisingly, this strange function is never used."
 ;; INFO: Used lq/sq
 (defun vector-degf ((arg0 vector) (arg1 vector))
   "Convert a vector (in integer degree units) to floating point rotations.
-Truncates to the nearest _rotation_.
-Like the previous function, this is stupid and unused."
+   Truncates to the nearest _rotation_.
+   Like the previous function, this is stupid and unused."
   (local-vars (v1-1 uint128))
   (rlet ((vf1 :class vf))
     (let ((v1-0 (-> arg1 quad)))
@@ -1238,7 +1238,7 @@ Like the previous function, this is stupid and unused."
 ;; definition for function vector-degmod
 (defun vector-degmod ((arg0 vector) (arg1 vector))
   "This one is actually right. Wraps degrees units (in floats, like they should be)
-to +/- half a rotation."
+   to +/- half a rotation."
   (local-vars (v1-0 uint128) (v1-1 uint128) (v1-2 uint128))
   (rlet ((vf1 :class vf))
     (.lvf vf1 (&-> arg1 quad))
@@ -1617,7 +1617,7 @@ to +/- half a rotation."
 ;; definition for function rand-vu-sphere-point!
 (defun rand-vu-sphere-point! ((arg0 vector) (arg1 float))
   "Get a random point on the sphere at the origin with radius arg1.
-The point is on the surface of the sphere."
+   The point is on the surface of the sphere."
   (set-vector!
     arg0
     (rand-vu-float-range -1.0 1.0)

--- a/test/decompiler/reference/jak2/engine/nav/nav-control_REF.gc
+++ b/test/decompiler/reference/jak2/engine/nav/nav-control_REF.gc
@@ -222,10 +222,10 @@
 ;; WARN: Function get-nav-control has a return type of none, but the expression builder found a return statement.
 (defun get-nav-control ((arg0 process-drawable) (arg1 nav-mesh))
   "Given a [[process-drawable]] get the associated [[nav-control]] using either:
-- the provided `nav-mesh` arg
-- the `nav-mesh` associated with the [[process-drawable]]'s [[entity]]
-If no [[nav-mesh]] is set or found, set the [[entity]]'s [[entity-perm-status]] to TODO and return an error.
-Note that this doesn't actually return the nav-control, but instead adds this process-drawable to the nav-mesh."
+   - the provided `nav-mesh` arg
+   - the `nav-mesh` associated with the [[process-drawable]]'s [[entity]]
+   If no [[nav-mesh]] is set or found, set the [[entity]]'s [[entity-perm-status]] to TODO and return an error.
+   Note that this doesn't actually return the nav-control, but instead adds this process-drawable to the nav-mesh."
   (if (not arg1)
       (set! arg1 (nav-mesh-from-res-tag (-> arg0 entity) 'nav-mesh-actor 0))
       )
@@ -397,7 +397,7 @@ Note that this doesn't actually return the nav-control, but instead adds this pr
 ;; WARN: Return type mismatch int vs none.
 (defun add-nav-sphere ((nav nav-control) (sphere sphere) (max-spheres int))
   "Adds the given [[sphere]] to the [[nav-control]]'s `sphere-array` so long as
-`max-spheres` is less than [[nav-control]]'s `sphere-count`"
+   `max-spheres` is less than [[nav-control]]'s `sphere-count`"
   (local-vars (a2-4 float))
   (rlet ((vf1 :class vf)
          (vf2 :class vf)

--- a/test/decompiler/reference/jak2/engine/nav/nav-enemy_REF.gc
+++ b/test/decompiler/reference/jak2/engine/nav/nav-enemy_REF.gc
@@ -25,7 +25,7 @@
 ;; definition for method 74 of type nav-enemy
 (defmethod general-event-handler ((this nav-enemy) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('nav-mesh-kill)
      (deactivate this)
@@ -207,9 +207,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod common-post ((self nav-enemy))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (if (and (nonzero? (-> self draw)) (logtest? (-> self draw status) (draw-control-status on-screen)))
       (set-time! (-> self last-draw-time))
       )
@@ -968,10 +968,10 @@
 ;; definition for method 98 of type nav-enemy
 (defmethod in-aggro-range? ((this nav-enemy) (arg0 process-focusable) (arg1 vector))
   "Should the enemy activate.
-- if `activate-distance` is `0.0`, always true
-- otherwise, check if the provided process is close enough
-@param proc The process used to distance check
-@returns true/false"
+   - if `activate-distance` is `0.0`, always true
+   - otherwise, check if the provided process is close enough
+   @param proc The process used to distance check
+   @returns true/false"
   (if (and arg0 (not arg1))
       (set! arg1 (get-trans arg0 1))
       )
@@ -1120,7 +1120,7 @@
 ;; WARN: Return type mismatch float vs none.
 (defmethod set-enemy-info! ((this nav-enemy) (arg0 nav-enemy-info))
   "In addition to setting the `enemy-info`, also init the `neck-joint` if applicable from it
-@param info Set `enemy-info` accordingly"
+   @param info Set `enemy-info` accordingly"
   (set! (-> this enemy-info) arg0)
   (set! (-> arg0 callback-info) *nav-enemy-callback-info*)
   (when (and (!= (-> this enemy-info neck-joint) -1) (zero? (-> this neck)))
@@ -1315,11 +1315,11 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-from-entity! ((this nav-enemy) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-enemy-collision! this)
   (process-drawable-from-entity! this arg0)
   (init-enemy! this)

--- a/test/decompiler/reference/jak2/engine/physics/rigid-body_REF.gc
+++ b/test/decompiler/reference/jak2/engine/physics/rigid-body_REF.gc
@@ -1099,11 +1099,11 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-from-entity! ((this rigid-body-object) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (allocate-and-init-cshape this)
   (process-drawable-from-entity! this arg0)
   (init-skel-and-rigid-body this)

--- a/test/decompiler/reference/jak2/engine/process-drawable/focus_REF.gc
+++ b/test/decompiler/reference/jak2/engine/process-drawable/focus_REF.gc
@@ -41,7 +41,7 @@
 ;; definition for method 10 of type focus
 (defmethod collide-check? ((this focus) (proc process-focusable))
   "If the focused process is not dead,
-check that the [[collide-spec]] of the focus and the process match."
+   check that the [[collide-spec]] of the focus and the process match."
   (when (and proc (not (logtest? (-> proc focus-status) (focus-status disable dead))))
     (let* ((root (-> proc root))
            (cshape (if (type? root collide-shape)

--- a/test/decompiler/reference/jak2/engine/process-drawable/process-taskable_REF.gc
+++ b/test/decompiler/reference/jak2/engine/process-drawable/process-taskable_REF.gc
@@ -14,8 +14,8 @@
 ;; WARN: Return type mismatch int vs none.
 (defbehavior process-taskable-anim-loop process-taskable ((arg0 (function process-taskable object)))
   "Takes in a function and loops as long as it's return value is truthy
-Seen take in - `true-func` which takes no args TODO - seems fishy
-- a `(process-taskable process) lambda"
+   Seen take in - `true-func` which takes no args TODO - seems fishy
+   - a `(process-taskable process) lambda"
   (while (arg0 self)
     (let ((s5-0 (get-art-elem self)))
       (when (!= (ja-group) s5-0)
@@ -42,7 +42,7 @@ Seen take in - `true-func` which takes no args TODO - seems fishy
 ;; WARN: Return type mismatch art-joint-anim vs art-element.
 (defmethod get-art-elem ((this process-taskable))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (the-as art-element (if (> (-> this skel active-channels) 0)
                           (-> this skel root-channel 0 frame-group)
                           )
@@ -430,11 +430,11 @@ Seen take in - `true-func` which takes no args TODO - seems fishy
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this process-taskable) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stack-size-set! (-> this main-thread) 512)
   (process-taskable-method-31 this)
   (process-drawable-from-entity! this arg0)

--- a/test/decompiler/reference/jak2/engine/ps2/pad_REF.gc
+++ b/test/decompiler/reference/jak2/engine/ps2/pad_REF.gc
@@ -222,7 +222,7 @@ It's 32 bytes + type tag (ignored by C kernel)."
 ;; definition for method 0 of type cpad-list
 (defmethod new cpad-list ((allocation symbol) (type-to-make type))
   "Create a cpad-list for 2 controllers. It's fine to do this even if one or both controllers
-aren't connected yet."
+   aren't connected yet."
   (let ((gp-0 (object-new allocation type-to-make (the-as int (-> type-to-make size)))))
     (set! (-> gp-0 num-cpads) 2)
     (set! (-> gp-0 cpads 0) (new 'global 'cpad-info 0))
@@ -234,9 +234,9 @@ aren't connected yet."
 ;; definition for function analog-input
 (defun analog-input ((arg0 int) (arg1 float) (arg2 float) (arg3 float) (arg4 float))
   "Convert integer input from pad into a float between -out-range and +out-range.
-The offset is applied directly to the input.
-The center val is the expected value for 0, after applying offset.
-The max val is the expected value with the stick pushed all the way."
+   The offset is applied directly to the input.
+   The center val is the expected value for 0, after applying offset.
+   The max val is the expected value with the stick pushed all the way."
   (let* ((f1-1 (- (the float arg0) arg1))
          (f0-3 (- (fabs f1-1) arg2))
          (v1-0 (- arg3 arg2))

--- a/test/decompiler/reference/jak2/engine/ps2/timer_REF.gc
+++ b/test/decompiler/reference/jak2/engine/ps2/timer_REF.gc
@@ -114,8 +114,8 @@
 ;; ERROR: Unsupported inline assembly instruction kind - [mfc0 a1, Count]
 (defun stopwatch-end ((arg0 stopwatch))
   "End a stopwatch level. Stops the stopwatch if it's back to level zero.
-There is no guard against ending a stopwatch too many times, and a negative level
-will cause errors!"
+   There is no guard against ending a stopwatch too many times, and a negative level
+   will cause errors!"
   (local-vars (a1-0 int))
   (+! (-> arg0 begin-level) -1)
   (when (zero? (-> arg0 begin-level))
@@ -180,7 +180,7 @@ will cause errors!"
 ;; definition for method 10 of type clock
 (defmethod advance-by! ((this clock) (arg0 float))
   "Advance the clock by arg0 timeframes (as a float).
-Both counters keep a separate fractional and integer counter."
+   Both counters keep a separate fractional and integer counter."
   (the int (+ arg0 (-> this accum)))
   (+! (-> this integral-accum) arg0)
   (set! (-> this old-integral-frame-counter) (-> this integral-frame-counter))

--- a/test/decompiler/reference/jak2/engine/sound/gsound_REF.gc
+++ b/test/decompiler/reference/jak2/engine/sound/gsound_REF.gc
@@ -715,8 +715,8 @@
 ;; INFO: Used lq/sq
 (defbehavior sound-play-by-name process-drawable ((arg0 sound-name) (arg1 sound-id) (arg2 int) (arg3 int) (arg4 int) (arg5 sound-group) (arg6 object))
   "Send play rpc to play a sound!
-Last arg can by a symbol with value [[#t]], in which case it will pull `trans` [[vector]] off the current [[process-drawable]]
-otherwise, an explicit [[vector]] can be provided"
+   Last arg can by a symbol with value [[#t]], in which case it will pull `trans` [[vector]] off the current [[process-drawable]]
+   otherwise, an explicit [[vector]] can be provided"
   (local-vars (sv-16 sound-group))
   (set! sv-16 arg5)
   (let ((s4-0 arg6))

--- a/test/decompiler/reference/jak2/engine/target/mech/carry-h_REF.gc
+++ b/test/decompiler/reference/jak2/engine/target/mech/carry-h_REF.gc
@@ -140,7 +140,7 @@
 ;; definition for method 10 of type carry-info
 (defmethod distance-from-destination ((this carry-info) (arg0 carry-info))
   "Returns the distance from the current `point` and the provided [[carry-info]]'s `point`.
-Returns `-1.0` if it exceeds the maximum allowed"
+   Returns `-1.0` if it exceeds the maximum allowed"
   (let* ((f28-0 (vector-y-angle (vector-! (new 'stack-no-clear 'vector) (-> arg0 point) (-> this point))))
          (f30-0 (fabs (deg-diff f28-0 (vector-y-angle (-> this normal)))))
          (f28-1 (fabs (deg-diff (+ 32768.0 f28-0) (vector-y-angle (-> arg0 normal)))))

--- a/test/decompiler/reference/jak2/engine/target/mech/grunt-mech_REF.gc
+++ b/test/decompiler/reference/jak2/engine/target/mech/grunt-mech_REF.gc
@@ -230,9 +230,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod common-post ((this grunt-mech))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   ((method-of-type grunt common-post) this)
   0
   (none)

--- a/test/decompiler/reference/jak2/engine/target/mech/mech_REF.gc
+++ b/test/decompiler/reference/jak2/engine/target/mech/mech_REF.gc
@@ -382,11 +382,11 @@
 ;; definition for method 11 of type mech
 (defmethod init-from-entity! ((this mech) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (mech-init arg0 (the-as matrix3 #f) (the-as handle #f) 100.0)
   (none)
   )

--- a/test/decompiler/reference/jak2/engine/target/target-tube_REF.gc
+++ b/test/decompiler/reference/jak2/engine/target/target-tube_REF.gc
@@ -1161,11 +1161,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this slide-control) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (logclear! (-> this mask) (process-mask actor-pause))

--- a/test/decompiler/reference/jak2/engine/target/target-turret_REF.gc
+++ b/test/decompiler/reference/jak2/engine/target/target-turret_REF.gc
@@ -2227,11 +2227,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this base-turret) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (turret-init! this arg0 (the-as matrix #f))
   (go (method-of-object this idle))
   (none)

--- a/test/decompiler/reference/jak2/engine/ui/minimap_REF.gc
+++ b/test/decompiler/reference/jak2/engine/ui/minimap_REF.gc
@@ -1177,9 +1177,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod run-pending-updates! ((this engine-minimap) (arg0 time-frame))
   "Run updates if they scheduled. If something is found that has no pending update, kill it.
-Note that we won't kill things on this call if they fail to update their `update-time`.
-They will survive until the next call to `run-pending-updates`!
-(or you can modify their `update-time` before that to prevent them from being killed.)"
+   Note that we won't kill things on this call if they fail to update their `update-time`.
+   They will survive until the next call to `run-pending-updates`!
+   (or you can modify their `update-time` before that to prevent them from being killed.)"
   (let ((s2-0 (the-as (pointer connection-pers) (&-> this alive-list)))
         (s3-0 (-> this alive-list))
         )

--- a/test/decompiler/reference/jak2/engine/ui/progress/progress-draw_REF.gc
+++ b/test/decompiler/reference/jak2/engine/ui/progress/progress-draw_REF.gc
@@ -5658,8 +5658,8 @@
 ;; definition for function get-highscore-type
 (defun get-highscore-type ((highscore-index-arg int))
   "Given a highscore index, return it's type as a symbol
-@param highscore-index-arg something
-@returns The type, as as symbol.  Either `'game` or `'race`"
+   @param highscore-index-arg something
+   @returns The type, as as symbol.  Either `'game` or `'race`"
   (let ((highscore-type 'game))
     (let ((highscore-index highscore-index-arg))
       (cond

--- a/test/decompiler/reference/jak2/engine/ui/text_REF.gc
+++ b/test/decompiler/reference/jak2/engine/ui/text_REF.gc
@@ -252,7 +252,7 @@
 ;; WARN: Found some very strange gotos. Check result carefully, this is not well tested.
 (defun load-game-text-info ((arg0 string) (arg1 (pointer object)) (arg2 kheap))
   "Load text, if needed. txt-name is the group name, curr-text is the _symbol_ for
-the game-text-info, and heap is the heap to load to. The heap will be cleared."
+   the game-text-info, and heap is the heap to load to. The heap will be cleared."
   (local-vars (v0-3 int) (sv-16 game-text-info) (sv-24 int) (sv-32 int) (sv-40 int))
   (set! sv-16 (the-as game-text-info (-> arg1 0)))
   (set! sv-24 (the-as int (-> *setting-control* user-current language)))
@@ -330,8 +330,8 @@ the game-text-info, and heap is the heap to load to. The heap will be cleared."
 ;; WARN: Return type mismatch int vs none.
 (defun load-level-text-files ((arg0 int))
   "Load the text files needed for level idx.
-This function made more sense back when text files were split up, but in the end they put everything
-in a single text group and file."
+   This function made more sense back when text files were split up, but in the end they put everything
+   in a single text group and file."
   (if (or *level-text-file-load-flag* (>= arg0 0))
       (load-game-text-info "common" (&-> '*common-text* value) *common-text-heap*)
       )

--- a/test/decompiler/reference/jak2/kernel/gcommon_REF.gc
+++ b/test/decompiler/reference/jak2/kernel/gcommon_REF.gc
@@ -250,7 +250,7 @@ This is the main vector type."
 ;; WARN: Using new Jak 2 rtype-of
 (defun type? ((obj object) (desired-type type))
   "Return if the given object is an instance of the given type.
-Works on basics, bintegers, or symbols."
+   Works on basics, bintegers, or symbols."
   (let ((v1-0 object)
         (a0-1 (rtype-of obj))
         )
@@ -270,8 +270,8 @@ Works on basics, bintegers, or symbols."
 ;; definition for function find-parent-method
 (defun find-parent-method ((typ type) (method-id int))
   "Find the closest parent type that has a different implementation of the given method and return that method.
-If it does not exist, return `nothing` function.
-This is used to implement call-parent-method."
+   If it does not exist, return `nothing` function.
+   This is used to implement call-parent-method."
   (local-vars (v0-0 function))
   (let ((v1-2 (-> typ method-table method-id)))
     (until (!= v0-0 v1-2)
@@ -341,11 +341,11 @@ This is used to implement call-parent-method."
 ;; definition for function member
 (defun member ((obj-to-find object) (list object))
   "See if the first argument is in the proper list of the second argument.
-Checked with simple equality.
-If so, return the list starting at the at point (a truthy value).
-Otherwise, return #f.
-(member 'b '(a b c)) -> (b c d).
-(member 'w '(a b c)) -> #f"
+   Checked with simple equality.
+   If so, return the list starting at the at point (a truthy value).
+   Otherwise, return #f.
+   (member 'b '(a b c)) -> (b c d).
+   (member 'w '(a b c)) -> #f"
   (let ((v1-0 list))
     (while (not (or (null? v1-0) (= (car v1-0) obj-to-find)))
       (set! v1-0 (cdr v1-0))
@@ -370,8 +370,8 @@ Otherwise, return #f.
 ;; definition for function assoc
 (defun assoc ((key object) (assoc-list object))
   "Search an association list for given object. Return #f if not found, otherwise the element with matching car.
-(assoc 'a '((a . 1) (b . 2) (c . 3))) -> (a . 1)
-(assoc 'x '((a . 1) (b . 2) (c . 3))) -> #f"
+   (assoc 'a '((a . 1) (b . 2) (c . 3))) -> (a . 1)
+   (assoc 'x '((a . 1) (b . 2) (c . 3))) -> #f"
   (let ((v1-0 assoc-list))
     (while (not (or (null? v1-0) (= (car (car v1-0)) key)))
       (set! v1-0 (cdr v1-0))
@@ -507,9 +507,9 @@ Otherwise, return #f.
 ;; definition for function insert-cons!
 (defun insert-cons! ((new-obj object) (list object))
   "Update an association list to have the given (key . value) pair.
-If a previous value exists, it is deleted first.
-This function always allocates a pair through `cons` on the global heap, which can never be freed,
-so it should almost never be used at runtime."
+   If a previous value exists, it is deleted first.
+   This function always allocates a pair through `cons` on the global heap, which can never be freed,
+   so it should almost never be used at runtime."
   (let ((a3-0 (delete-car! (car new-obj) list)))
     (cons new-obj a3-0)
     )
@@ -518,8 +518,8 @@ so it should almost never be used at runtime."
 ;; definition for function sort
 (defun sort ((list pair) (compare-func (function object object object)))
   "Sort a list using the given comparision function.
-The function can return a #t/#f value, or a positive/negative value.
-For example, you could use either `-` or `<` as functions to sort integers."
+   The function can return a #t/#f value, or a positive/negative value.
+   For example, you could use either `-` or `<` as functions to sort integers."
   (let ((s4-0 -1))
     (while (nonzero? s4-0)
       (set! s4-0 0)
@@ -915,7 +915,7 @@ The stride is stored in the heap-base of the inline-array-class child class."
 ;; definition for function mem-set32!
 (defun mem-set32! ((dst pointer) (word-count int) (value int))
   "Set memory to the given 32-bit value, repeated n times. (like C memset, but setting int32_t instead of char).
-Not an optimized implementation. Must be 4-byte aligned."
+   Not an optimized implementation. Must be 4-byte aligned."
   (let ((v0-0 dst))
     (dotimes (v1-0 word-count)
       (set! (-> (the-as (pointer int32) dst)) value)

--- a/test/decompiler/reference/jak2/kernel/gkernel_REF.gc
+++ b/test/decompiler/reference/jak2/kernel/gkernel_REF.gc
@@ -171,7 +171,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defbehavior remove-exit process ()
   "Remove the top stack frame. If you have no other stack frames, you can use this before a `go`
-to skip the `exit` of the state you are currently in."
+   to skip the `exit` of the state you are currently in."
   (if (-> self stack-frame-top)
       (set! (-> self stack-frame-top) (-> self stack-frame-top next))
       )
@@ -642,7 +642,6 @@ to skip the `exit` of the state you are currently in."
   )
 
 ;; definition for method 3 of type dead-pool-heap
-;; INFO: this function exists in multiple non-identical object files
 (defmethod inspect ((this dead-pool-heap))
   (format #t "[~8x] ~A~%" this (-> this type))
   (format #t "~Tname: ~A~%" (-> this name))

--- a/test/decompiler/reference/jak2/kernel/gstring_REF.gc
+++ b/test/decompiler/reference/jak2/kernel/gstring_REF.gc
@@ -218,7 +218,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defun copyn-charp<-string ((dst (pointer uint8)) (src string) (len int))
   "Copy part of a string to a c-string. Writes null terminator, repeatedly, to reach the given length.
-If the source is longer than the length, the null terminator is still included."
+   If the source is longer than the length, the null terminator is still included."
   (let ((v1-0 (-> src data)))
     (while (and (nonzero? (-> v1-0 0)) (< 1 len))
       (set! (-> dst 0) (-> v1-0 0))

--- a/test/decompiler/reference/jak2/levels/atoll/atoll-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/atoll/atoll-obs_REF.gc
@@ -144,11 +144,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this piston) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-64 res-tag))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
@@ -327,11 +327,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this turbine) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag) (sv-32 res-tag))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
@@ -500,11 +500,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this liftcat) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag) (sv-32 res-tag))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
@@ -705,11 +705,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this atollrotpipe) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
@@ -920,11 +920,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this slider) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec obstacle))
@@ -1101,11 +1101,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this atoll-windmill) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (logior! (-> this mask) (process-mask ambient))
   (let ((a1-1 (new 'stack-no-clear 'sync-info-params)))
     (let ((v1-2 0))
@@ -1186,11 +1186,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this atoll-valve) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (logior! (-> this mask) (process-mask ambient))
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
@@ -1243,11 +1243,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this atoll-hatch) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (logior! (-> this mask) (process-mask ambient))
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
@@ -1326,11 +1326,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this atoll-hellcat) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec obstacle))
@@ -1403,11 +1403,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this atoll-mar-symbol) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/atoll/atoll-tank_REF.gc
+++ b/test/decompiler/reference/jak2/levels/atoll/atoll-tank_REF.gc
@@ -1791,11 +1791,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this atoll-tank) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this is-master?) #t)
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 9) 0)))

--- a/test/decompiler/reference/jak2/levels/atoll/juicer_REF.gc
+++ b/test/decompiler/reference/jak2/levels/atoll/juicer_REF.gc
@@ -785,9 +785,9 @@
 ;; definition for method 55 of type juicer
 (defmethod common-post ((this juicer))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((t9-0 (method-of-type nav-enemy common-post)))
     (t9-0 this)
     )
@@ -821,7 +821,7 @@
 ;; definition for method 74 of type juicer
 (defmethod general-event-handler ((this juicer) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit-flinch)
      (cond

--- a/test/decompiler/reference/jak2/levels/castle/boss/castle-baron_REF.gc
+++ b/test/decompiler/reference/jak2/levels/castle/boss/castle-baron_REF.gc
@@ -48,11 +48,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cboss-tractor) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -139,7 +139,7 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-plat! ((this cboss-elevator))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   (set! (-> this sound-id) (new-sound-id))
   0
   (none)
@@ -148,10 +148,10 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; definition for method 43 of type cboss-elevator
 (defmethod move-between-points ((this cboss-elevator) (arg0 vector) (arg1 float) (arg2 float))
   "Move between two points on the elevator's path
-@param vec TODO not sure
-@param point-a The first point fetched from the elevator's path
-@param point-b The second point fetched from the path
-@see [[path-control]] and [[elevator]]"
+   @param vec TODO not sure
+   @param point-a The first point fetched from the elevator's path
+   @param point-b The second point fetched from the path
+   @see [[path-control]] and [[elevator]]"
   (let ((s4-0 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) arg1 'interp))
         (a0-3 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) arg2 'interp))
         (v1-3 (-> this root trans))
@@ -806,9 +806,9 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; WARN: Return type mismatch int vs none.
 (defmethod common-post ((this krew-boss-clone))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((t9-0 (method-of-type nav-enemy common-post)))
     (t9-0 this)
     )
@@ -883,7 +883,7 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; definition for method 74 of type krew-boss-clone
 (defmethod general-event-handler ((this krew-boss-clone) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (with-pp
     (case arg2
       (('touch 'bonk 'attack)
@@ -2117,7 +2117,7 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; WARN: disable def twice: 22. This may happen when a cond (no else) is nested inside of another conditional, but it should be rare.
 (defmethod general-event-handler ((this krew-boss) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('track)
      (cond

--- a/test/decompiler/reference/jak2/levels/castle/castle-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/castle/castle-obs_REF.gc
@@ -60,11 +60,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cas-conveyor) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (reset-root! this)
   (set! (-> this path) (new 'process 'path-control this 'path 0.0 (the-as entity #f) #f))
@@ -401,11 +401,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cas-conveyor-switch) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
@@ -702,11 +702,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cas-electric-fence) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec obstacle))
@@ -920,10 +920,10 @@ This commonly includes things such as:
 ;; definition for method 43 of type cas-elevator
 (defmethod move-between-points ((this cas-elevator) (arg0 vector) (arg1 float) (arg2 float))
   "Move between two points on the elevator's path
-@param vec TODO not sure
-@param point-a The first point fetched from the elevator's path
-@param point-b The second point fetched from the path
-@see [[path-control]] and [[elevator]]"
+   @param vec TODO not sure
+   @param point-a The first point fetched from the elevator's path
+   @param point-b The second point fetched from the path
+   @see [[path-control]] and [[elevator]]"
   (let ((s5-0 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) arg1 'interp))
         (a0-3 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) arg2 'interp))
         (v1-3 (-> this root trans))
@@ -1045,7 +1045,7 @@ This commonly includes things such as:
 ;; definition for method 33 of type cas-elevator
 (defmethod init-plat! ((this cas-elevator))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   (set! (-> this sound-id) (new-sound-id))
   (cas-elevator-method-49 this)
   (none)
@@ -1378,11 +1378,11 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cas-rot-bridge) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 5) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 6))
@@ -1635,11 +1635,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cas-switch) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
@@ -1864,11 +1864,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cas-trapdoor) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec obstacle))
@@ -1977,11 +1977,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cas-chain-plat) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec obstacle))
@@ -2114,11 +2114,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cas-rot-blade) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 3))
@@ -2239,11 +2239,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cas-flag-a) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -2302,11 +2302,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cas-flag-b) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -2690,11 +2690,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cas-robot-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag) (sv-32 res-tag))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
@@ -2857,11 +2857,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this lightning-ball) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-sphere s4-0 (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec obstacle))

--- a/test/decompiler/reference/jak2/levels/castle/pad/caspad-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/castle/pad/caspad-obs_REF.gc
@@ -39,10 +39,10 @@
 ;; definition for method 43 of type cpad-elevator
 (defmethod move-between-points ((this cpad-elevator) (vec vector) (point-a float) (point-b float))
   "Move between two points on the elevator's path
-@param vec TODO not sure
-@param point-a The first point fetched from the elevator's path
-@param point-b The second point fetched from the path
-@see [[path-control]] and [[elevator]]"
+   @param vec TODO not sure
+   @param point-a The first point fetched from the elevator's path
+   @param point-b The second point fetched from the path
+   @see [[path-control]] and [[elevator]]"
   (let ((path-point-a (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) point-a 'interp))
         (path-point-b (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) point-b 'interp))
         (elevator-trans (-> this root trans))
@@ -80,7 +80,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod configure-collision ((this cpad-elevator) (collide-with-jak? symbol))
   "Appropriately sets the collision on the elevator
-@param collide-with-jak? If set, the elevator will collide with Jak"
+   @param collide-with-jak? If set, the elevator will collide with Jak"
   (let ((prim (-> (the-as collide-shape-prim-group (-> this root root-prim)) child 1)))
     (cond
       (collide-with-jak?
@@ -185,7 +185,7 @@
 ;; WARN: Return type mismatch sound-id vs none.
 (defmethod init-plat! ((this cpad-elevator))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   (let ((last-path-index (+ (-> this path curve num-cverts) -1)))
     (calc-dist-between-points! this 0 last-path-index)
     (calc-dist-between-points! this last-path-index 0)

--- a/test/decompiler/reference/jak2/levels/castle/roboguard-level_REF.gc
+++ b/test/decompiler/reference/jak2/levels/castle/roboguard-level_REF.gc
@@ -976,7 +976,7 @@
 ;; INFO: Used lq/sq
 (defmethod general-event-handler ((this roboguard-level) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('attack)
      (cond

--- a/test/decompiler/reference/jak2/levels/city/bombbot/bombbot_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/bombbot/bombbot_REF.gc
@@ -1267,9 +1267,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod common-post ((this bombbot))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (local-vars (sv-16 sparticle-launcher) (sv-20 sparticle-launcher))
   (let ((t9-0 (method-of-type nav-enemy common-post)))
     (t9-0 this)
@@ -1395,7 +1395,7 @@
 ;; INFO: Used lq/sq
 (defmethod general-event-handler ((this bombbot) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('nav-mesh-kill)
      (change-to *default-nav-mesh* this)

--- a/test/decompiler/reference/jak2/levels/city/burning-bush/ctywide-bbush_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/burning-bush/ctywide-bbush_REF.gc
@@ -1829,11 +1829,11 @@
 ;; WARN: Return type mismatch entity-perm-status vs none.
 (defmethod init-from-entity! ((this bush-collect) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (process-entity-status! this (entity-perm-status dead) #t)
   (none)
   )

--- a/test/decompiler/reference/jak2/levels/city/common/height-map-h_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/common/height-map-h_REF.gc
@@ -53,6 +53,6 @@ all initialized from static data."
 ;; definition for function get-traffic-height
 (defun get-traffic-height ((arg0 vector))
   "@returns The value of [[xz-height-map::9]] using [[*traffic-height-map*]] and the [[vector]] provided
-@see [[xz-height-map::9]]"
+   @see [[xz-height-map::9]]"
   (get-height-at-point *traffic-height-map* arg0)
   )

--- a/test/decompiler/reference/jak2/levels/city/common/nav-graph-h_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/common/nav-graph-h_REF.gc
@@ -135,21 +135,21 @@
 ;; definition for method 11 of type nav-branch
 (defmethod get-density ((this nav-branch))
   "TODO
-@returns `density * 0.0078125` - is this some kind of trick?"
+   @returns `density * 0.0078125` - is this some kind of trick?"
   (* 0.0078125 (the float (-> this density)))
   )
 
 ;; definition for method 12 of type nav-branch
 (defmethod get-speed-limit ((this nav-branch))
   "TODO
-@returns `speed-limit * 1024.0`"
+   @returns `speed-limit * 1024.0`"
   (* 1024.0 (the float (-> this speed-limit)))
   )
 
 ;; definition for method 13 of type nav-branch
 (defmethod get-width ((this nav-branch))
   "TODO
-@returns `width * 256.0`"
+   @returns `width * 256.0`"
   (* 256.0 (the float (-> this width)))
   )
 
@@ -161,14 +161,14 @@
 ;; definition for method 15 of type nav-branch
 (defmethod dest-node-id-at-max? ((this nav-branch))
   "@returns if `dest-node`'s `id` is equal to `#FFFF`
-@see [[nav-node]]"
+   @see [[nav-node]]"
   (!= (-> this dest-node id) #xffff)
   )
 
 ;; definition for method 21 of type nav-node
 (defmethod get-radius ((this nav-node))
   "TODO
-@returns `radius * 1024.0"
+   @returns `radius * 1024.0"
   (* 1024.0 (the float (-> this radius)))
   )
 
@@ -180,8 +180,8 @@
 ;; definition for method 19 of type nav-node
 (defmethod calc-sine-and-cosine! ((this nav-node) (ret vector))
   "Computes the sine and cosine of the `angle`.
-@param! ret The result <cosine, 0.0, -(sine), 1.0>
-@returns Nothing, the result will be in `ret`"
+   @param! ret The result <cosine, 0.0, -(sine), 1.0>
+   @returns Nothing, the result will be in `ret`"
   (let ((angle (the float (-> this angle)))
         (sin-cos-result (new 'stack-no-clear 'vector))
         )
@@ -198,7 +198,7 @@
 ;; INFO: Used lq/sq
 (defmethod get-position ((this nav-node) (ret vector))
   "@param! ret The [[vector]] that is modified to hold the result
-@returns the `position` [[vector]] with a `w` component of `1.0`"
+   @returns the `position` [[vector]] with a `w` component of `1.0`"
   (set! (-> ret quad) (-> this position quad))
   (set! (-> ret w) 1.0)
   ret
@@ -314,8 +314,8 @@
 ;; definition for method 41 of type nav-graph
 (defmethod node-at-idx ((this nav-graph) (idx int))
   "Get the `nav-node` at a given position.
-@param idx The position in the `node-array` to return
-@returns the [[nav-node]] if it can be found, otherwise return [[#f]]"
+   @param idx The position in the `node-array` to return
+   @returns the [[nav-node]] if it can be found, otherwise return [[#f]]"
   (let ((v0-0 (the-as nav-node #f)))
     (if (and (>= idx 0) (< idx (-> this node-count)))
         (set! v0-0 (-> this node-array idx))

--- a/test/decompiler/reference/jak2/levels/city/common/nav-graph_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/common/nav-graph_REF.gc
@@ -1191,7 +1191,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod patch-nodes ((this nav-graph))
   "Patch nodes. Node pointers are stored as indices into arrays to be allocated on the level heap
-and patched at runtime after loading."
+   and patched at runtime after loading."
   (when (not (-> this patched))
     (set! (-> this patched) #t)
     (let ((s5-0 0))

--- a/test/decompiler/reference/jak2/levels/city/common/searchlight_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/common/searchlight_REF.gc
@@ -80,11 +80,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this searchlight) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (logclear! (-> this mask) (process-mask actor-pause))

--- a/test/decompiler/reference/jak2/levels/city/ctyport-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/ctyport-obs_REF.gc
@@ -984,11 +984,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this boat-manager) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this mesh) (nav-mesh-from-res-tag arg0 'nav-mesh-actor 0))
   (set! (-> this entity) arg0)
   (when (-> this mesh)

--- a/test/decompiler/reference/jak2/levels/city/ctywide-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/ctywide-obs_REF.gc
@@ -528,11 +528,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this security-wall) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (ctywide-entity-hack)
   (set! (-> this breach) #f)
   (set! (-> this pass) (res-lump-value arg0 'pickup-type int :time -1000000000.0))
@@ -1025,11 +1025,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fruit-stand) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (fruit-stand-method-28 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -2145,11 +2145,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cty-guard-turret) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (v1-23 handle))
   (with-pp
     (cty-guard-turret-method-32 this)
@@ -2384,11 +2384,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this parking-spot) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (set! (-> this minimap) #f)
   (set! (-> this vehicle) (the-as handle #f))
@@ -2940,11 +2940,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this propa) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (propa-method-29 this)
   (process-drawable-from-entity! this arg0)
   (ctywide-entity-hack)
@@ -3006,11 +3006,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this baron-statue) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -3955,11 +3955,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this burning-bush) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (burning-bush-method-30 this)
   (process-drawable-from-entity! this arg0)
   (ctywide-entity-hack)
@@ -4023,11 +4023,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this barons-ship-lores) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (when (demo?)
     (process-entity-status! this (entity-perm-status dead) #t)
     (go empty-state)
@@ -4296,11 +4296,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this lurker-pipe-lid) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (lurker-pipe-lid-method-28 this)
   (process-drawable-from-entity! this arg0)
   (ctywide-entity-hack)
@@ -4477,11 +4477,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this ctyn-lamp) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (ctyn-lamp-method-29 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/city/farm/ctyfarm-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/farm/ctyfarm-obs_REF.gc
@@ -1290,11 +1290,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this farm-marrow) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (farm-marrow-method-29 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -1564,11 +1564,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this farm-beetree) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (farm-beetree-method-29 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -1834,11 +1834,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this farm-cabbage) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (farm-cabbage-method-29 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -2091,11 +2091,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this farm-small-cabbage) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (farm-small-cabbage-method-29 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -2392,11 +2392,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this farm-chilirots) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (farm-chilirots-method-29 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -2517,11 +2517,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this farm-sprinkler-barrels) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (farm-sprinkler-barrels-method-28 this)
   (process-drawable-from-entity! this arg0)
   (logclear! (-> this mask) (process-mask actor-pause))

--- a/test/decompiler/reference/jak2/levels/city/farm/yakow_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/farm/yakow_REF.gc
@@ -219,7 +219,7 @@
 ;; definition for method 74 of type yakow
 (defmethod general-event-handler ((this yakow) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('attack)
      (let ((v1-1 (the-as object (-> arg3 param 1))))

--- a/test/decompiler/reference/jak2/levels/city/generic/neon-praxis-part_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/generic/neon-praxis-part_REF.gc
@@ -1210,11 +1210,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this city-neon-praxis) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (logclear! (-> this mask) (process-mask actor-pause enemy))

--- a/test/decompiler/reference/jak2/levels/city/kiddogescort/crocesc_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/kiddogescort/crocesc_REF.gc
@@ -179,7 +179,7 @@
 ;; definition for method 74 of type crocadog-escort
 (defmethod general-event-handler ((this crocadog-escort) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('attack)
      ((method-of-type bot general-event-handler) this arg0 arg1 arg2 arg3)
@@ -198,7 +198,7 @@
 ;; definition for method 59 of type crocadog-escort
 (defmethod get-penetrate-info ((this crocadog-escort))
   "@returns the allowed way(s) this enemy can take damage
-@see [[penetrate]] and [[penetrated-by-all&hit-points->penetrated-by]]"
+   @see [[penetrate]] and [[penetrated-by-all&hit-points->penetrated-by]]"
   (let ((v1-1 ((method-of-type bot get-penetrate-info) this)))
     (logior (penetrate jak-yellow-shot jak-red-shot jak-blue-shot) v1-1)
     )
@@ -373,11 +373,11 @@
 ;; definition for method 11 of type crocadog-escort
 (defmethod init-from-entity! ((this crocadog-escort) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stack-size-set! (-> this main-thread) 512)
   ((method-of-type bot init-from-entity!) this arg0)
   (none)

--- a/test/decompiler/reference/jak2/levels/city/kiddogescort/hal4-course_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/kiddogescort/hal4-course_REF.gc
@@ -117,7 +117,7 @@
 ;; definition for method 74 of type hal-escort
 (defmethod general-event-handler ((this hal-escort) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('notify)
      (case (-> arg3 param 0)

--- a/test/decompiler/reference/jak2/levels/city/kiddogescort/kidesc_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/kiddogescort/kidesc_REF.gc
@@ -179,7 +179,7 @@
 ;; definition for method 74 of type kid-escort
 (defmethod general-event-handler ((this kid-escort) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('arrest)
      (let* ((s4-0 (handle->process (-> this arrestor-handle)))
@@ -372,11 +372,11 @@
 ;; definition for method 11 of type kid-escort
 (defmethod init-from-entity! ((this kid-escort) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stack-size-set! (-> this main-thread) 512)
   ((method-of-type bot init-from-entity!) this arg0)
   (none)
@@ -636,7 +636,7 @@ This commonly includes things such as:
 ;; definition for method 59 of type kid-escort
 (defmethod get-penetrate-info ((this kid-escort))
   "@returns the allowed way(s) this enemy can take damage
-@see [[penetrate]] and [[penetrated-by-all&hit-points->penetrated-by]]"
+   @see [[penetrate]] and [[penetrated-by-all&hit-points->penetrated-by]]"
   (let ((v1-1 ((method-of-type bot get-penetrate-info) this)))
     (logior (penetrate jak-yellow-shot jak-red-shot jak-blue-shot) v1-1)
     )

--- a/test/decompiler/reference/jak2/levels/city/market/ashelin/ctyasha-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/market/ashelin/ctyasha-obs_REF.gc
@@ -921,7 +921,7 @@
 ;; definition for method 74 of type tanker-grunt
 (defmethod general-event-handler ((this tanker-grunt) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('skip-intro)
      (when (and (-> this next-state)
@@ -1039,7 +1039,7 @@
 ;; definition for method 74 of type tanker-juicer
 (defmethod general-event-handler ((this tanker-juicer) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('skip-intro)
      (when (and (-> this next-state) (let ((v1-4 (-> this next-state name)))
@@ -1334,11 +1334,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tanker-container) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 3) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 4))
@@ -1468,11 +1468,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tanker-crash) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 3) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 4))

--- a/test/decompiler/reference/jak2/levels/city/market/ctymark-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/market/ctymark-obs_REF.gc
@@ -1139,11 +1139,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this market-basket-a) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((prim-mesh (new 'process 'collide-shape-prim-mesh cshape (the-as uint 0) (the-as uint 0))))
       (set! (-> prim-mesh prim-core collide-as) (collide-spec crate))
@@ -1231,11 +1231,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this market-basket-b) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((prim-mesh (new 'process 'collide-shape-prim-mesh cshape (the-as uint 0) (the-as uint 0))))
       (set! (-> prim-mesh prim-core collide-as) (collide-spec crate))
@@ -1323,11 +1323,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this market-crate) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((prim-mesh (new 'process 'collide-shape-prim-mesh cshape (the-as uint 0) (the-as uint 0))))
       (set! (-> prim-mesh prim-core collide-as) (collide-spec crate))
@@ -1415,11 +1415,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this market-sack-a) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((prim-mesh (new 'process 'collide-shape-prim-mesh cshape (the-as uint 0) (the-as uint 0))))
       (set! (-> prim-mesh prim-core collide-as) (collide-spec crate))
@@ -1507,11 +1507,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this market-sack-b) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((prim-mesh (new 'process 'collide-shape-prim-mesh cshape (the-as uint 0) (the-as uint 0))))
       (set! (-> prim-mesh prim-core collide-as) (collide-spec crate))

--- a/test/decompiler/reference/jak2/levels/city/meet-brutter/meet-brutter_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/meet-brutter/meet-brutter_REF.gc
@@ -2126,7 +2126,7 @@
 ;; INFO: Used lq/sq
 (defmethod general-event-handler ((this city-lurker) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('nav-mesh-kill)
      (format 0 "nav-mesh-kill event recieved by ~s ~d~%" (-> this name) arg2)

--- a/test/decompiler/reference/jak2/levels/city/oracle/oracle-scenes_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/oracle/oracle-scenes_REF.gc
@@ -855,7 +855,7 @@
 ;; definition for method 35 of type oracle-npc
 (defmethod get-art-elem ((this oracle-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (logior! (-> this draw status) (draw-control-status no-draw-bounds))
   (let ((root-prim (-> this root root-prim)))
     (set! (-> root-prim prim-core collide-as) (collide-spec))

--- a/test/decompiler/reference/jak2/levels/city/package/delivery-task_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/package/delivery-task_REF.gc
@@ -106,11 +106,11 @@
 ;; WARN: Return type mismatch entity-perm-status vs none.
 (defmethod init-from-entity! ((this krew-package) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (process-entity-status! this (entity-perm-status dead) #t)
   (none)
   )

--- a/test/decompiler/reference/jak2/levels/city/palace/ctypal-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/palace/ctypal-obs_REF.gc
@@ -98,11 +98,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this palace-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -209,11 +209,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this ctypal-broke-wall) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (format #t "~A initialising~%" (-> this name))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
@@ -294,11 +294,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this ctypal-baron-statue-broken) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/city/port/ctyport-part_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/port/ctyport-part_REF.gc
@@ -3646,11 +3646,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hiphog-exterior-marquee) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (logclear! (-> this mask) (process-mask actor-pause enemy))
@@ -3779,11 +3779,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this farthy) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (set! (-> this root pause-adjust-distance) 1228800.0)

--- a/test/decompiler/reference/jak2/levels/city/protect/protect_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/protect/protect_REF.gc
@@ -87,11 +87,11 @@
 ;; WARN: Return type mismatch entity-perm-status vs none.
 (defmethod init-from-entity! ((this seal-of-mar) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (process-entity-status! this (entity-perm-status dead) #t)
   (none)
   )

--- a/test/decompiler/reference/jak2/levels/city/sack/collection-task_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/sack/collection-task_REF.gc
@@ -80,7 +80,7 @@
 ;; INFO: Used lq/sq
 (defmethod find-ground ((this krew-collection-item))
   "TODO - understand the collision query stuff more
-@returns whether or not the [[self]] is above the ground"
+   @returns whether or not the [[self]] is above the ground"
   (let ((on-ground? #f))
     (let ((query (new 'stack-no-clear 'collide-query-with-2vec)))
       (set! (-> query vec quad) (-> this root trans quad))
@@ -178,7 +178,7 @@
 ;; WARN: Return type mismatch object vs none.
 (defbehavior krew-collection-item-init-by-other krew-collection-item ((position vector))
   "Given a [[vector]] defining it's position, create a [[krew-collection-item]]
-@param position The intended position of the item"
+   @param position The intended position of the item"
   (set! (-> self level) (level-get *level* 'lsack))
   (set! (-> self root) (new 'process 'trsqv))
   (set! (-> self root trans quad) (-> position quad))
@@ -205,8 +205,8 @@
 ;; WARN: Return type mismatch process vs krew-collection-item.
 (defun krew-collection-item-spawn ((proc process) (position vector))
   "Given a [[vector]] defining it's position, create a [[krew-collection-item]] via [[process-spawn]]
-@param proc The [[process]] that is used to spawn the new item
-@param position The intended position of the item"
+   @param proc The [[process]] that is used to spawn the new item
+   @param position The intended position of the item"
   (let ((new-krew-item (the-as process #f)))
     (let ((new-proc (process-spawn krew-collection-item position :to proc)))
       (if new-proc

--- a/test/decompiler/reference/jak2/levels/city/shuttle/shuttle_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/shuttle/shuttle_REF.gc
@@ -672,7 +672,7 @@
 ;; WARN: disable def twice: 51. This may happen when a cond (no else) is nested inside of another conditional, but it should be rare.
 (defmethod general-event-handler ((this citizen-rebel) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit 'hit-flinch 'hit-knocked)
      (when (nonzero? (-> this gui-id))
@@ -733,7 +733,7 @@
 ;; definition for method 59 of type citizen-rebel
 (defmethod get-penetrate-info ((this citizen-rebel))
   "@returns the allowed way(s) this enemy can take damage
-@see [[penetrate]] and [[penetrated-by-all&hit-points->penetrated-by]]"
+   @see [[penetrate]] and [[penetrated-by-all&hit-points->penetrated-by]]"
   (let ((v1-1 ((method-of-type nav-enemy get-penetrate-info) this)))
     (logior (penetrate enemy-yellow-shot) v1-1)
     )

--- a/test/decompiler/reference/jak2/levels/city/slums/kor/kid_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/slums/kor/kid_REF.gc
@@ -179,7 +179,7 @@
 ;; definition for method 74 of type kid
 (defmethod general-event-handler ((this kid) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('arrest)
      (let* ((s4-0 (handle->process (-> this arrestor-handle)))

--- a/test/decompiler/reference/jak2/levels/city/slums/kor/kor_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/slums/kor/kor_REF.gc
@@ -197,7 +197,7 @@
 ;; definition for method 74 of type kor
 (defmethod general-event-handler ((this kor) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('arrest)
      (let* ((s4-0 (handle->process (-> this arrestor-handle)))

--- a/test/decompiler/reference/jak2/levels/city/slums/neon-baron-part_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/slums/neon-baron-part_REF.gc
@@ -3593,11 +3593,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this neon-baron) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (matrix-rotate-y! (-> this mat) (quaternion-y-angle (-> arg0 quat)))
   (set! (-> this mat trans quad) (-> arg0 extra trans quad))
   (set! (-> this master-enable) -1)
@@ -3642,11 +3642,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hide-door-a) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 1) 0)))

--- a/test/decompiler/reference/jak2/levels/city/traffic/citizen/citizen-enemy_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/traffic/citizen/citizen-enemy_REF.gc
@@ -30,9 +30,9 @@
 ;; definition for method 55 of type citizen-enemy
 (defmethod common-post ((this citizen-enemy))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((a1-0 (new 'stack-no-clear 'overlaps-others-params)))
     (set! (-> a1-0 options) (overlaps-others-options))
     (set! (-> a1-0 collide-with-filter) (-> this enemy-info overlaps-others-collide-with-filter))
@@ -115,7 +115,7 @@
 ;; definition for method 74 of type citizen-enemy
 (defmethod general-event-handler ((this citizen-enemy) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('event-death)
      #f

--- a/test/decompiler/reference/jak2/levels/city/traffic/citizen/citizen_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/traffic/citizen/citizen_REF.gc
@@ -97,8 +97,8 @@
 ;; WARN: Return type mismatch int vs enemy-aware.
 (defmethod update-target-awareness! ((this citizen) (arg0 process-focusable) (arg1 enemy-best-focus))
   "Checks a variety of criteria to determine the level of awareness the enemy is of the target.  Sets `aware` and related fields as well!
-@TODO - flesh out docs
-@returns the value that sets `aware`"
+   @TODO - flesh out docs
+   @returns the value that sets `aware`"
   (when arg1
     (let ((f0-0 (vector-vector-distance (get-trans arg0 0) (-> this root trans))))
       (when (< f0-0 (-> arg1 rating))
@@ -263,7 +263,7 @@
 ;; INFO: Used lq/sq
 (defmethod general-event-handler ((this citizen) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit 'hit-flinch 'hit-knocked)
      (let ((v1-1 #f))
@@ -386,9 +386,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod common-post ((this citizen))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (when (< (-> this next-time-look-at) (current-time))
     (when (nonzero? (-> this neck))
       (let ((a0-4 (handle->process (-> this focus handle))))
@@ -684,11 +684,11 @@
 ;; WARN: Return type mismatch entity-perm-status vs none.
 (defmethod init-from-entity! ((this citizen) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (process-entity-status! this (entity-perm-status dead) #t)
   (none)
   )

--- a/test/decompiler/reference/jak2/levels/city/traffic/citizen/civilian_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/traffic/citizen/civilian_REF.gc
@@ -342,7 +342,7 @@
 ;; INFO: Used lq/sq
 (defmethod general-event-handler ((this civilian) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('track)
      #f

--- a/test/decompiler/reference/jak2/levels/city/traffic/citizen/guard_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/traffic/citizen/guard_REF.gc
@@ -558,9 +558,9 @@
 ;; definition for method 55 of type crimson-guard
 (defmethod common-post ((this crimson-guard))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((t9-0 (method-of-type citizen common-post)))
     (t9-0 this)
     )
@@ -604,7 +604,7 @@
 ;; WARN: disable def twice: 122. This may happen when a cond (no else) is nested inside of another conditional, but it should be rare.
 (defmethod general-event-handler ((this crimson-guard) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit 'hit-flinch 'hit-knocked)
      (speech-control-method-13 *speech-control* (the-as handle this))

--- a/test/decompiler/reference/jak2/levels/city/traffic/citizen/metalhead-grunt_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/traffic/citizen/metalhead-grunt_REF.gc
@@ -280,7 +280,7 @@
 ;; definition for method 74 of type metalhead-grunt
 (defmethod general-event-handler ((this metalhead-grunt) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit 'hit-knocked)
      (logclear! (-> this mask) (process-mask actor-pause))

--- a/test/decompiler/reference/jak2/levels/city/traffic/citizen/metalhead-predator_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/traffic/citizen/metalhead-predator_REF.gc
@@ -425,9 +425,9 @@
 ;; definition for method 55 of type metalhead-predator
 (defmethod common-post ((this metalhead-predator))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((t9-0 (method-of-type citizen-enemy common-post)))
     (t9-0 this)
     )
@@ -441,7 +441,7 @@
 ;; WARN: disable def twice: 21. This may happen when a cond (no else) is nested inside of another conditional, but it should be rare.
 (defmethod general-event-handler ((this metalhead-predator) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('attack)
      (set! (-> this shock-effect-end) (the-as int (+ (current-time) (seconds 1))))

--- a/test/decompiler/reference/jak2/levels/city/traffic/traffic-engine_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/traffic/traffic-engine_REF.gc
@@ -262,7 +262,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod add-new-supression-box ((this traffic-suppressor) (arg0 traffic-suppression-params))
   "Create a suppression box for these params.
-The param object is updated with the ID of the box and can be later used with update-box-from-params."
+   The param object is updated with the ID of the box and can be later used with update-box-from-params."
   (set! (-> arg0 id) -1)
   (let ((v1-1 0))
     (b! #t cfg-4 :delay (nop!))
@@ -487,7 +487,7 @@ The param object is updated with the ID of the box and can be later used with up
 ;; WARN: Return type mismatch int vs none.
 (defmethod deactivate-object ((this traffic-tracker) (arg0 int) (arg1 symbol))
   "Send a traffic-off event (or traffic-off-force) to deactivate an object, specified by index in active object array.
-Process is recycled and moved to reserved, if it deactivates."
+   Process is recycled and moved to reserved, if it deactivates."
   (with-pp
     (let* ((s3-0 (-> this active-object-type-list arg0))
            (gp-0 'traffic-off)

--- a/test/decompiler/reference/jak2/levels/city/traffic/vehicle/transport_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/traffic/vehicle/transport_REF.gc
@@ -607,11 +607,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this transport) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (transport-method-31 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/city/traffic/vehicle/vehicle-rider_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/traffic/vehicle/vehicle-rider_REF.gc
@@ -260,11 +260,11 @@
 ;; WARN: Return type mismatch entity-perm-status vs none.
 (defmethod init-from-entity! ((this vehicle-rider) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (process-entity-status! this (entity-perm-status dead) #t)
   (none)
   )

--- a/test/decompiler/reference/jak2/levels/city/traffic/vehicle/vehicle-util_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/traffic/vehicle/vehicle-util_REF.gc
@@ -198,11 +198,11 @@
 ;; WARN: Return type mismatch entity-perm-status vs none.
 (defmethod init-from-entity! ((this vehicle) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (process-entity-status! this (entity-perm-status dead) #t)
   (none)
   )

--- a/test/decompiler/reference/jak2/levels/city/vinroom/vinroom-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/city/vinroom/vinroom-obs_REF.gc
@@ -209,11 +209,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this vin-turbine) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -265,11 +265,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this vin-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))

--- a/test/decompiler/reference/jak2/levels/common/ai/ashelin/ash_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/ai/ashelin/ash_REF.gc
@@ -229,7 +229,7 @@
 ;; definition for method 59 of type ashelin
 (defmethod get-penetrate-info ((this ashelin))
   "@returns the allowed way(s) this enemy can take damage
-@see [[penetrate]] and [[penetrated-by-all&hit-points->penetrated-by]]"
+   @see [[penetrate]] and [[penetrated-by-all&hit-points->penetrated-by]]"
   (let* ((t9-0 (method-of-type bot get-penetrate-info))
          (v0-0 (t9-0 this))
          )

--- a/test/decompiler/reference/jak2/levels/common/ai/bot_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/ai/bot_REF.gc
@@ -438,8 +438,8 @@
 ;; WARN: Return type mismatch int vs enemy-aware.
 (defmethod update-target-awareness! ((this bot) (arg0 process-focusable) (arg1 enemy-best-focus))
   "Checks a variety of criteria to determine the level of awareness the enemy is of the target.  Sets `aware` and related fields as well!
-@TODO - flesh out docs
-@returns the value that sets `aware`"
+   @TODO - flesh out docs
+   @returns the value that sets `aware`"
   (the-as enemy-aware 3)
   )
 
@@ -742,7 +742,7 @@
 ;; WARN: disable def twice: 280. This may happen when a cond (no else) is nested inside of another conditional, but it should be rare.
 (defmethod general-event-handler ((this bot) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (local-vars (v0-0 object))
   (case arg2
     (('track)
@@ -1078,7 +1078,7 @@
 ;; WARN: Using new Jak 2 rtype-of
 (defmethod bot-check-too-far ((this bot))
   "Call the current [[bot-waypoint]]'s `check-too-far` function if available, otherwise use the default `course` one.
-If the player is too far, play a warning speech."
+   If the player is too far, play a warning speech."
   (let ((result 0))
     (let ((too-far-check (-> this delay-too-far-check)))
       (cond
@@ -1147,9 +1147,9 @@ If the player is too far, play a warning speech."
 ;; definition for method 55 of type bot
 (defmethod common-post ((this bot))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (set! (-> this travel-prev-ry) (-> this travel-prev-ry1))
   (set! (-> this travel-prev-ry1) (quaternion-y-angle (-> this root quat)))
   (let ((f0-4 (/ (the float (-> this hit-points)) (the float (-> this enemy-info default-hit-points)))))

--- a/test/decompiler/reference/jak2/levels/common/ai/halt/hal_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/ai/halt/hal_REF.gc
@@ -399,7 +399,7 @@
 ;; INFO: Used lq/sq
 (defmethod general-event-handler ((this hal) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('notify)
      (case (-> arg3 param 0)

--- a/test/decompiler/reference/jak2/levels/common/ai/sig/sig_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/ai/sig/sig_REF.gc
@@ -373,7 +373,7 @@
 ;; definition for method 74 of type sig
 (defmethod general-event-handler ((this sig) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('untrigger)
      (sig-plasma-method-11 (-> this plasma) #t)
@@ -395,9 +395,9 @@
 ;; definition for method 55 of type sig
 (defmethod common-post ((this sig))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((v1-2 (-> this skel top-anim frame-group)))
     (cond
       ((time-elapsed? (-> this danger-time) (seconds 2))

--- a/test/decompiler/reference/jak2/levels/common/airlock_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/airlock_REF.gc
@@ -841,11 +841,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this com-airlock-outer) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -921,11 +921,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this com-airlock-inner) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -1018,11 +1018,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fort-entry-gate) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -1096,11 +1096,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hip-door-a) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -1176,11 +1176,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-mar-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s5-0 (the-as uint 0) (the-as uint 0))))
@@ -1260,11 +1260,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pal-throne-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -1339,11 +1339,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this vin-door-ctyinda) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -1418,11 +1418,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -1497,11 +1497,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this oracle-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))

--- a/test/decompiler/reference/jak2/levels/common/battle_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/battle_REF.gc
@@ -1995,11 +1995,11 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-from-entity! ((this battle) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (logior! (-> this mask) (process-mask enemy))
   (let ((s4-0 (new 'process 'trsqv)))
     (set! (-> this root) s4-0)

--- a/test/decompiler/reference/jak2/levels/common/elec-gate_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/elec-gate_REF.gc
@@ -773,7 +773,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod set-elec-scale-if-close! ((this elec-gate) (arg0 float))
   "If [[target]]'s position is within `80` [[meters]], set the scale to the value provided
-@see [[elec-gate::29]]"
+   @see [[elec-gate::29]]"
   (if (< (vector-vector-distance (-> this root trans) (target-pos 0)) 327680.0)
       (set-elec-scale! this arg0)
       )
@@ -855,9 +855,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod set-state! ((this elec-gate))
   "If either [[actor-option::17]] is set on the [[elec-gate]] or the related subtask is completed
-make the gate `idle`.
-
-Otherwise, the gate will be `active`."
+   make the gate `idle`.
+   
+   Otherwise, the gate will be `active`."
   (if (or (logtest? (actor-option user17) (-> this fact options))
           (and (-> this entity) (logtest? (-> this entity extra perm status) (entity-perm-status subtask-complete)))
           )
@@ -872,11 +872,11 @@ Otherwise, the gate will be `active`."
 ;; INFO: Used lq/sq
 (defmethod init-from-entity! ((this elec-gate) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (set! (-> this entity) arg0)
@@ -974,8 +974,8 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defmethod set-elec-scale! ((this fort-elec-gate) (scale float))
   "Calls associated mood functions to set the scale with the value provided
-@see mood-funcs
-@see mood-funcs2"
+   @see mood-funcs
+   @see mood-funcs2"
   (set-fordumpa-electricity-scale! scale)
   (set-forresca-electricity-scale! scale (-> this palette-id))
   (set-forrescb-electricity-scale! scale (-> this palette-id))
@@ -1016,8 +1016,8 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defmethod set-elec-scale! ((this drill-elec-gate) (arg0 float))
   "Calls associated mood functions to set the scale with the value provided
-@see mood-funcs
-@see mood-funcs2"
+   @see mood-funcs
+   @see mood-funcs2"
   (set-drill-electricity-scale! arg0 (-> this palette-id))
   0
   (none)
@@ -1072,8 +1072,8 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defmethod set-elec-scale! ((this castle-elec-gate) (arg0 float))
   "Calls associated mood functions to set the scale with the value provided
-@see mood-funcs
-@see mood-funcs2"
+   @see mood-funcs
+   @see mood-funcs2"
   (set-castle-electricity-scale! arg0)
   0
   (none)
@@ -1154,8 +1154,8 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defmethod set-elec-scale! ((this palroof-elec-gate) (arg0 float))
   "Calls associated mood functions to set the scale with the value provided
-@see mood-funcs
-@see mood-funcs2"
+   @see mood-funcs
+   @see mood-funcs2"
   (set-palroof-electricity-scale! arg0 (-> this palette-id))
   0
   (none)

--- a/test/decompiler/reference/jak2/levels/common/enemy/amphibian/amphibian_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/amphibian/amphibian_REF.gc
@@ -342,7 +342,7 @@
 ;; definition for method 74 of type amphibian
 (defmethod general-event-handler ((this amphibian) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit-knocked)
      (logclear! (-> this mask) (process-mask actor-pause))
@@ -963,9 +963,9 @@
 ;; definition for method 55 of type amphibian
 (defmethod common-post ((this amphibian))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (set! (-> this prev-ry) (-> this prev-ry1))
   (set! (-> this prev-ry1) (quaternion-y-angle (-> this root quat)))
   ((method-of-type nav-enemy common-post) this)

--- a/test/decompiler/reference/jak2/levels/common/enemy/bouncer_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/bouncer_REF.gc
@@ -240,11 +240,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this bouncer) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this mods) #f)
   (bouncer-method-24 this)
   (process-drawable-from-entity! this arg0)

--- a/test/decompiler/reference/jak2/levels/common/enemy/centurion_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/centurion_REF.gc
@@ -492,7 +492,7 @@
 ;; definition for method 74 of type centurion
 (defmethod general-event-handler ((this centurion) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('jump)
      #f
@@ -979,9 +979,9 @@
 ;; INFO: Used lq/sq
 (defmethod common-post ((this centurion))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (rlet ((acc :class vf)
          (vf0 :class vf)
          (vf4 :class vf)

--- a/test/decompiler/reference/jak2/levels/common/enemy/fodder/fodder_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/fodder/fodder_REF.gc
@@ -249,7 +249,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod look-at-target! ((this fodder) (arg0 enemy-flag))
   "Logic for looking at the target that is locked on, sets some flags and adjusts the neck to look at the target if available
-@param flag Reacts to [[enemy-flag::death-start]] and [[enemy-flag::enable-on-active]], see implementation for details"
+   @param flag Reacts to [[enemy-flag::death-start]] and [[enemy-flag::enable-on-active]], see implementation for details"
   (let ((parent-method (method-of-type nav-enemy look-at-target!)))
     (parent-method this arg0)
     )
@@ -283,8 +283,8 @@
 ;; definition for method 179 of type fodder
 (defmethod look-at-position! ((this fodder) (position vector))
   "Adjusts the eyes to look at particular position, or the focused target
-@param position If this is provided, it will be used with [[joint-mod::target-set!]] to adjust the eyes, otherwise the `focus` position is used
-@return TODO - unsure what the return value is, but it seems to make the eyes more lazy"
+   @param position If this is provided, it will be used with [[joint-mod::target-set!]] to adjust the eyes, otherwise the `focus` position is used
+   @return TODO - unsure what the return value is, but it seems to make the eyes more lazy"
   (when (not position)
     (let ((focus-proc (handle->process (-> this focus handle))))
       (if focus-proc
@@ -370,9 +370,9 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod common-post ((this fodder))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((parent-method (method-of-type nav-enemy common-post)))
     (parent-method this)
     )

--- a/test/decompiler/reference/jak2/levels/common/enemy/grenadier_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/grenadier_REF.gc
@@ -314,7 +314,7 @@
 ;; definition for method 74 of type grenadier
 (defmethod general-event-handler ((this grenadier) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit-knocked)
      (when (= (-> this incoming knocked-type) (knocked-type knocked-type-4))
@@ -1186,9 +1186,9 @@
 ;; definition for method 55 of type grenadier
 (defmethod common-post ((this grenadier))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((t9-0 (method-of-type nav-enemy common-post)))
     (t9-0 this)
     )

--- a/test/decompiler/reference/jak2/levels/common/enemy/grunt_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/grunt_REF.gc
@@ -394,7 +394,7 @@
 ;; definition for method 74 of type grunt
 (defmethod general-event-handler ((this grunt) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit 'hit-knocked)
      (logclear! (-> this mask) (process-mask actor-pause))

--- a/test/decompiler/reference/jak2/levels/common/enemy/guards/crimson-guard-level_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/guards/crimson-guard-level_REF.gc
@@ -1213,7 +1213,7 @@
 ;; definition for method 74 of type crimson-guard-level
 (defmethod general-event-handler ((this crimson-guard-level) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('event-death)
      (when (<= (-> this hit-points) 0)
@@ -1580,9 +1580,9 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod common-post ((this crimson-guard-level))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((t9-0 (method-of-type nav-enemy common-post)))
     (t9-0 this)
     )

--- a/test/decompiler/reference/jak2/levels/common/enemy/guards/guard-conversation_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/guards/guard-conversation_REF.gc
@@ -414,11 +414,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this guard-conversation) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (set! (-> this triggered?) #f)
   (set! (-> this root) (new 'process 'trsqv))

--- a/test/decompiler/reference/jak2/levels/common/enemy/guards/transport-level_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/guards/transport-level_REF.gc
@@ -357,11 +357,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this transport-level) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (transport-level-method-31 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/common/enemy/hover/crimson-guard-hover_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/hover/crimson-guard-hover_REF.gc
@@ -1181,7 +1181,7 @@
 ;; definition for method 74 of type crimson-guard-hover
 (defmethod general-event-handler ((this crimson-guard-hover) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (local-vars (v1-15 enemy-flag))
   (case arg2
     (('attack-invinc)
@@ -1412,9 +1412,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod common-post ((this crimson-guard-hover))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (seek! (-> this gun-x-angle) (-> this gun-x-angle-final) (* 21845.334 (seconds-per-frame)))
   (let* ((s5-0 (hover-nav-control-method-16 (-> this hover) (new 'stack-no-clear 'vector)))
          (s4-0

--- a/test/decompiler/reference/jak2/levels/common/enemy/hover/flamer_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/hover/flamer_REF.gc
@@ -265,7 +265,7 @@
 ;; INFO: Used lq/sq
 (defmethod general-event-handler ((this flamer) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit 'hit-flinch 'hit-knocked)
      (logclear! (-> this mask) (process-mask actor-pause))
@@ -621,9 +621,9 @@
 ;; definition for method 55 of type flamer
 (defmethod common-post ((this flamer))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (update-vol! (-> this sound) (-> this sound-volume))
   (flamer-method-191 this)
   ((method-of-type nav-enemy common-post) this)

--- a/test/decompiler/reference/jak2/levels/common/enemy/hover/hover-enemy_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/hover/hover-enemy_REF.gc
@@ -5,7 +5,7 @@
 ;; INFO: Used lq/sq
 (defmethod general-event-handler ((this hover-enemy) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (local-vars (v1-41 float))
   (rlet ((acc :class vf)
          (vf0 :class vf)
@@ -308,9 +308,9 @@
 ;; definition for method 55 of type hover-enemy
 (defmethod common-post ((this hover-enemy))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (hover-enemy-method-148 this)
   (enemy-method-129 this)
   (let ((t9-2 (method-of-type enemy common-post)))

--- a/test/decompiler/reference/jak2/levels/common/enemy/hover/hover-formation_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/hover/hover-formation_REF.gc
@@ -698,11 +698,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hover-formation) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-32 structure))
   (set! (-> this path) (new 'process 'path-control this 'path 0.0 (-> this entity) #f))
   (logior! (-> this path flags) (path-control-flag display draw-line draw-point draw-text))

--- a/test/decompiler/reference/jak2/levels/common/enemy/hover/wasp_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/hover/wasp_REF.gc
@@ -474,7 +474,7 @@
 ;; definition for method 74 of type wasp
 (defmethod general-event-handler ((this wasp) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit 'hit-knocked)
      (logclear! (-> this mask) (process-mask actor-pause))
@@ -582,9 +582,9 @@
 ;; definition for method 55 of type wasp
 (defmethod common-post ((this wasp))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (seek! (-> this gun-x-angle) (-> this gun-x-angle-final) (* 21845.334 (seconds-per-frame)))
   ((method-of-type hover-enemy common-post) this)
   (none)

--- a/test/decompiler/reference/jak2/levels/common/enemy/metalmonk_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/metalmonk_REF.gc
@@ -421,9 +421,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod common-post ((this metalmonk))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((t9-0 (method-of-type nav-enemy common-post)))
     (t9-0 this)
     )
@@ -436,7 +436,7 @@
 ;; definition for method 74 of type metalmonk
 (defmethod general-event-handler ((this metalmonk) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit 'hit-knocked 'hit-flinch)
      (logclear! (-> this mask) (process-mask actor-pause))

--- a/test/decompiler/reference/jak2/levels/common/enemy/spyder_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/enemy/spyder_REF.gc
@@ -299,7 +299,7 @@
 ;; definition for method 74 of type spyder
 (defmethod general-event-handler ((this spyder) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit-knocked)
      (logclear! (-> this mask) (process-mask actor-pause))
@@ -714,9 +714,9 @@
 ;; definition for method 55 of type spyder
 (defmethod common-post ((this spyder))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (spyder-method-185 this)
   (spyder-method-184 this (vector-z-quaternion! (new 'stack-no-clear 'vector) (-> this root quat)))
   (update-trans! (-> this sound) (-> this root trans))

--- a/test/decompiler/reference/jak2/levels/common/entities/com-elevator_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/entities/com-elevator_REF.gc
@@ -43,10 +43,10 @@
 ;; definition for method 43 of type com-elevator
 (defmethod move-between-points ((this com-elevator) (arg0 vector) (arg1 float) (arg2 float))
   "Move between two points on the elevator's path
-@param vec TODO not sure
-@param point-a The first point fetched from the elevator's path
-@param point-b The second point fetched from the path
-@see [[path-control]] and [[elevator]]"
+   @param vec TODO not sure
+   @param point-a The first point fetched from the elevator's path
+   @param point-b The second point fetched from the path
+   @see [[path-control]] and [[elevator]]"
   (let ((s4-0 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) arg1 'interp))
         (a0-3 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) arg2 'interp))
         (v1-3 (-> this root trans))
@@ -204,7 +204,7 @@
 ;; WARN: Return type mismatch sound-id vs none.
 (defmethod init-plat! ((this com-elevator))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   (dotimes (s5-0 (-> this path curve num-cverts))
     (let ((a1-1 (res-lump-struct (-> this entity) 'string-startup-vector structure :time (the float s5-0))))
       (cond
@@ -352,7 +352,7 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; WARN: Return type mismatch sound-id vs none.
 (defmethod init-plat! ((this tomb-trans-elevator))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   (call-parent-method this)
   (set! (-> this sound-id) (new-sound-id))
   (none)

--- a/test/decompiler/reference/jak2/levels/common/entities/fort-floor-spike_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/entities/fort-floor-spike_REF.gc
@@ -221,11 +221,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fort-floor-spike) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-spike-collision! this)
   (process-drawable-from-entity! this arg0)
   (init-spike-joints! this)

--- a/test/decompiler/reference/jak2/levels/common/entities/gun-buoy_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/entities/gun-buoy_REF.gc
@@ -932,7 +932,7 @@
 ;; definition for method 74 of type gun-buoy
 (defmethod general-event-handler ((this gun-buoy) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('jump)
      #f
@@ -948,9 +948,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod common-post ((this gun-buoy))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (-> this root)
   (let* ((s4-0 *target*)
          (s5-0 (if (type? s4-0 process-focusable)
@@ -1036,10 +1036,10 @@
 ;; WARN: disable def twice: 40. This may happen when a cond (no else) is nested inside of another conditional, but it should be rare.
 (defmethod in-aggro-range? ((this gun-buoy) (arg0 process-focusable) (arg1 vector))
   "Should the enemy activate.
-- if `activate-distance` is `0.0`, always true
-- otherwise, check if the provided process is close enough
-@param proc The process used to distance check
-@returns true/false"
+   - if `activate-distance` is `0.0`, always true
+   - otherwise, check if the provided process is close enough
+   @param proc The process used to distance check
+   @returns true/false"
   (local-vars (v1-19 process-focusable) (f30-1 meters))
   (if (and arg0 (not arg1))
       (set! arg1 (get-trans arg0 0))

--- a/test/decompiler/reference/jak2/levels/common/entities/spydroid_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/entities/spydroid_REF.gc
@@ -671,9 +671,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod common-post ((this spydroid))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((t9-0 (method-of-type nav-enemy common-post)))
     (t9-0 this)
     )
@@ -771,7 +771,7 @@
 ;; INFO: Used lq/sq
 (defmethod general-event-handler ((this spydroid) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (local-vars (v1-6 vector) (sv-144 vector))
   (rlet ((vf0 :class vf)
          (vf4 :class vf)

--- a/test/decompiler/reference/jak2/levels/common/scene-actor_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/scene-actor_REF.gc
@@ -322,7 +322,7 @@
 ;; definition for method 35 of type kor-npc
 (defmethod get-art-elem ((this kor-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (case (-> this task actor)
     (((game-task-actor kor-hideout))
      (-> this draw art-group data 5)
@@ -388,11 +388,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this metalkor-highres) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -471,7 +471,7 @@ This commonly includes things such as:
 ;; definition for method 35 of type tess-npc
 (defmethod get-art-elem ((this tess-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (case (-> this task actor)
     (((game-task-actor tess-alley))
      (if (task-node-closed? (game-task-node ruins-tower-resolution))
@@ -526,7 +526,6 @@ This commonly includes things such as:
   )
 
 ;; definition for method 3 of type keira-npc
-;; INFO: this function exists in multiple non-identical object files
 (defmethod inspect ((this keira-npc))
   (when (not this)
     (set! this this)
@@ -540,10 +539,9 @@ This commonly includes things such as:
   )
 
 ;; definition for method 35 of type keira-npc
-;; INFO: this function exists in multiple non-identical object files
 (defmethod get-art-elem ((this keira-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (case (-> this task actor)
     (((game-task-actor keira-stadium))
      (-> this draw art-group data 3)
@@ -555,7 +553,6 @@ This commonly includes things such as:
   )
 
 ;; definition for method 33 of type keira-npc
-;; INFO: this function exists in multiple non-identical object files
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-art! ((this keira-npc))
   "@see [[initialize-skeleton]]"
@@ -590,7 +587,7 @@ This commonly includes things such as:
 ;; definition for method 35 of type krew-npc
 (defmethod get-art-elem ((this krew-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (-> this draw art-group data 4)
   )
 
@@ -643,7 +640,7 @@ This commonly includes things such as:
 ;; definition for method 35 of type kid-npc
 (defmethod get-art-elem ((this kid-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (case (-> this task actor)
     (((game-task-actor kid-alley))
      (-> this draw art-group data 5)
@@ -681,7 +678,7 @@ This commonly includes things such as:
 ;; definition for method 35 of type crocadog-npc
 (defmethod get-art-elem ((this crocadog-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (case (-> this task actor)
     (((game-task-actor crocadog-vinroom))
      (-> this draw art-group data 5)
@@ -744,7 +741,7 @@ This commonly includes things such as:
 ;; definition for method 35 of type torn-npc
 (defmethod get-art-elem ((this torn-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (cond
     ((task-node-open? (game-task-node ruins-tower-introduction))
      (-> this draw art-group data 5)
@@ -835,7 +832,7 @@ This commonly includes things such as:
 ;; definition for method 35 of type youngsamos-npc
 (defmethod get-art-elem ((this youngsamos-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (case (-> this task actor)
     (((game-task-actor youngsamos-forest))
      (-> this draw art-group data 4)
@@ -896,7 +893,7 @@ This commonly includes things such as:
 ;; definition for method 35 of type samos-npc
 (defmethod get-art-elem ((this samos-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (case (-> this task actor)
     (((game-task-actor samos-hideout))
      (-> this draw art-group data 4)
@@ -945,7 +942,7 @@ This commonly includes things such as:
 ;; definition for method 35 of type onin-npc
 (defmethod get-art-elem ((this onin-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (let ((v1-1 (get-current-task-event (-> this task))))
     (case (-> v1-1 action)
       (((game-task-action play))
@@ -1028,7 +1025,7 @@ This commonly includes things such as:
 ;; definition for method 35 of type pecker-npc
 (defmethod get-art-elem ((this pecker-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (local-vars (s5-0 art-joint-anim) (f30-0 float))
   (cond
     ((logtest? (-> (get-current-task-event (-> this task)) flags) (game-task-flags gatflag-02))
@@ -1139,7 +1136,7 @@ This commonly includes things such as:
 ;; definition for method 35 of type ashelin-npc
 (defmethod get-art-elem ((this ashelin-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (case (-> this task actor)
     (((game-task-actor ashelin-throne))
      (logior! (-> this draw status) (draw-control-status no-draw-bounds))
@@ -1188,7 +1185,7 @@ This commonly includes things such as:
 ;; definition for method 35 of type daxter-npc
 (defmethod get-art-elem ((this daxter-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (-> this draw art-group data 3)
   )
 
@@ -1287,9 +1284,9 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defun intro-play ()
   "A dedicated function for playing the intro cutscenes in the correct order
-```opengoal
-\"intro-samos-hut\" \"intro-vortex\" \"intro-city-square\" \"intro-prison\"
-```"
+   ```opengoal
+   \"intro-samos-hut\" \"intro-vortex\" \"intro-city-square\" \"intro-prison\"
+   ```"
   (set! (-> *setting-control* user-default border-mode) #t)
   (set! (-> *level* play?) (-> *setting-control* user-default border-mode))
   (process-spawn
@@ -1307,9 +1304,9 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defun outro-play ()
   "A dedicated function for playing the intro cutscenes in the correct order
-```opengoal
-\"outro-nest\" \"outro-palace\" \"outro-hiphog\" \"outro-port\"
-```"
+   ```opengoal
+   \"outro-nest\" \"outro-palace\" \"outro-hiphog\" \"outro-port\"
+   ```"
   (set! (-> *setting-control* user-default border-mode) #t)
   (set! (-> *level* play?) (-> *setting-control* user-default border-mode))
   (process-spawn

--- a/test/decompiler/reference/jak2/levels/common/scene-looper_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/scene-looper_REF.gc
@@ -61,7 +61,7 @@
 ;; definition for function stop-loop-scene
 (defun stop-loop-scene ()
   "Kills the current [[scene-looper]]
-@see [[kill-by-type]]"
+   @see [[kill-by-type]]"
   (kill-by-type scene-looper *active-pool*)
   )
 
@@ -69,7 +69,7 @@
 ;; WARN: Return type mismatch (pointer process) vs (pointer scene-looper).
 (defun loop-scene ((scene-name symbol))
   "Stops looping the current scene, then spawns a new [[scene-looper]] for the given scene
-@see [[stop-loop-scene]"
+   @see [[stop-loop-scene]"
   (stop-loop-scene)
   (process-spawn scene-looper scene-name)
   )

--- a/test/decompiler/reference/jak2/levels/common/warp-gate_REF.gc
+++ b/test/decompiler/reference/jak2/levels/common/warp-gate_REF.gc
@@ -823,11 +823,11 @@
 ;; definition for method 11 of type warp-gate
 (defmethod init-from-entity! ((this warp-gate) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (warp-gate-init arg0 (the-as vector #f))
   (none)
   )

--- a/test/decompiler/reference/jak2/levels/consite/consite-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/consite/consite-obs_REF.gc
@@ -38,11 +38,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this consite-break-scaffold) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -115,11 +115,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this consite-bomb-elevator-hinges) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -199,11 +199,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this consite-bomb-elevator) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 1) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 2))
@@ -289,11 +289,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this consite-silo-doors) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 3))
@@ -363,7 +363,7 @@ This commonly includes things such as:
 ;; definition for method 35 of type baron-npc
 (defmethod get-art-elem ((this baron-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (case (-> this task actor)
     (((game-task-actor baron-consite))
      (-> this draw art-group data 4)

--- a/test/decompiler/reference/jak2/levels/dig/dig-digger_REF.gc
+++ b/test/decompiler/reference/jak2/levels/dig/dig-digger_REF.gc
@@ -726,11 +726,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this dig-clasp) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-sphere s4-0 (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec enemy))
@@ -786,11 +786,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this dig-clasp-b) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (when (not (task-node-closed? (game-task-node dig-knock-down-resolution)))
     (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
       (let ((v1-2 (new 'process 'collide-shape-prim-sphere s4-0 (the-as uint 0))))
@@ -1537,11 +1537,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this dig-digger) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))

--- a/test/decompiler/reference/jak2/levels/dig/dig-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/dig/dig-obs_REF.gc
@@ -730,11 +730,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this dig-log) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (set! (-> this hud-handle) (the-as handle #f))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
@@ -897,11 +897,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this dig-button) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec obstacle))

--- a/test/decompiler/reference/jak2/levels/dig/dig1-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/dig/dig1-obs_REF.gc
@@ -990,11 +990,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this dig-bomb-crate) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 penetrated-by)
           (penetrate

--- a/test/decompiler/reference/jak2/levels/dig/dig2-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/dig/dig2-obs_REF.gc
@@ -52,11 +52,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this dig-breakable-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stack-size-set! (-> this main-thread) 512)
   (logior! (-> this mask) (process-mask collectable))
   (let ((s4-0 (art-group-get-by-name *level* "skel-dig-breakable-door" (the-as (pointer uint32) #f))))

--- a/test/decompiler/reference/jak2/levels/dig/dig3-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/dig/dig3-obs_REF.gc
@@ -355,11 +355,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this dig-spikey-step) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 int))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
@@ -792,11 +792,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this dig-spikey-sphere-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -1067,11 +1067,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this dig-balloon-lurker) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 3) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 4))
@@ -1354,11 +1354,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this dig-wheel-step) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 3) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 4))
@@ -2139,11 +2139,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this dig-stomp-block-controller) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this played-fall?) #f)
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
@@ -2194,11 +2194,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this dig-totem) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec obstacle))

--- a/test/decompiler/reference/jak2/levels/drill/drill-baron_REF.gc
+++ b/test/decompiler/reference/jak2/levels/drill/drill-baron_REF.gc
@@ -1117,11 +1117,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-barons-ship) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 1) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 2))

--- a/test/decompiler/reference/jak2/levels/drill/drill-obs2_REF.gc
+++ b/test/decompiler/reference/jak2/levels/drill/drill-obs2_REF.gc
@@ -210,11 +210,11 @@
 ;; definition for method 11 of type drill-flip-step
 (defmethod init-from-entity! ((this drill-flip-step) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-plat-collision! this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton this (the-as skeleton-group (get-skel this)) (the-as pair 0))
@@ -385,11 +385,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-falling-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 3))
@@ -506,11 +506,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-sliding-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 3))
@@ -697,11 +697,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-breakable-barrel) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec obstacle))
@@ -931,11 +931,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-metalhead-eggs) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (init-collision! this)
   (process-drawable-from-entity! this arg0)
@@ -1331,11 +1331,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-bridge-shot) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 3) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 4))
@@ -1435,11 +1435,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-drill) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/drill/drill-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/drill/drill-obs_REF.gc
@@ -122,8 +122,8 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod start-bouncing! ((this drill-plat-falling))
   "Sets `bouncing` to [[#t]] and sets up the clock to periodically bounce
-and translate the platform via the `smush`
-@see [[smush-control]]"
+   and translate the platform via the `smush`
+   @see [[smush-control]]"
   (activate! (-> this smush) -1.0 24 120 1.0 1.0 (-> self clock))
   (set-time! (-> this bounce-time))
   (set! (-> this bouncing) #t)
@@ -195,11 +195,11 @@ and translate the platform via the `smush`
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-plat-falling) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> s3-0 prim-core collide-as) (collide-spec pusher))
@@ -498,10 +498,10 @@ This commonly includes things such as:
 ;; definition for method 43 of type drill-elevator
 (defmethod move-between-points ((this drill-elevator) (arg0 vector) (arg1 float) (arg2 float))
   "Move between two points on the elevator's path
-@param vec TODO not sure
-@param point-a The first point fetched from the elevator's path
-@param point-b The second point fetched from the path
-@see [[path-control]] and [[elevator]]"
+   @param vec TODO not sure
+   @param point-a The first point fetched from the elevator's path
+   @param point-b The second point fetched from the path
+   @see [[path-control]] and [[elevator]]"
   (let ((s4-0 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) arg1 'interp))
         (a0-3 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) arg2 'interp))
         (v1-3 (-> this root trans))
@@ -546,7 +546,7 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-plat! ((this drill-elevator))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   (set! (-> this shaft)
         (process-spawn drill-elevator-shaft (-> this entity extra trans) (-> this basetrans) :to this)
         )
@@ -659,8 +659,8 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; WARN: Return type mismatch int vs none.
 (defmethod move-to-next-point! ((this drill-mech-elevator))
   "If the [[*target*]] is in a valid state and there is a point to transition to in the elevator's path
-do so.
-@see [[elevator::47]]"
+   do so.
+   @see [[elevator::47]]"
   (local-vars (sv-16 float))
   (let ((a0-1 *target*))
     (when (and a0-1
@@ -698,7 +698,7 @@ do so.
 ;; definition for method 33 of type drill-mech-elevator
 (defmethod init-plat! ((this drill-mech-elevator))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   (set! (-> this running-sound-id) (new 'static 'sound-id))
   ((method-of-type drill-elevator init-plat!) this)
   (none)
@@ -950,11 +950,11 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fire-floor) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-sphere s4-0 (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec obstacle))
@@ -1670,11 +1670,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-laser) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (set! (-> this firing?) #f)
   (set! (-> this hit-sound-id) (new 'static 'sound-id))

--- a/test/decompiler/reference/jak2/levels/drill/drill-panel_REF.gc
+++ b/test/decompiler/reference/jak2/levels/drill/drill-panel_REF.gc
@@ -740,11 +740,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-control-panel) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-collision! this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -794,11 +794,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-control-panel-a) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-collision! this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/drill/drill-spool_REF.gc
+++ b/test/decompiler/reference/jak2/levels/drill/drill-spool_REF.gc
@@ -854,11 +854,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-wall) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (stack-size-set! (-> this main-thread) 512)
   (logior! (-> this mask) (process-mask collectable))
@@ -1057,11 +1057,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-crane) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag) (sv-32 res-tag))
   (stack-size-set! (-> this main-thread) 512)
   (logior! (-> this mask) (process-mask collectable))

--- a/test/decompiler/reference/jak2/levels/drill/drillmid-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/drill/drillmid-obs_REF.gc
@@ -29,11 +29,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-elevator-doors) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -122,10 +122,10 @@ This commonly includes things such as:
 ;; definition for method 43 of type drill-lift
 (defmethod move-between-points ((this drill-lift) (arg0 vector) (arg1 float) (arg2 float))
   "Move between two points on the elevator's path
-@param vec TODO not sure
-@param point-a The first point fetched from the elevator's path
-@param point-b The second point fetched from the path
-@see [[path-control]] and [[elevator]]"
+   @param vec TODO not sure
+   @param point-a The first point fetched from the elevator's path
+   @param point-b The second point fetched from the path
+   @see [[path-control]] and [[elevator]]"
   (let ((s4-0 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) arg1 'interp))
         (a0-3 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) arg2 'interp))
         (v1-3 (-> this root trans))

--- a/test/decompiler/reference/jak2/levels/drill/ginsu_REF.gc
+++ b/test/decompiler/reference/jak2/levels/drill/ginsu_REF.gc
@@ -409,9 +409,9 @@
 ;; WARN: Return type mismatch symbol vs none.
 (defmethod common-post ((this ginsu))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (ginsu-method-180 this)
   (let ((t9-1 (method-of-type nav-enemy common-post)))
     (t9-1 this)
@@ -580,7 +580,7 @@
 ;; WARN: disable def twice: 11. This may happen when a cond (no else) is nested inside of another conditional, but it should be rare.
 (defmethod general-event-handler ((this ginsu) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (local-vars (v0-1 object))
   (case arg2
     (('touched)

--- a/test/decompiler/reference/jak2/levels/forest/fish_REF.gc
+++ b/test/decompiler/reference/jak2/levels/forest/fish_REF.gc
@@ -486,11 +486,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fish-manager) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)

--- a/test/decompiler/reference/jak2/levels/forest/forest-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/forest/forest-obs_REF.gc
@@ -36,11 +36,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this forest-hover-manager) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this entity) arg0)
   (hover-enemy-manager-init! this *forest-protect-battle*)
   (set! (-> this transport-actor 0) (entity-actor-lookup arg0 'alt-actor 0))
@@ -443,11 +443,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this forest-youngsamos) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum hit-by-others))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) forest-youngsamos-bounce-reaction)

--- a/test/decompiler/reference/jak2/levels/forest/pegasus_REF.gc
+++ b/test/decompiler/reference/jak2/levels/forest/pegasus_REF.gc
@@ -239,8 +239,8 @@
 ;; WARN: Return type mismatch int vs enemy-aware.
 (defmethod update-target-awareness! ((this pegasus) (proc process-focusable) (focus enemy-best-focus))
   "Checks a variety of criteria to determine the level of awareness the enemy is of the target.  Sets `aware` and related fields as well!
-For pegasus, it will call [[enemy::57]] only if the [[pegasus]] has been targetted for more than 5 [[seconds]]
-@returns the value from [[enemy::57]], otherwise [[enemy-aware::4]]"
+   For pegasus, it will call [[enemy::57]] only if the [[pegasus]] has been targetted for more than 5 [[seconds]]
+   @returns the value from [[enemy::57]], otherwise [[enemy-aware::4]]"
   (the-as enemy-aware (if (time-elapsed? (-> this targetted-timer) (seconds 5))
                           (the-as int ((method-of-type enemy update-target-awareness!) this proc focus))
                           4
@@ -251,7 +251,7 @@ For pegasus, it will call [[enemy::57]] only if the [[pegasus]] has been targett
 ;; definition for method 74 of type pegasus
 (defmethod general-event-handler ((this pegasus) (proc process) (arg2 int) (event-type symbol) (event event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case event-type
     (('track)
      #f
@@ -291,9 +291,9 @@ For pegasus, it will call [[enemy::57]] only if the [[pegasus]] has been targett
 ;; definition for method 56 of type pegasus
 (defmethod damage-amount-from-attack ((this pegasus) (arg0 process) (arg1 event-message-block))
   "Only attacks from the jetboard will deal max damage (6), but by default it will return `1`.
-This is why the scouts are technically killable by other means
-@returns the amount of damage taken from an attack.  Also updates the `targetted-timer`.
-@see [[*pegasus-enemy-info*]]"
+   This is why the scouts are technically killable by other means
+   @returns the amount of damage taken from an attack.  Also updates the `targetted-timer`.
+   @see [[*pegasus-enemy-info*]]"
   (let ((hitpoints 1))
     (let ((attack-info (the-as attack-info (-> arg1 param 1))))
       (case (-> arg1 message)
@@ -313,10 +313,10 @@ This is why the scouts are technically killable by other means
 ;; WARN: Return type mismatch symbol vs none.
 (defbehavior pegasus-draw-section pegasus ((path-percent-a float) (path-percent-b float) (color rgba))
   "Draws the [[pegasus]] curve section between the two provided points.
-@param path-percent-a Percentage along the path for the first point
-@param path-percent-b Percentage along the path for the second point
-param color The color to draw the curve with
-@see [[curve-control]]"
+   @param path-percent-a Percentage along the path for the first point
+   @param path-percent-b Percentage along the path for the second point
+   param color The color to draw the curve with
+   @see [[curve-control]]"
   (let ((point-a (new 'stack-no-clear 'vector))
         (point-b (new 'stack-no-clear 'vector))
         )
@@ -340,9 +340,9 @@ param color The color to draw the curve with
 ;; definition for function pegasus-show-runs
 (defbehavior pegasus-show-runs pegasus ()
   "When [[*display-path-marks*]] is enabled, allow the user to cycle through the displayed path
-- Pressing [[up]] on the D-Pad will increment the path index
-- Pressing [[down]] on the D-Pad will decrement the path index
-Additional debug text will be displayed as well.  This is useful as many paths overlap other paths"
+   - Pressing [[up]] on the D-Pad will increment the path index
+   - Pressing [[down]] on the D-Pad will decrement the path index
+   Additional debug text will be displayed as well.  This is useful as many paths overlap other paths"
   (when *display-path-marks*
     (when (cpad-pressed? 0 up)
       (+! (-> self display-path) 1)
@@ -393,10 +393,10 @@ Additional debug text will be displayed as well.  This is useful as many paths o
 ;; WARN: Return type mismatch vector vs none.
 (defbehavior pegasus-rotate pegasus ((influenced-by-target? symbol) (angle float))
   "Rotates the [[pegasus]] along the path, factoring in the current speed and the target's position
-@param influenced-by-target? Whether or not to care about [[target]]'s position
-@param angle The hopeful angle to use when constructing the rotation matrix, ultimately limited to `0.25` (radians?) though
-@see [[target-pos]] and [[matrix-from-two-vectors-max-angle-partial!]]
-@TODO - `float` should be `degrees` -- The usual amount passed in is `(degrees 100.0835)`"
+   @param influenced-by-target? Whether or not to care about [[target]]'s position
+   @param angle The hopeful angle to use when constructing the rotation matrix, ultimately limited to `0.25` (radians?) though
+   @see [[target-pos]] and [[matrix-from-two-vectors-max-angle-partial!]]
+   @TODO - `float` should be `degrees` -- The usual amount passed in is `(degrees 100.0835)`"
   (let ((rotation-matrix (new 'stack-no-clear 'matrix))
         (flee-direction-vec (new 'stack-no-clear 'vector))
         )
@@ -439,14 +439,14 @@ Additional debug text will be displayed as well.  This is useful as many paths o
 ;; WARN: Return type mismatch float vs none.
 (defbehavior pegasus-loop-on-same-path pegasus ()
   "Creates an endless loop on the same path as the name suggests
-- If we are beyond the end of the path, start again near the beginning (1%)
-- If we are far before the beginning, start at the beginning (0%)
-- If we are atleast 1% into the path, step back 1%
-- If we are less than 0% somehow, slowly add 1%
-Ultimately this appears to be some sort of safe-guard to get things back into a somewhat working state
-if there are unexpected path conditions -- but the results of this are not great!
-Another potential explaination is to make it easy during development to identify and debug a bad path
-In practice, this is never called"
+   - If we are beyond the end of the path, start again near the beginning (1%)
+   - If we are far before the beginning, start at the beginning (0%)
+   - If we are atleast 1% into the path, step back 1%
+   - If we are less than 0% somehow, slowly add 1%
+   Ultimately this appears to be some sort of safe-guard to get things back into a somewhat working state
+   if there are unexpected path conditions -- but the results of this are not great!
+   Another potential explaination is to make it easy during development to identify and debug a bad path
+   In practice, this is never called"
   (cond
     ((< 100.0 (-> self curve-position))
      (set! (-> self curve-position) 1.0)
@@ -467,9 +467,9 @@ In practice, this is never called"
 ;; definition for function pegasus-choose-path
 (defbehavior pegasus-choose-path pegasus ()
   "Determines the next path the pegasus should take if we have completed the current path it's on
-There are many fail-safes here if something goes wrong to try to keep the pegasus behaving
-@see [[pegasus-look-on-same-path]]
-@TODO - understand the path selection better"
+   There are many fail-safes here if something goes wrong to try to keep the pegasus behaving
+   @see [[pegasus-look-on-same-path]]
+   @TODO - understand the path selection better"
   (local-vars (f0-15 float) (f30-0 float))
   (while (begin (label cfg-61) (or (< 1.0 (-> self curve-position)) (< (-> self curve-position) 0.0)))
     (let ((curr-pegasus-path (-> self path-info (-> self current-path)))
@@ -586,8 +586,8 @@ There are many fail-safes here if something goes wrong to try to keep the pegasu
 ;; WARN: Return type mismatch int vs none.
 (defbehavior pegasus-move pegasus ((explicit-y-vel float) (adjust-y-offset? symbol))
   "Moves the pegasus along the path by smoothly interpolating along it
-@param explicit-y-vel Normally `0.0` but this value is used when the pegasus needs to switch direction
-@param adjust-y-offset? Normally [[#f]] which forces the movement to reflect the result of the collison query - the [[pegasus]] will stay close to the ground.  [[#t]] ignores this"
+   @param explicit-y-vel Normally `0.0` but this value is used when the pegasus needs to switch direction
+   @param adjust-y-offset? Normally [[#f]] which forces the movement to reflect the result of the collison query - the [[pegasus]] will stay close to the ground.  [[#t]] ignores this"
   (+! (-> self curve-position)
       (/ (the float (* (- (current-time) (-> self clock old-frame-counter)) (the int (-> self speed))))
          (total-distance (-> self path-info (-> self current-path) path-data))
@@ -676,13 +676,13 @@ There are many fail-safes here if something goes wrong to try to keep the pegasu
 ;; definition for function pegasus-calc-speed
 (defbehavior pegasus-calc-speed pegasus ((min-dist float) (max-dist float) (max-speed float) (min-speed float))
   "Calculates the pegasus' speed based on a number of factors:
-- Speed up as the target gets closer (up to a max) and slow down as the target is further away (up to a min)
-This function also is what causes the pegasus to flip around
-@param min-dist TODO
-@param max-dist TODO
-@param max-speed The maximum speed the pegasus can go
-@param min-speed The minimum speed the pegasus can go
-@returns If there should be a reaction to the target via [[enemy::72]]"
+   - Speed up as the target gets closer (up to a max) and slow down as the target is further away (up to a min)
+   This function also is what causes the pegasus to flip around
+   @param min-dist TODO
+   @param max-dist TODO
+   @param max-speed The maximum speed the pegasus can go
+   @param min-speed The minimum speed the pegasus can go
+   @returns If there should be a reaction to the target via [[enemy::72]]"
   (let ((dir-to-target (vector-! (new 'stack-no-clear 'vector) (-> self root trans) (target-pos 0)))
         (react-to-target? #f)
         )
@@ -741,9 +741,9 @@ This function also is what causes the pegasus to flip around
 ;; definition for function pegasus-calc-anim-speed
 (defbehavior pegasus-calc-anim-speed pegasus ()
   "Based on `speed`, adjust how fast the pegasus should animate.
-The faster it's moving the fast it flaps it's wings, etc
-@TODO understand the magic values here better
-@returns The anim speed, it can be no lower than `1.5`"
+   The faster it's moving the fast it flaps it's wings, etc
+   @TODO understand the magic values here better
+   @returns The anim speed, it can be no lower than `1.5`"
   (let* ((speed-abs (fabs (-> self speed)))
          (f0-2 (* 0.07324219 speed-abs))
          (f0-3 (+ -15.0 f0-2))
@@ -756,9 +756,9 @@ The faster it's moving the fast it flaps it's wings, etc
 ;; definition for method 55 of type pegasus
 (defmethod common-post ((this pegasus))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (track-how-long-aimed-at! this)
   (pegasus-show-runs)
   ((method-of-type enemy common-post) this)
@@ -898,7 +898,7 @@ The faster it's moving the fast it flaps it's wings, etc
 ;; definition for function pegasus-fly-code
 (defbehavior pegasus-fly-code pegasus ((arg0 int))
   "Handles the flying animations and sounds
-@TODO - cleanup a bit more"
+   @TODO - cleanup a bit more"
   (let ((anim-speed (pegasus-calc-anim-speed)))
     (let ((gp-0 (and (-> self can-run) (< (the-as time-frame (-> self ambient-possible)) (current-time)))))
       (let* ((min-dist (lerp-scale 61440.0 32768.0 (the float arg0) 0.0 3000.0))

--- a/test/decompiler/reference/jak2/levels/forest/predator_REF.gc
+++ b/test/decompiler/reference/jak2/levels/forest/predator_REF.gc
@@ -461,7 +461,7 @@
 ;; definition for method 74 of type predator
 (defmethod general-event-handler ((this predator) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('attack)
      (set! (-> this shock-effect-end) (the-as uint (+ (current-time) (seconds 1))))
@@ -1390,9 +1390,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod common-post ((this predator))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((t9-0 (method-of-type nav-enemy common-post)))
     (t9-0 this)
     )
@@ -1540,11 +1540,11 @@
 ;; WARN: Return type mismatch entity-perm-status vs none.
 (defmethod init-from-entity! ((this predator) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (process-entity-status! this (entity-perm-status dead) #t)
   (none)
   )
@@ -1717,11 +1717,11 @@ This commonly includes things such as:
 ;; WARN: new jak 2 until loop case, check carefully
 (defmethod init-from-entity! ((this predator-manager) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (rlet ((acc :class vf)
          (vf0 :class vf)

--- a/test/decompiler/reference/jak2/levels/forest/wren_REF.gc
+++ b/test/decompiler/reference/jak2/levels/forest/wren_REF.gc
@@ -138,7 +138,7 @@
 ;; WARN: Return type mismatch object vs symbol.
 (defmethod spooked? ((this wren))
   "@returns a [[symbol]] indicating if Jak is considered close enough to the wren to spook it.
-If so, it transitions from [[wren::peck]] to [[wren::hunt]]"
+   If so, it transitions from [[wren::peck]] to [[wren::hunt]]"
   (let* ((gp-0 *target*)
          (a0-2 (if (type? gp-0 process-focusable)
                    gp-0
@@ -457,11 +457,11 @@ If so, it transitions from [[wren::peck]] to [[wren::hunt]]"
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this wren) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/fortress/dump/fordumpa-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/fortress/dump/fordumpa-obs_REF.gc
@@ -255,11 +255,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fort-elec-switch) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
@@ -493,11 +493,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fort-fence) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stack-size-set! (-> this main-thread) 512)
   (fort-fence-method-23 this)
   (process-drawable-from-entity! this arg0)

--- a/test/decompiler/reference/jak2/levels/fortress/dump/fordumpb-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/fortress/dump/fordumpb-obs_REF.gc
@@ -63,11 +63,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fort-plat-orbit) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)
@@ -354,11 +354,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fort-plat-shuttle) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-64 int))
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
@@ -486,7 +486,7 @@ This commonly includes things such as:
 ;; definition for method 25 of type fort-conveyor
 (defmethod set-and-get-ambient-sound! ((this fort-conveyor))
   "So long as [[actor-option::16]] is not set, fetch the [[ambient-sound]] for the [[conveyor]]
-and return it as well.  Otherwise, set it to `0`"
+   and return it as well.  Otherwise, set it to `0`"
   (let* ((s5-0 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) 0.0 'interp))
          (v1-2 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) 1.0 'interp))
          (a3-3 (vector+! (new 'stack-no-clear 'vector) s5-0 v1-2))

--- a/test/decompiler/reference/jak2/levels/fortress/dump/fordumpc-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/fortress/dump/fordumpc-obs_REF.gc
@@ -163,11 +163,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fort-dump-bomb-a) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec bot))
@@ -992,11 +992,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fort-missile) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stack-size-set! (-> this main-thread) 512)
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))

--- a/test/decompiler/reference/jak2/levels/fortress/dump/fort-robotank_REF.gc
+++ b/test/decompiler/reference/jak2/levels/fortress/dump/fort-robotank_REF.gc
@@ -1100,11 +1100,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fort-robotank) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)

--- a/test/decompiler/reference/jak2/levels/fortress/exit/forexita-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/fortress/exit/forexita-obs_REF.gc
@@ -214,7 +214,7 @@
 ;; WARN: Return type mismatch sound-id vs none.
 (defmethod init-plat! ((this fort-lift-plat))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   (set! (-> this root pause-adjust-distance) 327680.0)
   (set! (-> this sound-id) (new-sound-id))
   (none)
@@ -231,9 +231,9 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; definition for method 36 of type fort-lift-plat
 (defmethod plat-path-sync ((this fort-lift-plat))
   "If the `sync` period is greater than `0` then transition the state to [[plat::35]]
-otherwise, [[plat::34]]
-
-@see [[sync-eased]]"
+   otherwise, [[plat::34]]
+   
+   @see [[sync-eased]]"
   (cond
     ((logtest? (-> this path flags) (path-control-flag not-found))
      (go (method-of-object this plat-idle))
@@ -326,11 +326,11 @@ otherwise, [[plat::34]]
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fort-claw) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/fortress/fort-turret_REF.gc
+++ b/test/decompiler/reference/jak2/levels/fortress/fort-turret_REF.gc
@@ -560,9 +560,9 @@
 ;; definition for method 55 of type fort-turret
 (defmethod common-post ((this fort-turret))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((t9-0 (method-of-type enemy common-post)))
     (t9-0 this)
     )
@@ -921,7 +921,7 @@
 ;; definition for method 74 of type fort-turret
 (defmethod general-event-handler ((this fort-turret) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (if (and (= arg2 'notify) (< 1 arg1) (= (-> arg3 param 0) 'attack) (= (-> arg3 param 1) *target*))
       (set-time! (-> this last-hit-time))
       )
@@ -1018,7 +1018,7 @@
 ;; WARN: Return type mismatch int vs penetrate.
 (defmethod get-penetrate-info ((this fort-turret))
   "@returns the allowed way(s) this enemy can take damage
-@see [[penetrate]] and [[penetrated-by-all&hit-points->penetrated-by]]"
+   @see [[penetrate]] and [[penetrated-by-all&hit-points->penetrated-by]]"
   (the-as penetrate 0)
   )
 

--- a/test/decompiler/reference/jak2/levels/fortress/fortress-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/fortress/fortress-obs_REF.gc
@@ -158,11 +158,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fort-trap-door) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((prim-mesh (new 'process 'collide-shape-prim-mesh cshape (the-as uint 0) (the-as uint 0))))
       (set! (-> prim-mesh prim-core collide-as) (collide-spec obstacle))

--- a/test/decompiler/reference/jak2/levels/fortress/prison/prison-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/fortress/prison/prison-obs_REF.gc
@@ -265,11 +265,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this prsn-hang-cell) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -448,11 +448,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this prsn-cell-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec obstacle))
@@ -531,11 +531,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this prsn-vent-fan) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -592,11 +592,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this prsn-torture) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 penetrated-by) (penetrate))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 9) 0)))

--- a/test/decompiler/reference/jak2/levels/fortress/rescue/forresca-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/fortress/rescue/forresca-obs_REF.gc
@@ -198,11 +198,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fort-led) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -429,9 +429,9 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod set-state! ((this elec-lock-gate))
   "If either [[actor-option::17]] is set on the [[elec-gate]] or the related subtask is completed
-make the gate `idle`.
-
-Otherwise, the gate will be `active`."
+   make the gate `idle`.
+   
+   Otherwise, the gate will be `active`."
   (if (elec-lock-gate-method-31 this #f)
       (go (method-of-object this shutdown))
       ((method-of-type fort-elec-gate set-state!) this)

--- a/test/decompiler/reference/jak2/levels/fortress/rescue/forrescb-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/fortress/rescue/forrescb-obs_REF.gc
@@ -49,11 +49,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fort-twist-rail) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)
@@ -584,11 +584,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fort-elec-belt) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-64 int))
   (quaternion-copy! (-> this init-quat) (-> arg0 quat))
   (let ((s5-0 (new 'stack-no-clear 'sync-info-params)))
@@ -726,7 +726,7 @@ This commonly includes things such as:
 ;; definition for method 25 of type fort-conveyor
 (defmethod set-and-get-ambient-sound! ((this fort-conveyor))
   "So long as [[actor-option::16]] is not set, fetch the [[ambient-sound]] for the [[conveyor]]
-and return it as well.  Otherwise, set it to `0`"
+   and return it as well.  Otherwise, set it to `0`"
   (let* ((s5-0 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) 0.0 'interp))
          (v1-2 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) 1.0 'interp))
          (a3-3 (vector+! (new 'stack-no-clear 'vector) s5-0 v1-2))

--- a/test/decompiler/reference/jak2/levels/gungame/gun-dummy_REF.gc
+++ b/test/decompiler/reference/jak2/levels/gungame/gun-dummy_REF.gc
@@ -2050,10 +2050,10 @@
 ;; INFO: Used lq/sq
 (defmethod path-playing? ((this gun-dummy))
   "Core functionality for playing back the dummy's path.  Does things like:
-- calculates the score in case the dummy is hit based on the time elapsed
-- moves around the dummy
-- plays sounds accordingly
-@returns if the dummy's current path is still in progress"
+   - calculates the score in case the dummy is hit based on the time elapsed
+   - moves around the dummy
+   - plays sounds accordingly
+   @returns if the dummy's current path is still in progress"
   (local-vars (at-0 int) (ret symbol))
   (with-pp
     (rlet ((acc :class vf)
@@ -2469,11 +2469,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this gun-dummy) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-dummy-collison! this)
   (process-drawable-from-entity! this arg0)
   (logclear! (-> this mask) (process-mask actor-pause))

--- a/test/decompiler/reference/jak2/levels/gungame/gungame-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/gungame/gungame-obs_REF.gc
@@ -212,11 +212,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this training-path) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (length "training-path-"))
         (a0-3 (length (-> this name)))
         (v1-2 0)
@@ -2224,11 +2224,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this training-manager) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (set-setting! 'darkjak #f 0.0 0)
   (set! sv-16 (new 'static 'res-tag))
@@ -2520,11 +2520,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this gungame-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)

--- a/test/decompiler/reference/jak2/levels/hideout/hideout-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/hideout/hideout-obs_REF.gc
@@ -30,11 +30,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hide-door-b) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -173,11 +173,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hide-light) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (logior! (-> this mask) (process-mask ambient))
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)

--- a/test/decompiler/reference/jak2/levels/hiphog/hiphog-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/hiphog/hiphog-obs_REF.gc
@@ -39,11 +39,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hip-trophy-a) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -98,11 +98,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hip-trophy-d) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -157,11 +157,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hip-trophy-f) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -216,11 +216,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hip-trophy-g) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -275,11 +275,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hip-trophy-i) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -334,11 +334,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hip-trophy-j) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -393,11 +393,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hip-trophy-n) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -452,11 +452,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hip-trophy-m) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/hiphog/hiphog-part_REF.gc
+++ b/test/decompiler/reference/jak2/levels/hiphog/hiphog-part_REF.gc
@@ -1231,8 +1231,8 @@
                         (arg4 sparticle-launch-state)
                         )
   "Determines the position of the minute hand of the hiphog's clock associated with [[time-of-day-proc]]
-TODO - check args
-Every real second is 1 minute in Jak's time of day"
+   TODO - check args
+   Every real second is 1 minute in Jak's time of day"
   (local-vars (v1-4 float) (v1-5 float))
   (rlet ((vf0 :class vf)
          (vf1 :class vf)
@@ -1284,8 +1284,8 @@ Every real second is 1 minute in Jak's time of day"
                       (arg4 sparticle-launch-state)
                       )
   "Determines the position of the hour hand of the hiphog's clock associated with [[time-of-day-proc]]
-TODO - check args
-Every real minute is 1 hour in Jak's time of day"
+   TODO - check args
+   Every real minute is 1 hour in Jak's time of day"
   (local-vars (v1-4 float) (v1-5 float))
   (rlet ((vf0 :class vf)
          (vf1 :class vf)
@@ -1337,9 +1337,9 @@ Every real minute is 1 hour in Jak's time of day"
                         (arg4 sparticle-launch-state)
                         )
   "Determines the position of the second hand of the hiphog's clock associated with [[time-of-day-proc]]
-TODO - check args
-The clock actually only has 2 hands, this one does not appear to have been used?
-Every real second is 1/60th of a second in Jak's time of day"
+   TODO - check args
+   The clock actually only has 2 hands, this one does not appear to have been used?
+   Every real second is 1/60th of a second in Jak's time of day"
   (local-vars (v1-4 float) (v1-5 float))
   (rlet ((vf0 :class vf)
          (vf1 :class vf)
@@ -1610,7 +1610,7 @@ Every real second is 1/60th of a second in Jak's time of day"
 ;; WARN: Return type mismatch int vs none.
 (defun hiphog-mirror-sheen-func ((arg0 sparticle-system) (arg1 sparticle-cpuinfo) (arg2 matrix))
   "Handles the effect on the hiphogs mirror, which involves using [[*hiphog-mirror-sheen-waveform*]]
-TODO on args and some more documentation"
+   TODO on args and some more documentation"
   (let ((s5-0 (new 'stack-no-clear 'vector)))
     (set-vector! s5-0 -1515.52 0.0 -95436.8 1.0)
     (vector-! s5-0 (camera-pos) s5-0)

--- a/test/decompiler/reference/jak2/levels/hiphog/hiphog-scenes_REF.gc
+++ b/test/decompiler/reference/jak2/levels/hiphog/hiphog-scenes_REF.gc
@@ -29,11 +29,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hip-door-b) (entiy entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> cshape penetrated-by) (penetrate))
     (let ((cshape-group (new 'process 'collide-shape-prim-group cshape (the-as uint 2) 0)))
@@ -131,7 +131,7 @@ This commonly includes things such as:
 ;; definition for method 35 of type hip-whack-a-metal
 (defmethod get-art-elem ((this hip-whack-a-metal))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (case (-> (get-current-task-event (-> this task)) action)
     (((game-task-action play))
      (set! (-> this talk-message) (text-id press-triangle-to-play))
@@ -214,11 +214,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hip-mirror) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this entity)
   (initialize-skeleton
@@ -419,7 +419,7 @@ This commonly includes things such as:
 ;; definition for method 35 of type sig-npc
 (defmethod get-art-elem ((this sig-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (if (task-node-open? (game-task-node forest-hunt-introduction))
       (-> this draw art-group data 4)
       (-> this draw art-group data 4)

--- a/test/decompiler/reference/jak2/levels/intro/intro-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/intro/intro-obs_REF.gc
@@ -224,11 +224,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this intro-flamer) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -398,11 +398,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this metalhead-spawner) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this init-pos quad) (-> arg0 extra trans quad))
   (vector-reset! (-> this average-dir))
   (dotimes (s5-0 19)
@@ -470,11 +470,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this vil-windmill-sail) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/mountain/canyon/mincan-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/mountain/canyon/mincan-obs_REF.gc
@@ -123,11 +123,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mincan-lighthouse-lens) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -232,11 +232,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mincan-lighthouse) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -321,11 +321,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mincan-lens) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((prim-group (new 'process 'collide-shape-prim-group cshape (the-as uint 7) 0)))
       (set! (-> cshape total-prims) (the-as uint 8))
@@ -449,11 +449,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mincan-cogs) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/mountain/mountain-obs2_REF.gc
+++ b/test/decompiler/reference/jak2/levels/mountain/mountain-obs2_REF.gc
@@ -74,11 +74,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-iris-door) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((prim-mesh (new 'process 'collide-shape-prim-mesh cshape (the-as uint 0) (the-as uint 0))))
       (set! (-> prim-mesh prim-core collide-as) (collide-spec obstacle))
@@ -195,7 +195,7 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-plat! ((this mtn-plat-shoot))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   (logclear! (-> this mask) (process-mask actor-pause))
   (logior! (-> this mask) (process-mask enemy))
   (set-vector! (-> this axe-flip) 1.0 0.0 0.0 1.0)

--- a/test/decompiler/reference/jak2/levels/mountain/mountain-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/mountain/mountain-obs_REF.gc
@@ -1367,11 +1367,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-dice) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 6) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 7))
@@ -1555,10 +1555,10 @@ This commonly includes things such as:
 ;; definition for method 43 of type mtn-plat-elevator
 (defmethod move-between-points ((this mtn-plat-elevator) (arg0 vector) (arg1 float) (arg2 float))
   "Move between two points on the elevator's path
-@param vec TODO not sure
-@param point-a The first point fetched from the elevator's path
-@param point-b The second point fetched from the path
-@see [[path-control]] and [[elevator]]"
+   @param vec TODO not sure
+   @param point-a The first point fetched from the elevator's path
+   @param point-b The second point fetched from the path
+   @see [[path-control]] and [[elevator]]"
   (let ((s4-0 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) arg1 'interp))
         (a0-3 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) arg2 'interp))
         )
@@ -1686,11 +1686,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-plat-updown) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-plat-collision! this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -1843,11 +1843,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-plat-eject) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (mtn-plat-eject-method-22 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -1954,11 +1954,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-plat-long) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-plat-collision! this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -2065,11 +2065,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-gate) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 3))
@@ -2561,11 +2561,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-aval-rocks) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 collide-shape-prim-sphere) (sv-48 collide-shape-prim-sphere) (sv-64 vector))
   (stack-size-set! (-> this main-thread) 512)
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
@@ -2892,11 +2892,11 @@ This commonly includes things such as:
 ;; definition for method 11 of type mtn-plat-return
 (defmethod init-from-entity! ((this mtn-plat-return) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-plat-collision! this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -3094,11 +3094,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-button) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 3))
@@ -3215,11 +3215,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-gear-device) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (cond
     ((task-complete? *game-info* (game-task mountain-gear))
      (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
@@ -3546,7 +3546,7 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch float vs none.
 (defmethod init-plat! ((this trans-plat))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   (logior! (-> this flags) (mtn-plat-flags mtpflags-1))
   (let* ((s5-0 *target*)
          (a0-2 (if (type? s5-0 process-focusable)

--- a/test/decompiler/reference/jak2/levels/mountain/mountain-scenes_REF.gc
+++ b/test/decompiler/reference/jak2/levels/mountain/mountain-scenes_REF.gc
@@ -1754,11 +1754,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-plat-buried-rocks) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((prim-mesh (new 'process 'collide-shape-prim-mesh cshape (the-as uint 0) (the-as uint 0))))
       (set! (-> prim-mesh prim-core collide-as) (collide-spec obstacle))
@@ -1959,9 +1959,9 @@ This commonly includes things such as:
 ;; definition for method 36 of type mtn-plat-buried
 (defmethod plat-path-sync ((this mtn-plat-buried))
   "If the `sync` period is greater than `0` then transition the state to [[plat::35]]
-otherwise, [[plat::34]]
-
-@see [[sync-eased]]"
+   otherwise, [[plat::34]]
+   
+   @see [[sync-eased]]"
   (cond
     ((or (logtest? (-> this path flags) (path-control-flag not-found))
          (and (not (and (-> this entity) (logtest? (-> this entity extra perm status) (entity-perm-status subtask-complete)))
@@ -3103,11 +3103,11 @@ otherwise, [[plat::34]]
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-lens) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this entity)
   (logclear! (-> this mask) (process-mask actor-pause))
@@ -3152,11 +3152,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-lens-base) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this entity)
   (logclear! (-> this mask) (process-mask actor-pause))
@@ -3212,11 +3212,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-lens-floor) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((prim-mesh (new 'process 'collide-shape-prim-mesh cshape (the-as uint 0) (the-as uint 0))))
       (set! (-> prim-mesh prim-core collide-as) (collide-spec obstacle))
@@ -3281,11 +3281,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-shard) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this entity)
   (logclear! (-> this mask) (process-mask actor-pause))
@@ -3321,11 +3321,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-step-plat-rocks-a) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 collide-shape-prim-mesh) (sv-32 symbol) (sv-48 type) (sv-64 collide-shape))
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((prim-group (new 'process 'collide-shape-prim-group cshape (the-as uint 3) 0)))
@@ -3416,11 +3416,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-step-plat-rocks-b) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 collide-shape-prim-mesh) (sv-32 symbol) (sv-48 type) (sv-64 collide-shape))
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((prim-group (new 'process 'collide-shape-prim-group cshape (the-as uint 17) 0)))
@@ -3529,11 +3529,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this mtn-step-plat-rocks-c) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 collide-shape-prim-mesh) (sv-32 symbol) (sv-48 type) (sv-64 collide-shape))
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((prim-group (new 'process 'collide-shape-prim-group cshape (the-as uint 24) 0)))

--- a/test/decompiler/reference/jak2/levels/mountain/rhino-wall_REF.gc
+++ b/test/decompiler/reference/jak2/levels/mountain/rhino-wall_REF.gc
@@ -114,11 +114,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this rhino-wall) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stack-size-set! (-> this main-thread) 512)
   (logior! (-> this mask) (process-mask collectable))
   (let ((s3-0 (res-lump-struct (-> this entity) 'art-name structure))

--- a/test/decompiler/reference/jak2/levels/mountain/rhino_REF.gc
+++ b/test/decompiler/reference/jak2/levels/mountain/rhino_REF.gc
@@ -628,7 +628,7 @@
 ;; INFO: Used lq/sq
 (defmethod general-event-handler ((this rhino) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (local-vars
     (sv-96 int)
     (sv-112 symbol)

--- a/test/decompiler/reference/jak2/levels/nest/boss/metalkor-extras_REF.gc
+++ b/test/decompiler/reference/jak2/levels/nest/boss/metalkor-extras_REF.gc
@@ -1719,11 +1719,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this rift-ring-ingame) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -1984,11 +1984,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this nest-break-precipice) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/nest/boss/metalkor-setup_REF.gc
+++ b/test/decompiler/reference/jak2/levels/nest/boss/metalkor-setup_REF.gc
@@ -1067,11 +1067,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this nestb-tail-bound) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-others))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec special-obstacle))
@@ -1940,11 +1940,11 @@ This commonly includes things such as:
 ;; INFO: Used lq/sq
 (defmethod init-from-entity! ((this metalkor) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
@@ -2097,7 +2097,3 @@ This commonly includes things such as:
   (metalkor-go-next-stage)
   (none)
   )
-
-
-
-

--- a/test/decompiler/reference/jak2/levels/nest/boss/nestb-scenes_REF.gc
+++ b/test/decompiler/reference/jak2/levels/nest/boss/nestb-scenes_REF.gc
@@ -1682,11 +1682,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this nest-gun-parts) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -1747,11 +1747,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this nest-unbroken-rocks) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/nest/flying-spider_REF.gc
+++ b/test/decompiler/reference/jak2/levels/nest/flying-spider_REF.gc
@@ -570,7 +570,7 @@
 ;; definition for method 74 of type flying-spider
 (defmethod general-event-handler ((this flying-spider) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit 'hit-knocked)
      (logclear! (-> this mask) (process-mask actor-pause))
@@ -638,9 +638,9 @@
 ;; definition for method 55 of type flying-spider
 (defmethod common-post ((this flying-spider))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   ((method-of-type nav-enemy common-post) this)
   (none)
   )
@@ -745,7 +745,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod look-at-target! ((this flying-spider) (arg0 enemy-flag))
   "Logic for looking at the target that is locked on, sets some flags and adjusts the neck to look at the target if available
-@param flag Reacts to [[enemy-flag::death-start]] and [[enemy-flag::enable-on-active]], see implementation for details"
+   @param flag Reacts to [[enemy-flag::death-start]] and [[enemy-flag::enable-on-active]], see implementation for details"
   0
   (none)
   )
@@ -754,7 +754,7 @@
 ;; WARN: Return type mismatch int vs penetrate.
 (defmethod get-penetrate-info ((this flying-spider))
   "@returns the allowed way(s) this enemy can take damage
-@see [[penetrate]] and [[penetrated-by-all&hit-points->penetrated-by]]"
+   @see [[penetrate]] and [[penetrated-by-all&hit-points->penetrated-by]]"
   (the-as penetrate 0)
   )
 

--- a/test/decompiler/reference/jak2/levels/nest/mammoth_REF.gc
+++ b/test/decompiler/reference/jak2/levels/nest/mammoth_REF.gc
@@ -755,7 +755,7 @@
 ;; definition for method 74 of type mammoth
 (defmethod general-event-handler ((this mammoth) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit)
      (logclear! (-> this mask) (process-mask actor-pause))
@@ -1429,9 +1429,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod common-post ((this mammoth))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (local-vars (sv-752 lightning-spec) (sv-768 int) (sv-784 symbol) (sv-800 mammoth))
   (let ((t9-0 (method-of-type nav-enemy common-post)))
     (t9-0 this)

--- a/test/decompiler/reference/jak2/levels/nest/mantis_REF.gc
+++ b/test/decompiler/reference/jak2/levels/nest/mantis_REF.gc
@@ -1241,7 +1241,7 @@
 ;; definition for method 74 of type mantis
 (defmethod general-event-handler ((this mantis) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('track)
      (if (and (-> arg3 param 0) (time-elapsed? (-> this track-timer) (seconds 0.5)))
@@ -1503,9 +1503,9 @@
 ;; WARN: Return type mismatch vector vs none.
 (defmethod common-post ((this mantis))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (local-vars (s5-0 vector))
   (let ((t9-0 (method-of-type nav-enemy common-post)))
     (t9-0 this)

--- a/test/decompiler/reference/jak2/levels/nest/nest-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/nest/nest-obs_REF.gc
@@ -134,11 +134,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this nest-switch) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 3) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 4))
@@ -258,11 +258,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this nest-piston) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> s3-0 prim-core collide-as) (collide-spec obstacle pusher))

--- a/test/decompiler/reference/jak2/levels/palace/boss/squid-setup_REF.gc
+++ b/test/decompiler/reference/jak2/levels/palace/boss/squid-setup_REF.gc
@@ -1800,11 +1800,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this squid) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 penetrated-by)
           (penetrate

--- a/test/decompiler/reference/jak2/levels/palace/cable/palcab-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/palace/cable/palcab-obs_REF.gc
@@ -248,11 +248,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pal-electric-fan) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)
@@ -497,11 +497,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pal-cable-nut) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)
@@ -1026,11 +1026,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pal-rot-gun) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -1107,11 +1107,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pal-windmill) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (logior! (-> this mask) (process-mask ambient))
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
@@ -1201,11 +1201,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pal-flip-step) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)

--- a/test/decompiler/reference/jak2/levels/palace/pal-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/palace/pal-obs_REF.gc
@@ -98,11 +98,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pal-falling-plat) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)
@@ -192,11 +192,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pal-ent-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s5-0 (the-as uint 0) (the-as uint 0))))
@@ -392,11 +392,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pal-grind-ring-center) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (pal-grind-ring-center-method-29 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -418,11 +418,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pal-grind-ring-center) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (pal-grind-ring-center-method-29 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -610,11 +610,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pal-grind-ring) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (pal-grind-ring-method-29 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -796,11 +796,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pal-ent-glass) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (pal-ent-glass-method-29 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -1004,11 +1004,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this palent-turret) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (palent-turret-method-28 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -1200,11 +1200,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pal-breakable-window) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (pal-breakable-window-method-29 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/palace/roof/palroof-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/palace/roof/palroof-obs_REF.gc
@@ -144,11 +144,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pal-prong) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 3))

--- a/test/decompiler/reference/jak2/levels/palace/throne/palace-scenes_REF.gc
+++ b/test/decompiler/reference/jak2/levels/palace/throne/palace-scenes_REF.gc
@@ -48,11 +48,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this throne-throne) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((prim-group (new 'process 'collide-shape-prim-group cshape (the-as uint 1) 0)))
       (set! (-> cshape total-prims) (the-as uint 2))

--- a/test/decompiler/reference/jak2/levels/ruins/breakable-wall_REF.gc
+++ b/test/decompiler/reference/jak2/levels/ruins/breakable-wall_REF.gc
@@ -464,11 +464,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this ruins-breakable-wall) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stack-size-set! (-> this main-thread) 512)
   (logior! (-> this mask) (process-mask collectable))
   (set! (-> this side) #f)

--- a/test/decompiler/reference/jak2/levels/ruins/mechtest-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/ruins/mechtest-obs_REF.gc
@@ -470,11 +470,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this throwblock) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)
@@ -560,11 +560,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pushblock) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)

--- a/test/decompiler/reference/jak2/levels/ruins/pillar-collapse_REF.gc
+++ b/test/decompiler/reference/jak2/levels/ruins/pillar-collapse_REF.gc
@@ -222,11 +222,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this ruins-pillar-collapse) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 collide-shape-prim-mesh) (sv-32 symbol) (sv-48 type) (sv-64 collide-shape-moving))
   (stack-size-set! (-> this main-thread) 512)
   (logior! (-> this mask) (process-mask collectable))

--- a/test/decompiler/reference/jak2/levels/ruins/rapid-gunner_REF.gc
+++ b/test/decompiler/reference/jak2/levels/ruins/rapid-gunner_REF.gc
@@ -260,7 +260,7 @@
 ;; definition for method 74 of type rapid-gunner
 (defmethod general-event-handler ((this rapid-gunner) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit 'hit-flinch)
      (logclear! (-> this mask) (process-mask actor-pause))
@@ -489,10 +489,10 @@
 ;; definition for method 98 of type rapid-gunner
 (defmethod in-aggro-range? ((this rapid-gunner) (arg0 process-focusable) (arg1 vector))
   "Should the enemy activate.
-- if `activate-distance` is `0.0`, always true
-- otherwise, check if the provided process is close enough
-@param proc The process used to distance check
-@returns true/false"
+   - if `activate-distance` is `0.0`, always true
+   - otherwise, check if the provided process is close enough
+   @param proc The process used to distance check
+   @returns true/false"
   (let ((t9-0 (method-of-type nav-enemy in-aggro-range?)))
     (and (t9-0 this arg0 arg1)
          (or (not (logtest? (-> this fact enemy-options) (enemy-option user8)))
@@ -601,9 +601,9 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod common-post ((this rapid-gunner))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((t9-0 (method-of-type nav-enemy common-post)))
     (t9-0 this)
     )

--- a/test/decompiler/reference/jak2/levels/ruins/ruins-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/ruins/ruins-obs_REF.gc
@@ -213,11 +213,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this beam) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -267,8 +267,8 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defmethod start-bouncing! ((this ruins-bridge))
   "Sets `bouncing` to [[#t]] and sets up the clock to periodically bounce
-and translate the platform via the `smush`
-@see [[smush-control]]"
+   and translate the platform via the `smush`
+   @see [[smush-control]]"
   (logclear! (-> this mask) (process-mask sleep))
   (logclear! (-> this mask) (process-mask sleep-code))
   0
@@ -286,11 +286,11 @@ and translate the platform via the `smush`
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this ruins-bridge) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stack-size-set! (-> this main-thread) 512)
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
@@ -438,8 +438,8 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defmethod start-bouncing! ((this ruins-drop-plat))
   "Sets `bouncing` to [[#t]] and sets up the clock to periodically bounce
-and translate the platform via the `smush`
-@see [[smush-control]]"
+   and translate the platform via the `smush`
+   @see [[smush-control]]"
   (activate! (-> this smush) -1.0 60 150 1.0 1.0 (-> self clock))
   (set-time! (-> this bounce-time))
   (set! (-> this bouncing) #t)
@@ -494,11 +494,11 @@ and translate the platform via the `smush`
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this ruins-drop-plat) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stack-size-set! (-> this main-thread) 512)
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))

--- a/test/decompiler/reference/jak2/levels/ruins/ruins-part_REF.gc
+++ b/test/decompiler/reference/jak2/levels/ruins/ruins-part_REF.gc
@@ -716,7 +716,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defun ruins-bird-bob-func ((arg0 sparticle-system) (arg1 sparticle-cpuinfo) (arg2 matrix))
   "Move the bird particles up and down, on a sinusoidal period with a wavelength of 300 frames
-TODO - check argument types / what birds?"
+   TODO - check argument types / what birds?"
   (set! (-> arg2 vector 0 y)
         (+ (-> arg1 key proc root trans y) (* -2048.0 (sin (* 218.45334 (the float (mod (current-time) 300))))))
         )

--- a/test/decompiler/reference/jak2/levels/ruins/ruins-scenes_REF.gc
+++ b/test/decompiler/reference/jak2/levels/ruins/ruins-scenes_REF.gc
@@ -126,8 +126,8 @@
 ;; WARN: Return type mismatch int vs none.
 (defun ruins-slide-sparks ((arg0 object) (position vector))
   "Generates simple sparks (2D particles) at the location specified. This is used in the cutscene.
-@param position The position to render the sparks at
-TODO - first arg type?"
+   @param position The position to render the sparks at
+   TODO - first arg type?"
   (launch-particles (-> *part-id-table* 1247) position)
   0
   (none)
@@ -1374,11 +1374,11 @@ The scale will be linearly-interpolated based on the distance from the camera"
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this flag) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (logclear! (-> this mask) (process-mask actor-pause))
@@ -1479,11 +1479,11 @@ Touching it flips the `play?` field which will trigger the cutscene"
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this ruins-precipice) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((cshape-mesh (new 'process 'collide-shape-prim-mesh cshape (the-as uint 0) (the-as uint 0))))
       (set! (-> cshape-mesh prim-core collide-as) (collide-spec obstacle))

--- a/test/decompiler/reference/jak2/levels/sewer/escort/jinx_REF.gc
+++ b/test/decompiler/reference/jak2/levels/sewer/escort/jinx_REF.gc
@@ -239,7 +239,7 @@
 ;; definition for method 74 of type jinx
 (defmethod general-event-handler ((this jinx) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('request)
      (case (-> arg3 param 0)

--- a/test/decompiler/reference/jak2/levels/sewer/gator_REF.gc
+++ b/test/decompiler/reference/jak2/levels/sewer/gator_REF.gc
@@ -160,7 +160,7 @@
 ;; definition for method 74 of type gator
 (defmethod general-event-handler ((this gator) (proc process) (arg2 int) (event-type symbol) (event event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case event-type
     (('hit-knocked)
      (when (= (-> this incoming knocked-type) (knocked-type knocked-type-4))
@@ -181,7 +181,7 @@
 ;; definition for method 179 of type gator
 (defmethod adjust-depth! ((this gator))
   "Changes the height based on the ocean depth
-@see [[get-height]]"
+   @see [[get-height]]"
   (set! (-> this ocean-y) (get-height *ocean* (-> this root trans) #t))
   (set! (-> this root trans y) (+ -10240.0 (-> this ocean-y)))
   )
@@ -199,7 +199,7 @@
 ;; definition for method 181 of type gator
 (defmethod encircle-target! ((this gator) (arg0 float) (arg1 float) (arg2 symbol))
   "Core movement for the [[gator]], circles the target, charges at the target, etc
-@params TODO - not sure, they all dont seem to do very much and this method is a mess"
+   @params TODO - not sure, they all dont seem to do very much and this method is a mess"
   (local-vars (v1-17 object) (a0-5 object))
   (let ((f30-0 (vector-dot (-> this new-facing) (-> this old-facing)))
         (s5-0 75)
@@ -298,9 +298,9 @@
 ;; WARN: Return type mismatch vector vs none.
 (defmethod common-post ((this gator))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((func (method-of-type nav-enemy common-post)))
     (func this)
     )
@@ -338,10 +338,10 @@
 ;; INFO: Used lq/sq
 (defmethod in-aggro-range? ((this gator) (arg0 process-focusable) (arg1 vector))
   "Should the enemy activate.
-- if `activate-distance` is `0.0`, always true
-- otherwise, check if the provided process is close enough
-@param proc The process used to distance check
-@returns true/false"
+   - if `activate-distance` is `0.0`, always true
+   - otherwise, check if the provided process is close enough
+   @param proc The process used to distance check
+   @returns true/false"
   (let ((target-pos (new 'stack-no-clear 'vector)))
     (when (and (= *target* arg0) (not arg1) (= (-> *target* control ground-pat material) (pat-material waterbottom)))
       (set! (-> target-pos quad) (-> (get-trans arg0 0) quad))

--- a/test/decompiler/reference/jak2/levels/sewer/hal2-course_REF.gc
+++ b/test/decompiler/reference/jak2/levels/sewer/hal2-course_REF.gc
@@ -98,7 +98,7 @@
 ;; definition for method 74 of type hal-sewer
 (defmethod general-event-handler ((this hal-sewer) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('notify)
      (case (-> arg3 param 0)

--- a/test/decompiler/reference/jak2/levels/sewer/hosehead_REF.gc
+++ b/test/decompiler/reference/jak2/levels/sewer/hosehead_REF.gc
@@ -863,7 +863,7 @@
 ;; definition for method 74 of type hosehead
 (defmethod general-event-handler ((this hosehead) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('cue-chase)
      (cond
@@ -2127,9 +2127,9 @@
 ;; definition for method 55 of type hosehead
 (defmethod common-post ((this hosehead))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((t9-0 (method-of-type nav-enemy common-post)))
     (t9-0 this)
     )

--- a/test/decompiler/reference/jak2/levels/sewer/sew-gunturret_REF.gc
+++ b/test/decompiler/reference/jak2/levels/sewer/sew-gunturret_REF.gc
@@ -593,7 +593,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod aim-turret! ((this sew-gunturret) (aim-at-target? symbol))
   "Calculates the angle and tilt for the turret to either aim at the target, or it's default direction
-@param aim-at-target? Whether or not the turret should aim at the target, will ignore the target if #f"
+   @param aim-at-target? Whether or not the turret should aim at the target, will ignore the target if #f"
   (cond
     ((and aim-at-target? (-> this los-clear))
      (let ((target-proc (handle->process (-> this focus handle))))
@@ -722,7 +722,7 @@
 ;; INFO: Used lq/sq
 (defmethod fire-turret! ((this sew-gunturret) (fire-sound? symbol))
   "Actually fires the turret, sets `flash-state` to [[#t]]
-@param fire-sound? Whether to play the fire sound effect or not"
+   @param fire-sound? Whether to play the fire sound effect or not"
   (let ((v1-4 (vector<-cspace! (new 'stack-no-clear 'vector) (-> this node-list data (-> this params gun-joint))))
         (proj-params (new 'stack-no-clear 'projectile-init-by-other-params))
         )
@@ -872,7 +872,7 @@
 ;; definition for method 74 of type sew-gunturret
 (defmethod general-event-handler ((this sew-gunturret) (proc process) (arg2 int) (event-type symbol) (event event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (if (and (= event-type 'notify) (< 1 arg2) (= (-> event param 0) 'attack) (= (-> event param 1) *target*))
       (set-time! (-> this last-hit-time))
       )
@@ -1025,10 +1025,10 @@
 ;; definition for method 98 of type sew-gunturret
 (defmethod in-aggro-range? ((this sew-gunturret) (proc process-focusable) (arg1 vector))
   "Should the enemy activate.
-- if `activate-distance` is `0.0`, always true
-- otherwise, check if the provided process is close enough
-@param proc The process used to distance check
-@returns true/false"
+   - if `activate-distance` is `0.0`, always true
+   - otherwise, check if the provided process is close enough
+   @param proc The process used to distance check
+   @returns true/false"
   (cond
     ((= (-> this activate-distance) 0.0)
      (return #t)

--- a/test/decompiler/reference/jak2/levels/sewer/sewer-obs2_REF.gc
+++ b/test/decompiler/reference/jak2/levels/sewer/sewer-obs2_REF.gc
@@ -39,10 +39,10 @@
 ;; definition for method 43 of type sew-elevator
 (defmethod move-between-points ((this sew-elevator) (arg1 vector) (point-a float) (point-b float))
   "Move between two points on the elevator's path
-@param vec TODO not sure
-@param point-a The first point fetched from the elevator's path
-@param point-b The second point fetched from the path
-@see [[path-control]] and [[elevator]]"
+   @param vec TODO not sure
+   @param point-a The first point fetched from the elevator's path
+   @param point-b The second point fetched from the path
+   @see [[path-control]] and [[elevator]]"
   (let ((path-point-a (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) point-a 'interp))
         (path-point-b (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) point-b 'interp))
         (elevator-pos (-> this root trans))
@@ -83,7 +83,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod configure-collision ((this sew-elevator) (collide-with-jak? symbol))
   "Appropriately sets the collision on the elevator
-@param collide-with-jak? If set, the elevator will collide with Jak"
+   @param collide-with-jak? If set, the elevator will collide with Jak"
   (let ((prim-group (-> (the-as collide-shape-prim-group (-> this root root-prim)) child 1)))
     (cond
       (collide-with-jak?
@@ -158,7 +158,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-plat! ((this sew-elevator))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   (set! (-> this sound-id) (new-sound-id))
   0
   (none)
@@ -168,11 +168,11 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-defaults! ((this sew-elevator))
   "Initializes default settings related to the [[elevator]]:
-- `elevator-xz-threshold`
-- `elevator-y-threshold`
-- `elevator-start-pos`
-- `elevator-move-rate`
-- `elevator-flags`"
+   - `elevator-xz-threshold`
+   - `elevator-y-threshold`
+   - `elevator-start-pos`
+   - `elevator-move-rate`
+   - `elevator-flags`"
   (let ((func (method-of-type elevator init-defaults!)))
     (func this)
     )
@@ -366,11 +366,11 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this sew-valve) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (tag-1 res-tag) (tag-2 res-tag))
   (let ((cshape (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> cshape dynam) (copy *standard-dynamics* 'process))
@@ -664,11 +664,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this sew-mar-statue) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this spawned-debris?) #f)
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((prim-mesh (new 'process 'collide-shape-prim-mesh cshape (the-as uint 0) (the-as uint 0))))
@@ -738,8 +738,8 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defmethod start-bouncing! ((this sew-catwalk))
   "Sets `bouncing` to [[#t]] and sets up the clock to periodically bounce
-and translate the platform via the `smush`
-@see [[smush-control]]"
+   and translate the platform via the `smush`
+   @see [[smush-control]]"
   (logclear! (-> this mask) (process-mask sleep))
   (logclear! (-> this mask) (process-mask sleep-code))
   0
@@ -785,11 +785,11 @@ and translate the platform via the `smush`
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this sew-catwalk) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 collide-shape-prim-mesh) (sv-32 symbol) (sv-48 type) (sv-64 collide-shape-moving))
   (stack-size-set! (-> this main-thread) 512)
   (let ((cshape (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
@@ -1046,11 +1046,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this sew-mine-a) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((prim-mesh (new 'process 'collide-shape-prim-mesh cshape (the-as uint 0) (the-as uint 0))))
       (set! (-> prim-mesh prim-core collide-as) (collide-spec pusher))
@@ -1147,11 +1147,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this sew-mine-b) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((cshape (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((prim-mesh (new 'process 'collide-shape-prim-mesh cshape (the-as uint 0) (the-as uint 0))))
       (set! (-> prim-mesh prim-core collide-as) (collide-spec pusher))
@@ -1396,11 +1396,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this sew-wall) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stack-size-set! (-> this main-thread) 512)
   (logior! (-> this mask) (process-mask collectable))
   (let ((data ((method-of-type res-lump get-property-struct)
@@ -1556,11 +1556,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this sew-grill) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this entity)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/sewer/sewer-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/sewer/sewer-obs_REF.gc
@@ -151,11 +151,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this sew-single-blade) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (logior! (-> this mask) (process-mask ambient))
   (let ((cshape (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> cshape dynam) (copy *standard-dynamics* 'process))
@@ -357,11 +357,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this sew-tri-blade) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (logior! (-> this mask) (process-mask ambient))
   (let ((cshape (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> cshape dynam) (copy *standard-dynamics* 'process))
@@ -509,11 +509,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this sew-arm-blade) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (logior! (-> this mask) (process-mask ambient))
   (let ((cshape (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> cshape dynam) (copy *standard-dynamics* 'process))
@@ -641,11 +641,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this sew-multi-blade) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (logior! (-> this mask) (process-mask ambient))
   (let ((cshape (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> cshape dynam) (copy *standard-dynamics* 'process))
@@ -803,11 +803,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this sew-twist-blade) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (logior! (-> this mask) (process-mask ambient))
   (let ((cshape (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> cshape dynam) (copy *standard-dynamics* 'process))
@@ -1028,7 +1028,7 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod broadcast-to-actors ((this sew-light-switch) (event-type symbol))
   "Broadcast event to all associated [[entity]]s via the `actor-group`s
-@param `event-type` the symbol to broadcast"
+   @param `event-type` the symbol to broadcast"
   (with-pp
     (dotimes (group-idx (-> this actor-group-count))
       (let ((group (-> this actor-group group-idx)))
@@ -1063,11 +1063,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this sew-light-switch) (entity entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (tag res-tag))
   (init-switch-collision! this)
   (process-drawable-from-entity! this entity)
@@ -1100,7 +1100,7 @@ This commonly includes things such as:
 ;; ERROR: failed type prop at 53: Could not figure out load: (set! v1 (l.w s4))
 (defmethod sew-light-control-method-16 ((a0-0 sew-light-control) (a1-0 object) (a2-0 vector) (a3-0 float))
   "@unused
-@TODO - not done yet, no callers?"
+   @TODO - not done yet, no callers?"
   (local-vars
     (v0-0 symbol)
     (v0-1 none)
@@ -1281,8 +1281,8 @@ This commonly includes things such as:
 ;; definition for method 15 of type sew-light-control
 (defmethod press! ((this sew-light-control) (switched-on? symbol) (should-turret-flash? symbol))
   "Turns the lights on (or off)
-@param switched-on? Should the sewer lights be turned on or off?
-@param should-turret-flash? Should the turret have it's `flash` set as well"
+   @param switched-on? Should the sewer lights be turned on or off?
+   @param should-turret-flash? Should the turret have it's `flash` set as well"
   (set-sewer-lights-flag! switched-on?)
   (if should-turret-flash?
       (set-sewer-turret-flash!)
@@ -1293,8 +1293,8 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defbehavior sew-light-control-init-by-other sew-light-control ((switch entity-actor) (turret entity-actor))
   "Creates a [[sew-light-control]] given two entities for the turret and switch itself
-@param switch The entity for the switch
-@param turret The entity for the turret"
+   @param switch The entity for the switch
+   @param turret The entity for the turret"
   (process-entity-set! self switch)
   (set! (-> *game-info* controller 0) (process->handle self))
   (set! (-> self switch-ent) switch)
@@ -1308,8 +1308,8 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defun sewer-startup ()
   "Basic house-keeping for starting the sewer area:
-- sets up the bigmap
-- spawns the first switch and turret"
+   - sets up the bigmap
+   - spawns the first switch and turret"
   (cond
     ((task-node-closed? (game-task-node sewer-board-introduction))
      (set! (-> sewer bigmap-id) (bigmap-id sewer-with-board-area))

--- a/test/decompiler/reference/jak2/levels/stadium/skate/skatea-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/stadium/skate/skatea-obs_REF.gc
@@ -1370,11 +1370,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this hoverboard-training-manager) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (set! sv-16 (new 'static 'res-tag))
   (let ((v1-1 (res-lump-data (-> this entity) 'actor-groups pointer :tag-ptr (& sv-16))))
@@ -1558,11 +1558,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this skate-training-ramp) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (skate-training-ramp-method-28 this)
   (process-drawable-from-entity! this arg0)
   (logclear! (-> this mask) (process-mask actor-pause))
@@ -1698,11 +1698,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this skate-gate) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (skate-gate-method-29 this)
   (process-drawable-from-entity! this arg0)
   (logclear! (-> this mask) (process-mask actor-pause))
@@ -1979,11 +1979,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this skatea-floating-ring) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (skatea-floating-ring-method-28 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/stadium/stadium-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/stadium/stadium-obs_REF.gc
@@ -88,11 +88,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this dummy-vehicle) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)
@@ -215,11 +215,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this gar-curtain) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 collide-shape-prim-mesh) (sv-32 symbol) (sv-48 type) (sv-64 collide-shape))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 8) 0)))
@@ -1183,11 +1183,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this spotlight) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -1228,11 +1228,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this gar-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -2142,11 +2142,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this stad-samos) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum hit-by-others))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)
@@ -2470,11 +2470,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch entity-perm-status vs none.
 (defmethod init-from-entity! ((this stadium-barrier) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (process-entity-status! this (entity-perm-status dead) #t)
   (none)
   )
@@ -2835,11 +2835,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this stad-force-field) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stad-force-field-method-28 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -2883,11 +2883,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this stad-c-force-field) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stad-force-field-method-28 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -2931,11 +2931,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this stad-d-force-field) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stad-force-field-method-28 this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -3205,11 +3205,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this brutter-balloon) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 3) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 4))

--- a/test/decompiler/reference/jak2/levels/stadium/stadium-race-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/stadium/stadium-race-obs_REF.gc
@@ -132,11 +132,11 @@
 ;; definition for method 11 of type stdmb-race-hatch
 (defmethod init-from-entity! ((this stdmb-race-hatch) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stdmb-race-hatch-method-21 this)
   (process-drawable-from-entity! this arg0)
   (stdmb-race-hatch-method-22 this)

--- a/test/decompiler/reference/jak2/levels/stadium/stadium-scenes_REF.gc
+++ b/test/decompiler/reference/jak2/levels/stadium/stadium-scenes_REF.gc
@@ -3244,7 +3244,7 @@
 ;; definition for method 35 of type keira-npc
 (defmethod get-art-elem ((this keira-npc))
   "Checks various things such the current actor, task status, etc to determine the right art-group data to use
-@returns the appropriate [[art-element]] for the given NPC"
+   @returns the appropriate [[art-element]] for the given NPC"
   (case (-> this task actor)
     (((game-task-actor keira-stadium))
      (-> this draw art-group data 4)

--- a/test/decompiler/reference/jak2/levels/strip/chaincrate_REF.gc
+++ b/test/decompiler/reference/jak2/levels/strip/chaincrate_REF.gc
@@ -364,11 +364,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this strip-chain-crate) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 int))
   (set! (-> this root) (new 'process 'trsqv))
   (set! (-> this path) (new 'process 'curve-control this 'path -1000000000.0))

--- a/test/decompiler/reference/jak2/levels/strip/strip-drop_REF.gc
+++ b/test/decompiler/reference/jak2/levels/strip/strip-drop_REF.gc
@@ -465,11 +465,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this crane) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -556,11 +556,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cranecrate) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec obstacle))
@@ -750,11 +750,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this grunt-egg) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (cond
     ((>= (res-lump-value arg0 'extra-id int :default (the-as uint128 -1) :time -1000000000.0) 0)
      (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))

--- a/test/decompiler/reference/jak2/levels/strip/strip-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/strip/strip-obs_REF.gc
@@ -171,11 +171,11 @@
 ;; INFO: Used lq/sq
 (defmethod init-from-entity! ((this strip-hazard) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-64 res-tag))
   (set-vector! (-> this shove-vec) 0.0 12288.0 24576.0 1.0)
   (set! (-> this no-collision-timer) (the-as uint 0))
@@ -272,11 +272,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this fencespikes) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 string))
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
@@ -429,11 +429,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this pitspikes) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)
@@ -539,11 +539,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this curtainsaw) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)
@@ -951,11 +951,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this grenade-point) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this parented?) #f)
   (when (not (-> this parented?))
     (let ((a1-1 (handle->process (-> *game-info* controller 0))))
@@ -1794,11 +1794,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this drill-plat) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)

--- a/test/decompiler/reference/jak2/levels/strip/strip-rescue_REF.gc
+++ b/test/decompiler/reference/jak2/levels/strip/strip-rescue_REF.gc
@@ -61,11 +61,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cntrlrm-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 3) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 4))
@@ -163,11 +163,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cntrlrm-button) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 3))

--- a/test/decompiler/reference/jak2/levels/tomb/monster-frog_REF.gc
+++ b/test/decompiler/reference/jak2/levels/tomb/monster-frog_REF.gc
@@ -879,9 +879,9 @@
 ;; definition for method 55 of type monster-frog
 (defmethod common-post ((this monster-frog))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (water-control-method-10 (-> this water))
   ((method-of-type nav-enemy common-post) this)
   (none)

--- a/test/decompiler/reference/jak2/levels/tomb/tomb-beetle_REF.gc
+++ b/test/decompiler/reference/jak2/levels/tomb/tomb-beetle_REF.gc
@@ -226,7 +226,7 @@
 ;; definition for method 74 of type tomb-beetle
 (defmethod general-event-handler ((this tomb-beetle) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (let ((v1-0 (new 'static 'array int64 2 -1 0)))
     (case arg2
       (('cue-chase)

--- a/test/decompiler/reference/jak2/levels/tomb/tomb-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/tomb/tomb-obs_REF.gc
@@ -145,11 +145,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-plat-wall) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (logior! (-> this mask) (process-mask platform))
   (init-plat-collision! this)
   (process-drawable-from-entity! this arg0)
@@ -813,11 +813,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-stair-block) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 penetrated-by) (penetrate))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 8) 0)))
@@ -1151,11 +1151,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-defaults! ((this tomb-elevator))
   "Initializes default settings related to the [[elevator]]:
-- `elevator-xz-threshold`
-- `elevator-y-threshold`
-- `elevator-start-pos`
-- `elevator-move-rate`
-- `elevator-flags`"
+   - `elevator-xz-threshold`
+   - `elevator-y-threshold`
+   - `elevator-start-pos`
+   - `elevator-move-rate`
+   - `elevator-flags`"
   (let ((t9-0 (method-of-type elevator init-defaults!)))
     (t9-0 this)
     )
@@ -1235,11 +1235,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-boss-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 2) 0)))
@@ -1360,11 +1360,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-wing-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s5-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 penetrated-by) (penetrate))
     (let ((s4-0 (new 'process 'collide-shape-prim-group s5-0 (the-as uint 3) 0)))
@@ -1488,11 +1488,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-boulder-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec obstacle camera-blocker))
@@ -1781,11 +1781,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-plat-return) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (init-plat-collision! this)
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -2119,11 +2119,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-sphinx) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (the-as collide-shape-moving (new 'process 'trsqv)))
   (process-drawable-from-entity! this arg0)
   (set! (-> this target-actor) (entity-actor-lookup arg0 'alt-actor 0))

--- a/test/decompiler/reference/jak2/levels/tomb/tomb-water_REF.gc
+++ b/test/decompiler/reference/jak2/levels/tomb/tomb-water_REF.gc
@@ -130,11 +130,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 3))
@@ -327,11 +327,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-beetle-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
@@ -697,9 +697,9 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch symbol vs none.
 (defmethod send-event! ((this tomb-beetle-button) (arg0 symbol))
   "Prepares an [[event-message-block]] using the provided type to send an event to:
-- the `notify-actor`
-- every [[entity-actor]] in the `actor-group` array
-@see [[entity-actor]]"
+   - the `notify-actor`
+   - every [[entity-actor]] in the `actor-group` array
+   @see [[entity-actor]]"
   (when arg0
     (let ((a1-1 (new 'stack-no-clear 'event-message-block)))
       (set! (-> a1-1 from) (process->ppointer self))
@@ -1137,11 +1137,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-plat-simon) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
@@ -1786,11 +1786,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-simon-button) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 5) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 6))
@@ -2228,11 +2228,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-vibe) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag) (sv-32 res-tag))
   (with-pp
     (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum hit-by-player))))
@@ -2643,11 +2643,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-water-trap) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (let ((a1-3 (new 'stack-no-clear 'sync-info-params)))
@@ -2846,11 +2846,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-smash-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 3))

--- a/test/decompiler/reference/jak2/levels/tomb/widow-baron_REF.gc
+++ b/test/decompiler/reference/jak2/levels/tomb/widow-baron_REF.gc
@@ -713,11 +713,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-boss-bridge) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (case ((method-of-type res-lump get-property-struct)
          (-> this entity)
          'tomb-boss-bridge-type

--- a/test/decompiler/reference/jak2/levels/tomb/widow-extras_REF.gc
+++ b/test/decompiler/reference/jak2/levels/tomb/widow-extras_REF.gc
@@ -533,11 +533,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-boss-catwalk) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((a2-1 (res-lump-value arg0 'mode uint128 :time -1000000000.0)))
     (tomb-boss-catwalk-method-22 this (-> arg0 extra trans) (the-as int a2-1))
     )
@@ -1692,11 +1692,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-boss-pillar) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 3))
@@ -1917,11 +1917,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this tomb-boss-firepot) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 3))

--- a/test/decompiler/reference/jak2/levels/tomb/widow-more-extras_REF.gc
+++ b/test/decompiler/reference/jak2/levels/tomb/widow-more-extras_REF.gc
@@ -520,11 +520,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this cave-in-master) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (set! (-> this path) (new 'process 'path-control this 'path 0.0 (the-as entity #f) #f))

--- a/test/decompiler/reference/jak2/levels/tomb/widow2_REF.gc
+++ b/test/decompiler/reference/jak2/levels/tomb/widow2_REF.gc
@@ -181,11 +181,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this widow) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)

--- a/test/decompiler/reference/jak2/levels/under/centipede_REF.gc
+++ b/test/decompiler/reference/jak2/levels/under/centipede_REF.gc
@@ -217,7 +217,7 @@
 ;; definition for method 74 of type centipede
 (defmethod general-event-handler ((this centipede) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('under-break-floor)
      (go (method-of-object this thru-grating))
@@ -566,10 +566,10 @@
 ;; definition for method 98 of type centipede
 (defmethod in-aggro-range? ((this centipede) (arg0 process-focusable) (arg1 vector))
   "Should the enemy activate.
-- if `activate-distance` is `0.0`, always true
-- otherwise, check if the provided process is close enough
-@param proc The process used to distance check
-@returns true/false"
+   - if `activate-distance` is `0.0`, always true
+   - otherwise, check if the provided process is close enough
+   @param proc The process used to distance check
+   @returns true/false"
   (when arg0
     (if (not arg1)
         (set! arg1 (get-trans arg0 0))
@@ -675,9 +675,9 @@
 ;; INFO: Used lq/sq
 (defmethod common-post ((this centipede))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((t9-0 (method-of-type nav-enemy common-post)))
     (t9-0 this)
     )

--- a/test/decompiler/reference/jak2/levels/under/jellyfish_REF.gc
+++ b/test/decompiler/reference/jak2/levels/under/jellyfish_REF.gc
@@ -901,7 +901,7 @@
 ;; definition for method 74 of type jellyfish
 (defmethod general-event-handler ((this jellyfish) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (case arg2
     (('hit 'hit-knocked)
      (logclear! (-> this mask) (process-mask actor-pause))
@@ -1137,9 +1137,9 @@
 ;; INFO: Used lq/sq
 (defmethod common-post ((this jellyfish))
   "Does a lot of various things relating to interacting with the target
-- tracks when the enemy was last drawn
-- looks at the target and handles attacking
-@TODO Not extremely well understood yet"
+   - tracks when the enemy was last drawn
+   - looks at the target and handles attacking
+   @TODO Not extremely well understood yet"
   (let ((v1-1 (vector-inv-orient-by-quat! (new 'stack-no-clear 'vector) (-> this main-joint-acc) (-> this root quat)))
         )
     (+! (-> this tentacle-clock)

--- a/test/decompiler/reference/jak2/levels/under/sig5-course_REF.gc
+++ b/test/decompiler/reference/jak2/levels/under/sig5-course_REF.gc
@@ -144,7 +144,7 @@
 ;; definition for method 74 of type sig-under
 (defmethod general-event-handler ((this sig-under) (arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
   "Handles various events for the enemy
-@TODO - unsure if there is a pattern for the events and this should have a more specific name"
+   @TODO - unsure if there is a pattern for the events and this should have a more specific name"
   (with-pp
     (case arg2
       (('set-task)

--- a/test/decompiler/reference/jak2/levels/under/under-laser_REF.gc
+++ b/test/decompiler/reference/jak2/levels/under/under-laser_REF.gc
@@ -437,11 +437,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-laser) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-64 res-tag))
   (set! (-> this root) (the-as collide-shape-moving (new 'process 'trsqv)))
   (process-drawable-from-entity! this arg0)

--- a/test/decompiler/reference/jak2/levels/under/under-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/under/under-obs_REF.gc
@@ -394,11 +394,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this bubbler) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (set! (-> this part) (create-launch-control (-> *part-group-id-table* 500) this))
@@ -647,11 +647,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-rise-plat) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
@@ -1550,11 +1550,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-mine) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-sphere s4-0 (the-as uint 0))))
       (set! (-> v1-2 prim-core collide-as) (collide-spec enemy camera-blocker))
@@ -1640,10 +1640,10 @@ This commonly includes things such as:
 ;; definition for method 43 of type under-lift
 (defmethod move-between-points ((this under-lift) (arg0 vector) (arg1 float) (arg2 float))
   "Move between two points on the elevator's path
-@param vec TODO not sure
-@param point-a The first point fetched from the elevator's path
-@param point-b The second point fetched from the path
-@see [[path-control]] and [[elevator]]"
+   @param vec TODO not sure
+   @param point-a The first point fetched from the elevator's path
+   @param point-b The second point fetched from the path
+   @see [[path-control]] and [[elevator]]"
   (let ((s4-0 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) arg1 'interp))
         (a0-3 (get-point-in-path! (-> this path) (new 'stack-no-clear 'vector) arg2 'interp))
         (v1-3 (-> this root trans))
@@ -1754,7 +1754,7 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-plat! ((this under-lift))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   (set! (-> this sound-id) (new-sound-id))
   (set! (-> this draw light-index) (the-as uint 4))
   0
@@ -1890,11 +1890,11 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-break-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (stack-size-set! (-> this main-thread) 512)
   (logior! (-> this mask) (process-mask collectable))
   (let ((s3-0 ((method-of-type res-lump get-property-struct)
@@ -2033,11 +2033,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-seaweed-a) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)
@@ -2145,11 +2145,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-seaweed-b) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -2211,11 +2211,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-seaweed-c) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton
@@ -2277,11 +2277,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-seaweed-d) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)
   (initialize-skeleton

--- a/test/decompiler/reference/jak2/levels/under/under-shoot-block_REF.gc
+++ b/test/decompiler/reference/jak2/levels/under/under-shoot-block_REF.gc
@@ -2353,11 +2353,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-shoot-block) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (set! (-> this root) (new 'process 'trsqv))
   (process-drawable-from-entity! this arg0)

--- a/test/decompiler/reference/jak2/levels/under/under-sig-obs_REF.gc
+++ b/test/decompiler/reference/jak2/levels/under/under-sig-obs_REF.gc
@@ -136,7 +136,7 @@
 ;; WARN: Return type mismatch int vs none.
 (defmethod init-plat! ((this under-plat-shoot))
   "Does any necessary initial platform setup.
-For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
+   For example for an elevator pre-compute the distance between the first and last points (both ways) and clear the sound."
   (logclear! (-> this mask) (process-mask actor-pause))
   (logior! (-> this mask) (process-mask enemy))
   (set-vector! (-> this axe-flip) 1.0 0.0 0.0 1.0)
@@ -436,9 +436,9 @@ For example for an elevator pre-compute the distance between the first and last 
 ;; definition for method 36 of type under-plat-shoot
 (defmethod plat-path-sync ((this under-plat-shoot))
   "If the `sync` period is greater than `0` then transition the state to [[plat::35]]
-otherwise, [[plat::34]]
-
-@see [[sync-eased]]"
+   otherwise, [[plat::34]]
+   
+   @see [[sync-eased]]"
   (cond
     ((and (script-eval (the-as pair (-> this draw-test-script))) (= *bot-record-path* -1))
      (go (method-of-object this dormant))
@@ -582,11 +582,11 @@ otherwise, [[plat::34]]
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-break-floor) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
       (set! (-> s4-0 total-prims) (the-as uint 3))
@@ -692,11 +692,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-break-wall) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((v1-2 (new 'process 'collide-shape-prim-mesh s4-0 (the-as uint 0) (the-as uint 0))))
@@ -831,11 +831,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-break-bridge) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (set! (-> this bridge-id) (res-lump-value (-> this entity) 'extra-id int :time -1000000000.0))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
@@ -979,11 +979,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-int-door) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (let ((s4-0 (new 'process 'collide-shape this (collide-list-enum usually-hit-by-player))))
     (let ((s3-0 (new 'process 'collide-shape-prim-group s4-0 (the-as uint 2) 0)))
@@ -1148,11 +1148,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-plat-long) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (init-plat-collision! this)
   (process-drawable-from-entity! this arg0)
@@ -1304,11 +1304,11 @@ This commonly includes things such as:
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-plat-wall) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (set! (-> this extended-amount) 0.0)
   (logior! (-> this mask) (process-mask platform))
   (set! (-> this clock) (-> *display* user0-clock))

--- a/test/decompiler/reference/jak2/levels/under/underb-master_REF.gc
+++ b/test/decompiler/reference/jak2/levels/under/underb-master_REF.gc
@@ -1125,11 +1125,11 @@
 ;; WARN: Return type mismatch object vs none.
 (defmethod init-from-entity! ((this under-locking) (arg0 entity-actor))
   "Typically the method that does the initial setup on the process, potentially using the [[entity-actor]] provided as part of that.
-This commonly includes things such as:
-- stack size
-- collision information
-- loading the skeleton group / bones
-- sounds"
+   This commonly includes things such as:
+   - stack size
+   - collision information
+   - loading the skeleton group / bones
+   - sounds"
   (local-vars (sv-16 res-tag))
   (set! (-> this which-reminder?) #f)
   (set! (-> this spooled-sound-id) (new 'static 'sound-id))


### PR DESCRIPTION
Previously was only applying to game versions above Jak 2, Fixes #3342