### PR TITLE
game: ensure the default `game-size` is also valid when initializing the `pc-settings.gc` file

### DIFF
--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -322,3 +322,6 @@ endif()
 
 add_executable(gk main.cpp)
 target_link_libraries(gk runtime)
+if(WIN32)
+    set_target_properties(gk PROPERTIES VS_DPI_AWARE "PerMonitor")
+endif()

--- a/goal_src/jak1/pc/pckernel-common.gc
+++ b/goal_src/jak1/pc/pckernel-common.gc
@@ -34,13 +34,14 @@
 (defmethod set-window-size! ((obj pc-settings) (width int) (height int))
   "sets the size of the display window"
   (let ((display-mode (pc-get-display-mode)))
-    (format 0 "Setting window size to ~D x ~D~%" display-mode width height)
     (cond
       ((= display-mode 'windowed)
         (set! (-> obj window-width) width)
         (set! (-> obj window-height) height)
+        (format 0 "Setting window size to ~D x ~D~%" width height)
         (pc-set-window-size! (max PC_MIN_WIDTH (-> obj window-width)) (max PC_MIN_HEIGHT (-> obj window-height))))
       (else
+        (format 0 "Setting borderless/fullscreen size to ~D x ~D~%" width height)
         (set! (-> obj width) width)
         (set! (-> obj height) height))))
   (none))

--- a/goal_src/jak1/pc/pckernel-common.gc
+++ b/goal_src/jak1/pc/pckernel-common.gc
@@ -642,7 +642,11 @@
      (unless (read-from-file obj *pc-temp-string-1*)
        (format 0 "[PC] PC Settings found at '~S' but could not be loaded, using defaults!~%" *pc-temp-string-1*)
        (reset obj #t)))
-    (else (format 0 "[PC] PC Settings not found at '~S'...initializing with defaults!~%" *pc-temp-string-1*) (reset obj #t)))
+    (else
+      (format 0 "[PC] PC Settings not found at '~S'...initializing with defaults!~%" *pc-temp-string-1*)
+      (reset obj #t)
+      ;; save the file so users aren't confused, and so we can debug what the game is producing for them
+      (commit-to-file obj)))
   0)
 
 (defmethod initialize ((obj pc-settings))

--- a/goal_src/jak1/pc/pckernel-common.gc
+++ b/goal_src/jak1/pc/pckernel-common.gc
@@ -34,7 +34,7 @@
 (defmethod set-window-size! ((obj pc-settings) (width int) (height int))
   "sets the size of the display window"
   (let ((display-mode (pc-get-display-mode)))
-    (format 0 "Setting ~A size to ~D x ~D~%" display-mode width height)
+    (format 0 "Setting window size to ~D x ~D~%" display-mode width height)
     (cond
       ((= display-mode 'windowed)
         (set! (-> obj window-width) width)

--- a/goal_src/jak1/pc/pckernel-h.gc
+++ b/goal_src/jak1/pc/pckernel-h.gc
@@ -329,7 +329,17 @@
      (max! (-> obj width) PC_MIN_WIDTH)
      (max! (-> obj height) PC_MIN_HEIGHT)
      (format 0 "!!!! failed to get any screen resolutions !!!!")))
-  (format 0 "fullscreen resolution defaulted to ~D x ~D~%" (-> obj width) (-> obj height))
+  ;; ensure the default resolution was a valid choice
+  (let* ((saved-width (-> obj width))
+         (saved-height (-> obj height))
+         (supported-resolution? (pc-is-supported-resolution? saved-width saved-height)))
+   (cond
+     (supported-resolution?
+      (format 0 "[PC Settings]: Valid default game-size resolution set ~D x ~D~%" saved-width saved-height))
+     (else
+      (pc-get-active-display-size (&-> obj width) (&-> obj height))
+      (format 0 "[PC Settings]: Invalid game-size resolution ~D x ~D, defaulting to ~D x ~D~%" saved-width saved-height (-> obj width) (-> obj height)))))
+  (format 0 "[PC Settings]: fullscreen resolution defaulted to ~D x ~D~%" (-> obj width) (-> obj height))
   (set! (-> obj gfx-msaa) PC_DEFAULT_MSAA) ;; default msaa
   0)
 

--- a/goal_src/jak1/pc/pckernel-h.gc
+++ b/goal_src/jak1/pc/pckernel-h.gc
@@ -318,17 +318,10 @@
   (set! (-> obj aspect-ratio-auto?) #t)
   (set! (-> obj vsync?) #t)
   (set! (-> obj letterbox?) #t)
-  ;; get screen size and set to borderless at screen res (if retail)
-  (cond
-    ((> (pc-get-num-resolutions) 0)
-     ;; pick first available resolution by default
-     (pc-get-resolution 0 (&-> obj width) (&-> obj height)))
-    (else
-     ;; somehow didn't get a single resolution. this is pretty bad.
-     (pc-get-active-display-size (&-> obj width) (&-> obj height))
-     (max! (-> obj width) PC_MIN_WIDTH)
-     (max! (-> obj height) PC_MIN_HEIGHT)
-     (format 0 "!!!! failed to get any screen resolutions !!!!")))
+  ;; default to the displays currently chosen resolution
+  (pc-get-active-display-size (&-> obj width) (&-> obj height))
+  (max! (-> obj width) PC_MIN_WIDTH)
+  (max! (-> obj height) PC_MIN_HEIGHT)
   ;; ensure the default resolution was a valid choice
   (let* ((saved-width (-> obj width))
          (saved-height (-> obj height))


### PR DESCRIPTION
Also saves out the default `pc-settings.gc` file so it's less confusing _and_ so we can request it from users to actually see what it's doing.

The fix in the last release was only to fix bad `game-size` values when _loading_ the file.  But if you don't have a file, it picks a default.

Right now it picks that default by:
1. Your largest reported resolution
2. If that fails, the one that is currently set

In reality this scenario can never really happen (if you have a set resolution, it will be one of the reported ones).  However what can happen is for SDL to be misinformed by bad display/monitor drivers/the OS and be given "supported" resolutions that aren't actually supported.  For example some users have a 4K resolution as their highest, despite them using a 1080p monitor.

The solution is to not blindly assume the largest resolution is valid, instead use the one the user already has set.

I'm also now filtering out resolutions by refresh rate, as perhaps this also caused a problem.  ie. the monitor supports a resolution if the refresh rate is lowered, but it's currently set high (at 144hz for example).