### PR TITLE
Add more autosplit points for Jak 2 Any%

### DIFF
--- a/goal_src/jak2/pc/features/autosplit-h.gc
+++ b/goal_src/jak2/pc/features/autosplit-h.gc
@@ -127,6 +127,13 @@
    (res-stadium-burning-bush-race-class3-r uint8)
    (res-stadium-burning-bush-race-class2-r uint8)
    (res-stadium-burning-bush-race-class1-r uint8)
+   ;; misc other task-nodes
+   (tomb-poles-poles uint8) ;; left tomb/daxter boulder start
+   (fortress-save-friends-introduction uint8) ;; talk to torn (before rescue friends)
+   (sewer-escort-get-gun uint8) ;; get peacemaker
+   (forest-protect-introduction uint8) ;; talk to onin (protect samos)
+   (forest-protect-meeting uint8) ;; talk to samos (protect samos)
+
    ;; TODO - orbs in level X
    ;; end marker just to make things look nice in a memory view
    (end-marker uint8 4))

--- a/goal_src/jak2/pc/features/autosplit.gc
+++ b/goal_src/jak2/pc/features/autosplit.gc
@@ -14,7 +14,17 @@
 
 (defmacro autosplit-flag-task-complete! (field-name task-name)
   "Given a field name in the autosplitter struct, and a [[game-task]] name to check, sets either a 0 or a 1"
-  `(set! (-> this ,field-name) (if (task-complete? *game-info* (game-task ,task-name)) 1 0)))
+  `(begin
+    (if (!= (-> this ,field-name) (if (task-complete? *game-info* (game-task ,task-name)) 1 0))
+      (format 0 "AUTOSPLIT for ~A~%" (quote ,task-name)))
+    (set! (-> this ,field-name) (if (task-complete? *game-info* (game-task ,task-name)) 1 0))))
+
+(defmacro autosplit-flag-task-node-closed! (field-name task-node-name)
+  "Given a field name in the autosplitter struct, and a [[game-task-node]] name to check, sets either a 0 or a 1"
+  `(begin
+    (if (!= (-> this ,field-name) (if (task-node-closed? (game-task-node ,task-node-name)) 1 0))
+      (format 0 "AUTOSPLIT for ~A~%" (quote ,task-node-name)))
+    (set! (-> this ,field-name) (if (task-node-closed? (game-task-node ,task-node-name)) 1 0))))
 
 (defmethod update! ((this autosplit-info))
   ;; general statistics
@@ -139,6 +149,12 @@
   (autosplit-flag-task-complete! res-stadium-burning-bush-race-class3-r stadium-burning-bush-race-class3-r)
   (autosplit-flag-task-complete! res-stadium-burning-bush-race-class2-r stadium-burning-bush-race-class2-r)
   (autosplit-flag-task-complete! res-stadium-burning-bush-race-class1-r stadium-burning-bush-race-class1-r)
+  ;; misc other tasks
+  (autosplit-flag-task-node-closed! tomb-poles-poles tomb-poles-poles)  ;; left tomb/daxter boulder start
+  (autosplit-flag-task-node-closed! fortress-save-friends-introduction fortress-save-friends-introduction) ;; talk to torn (before rescue friends)
+  (autosplit-flag-task-node-closed! sewer-escort-get-gun sewer-escort-get-gun) ;; get peacemaker
+  (autosplit-flag-task-node-closed! forest-protect-introduction forest-protect-introduction) ;; talk to onin (protect samos)
+  (autosplit-flag-task-node-closed! forest-protect-meeting forest-protect-meeting) ;; talk to samos (protect samos)
 
   ;; debug only, draw stuff to the screen so i don't have to stare at a memory editor
   ;; (debug-draw this)


### PR DESCRIPTION
Goes with https://github.com/open-goal/speedrunning/pull/21

Based on some of the autosplit points from the [comgold sheet](https://docs.google.com/spreadsheets/d/1ZtceX0ZxCLkufVFQuCgVxptvmVgp6deHwPYWxUPi258/edit?gid=0#gid=0), plus one after talking to samos to give a clean split for timing the deload.

```
   (tomb-poles-poles uint8) ;; left tomb/daxter boulder start
   (fortress-save-friends-introduction uint8) ;; talk to torn (before rescue friends)
   (sewer-escort-get-gun uint8) ;; get peacemaker
   (forest-protect-introduction uint8) ;; talk to onin (protect samos)
   (forest-protect-meeting uint8) ;; talk to samos (protect samos)
```