### PR TITLE
[jak2] Workaround for sound effects getting dropped

### DIFF
--- a/game/overlord/common/ssound.h
+++ b/game/overlord/common/ssound.h
@@ -41,6 +41,8 @@ struct Sound {
   s32 auto_time;
   SoundParams params;
   SoundRecord* bank_entry;
+
+  s64 add_index = 0;
 };
 
 struct Curve {
@@ -61,7 +63,7 @@ extern u32 sLastTick;
 void ssound_init_globals();
 
 Sound* LookupSound(s32 id);
-Sound* AllocateSound();
+Sound* AllocateSound(bool remove_old_sounds);
 s32 GetVolume(Sound* sound);
 void UpdateVolume(Sound* sound);
 s32 CalculateFalloffVolume(Vec3w* pos, s32 volume, s32 fo_curve, s32 fo_min, s32 fo_max);

--- a/game/overlord/jak1/srpc.cpp
+++ b/game/overlord/jak1/srpc.cpp
@@ -93,7 +93,7 @@ void* RPC_Player(unsigned int /*fno*/, void* data, int size) {
     if (!PollSema(gSema)) {
       if (gMusic) {
         if (!gMusicPause && !LookupSound(666)) {
-          Sound* music = AllocateSound();
+          Sound* music = AllocateSound(false);
           if (music != nullptr) {
             gMusicFade = 0;
             gMusicFadeDir = 1;
@@ -183,7 +183,7 @@ void* RPC_Player(unsigned int /*fno*/, void* data, int size) {
             break;
           }
 
-          sound = AllocateSound();
+          sound = AllocateSound(false);
           if (!sound) {
             break;
           }

--- a/game/overlord/jak2/srpc.cpp
+++ b/game/overlord/jak2/srpc.cpp
@@ -40,7 +40,7 @@ void* RPC_Player(unsigned int /*fno*/, void* data, int size) {
   if (!PollSema(gSema)) {
     if (gMusic) {
       if (!gMusicPause && !LookupSound(666)) {
-        Sound* music = AllocateSound();
+        Sound* music = AllocateSound(true);
         if (music != nullptr) {
           gMusicFade = 0;
           gMusicFadeDir = 1;
@@ -117,7 +117,7 @@ void* RPC_Player(unsigned int /*fno*/, void* data, int size) {
 
         } else {
           // new sound
-          sound = AllocateSound();
+          sound = AllocateSound(true);
           if (sound == nullptr) {
             // no free sounds
             break;


### PR DESCRIPTION
Similar to the workaround added in jak 3, if too many sounds are playing, a sound will be removed. If there are multiple instances of the same sound being played, those will be removed first. Within that, older sounds are removed first.

It's not exactly the same as the instance limits of 989snd, but it seems to work well. It's at least better than what we had before.