### PR TITLE
jak3: misc fixes

### DIFF
--- a/decompiler/config/jak3/all-types.gc
+++ b/decompiler/config/jak3/all-types.gc
@@ -44457,9 +44457,9 @@
    (within-outer-ring   symbol         :offset-assert 136)
    (within-inner-ring   symbol         :offset-assert 140)
    (ouched              symbol         :offset-assert 144)
-   (bound-cam           basic          :offset-assert 148)
+   (bound-cam           string         :offset-assert 148)
    (trans               vector :inline :offset-assert 160)
-   (state-time          uint64         :offset-assert 176)
+   (state-time          time-frame     :offset-assert 176)
    (jak-in-hint-region  symbol         :offset-assert 184)
    (watchers-vulnerable symbol         :offset-assert 188)
    )
@@ -44492,7 +44492,7 @@
     standing-down ;; 31
     )
   (:methods
-    (tpl-watcher-method-32 (_type_) none) ;; 32
+    (init-collision! (_type_) none) ;; 32
     )
   )
 

--- a/decompiler/config/jak3/ntsc_v1/label_types.jsonc
+++ b/decompiler/config/jak3/ntsc_v1/label_types.jsonc
@@ -1046,7 +1046,7 @@
   "desertf-obs": [["L99", "(inline-array vector)", 2]],
   "desert-dust-storm": [["L89", "vector"]],
   "artifact-race": [
-    ["L162", "(inline-array talker-speech-class)", 16],
+    ["L162", "(inline-array talker-speech-class)", 32],
     ["L160", "vector"],
     ["L159", "vector"],
     ["L158", "vector"],

--- a/goal_src/jak3/engine/level/level.gc
+++ b/goal_src/jak3/engine/level/level.gc
@@ -3832,12 +3832,13 @@
         )
       )
     )
-  (let ((v1-194 (- #x2000000 (the-as int (-> global current)))))
-    (if (and (not *debug-segment*) (or (< v1-194 #x4000) (= *cheat-mode* 'debug)))
+  ;; og:preserve-this this was hardcoded to the top of EE memory (#x2000000)
+  (let ((v1-194 (&- (-> global top-base) (-> global current))))
+    (if (and (not *debug-segment*) (or (< v1-194 (* 16 1024)) (= *cheat-mode* 'debug)))
         (format
           *stdcon*
           "~3Lglobal heap fatally low at ~D.~DK free~%~0L"
-          (sar v1-194 10)
+          (/ v1-194 (* 1024 1024))
           (/ (logand v1-194 1023) 103)
           )
         )

--- a/goal_src/jak3/levels/desert/artifact-race/artifact-race.gc
+++ b/goal_src/jak3/levels/desert/artifact-race/artifact-race.gc
@@ -357,7 +357,7 @@
   )
 
 
-(define *artifact-race-speech-list* (new 'static 'inline-array talker-speech-class 16
+(define *artifact-race-speech-list* (new 'static 'inline-array talker-speech-class 32
                                       (new 'static 'talker-speech-class :name "none")
                                       (new 'static 'talker-speech-class
                                         :name "dax128"
@@ -503,6 +503,166 @@
                                         :channel (gui-channel daxter)
                                         :flags (talker-flags tf0)
                                         :speech #xf
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax177"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x10
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax178"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x11
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax179"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x12
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax180"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x13
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax181"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x14
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax182"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x15
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax183"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x16
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax184"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x17
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax185"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x18
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax186"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x19
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax187"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x1a
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax188"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x1b
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax189"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x1c
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax190"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x1d
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax191"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x1e
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax192"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x1f
                                         :text-duration (seconds 1)
                                         :neg #x1
                                         :on-close #f

--- a/goal_src/jak3/levels/temple/temple-obs2.gc
+++ b/goal_src/jak3/levels/temple/temple-obs2.gc
@@ -1262,6 +1262,8 @@
   )
 
 (defmethod init-from-entity! ((this tpl-door-switch) (arg0 entity-actor))
+  ;; og:preserve-this added
+  (stack-size-set! (-> this main-thread) 512)
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)

--- a/goal_src/jak3/levels/temple/temple-obs2.gc
+++ b/goal_src/jak3/levels/temple/temple-obs2.gc
@@ -99,7 +99,8 @@
         (suspend)
         )
       (set-setting! 'entity-name "camera-356" 0.0 0)
-      (suspend-for (seconds 1))
+      (suspend-for (seconds 1)
+        )
       )
     (sound-play "gate-raise")
     (ja-no-eval :group! tpl-gate-close-ja :num! (seek!) :frame-num 0.0)
@@ -108,7 +109,8 @@
       (suspend)
       (ja :num! (seek!))
       )
-    (suspend-for (seconds 0.1))
+    (suspend-for (seconds 0.1)
+      )
     (let ((a1-6 (new 'stack-no-clear 'event-message-block)))
       (set! (-> a1-6 from) (process->ppointer self))
       (set! (-> a1-6 num-params) 0)
@@ -125,9 +127,11 @@
         )
       )
     (when (= (-> self extra-id) 1)
-      (suspend-for (seconds 0.5))
+      (suspend-for (seconds 0.5)
+        )
       (remove-setting! 'entity-name)
-      (suspend-for (seconds 2.5))
+      (suspend-for (seconds 2.5)
+        )
       (until (process-release? *target*)
         (suspend)
         )
@@ -251,9 +255,9 @@
    (within-outer-ring    symbol)
    (within-inner-ring    symbol)
    (ouched               symbol)
-   (bound-cam            basic)
+   (bound-cam            string)
    (trans                vector  :inline)
-   (state-time           uint64)
+   (state-time           time-frame)
    (jak-in-hint-region   symbol)
    (watchers-vulnerable  symbol)
    )
@@ -360,7 +364,7 @@
          (logior! (-> v1-8 status) (entity-perm-status bit-14))
          )
        )
-     (set! (-> self bound-cam) (the-as basic (-> arg3 param 0)))
+     (set! (-> self bound-cam) (the-as string (-> arg3 param 0)))
      (set! (-> self ouched) #t)
      (go-virtual until-watchers-dead)
      )
@@ -405,7 +409,8 @@
   :event tpl-watcher-manager-ehandler
   :trans watcher-man-trans
   :code (behavior ()
-    (suspend-for (seconds 1))
+    (suspend-for (seconds 1)
+      )
     (while (and *target* (focus-test? *target* dead))
       (suspend)
       )
@@ -417,7 +422,7 @@
   :virtual #t
   :event tpl-watcher-manager-ehandler
   :enter (behavior ()
-    (set! (-> self state-time) (the-as uint (current-time)))
+    (set-time! (-> self state-time))
     )
   :trans watcher-man-trans
   :code (behavior ()
@@ -428,7 +433,8 @@
         (suspend)
         )
       (process-entity-status! self (entity-perm-status no-kill) #t)
-      (suspend-for (seconds 2.5))
+      (suspend-for (seconds 2.5)
+        )
       (while (not (process-release? *target*))
         (suspend)
         )
@@ -457,7 +463,7 @@
           )
         )
       )
-    (until (time-elapsed? (the-as int (-> self state-time)) (seconds 1))
+    (until (time-elapsed? (-> self state-time) (seconds 1))
       (suspend)
       )
     (task-close! "temple-oracle-watchers-complete")
@@ -557,7 +563,7 @@
     standing-down
     )
   (:methods
-    (tpl-watcher-method-32 (_type_) none)
+    (init-collision! (_type_) none)
     )
   )
 
@@ -841,6 +847,8 @@
                 )
               )
             (suspend)
+            ;; og:preserve-this fix vf0 clobbering after suspend
+            (init-vf0-vector)
             (set! v1-32 (- (current-time) s4-0))
             (let ((a0-14 (-> self manager)))
               (set! a1-12 (if a0-14
@@ -910,7 +918,9 @@
                )
              )
             (sound-play "wtcher-fire")
-            (suspend-for (seconds 1) '())
+            (suspend-for (seconds 1)
+              '()
+              )
             )
           )
         )
@@ -978,7 +988,8 @@
           )
         )
       )
-    (suspend-for (seconds 4))
+    (suspend-for (seconds 4)
+      )
     (while (-> self child)
       (suspend)
       )
@@ -1013,13 +1024,14 @@
     (let ((gp-0 (-> self root quat))
           (s5-0 (-> self entity quat))
           )
-      (suspend-for (seconds 1.5) (quaternion-slerp!
-                                   (-> self root quat)
-                                   gp-0
-                                   s5-0
-                                   (* 0.0022222223 (the float (- (current-time) (-> self state-time))))
-                                   )
-                   )
+      (suspend-for (seconds 1.5)
+        (quaternion-slerp!
+          (-> self root quat)
+          gp-0
+          s5-0
+          (* 0.0022222223 (the float (- (current-time) (-> self state-time))))
+          )
+        )
       )
     (go-virtual idle)
     )
@@ -1027,7 +1039,7 @@
   )
 
 ;; WARN: Return type mismatch collide-shape-moving vs none.
-(defmethod tpl-watcher-method-32 ((this tpl-watcher))
+(defmethod init-collision! ((this tpl-watcher))
   (let ((s5-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s5-0 reaction) cshape-reaction-default)
@@ -1082,7 +1094,7 @@
 (defmethod init-from-entity! ((this tpl-watcher) (arg0 entity-actor))
   (local-vars (sv-16 res-tag))
   (stack-size-set! (-> this main-thread) 384)
-  (tpl-watcher-method-32 this)
+  (init-collision! this)
   (process-drawable-from-entity! this arg0)
   (logior! (-> this mask) (process-mask enemy))
   (initialize-skeleton
@@ -1250,8 +1262,6 @@
   )
 
 (defmethod init-from-entity! ((this tpl-door-switch) (arg0 entity-actor))
-  ;; og:preserve-this added
-  (stack-size-set! (-> this main-thread) 512)
   (let ((s4-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s4-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s4-0 reaction) cshape-reaction-default)
@@ -1630,8 +1640,7 @@
         (quaternion-normalize! s5-2)
         (set-time! (-> self state-time))
         (let ((f30-1 (lerp-scale 45.0 9.0 (-> self clock clock-ratio) 1.0 0.05)))
-          (suspend-for
-            (the int f30-1)
+          (suspend-for (the int f30-1)
             (quaternion-slerp!
               (-> self root quat)
               gp-3
@@ -1657,7 +1666,9 @@
   :trans rider-trans
   :code (behavior ()
     (let ((f30-0 (res-lump-float (-> self entity) 'tpl-platform-predelay)))
-      (suspend-for (the int (* 300.0 f30-0)) '())
+      (suspend-for (the int (* 300.0 f30-0))
+        '()
+        )
       )
     (go-virtual flip)
     )
@@ -1711,7 +1722,9 @@
   :code (behavior ()
     (set-time! (-> self state-time))
     (set! (-> self state-time) (-> *display* real-clock frame-counter))
-    (suspend-for (seconds 0.25) '())
+    (suspend-for (seconds 0.25)
+      '()
+      )
     (while (< (+ (-> *display* real-clock frame-counter) (seconds -1)) (-> self last-ridden))
       (suspend)
       )

--- a/test/decompiler/reference/jak3/levels/desert/artifact-race/artifact-race_REF.gc
+++ b/test/decompiler/reference/jak3/levels/desert/artifact-race/artifact-race_REF.gc
@@ -422,7 +422,7 @@
   )
 
 ;; definition for symbol *artifact-race-speech-list*, type (inline-array talker-speech-class)
-(define *artifact-race-speech-list* (new 'static 'inline-array talker-speech-class 16
+(define *artifact-race-speech-list* (new 'static 'inline-array talker-speech-class 32
                                       (new 'static 'talker-speech-class :name "none")
                                       (new 'static 'talker-speech-class
                                         :name "dax128"
@@ -568,6 +568,166 @@
                                         :channel (gui-channel daxter)
                                         :flags (talker-flags tf0)
                                         :speech #xf
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax177"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x10
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax178"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x11
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax179"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x12
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax180"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x13
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax181"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x14
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax182"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x15
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax183"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x16
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax184"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x17
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax185"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x18
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax186"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x19
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax187"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x1a
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax188"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x1b
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax189"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x1c
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax190"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x1d
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax191"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x1e
+                                        :text-duration (seconds 1)
+                                        :neg #x1
+                                        :on-close #f
+                                        :camera #f
+                                        )
+                                      (new 'static 'talker-speech-class
+                                        :name "dax192"
+                                        :channel (gui-channel daxter)
+                                        :flags (talker-flags tf0)
+                                        :speech #x1f
                                         :text-duration (seconds 1)
                                         :neg #x1
                                         :on-close #f
@@ -1008,3 +1168,7 @@
       )
     )
   )
+
+
+
+

--- a/test/decompiler/reference/jak3/levels/temple/temple-obs2_REF.gc
+++ b/test/decompiler/reference/jak3/levels/temple/temple-obs2_REF.gc
@@ -272,9 +272,9 @@
    (within-outer-ring    symbol)
    (within-inner-ring    symbol)
    (ouched               symbol)
-   (bound-cam            basic)
+   (bound-cam            string)
    (trans                vector  :inline)
-   (state-time           uint64)
+   (state-time           time-frame)
    (jak-in-hint-region   symbol)
    (watchers-vulnerable  symbol)
    )
@@ -408,7 +408,7 @@
          (logior! (-> v1-8 status) (entity-perm-status bit-14))
          )
        )
-     (set! (-> self bound-cam) (the-as basic (-> arg3 param 0)))
+     (set! (-> self bound-cam) (the-as string (-> arg3 param 0)))
      (set! (-> self ouched) #t)
      (go-virtual until-watchers-dead)
      )
@@ -470,7 +470,7 @@
   :virtual #t
   :event tpl-watcher-manager-ehandler
   :enter (behavior ()
-    (set! (-> self state-time) (the-as uint (current-time)))
+    (set-time! (-> self state-time))
     )
   :trans watcher-man-trans
   :code (behavior ()
@@ -511,7 +511,7 @@
           )
         )
       )
-    (until (time-elapsed? (the-as int (-> self state-time)) (seconds 1))
+    (until (time-elapsed? (-> self state-time) (seconds 1))
       (suspend)
       )
     (task-close! "temple-oracle-watchers-complete")
@@ -615,7 +615,7 @@
     standing-down
     )
   (:methods
-    (tpl-watcher-method-32 (_type_) none)
+    (init-collision! (_type_) none)
     )
   )
 
@@ -1120,7 +1120,7 @@
 
 ;; definition for method 32 of type tpl-watcher
 ;; WARN: Return type mismatch collide-shape-moving vs none.
-(defmethod tpl-watcher-method-32 ((this tpl-watcher))
+(defmethod init-collision! ((this tpl-watcher))
   (let ((s5-0 (new 'process 'collide-shape-moving this (collide-list-enum usually-hit-by-player))))
     (set! (-> s5-0 dynam) (copy *standard-dynamics* 'process))
     (set! (-> s5-0 reaction) cshape-reaction-default)
@@ -1179,7 +1179,7 @@
 (defmethod init-from-entity! ((this tpl-watcher) (arg0 entity-actor))
   (local-vars (sv-16 res-tag))
   (stack-size-set! (-> this main-thread) 384)
-  (tpl-watcher-method-32 this)
+  (init-collision! this)
   (process-drawable-from-entity! this arg0)
   (logior! (-> this mask) (process-mask enemy))
   (initialize-skeleton
@@ -2235,3 +2235,7 @@
   ((method-of-type process-focusable deactivate) (the-as process-focusable this))
   (none)
   )
+
+
+
+


### PR DESCRIPTION
- Fix global heap display in cheat mode
- Fix `tpl-watcher` NaNs after they fire their laser (`vf0` was being clobbered) (Fixes #3684)
- Fix `artifact-race` talkers (Fixes #3685)