### PR TITLE
game: dont filter resolutions in windowed mode

### DIFF
--- a/game/graphics/opengl_renderer/loader/LoaderStages.cpp
+++ b/game/graphics/opengl_renderer/loader/LoaderStages.cpp
@@ -344,8 +344,8 @@ class TieLoadStage : public LoaderStage {
           if (m_next_tree >= data.lev_data->level->tie_trees[m_next_geo].size()) {
             m_next_tree = 0;
             m_next_geo++;
-            while (data.lev_data->level->tie_trees[m_next_geo].empty() &&
-                   m_next_geo < tfrag3::TIE_GEOS) {
+            while (m_next_geo < tfrag3::TIE_GEOS &&
+                   data.lev_data->level->tie_trees[m_next_geo].empty()) {
               m_next_geo++;
             }
             if (m_next_geo >= tfrag3::TIE_GEOS) {
@@ -452,8 +452,8 @@ class TieLoadStage : public LoaderStage {
           if (m_next_tree >= data.lev_data->level->tie_trees[m_next_geo].size()) {
             m_next_tree = 0;
             m_next_geo++;
-            while (data.lev_data->level->tie_trees[m_next_geo].empty() &&
-                   m_next_geo < tfrag3::TIE_GEOS) {
+            while (m_next_geo < tfrag3::TIE_GEOS &&
+                   data.lev_data->level->tie_trees[m_next_geo].empty()) {
               m_next_geo++;
             }
             if (m_next_geo >= tfrag3::TIE_GEOS) {

--- a/game/kernel/common/kmachine.cpp
+++ b/game/kernel/common/kmachine.cpp
@@ -586,16 +586,18 @@ void pc_set_window_size(u64 width, u64 height) {
   }
 }
 
-s64 pc_get_num_resolutions() {
+s64 pc_get_num_resolutions(u32 for_windowed) {
   if (Display::GetMainDisplay()) {
-    return Display::GetMainDisplay()->get_display_manager()->get_num_resolutions();
+    return Display::GetMainDisplay()->get_display_manager()->get_num_resolutions(
+        symbol_to_bool(for_windowed));
   }
   return 0;
 }
 
-void pc_get_resolution(u32 id, u32 w_ptr, u32 h_ptr) {
+void pc_get_resolution(u32 id, u32 for_windowed, u32 w_ptr, u32 h_ptr) {
   if (Display::GetMainDisplay()) {
-    auto res = Display::GetMainDisplay()->get_display_manager()->get_resolution(id);
+    auto res = Display::GetMainDisplay()->get_display_manager()->get_resolution(
+        id, symbol_to_bool(for_windowed));
     auto w = Ptr<s64>(w_ptr).c();
     if (w) {
       *w = res.width;

--- a/game/system/hid/display_manager.h
+++ b/game/system/hid/display_manager.h
@@ -80,8 +80,8 @@ class DisplayManager {
   game_settings::DisplaySettings::DisplayMode get_display_mode() {
     return m_display_settings.display_mode;
   }
-  int get_num_resolutions() { return m_available_resolutions.size(); }
-  Resolution get_resolution(int id);
+  int get_num_resolutions(bool for_window_size);
+  Resolution get_resolution(int id, bool for_window_size);
   bool is_supported_resolution(int width, int height);
 
   // Mutators
@@ -123,6 +123,7 @@ class DisplayManager {
   // ie. allowing someone to set 150fps on a monitor set to 60hz is not correct
   std::unordered_map<int, DisplayMode> m_current_display_modes;
   std::vector<Resolution> m_available_resolutions;
+  std::vector<Resolution> m_available_window_sizes;
 
   void initialize_window_position_from_settings();
   void update_curr_display_info();

--- a/goal_src/jak1/kernel-defs.gc
+++ b/goal_src/jak1/kernel-defs.gc
@@ -507,9 +507,9 @@
 
 (define-extern pc-set-display-mode! (function symbol none))
 
-(define-extern pc-get-num-resolutions (function int))
+(define-extern pc-get-num-resolutions (function symbol int))
 
-(define-extern pc-get-resolution (function int (pointer int64) (pointer int64) none))
+(define-extern pc-get-resolution (function int symbol (pointer int64) (pointer int64) none))
 
 (define-extern pc-is-supported-resolution? (function int int symbol))
 

--- a/goal_src/jak1/pc/progress-pc.gc
+++ b/goal_src/jak1/pc/progress-pc.gc
@@ -1179,7 +1179,7 @@
   (let ((window-width 0)
         (window-height 0)
         (window-aspect-ratio 0.0)
-        (num-resolutions (pc-get-num-resolutions))
+        (num-resolutions (pc-get-num-resolutions (= (pc-get-display-mode) 'windowed)))
         (num-resolutions-added 0))
     (when (> num-resolutions 0)
       (pc-get-window-size (& window-width) (& window-height))
@@ -1188,7 +1188,7 @@
         (let ((res-width 0)
               (res-height 0)
               (res-aspect-ratio 0.0))
-          (pc-get-resolution i (& res-width) (& res-height))
+          (pc-get-resolution i (= (pc-get-display-mode) 'windowed) (& res-width) (& res-height))
           (set! res-aspect-ratio (/ (the float res-width) (the float res-height)))
           ;; Ignore those that aren't relevant to the current window's aspect ratio
           ;; we only do this when we aren't in windowed mode, because in windowed mode

--- a/goal_src/jak2/kernel-defs.gc
+++ b/goal_src/jak2/kernel-defs.gc
@@ -221,8 +221,8 @@
 (define-extern pc-get-display-id (function int))
 (define-extern pc-set-display-id! (function int none))
 (define-extern pc-set-display-mode! (function symbol none))
-(define-extern pc-get-num-resolutions (function int))
-(define-extern pc-get-resolution (function int (pointer int64) (pointer int64) none))
+(define-extern pc-get-num-resolutions (function symbol int))
+(define-extern pc-get-resolution (function int symbol (pointer int64) (pointer int64) none))
 (define-extern pc-is-supported-resolution? (function int int symbol))
 
 (define-extern pc-set-frame-rate (function int none))

--- a/goal_src/jak2/pc/progress/progress-draw-pc.gc
+++ b/goal_src/jak2/pc/progress/progress-draw-pc.gc
@@ -3198,7 +3198,7 @@
 
           ;; count "valid" resolutions
           (let ((this-w 0) (this-h 0) (this-aspect 0.0))
-          (pc-get-resolution i (& this-w) (& this-h))
+          (pc-get-resolution i (= (pc-get-display-mode) 'windowed) (& this-w) (& this-h))
           (set! this-aspect (/ (the float this-w) (the float this-h)))
 
           (when (or (= (pc-get-display-mode) 'windowed)

--- a/goal_src/jak2/pc/progress/progress-pc.gc
+++ b/goal_src/jak2/pc/progress/progress-pc.gc
@@ -679,8 +679,8 @@
         (res-h 0)
         (res-aspect 0.0)
         (res-valid 0))
-      (dotimes (i (pc-get-num-resolutions))
-        (pc-get-resolution i (& res-w) (& res-h))
+      (dotimes (i (pc-get-num-resolutions (= (pc-get-display-mode) 'windowed)))
+        (pc-get-resolution i (= (pc-get-display-mode) 'windowed) (& res-w) (& res-h))
         (set! res-aspect (/ (the float res-w) (the float res-h)))
         (when (or (= (pc-get-display-mode) 'windowed)
                   (< (fabs (- want-aspect res-aspect)) 0.05))
@@ -716,7 +716,7 @@
         (select-h -1)
         )
 
-    (set! (-> this num-resolutions) (pc-get-num-resolutions))
+    (set! (-> this num-resolutions) (pc-get-num-resolutions (= (pc-get-display-mode) 'windowed)))
     (cond
       ;; valid state
       ((> (-> this num-resolutions) 0)
@@ -770,7 +770,7 @@
 
             ;; count "valid" resolutions
             (let ((this-w 0) (this-h 0) (this-aspect 0.0))
-            (pc-get-resolution i (& this-w) (& this-h))
+            (pc-get-resolution i (= (pc-get-display-mode) 'windowed) (& this-w) (& this-h))
             (set! this-aspect (/ (the float this-w) (the float this-h)))
 
             (when (or (= (pc-get-display-mode) 'windowed)

--- a/goal_src/jak3/kernel-defs.gc
+++ b/goal_src/jak3/kernel-defs.gc
@@ -210,8 +210,8 @@
 (define-extern pc-get-display-id (function int))
 (define-extern pc-set-display-id! (function int none))
 (define-extern pc-set-display-mode! (function symbol none))
-(define-extern pc-get-num-resolutions (function int))
-(define-extern pc-get-resolution (function int (pointer int64) (pointer int64) none))
+(define-extern pc-get-num-resolutions (function symbol int))
+(define-extern pc-get-resolution (function int symbol (pointer int64) (pointer int64) none))
 (define-extern pc-is-supported-resolution? (function int int symbol))
 
 (define-extern pc-set-frame-rate (function int none))


### PR DESCRIPTION
I'll test this more thoroughly tomorrow, quick change to allow picking resolutions that would normally be filtered out, while in windowed mode.