### PR TITLE
[jak3] fix envmap texture and strength

### DIFF
--- a/decompiler/level_extractor/extract_merc.cpp
+++ b/decompiler/level_extractor/extract_merc.cpp
@@ -853,7 +853,7 @@ ConvertedMercEffect convert_merc_effect(const MercEffect& input_effect,
         u32 tidx = (env >> 8) & 0b1111'1111'1111;
         tex_combo = (((u32)tpage) << 16) | tidx;
       } break;
-      case GameVersion::Jak2:{
+      case GameVersion::Jak2: {
         u32 tpage = 0x1f;
         u32 tidx = 2;
         tex_combo = (((u32)tpage) << 16) | tidx;

--- a/decompiler/level_extractor/extract_merc.cpp
+++ b/decompiler/level_extractor/extract_merc.cpp
@@ -853,10 +853,17 @@ ConvertedMercEffect convert_merc_effect(const MercEffect& input_effect,
         u32 tidx = (env >> 8) & 0b1111'1111'1111;
         tex_combo = (((u32)tpage) << 16) | tidx;
       } break;
-      case GameVersion::Jak2:
-      case GameVersion::Jak3: {
+      case GameVersion::Jak2:{
         u32 tpage = 0x1f;
         u32 tidx = 2;
+        tex_combo = (((u32)tpage) << 16) | tidx;
+      } break;
+      case GameVersion::Jak3: {
+        // (define *generic-envmap-texture* (get-texture pal-environment-front environment-generic))
+        // (defconstant environment-generic 2) tpage
+        // (def-tex pal-environment-front environment-generic 1) texture
+        u32 tpage = 2;
+        u32 tidx = 1;
         tex_combo = (((u32)tpage) << 16) | tidx;
       } break;
       default:

--- a/game/graphics/opengl_renderer/shaders/emerc.frag
+++ b/game/graphics/opengl_renderer/shaders/emerc.frag
@@ -22,9 +22,7 @@ void main() {
 
     color.a = T0.a;
     color.rgb = T0.rgb * vtx_color;
-    // this multiply by two was mistakenly here in OpenGOAL for a long time, making things overly shiny.
-    // uncomment the following line to get the old shiny behavior back.
-    // color *= 2;
+    color *= 2;
   } else {
     color.rgb = vtx_color;
     color.a = 1;

--- a/game/graphics/opengl_renderer/shaders/emerc.frag
+++ b/game/graphics/opengl_renderer/shaders/emerc.frag
@@ -22,7 +22,9 @@ void main() {
 
     color.a = T0.a;
     color.rgb = T0.rgb * vtx_color;
-    color *= 2;
+    // this multiply by two was mistakenly here in OpenGOAL for a long time, making things overly shiny.
+    // uncomment the following line to get the old shiny behavior back.
+    // color *= 2;
   } else {
     color.rgb = vtx_color;
     color.a = 1;

--- a/game/kernel/jak3/kscheme.cpp
+++ b/game/kernel/jak3/kscheme.cpp
@@ -1085,8 +1085,6 @@ u64 type_typep(Ptr<Type> t1, Ptr<Type> t2) {
 
 u64 method_set(u32 type_, u32 method_id, u32 method) {
   Ptr<Type> type(type_);
-  if (method_id > 255)
-    printf("[METHOD SET ERROR] tried to set method %d\n", method_id);
 
   auto existing_method = type->get_method(method_id).offset;
 

--- a/goal_src/jak2/engine/gfx/foreground/foreground.gc
+++ b/goal_src/jak2/engine/gfx/foreground/foreground.gc
@@ -1423,7 +1423,8 @@
                                     )
                                (cond
                                  ((or (nonzero? (-> bucket-info must-use-mercneric-for-clip))
-                                      (or (< 0.0 t-amount) (logtest? (-> geo effect effect-idx effect-bits) (effect-bits cross-fade)))
+                                      ;; force envmap mode, even if strength is zero - PC renderer will handle this case.
+                                      (or #|(< 0.0 t-amount)|# #t (logtest? (-> geo effect effect-idx effect-bits) (effect-bits cross-fade)))
                                       )
                                   (let ((a0-33 (&-> tint-info tint))
                                         (v1-74 (the-as object (-> bucket-info effect effect-idx)))

--- a/goal_src/jak3/engine/gfx/foreground/foreground.gc
+++ b/goal_src/jak3/engine/gfx/foreground/foreground.gc
@@ -2102,7 +2102,8 @@
                                     )
                                (cond
                                  ((or (nonzero? (-> bucket-info must-use-mercneric-for-clip))
-                                      (or (< 0.0 t-amount) (logtest? (-> geo effect effect-idx effect-bits) (effect-bits cross-fade)))
+                                      ;; force envmap mode, even if strength is zero - PC renderer will handle this case.
+                                      (or #t #|(< 0.0 t-amount)|# (logtest? (-> geo effect effect-idx effect-bits) (effect-bits cross-fade)))
                                       )
                                   (let ((a0-33 (&-> tint-info tint))
                                         (v1-74 (the-as object (-> bucket-info effect effect-idx)))


### PR DESCRIPTION
Fix the envmap texture using the eye texture by default (will require a re-extract to fix), fix envmap strength in all three games being off by 2x. (oops)

With envmap scale fix:
![image](https://github.com/user-attachments/assets/3b0ef8b7-cbdc-4402-8a12-af368538c16e)

without envmap scale fix (but with texture fix):
![image](https://github.com/user-attachments/assets/fd72d75b-f0bb-455c-a7c9-56916fbd4a67)

