### PR TITLE
game: Update game's GPU test to output the GPU vendor info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # logs
 /log
 prof.json
+/gpu-test.json
 
 # for CMake
 /Testing

--- a/.vs/launch.vs.json
+++ b/.vs/launch.vs.json
@@ -142,6 +142,19 @@
       "type": "default",
       "project": "CMakeLists.txt",
       "projectTarget": "gk.exe (bin\\gk.exe)",
+      "name": "Game - GPU Test",
+      "args": [
+        "-v",
+        "--gpu-test",
+        "opengl",
+        "--gpu-test-out-path",
+        "./gpu-test.json"
+      ]
+    },
+    {
+      "type": "default",
+      "project": "CMakeLists.txt",
+      "projectTarget": "gk.exe (bin\\gk.exe)",
       "name": "Game - Jak 1 - Runtime (boot)",
       "args": [
         "-v",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -164,6 +164,13 @@ tasks:
   lint:
     cmds:
       - python ./scripts/ci/lint-trailing-whitespace.py
+  run-gpu-test:
+    desc: "Runs the game's built in GPU test"
+    preconditions:
+      - sh: test -f {{.GK_BIN_RELEASE_DIR}}/gk{{.EXE_FILE_EXTENSION}}
+        msg: "Couldn't locate runtime executable in '{{.GK_BIN_RELEASE_DIR}}/gk'"
+    cmds:
+      - "{{.GK_BIN_RELEASE_DIR}}/gk -v --gpu-test opengl --gpu-test-out-path ./gpu-test.json"
   # TESTS
   offline-tests: # ran by jenkins
     cmds:

--- a/game/graphics/gfx_test.h
+++ b/game/graphics/gfx_test.h
@@ -9,6 +9,8 @@ struct GPUTestOutput {
   bool success;
   std::string error;
   std::string errorCause;
+  std::optional<std::string> gpuRendererString;
+  std::optional<std::string> gpuVendorString;
 };
 void to_json(json& j, const GPUTestOutput& obj);
 


### PR DESCRIPTION
This is so I can get rid of wgpu from the launcher, where it's only purpose is to figure out the GPU name for the support package.

The problem with it is that on some environments, it errors, but the function cannot have it's errors gracefully handled (it panics and crashes instead).

So I'm tired of it, do it ourselves.

![image](https://github.com/user-attachments/assets/fa8ae365-b3f7-4794-81ed-fde0c2ffc651)
