### PR TITLE
[jak3] Fix target marker texture

### DIFF
--- a/decompiler/level_extractor/extract_level.cpp
+++ b/decompiler/level_extractor/extract_level.cpp
@@ -279,20 +279,25 @@ void extract_common(const ObjectFileDB& db,
   extract_art_groups_from_level(db, tex_db, {}, "ARTSPOOL", tfrag_level, art_group_data);
 
   std::set<std::string> textures_we_have;
+  std::set<u32> textures_we_have_id;
 
   // put _all_ index textures in common.
   for (const auto& [id, tex] : tex_db.index_textures_by_combo_id) {
     tfrag_level.index_textures.push_back(tex);
   }
 
+  // remember which textures we already added.
+  // textures with the same name or the same ID always have the same data.
   for (const auto& t : tfrag_level.textures) {
     textures_we_have.insert(t.debug_name);
+    textures_we_have_id.insert(t.combo_id);
   }
 
+  // for common textures, add if the ID isn't there - common textures are looked up by ID.
   for (const auto& [id, normal_texture] : tex_db.textures) {
-    if (config.common_tpages.count(normal_texture.page) &&
-        !textures_we_have.count(normal_texture.name)) {
+    if (config.common_tpages.count(normal_texture.page) && !textures_we_have_id.count(id)) {
       textures_we_have.insert(normal_texture.name);
+      textures_we_have_id.insert(id);
       tfrag_level.textures.push_back(
           make_texture(id, normal_texture, tex_db.tpage_names.at(normal_texture.page), true));
     }

--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -366,10 +366,8 @@ void OpenGLRenderer::init_bucket_renderers_jak3() {
                                                BucketId::DEBUG_NO_ZBUF1, m_texture_animator, true);
     // 578
     init_bucket_renderer<TextureUploadHandler>("tex-hud-hud-alpha", BucketCategory::TEX,
-                                               BucketId::TEX_HUD_HUD_ALPHA, m_texture_animator);
-
-    init_bucket_renderer<TextureUploadHandler>("tex-hud-hud-alpha", BucketCategory::TEX,
-                                               BucketId::TEX_HUD_HUD_ALPHA, m_texture_animator);
+                                               BucketId::TEX_HUD_HUD_ALPHA, m_texture_animator,
+                                               true);
     init_bucket_renderer<ProgressRenderer>("hud-draw-hud-alpha", BucketCategory::OTHER,
                                            BucketId::HUD_DRAW_HUD_ALPHA, 0x8000);
     init_bucket_renderer<TextureUploadHandler>("tex-hud-pris2", BucketCategory::TEX,


### PR DESCRIPTION
Fixes https://github.com/open-goal/jak-project/issues/3720.

The texture page and texture name appear multiple times with different IDs, meaning that we insert the texture with the wrong ID.  Fixed by using IDs for common_tpage textures.  Since this common_tpage feature is only used for minimap stuff, I don't think it can mess up texture animations.

![image](https://github.com/user-attachments/assets/0d5d45e9-b69a-48b5-86c9-b9c597f0872e)
