### PR TITLE
[jak3] Fix neosat particles and tentacle

### DIFF
--- a/game/graphics/opengl_renderer/shaders/sprite3_3d.vert
+++ b/game/graphics/opengl_renderer/shaders/sprite3_3d.vert
@@ -119,7 +119,7 @@ void main() {
     float sp_sin = sin(quat.z);
     float sp_cos = cos(quat.z);
 
-    vec4 xy0_vf19 = xy_array[vert_id + flags_matrix.x];
+    vec4 xy0_vf19 = xy_array[vert_id + (flags_matrix.x & 15)];
     vec4 vf12_rotated = (basis_x * sp_cos) - (basis_y * sp_sin);
     vec4 vf13_rotated_trans = (basis_x * sp_sin) + (basis_y * sp_cos);
 
@@ -141,7 +141,7 @@ void main() {
     float sp_sin = sin(quat.z);
     float sp_cos = cos(quat.z);
 
-    vec4 xy0_vf19 = xy_array[vert_id + flags_matrix.x];
+    vec4 xy0_vf19 = xy_array[vert_id + (flags_matrix.x & 15)];
     vec4 vf12_rotated = (basis_x * sp_cos) - (basis_y * sp_sin);
     vec4 vf13_rotated_trans = (basis_x * sp_sin) + (basis_y * sp_cos);
 

--- a/game/graphics/opengl_renderer/sprite/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/sprite/Sprite3.cpp
@@ -837,6 +837,7 @@ void Sprite3::do_block_common(SpriteMode mode,
 
     if (render_state->version == GameVersion::Jak3) {
       auto flag = m_vec_data_2d[sprite_idx].flag();
+
       if ((flag & 0x10) || (flag & 0x20)) {
         // these flags mean we need to swap vertex order around - not yet implemented since it's too
         // hard to get right without this code running.
@@ -867,6 +868,34 @@ void Sprite3::do_block_common(SpriteMode mode,
     m_vertices_3d.at(start_vtx_id + 1).info[2] = 1;
     m_vertices_3d.at(start_vtx_id + 2).info[2] = 3;
     m_vertices_3d.at(start_vtx_id + 3).info[2] = 2;
+
+    // note that PC swaps the last two vertices
+    if (render_state->version == GameVersion::Jak3) {
+      auto flag = m_vec_data_2d[sprite_idx].flag();
+      switch (flag & 0x30) {
+        case 0x10:
+          // FLAG 16: 1, 0, 3, 2
+          m_vertices_3d.at(start_vtx_id + 0).info[2] = 0;
+          m_vertices_3d.at(start_vtx_id + 1).info[2] = 1;
+          m_vertices_3d.at(start_vtx_id + 2).info[2] = 2;
+          m_vertices_3d.at(start_vtx_id + 3).info[2] = 2;
+          break;
+        case 0x20:
+          // FLAG 32: 3, 2, 1, 0
+          m_vertices_3d.at(start_vtx_id + 0).info[2] = 3;
+          m_vertices_3d.at(start_vtx_id + 1).info[2] = 2;
+          m_vertices_3d.at(start_vtx_id + 2).info[2] = 1;
+          m_vertices_3d.at(start_vtx_id + 3).info[2] = 0;
+          break;
+        case 0x30:
+          // 2, 3, 0, 1
+          m_vertices_3d.at(start_vtx_id + 0).info[2] = 2;
+          m_vertices_3d.at(start_vtx_id + 1).info[2] = 3;
+          m_vertices_3d.at(start_vtx_id + 2).info[2] = 1;
+          m_vertices_3d.at(start_vtx_id + 3).info[2] = 0;
+          break;
+      }
+    }
 
     ++m_sprite_idx;
   }

--- a/game/graphics/opengl_renderer/sprite/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/sprite/Sprite3.cpp
@@ -877,15 +877,15 @@ void Sprite3::do_block_common(SpriteMode mode,
           // FLAG 16: 1, 0, 3, 2
           m_vertices_3d.at(start_vtx_id + 0).info[2] = 0;
           m_vertices_3d.at(start_vtx_id + 1).info[2] = 1;
-          m_vertices_3d.at(start_vtx_id + 2).info[2] = 2;
+          m_vertices_3d.at(start_vtx_id + 2).info[2] = 3;
           m_vertices_3d.at(start_vtx_id + 3).info[2] = 2;
           break;
         case 0x20:
           // FLAG 32: 3, 2, 1, 0
           m_vertices_3d.at(start_vtx_id + 0).info[2] = 3;
           m_vertices_3d.at(start_vtx_id + 1).info[2] = 2;
-          m_vertices_3d.at(start_vtx_id + 2).info[2] = 1;
-          m_vertices_3d.at(start_vtx_id + 3).info[2] = 0;
+          m_vertices_3d.at(start_vtx_id + 2).info[2] = 0;
+          m_vertices_3d.at(start_vtx_id + 3).info[2] = 1;
           break;
         case 0x30:
           // 2, 3, 0, 1

--- a/goal_src/jak3/levels/desert/rescue/neo-satellite.gc
+++ b/goal_src/jak3/levels/desert/rescue/neo-satellite.gc
@@ -2183,7 +2183,10 @@
          )
     (set! (-> s3-0 quad) (-> this node-list data gp-0 bone transform fvec quad))
     (let ((gp-1 (-> this ropes (-> *neo-sat-laser-array* arg0 rope-index))))
-      (set! (-> gp-1 knots data 0 mass) (the-as float #x7f800000))
+      ;; og:preserve-this made infinite mass slightly less infinite.
+      ;; PS2 does math on this float, and it behaves like an extremely large float rather than
+      ;; IEEE754 inf.
+      (set! (-> gp-1 knots data 0 mass) (the-as float #x7f700000))
       (if (and (-> this next-state) (= (-> this next-state name) 'neo-sat-sit-and-spin))
           (set! (-> gp-1 gravity-dir quad) (-> s3-0 quad))
           )


### PR DESCRIPTION
Fixes issue with not handling texture flipping flags in sprite renderer (new jak 3 feature). As far as I can tell, there is no visible difference because the textures that use this flag are symmetric.

Fix issue with not adding an `and` with `0xf` on the offset into the xy table. This is added only in jak 3, where `vi07`'s upper bits are sometimes nonzero, but doesn't hurt to have in all three games.
```
  iaddi vi09, vi00, 0xf      |  nop                      
  iand vi07, vi07, vi09      |  nop  
```
![image](https://github.com/user-attachments/assets/559d749a-957a-47dc-af6a-5b4b7d72a65b)

Fix issue with inf/nan causing the tentacle to not appear:
![image](https://github.com/user-attachments/assets/7c316cdf-7ff8-452d-b4af-ddb8d5ba4e44)

