### PR TITLE
[jak2] Fix bug where spinning into grind doesnt break clasps in dig1

### DIFF
--- a/goal_src/jak2/levels/dig/dig-digger.gc
+++ b/goal_src/jak2/levels/dig/dig-digger.gc
@@ -657,7 +657,10 @@
       (('attack)
        (let ((v1-2 (the-as attack-info (-> block param 1))))
          (when (and (logtest? (-> v1-2 mask) (attack-mask mode))
-                    (or (= (-> v1-2 mode) 'board) (= (-> v1-2 mode) 'board-spin))) ;; og:preserve-this fix bug where spinning into grind doesnt break
+                    ;; og:preserve-this fix bug where spinning into grind doesnt break
+                    (#if PC_PORT
+                      (or (= (-> v1-2 mode) 'board) (= (-> v1-2 mode) 'board-spin))
+                      (= (-> v1-2 mode) 'board)))
            (cpad-set-buzz! (-> *cpad-list* cpads 0) 0 85 (seconds 0.1))
            (go-virtual break-it)
            )

--- a/goal_src/jak2/levels/dig/dig-digger.gc
+++ b/goal_src/jak2/levels/dig/dig-digger.gc
@@ -656,7 +656,8 @@
        )
       (('attack)
        (let ((v1-2 (the-as attack-info (-> block param 1))))
-         (when (and (logtest? (-> v1-2 mask) (attack-mask mode)) (= (-> v1-2 mode) 'board))
+         (when (and (logtest? (-> v1-2 mask) (attack-mask mode))
+                    (or (= (-> v1-2 mode) 'board) (= (-> v1-2 mode) 'board-spin))) ;; og:preserve-this fix bug where spinning into grind doesnt break
            (cpad-set-buzz! (-> *cpad-list* cpads 0) 0 85 (seconds 0.1))
            (go-virtual break-it)
            )

--- a/goal_src/jak2/levels/dig/dig-digger.gc
+++ b/goal_src/jak2/levels/dig/dig-digger.gc
@@ -659,7 +659,7 @@
          (when (and (logtest? (-> v1-2 mask) (attack-mask mode))
                     ;; og:preserve-this fix bug where spinning into grind doesnt break
                     (#if PC_PORT
-                      (or (= (-> v1-2 mode) 'board) 
+                      (or (= (-> v1-2 mode) 'board)
                           (and (= (-> v1-2 mode) 'board-spin) (focus-test? *target* rail)))
                       (= (-> v1-2 mode) 'board)))
            (cpad-set-buzz! (-> *cpad-list* cpads 0) 0 85 (seconds 0.1))

--- a/goal_src/jak2/levels/dig/dig-digger.gc
+++ b/goal_src/jak2/levels/dig/dig-digger.gc
@@ -659,7 +659,8 @@
          (when (and (logtest? (-> v1-2 mask) (attack-mask mode))
                     ;; og:preserve-this fix bug where spinning into grind doesnt break
                     (#if PC_PORT
-                      (or (= (-> v1-2 mode) 'board) (= (-> v1-2 mode) 'board-spin))
+                      (or (= (-> v1-2 mode) 'board) 
+                          (and (= (-> v1-2 mode) 'board-spin) (focus-test? *target* rail)))
                       (= (-> v1-2 mode) 'board)))
            (cpad-set-buzz! (-> *cpad-list* cpads 0) 0 85 (seconds 0.1))
            (go-virtual break-it)


### PR DESCRIPTION
if you sideflip into grind in the digsite mission, the clasps wont break because it is considered a `board-spin` attack instead of `board`. This extends the condition to allow for `board-spin` as well.

~~Should I wrap this in an `#if PC_PORT`?~~ done