### PR TITLE
[jak2] Correct behavior of hint subtitles toggle

### DIFF
--- a/goal_src/jak2/pc/pckernel-impl.gc
+++ b/goal_src/jak2/pc/pckernel-impl.gc
@@ -102,7 +102,6 @@
    (controller-led-status?    symbol)
    (speedrunner-mode-custom-bind uint32)
    (memcard-subtitles? symbol)
-   (hint-subtitles? symbol)
 
    (text-language pc-language) ;; language for game text
 	 )
@@ -169,7 +168,7 @@
   (set! (-> obj memcard-volume-dialog) 0.75)
   (set! (-> obj memcard-vibration?) #t)
   (set! (-> obj memcard-subtitles?) #f)
-  (set! (-> obj hint-subtitles?) #t)
+  (set! (-> obj hinttitles?) #t)
   0)
 
 (defmethod reset-extra ((obj pc-settings-jak2) (call-handlers symbol))

--- a/goal_src/jak2/pc/pckernel.gc
+++ b/goal_src/jak2/pc/pckernel.gc
@@ -768,7 +768,7 @@
     (("cheats-unlocked") (set! (-> obj cheats-unlocked) (the-as pc-cheats (file-stream-read-int file))))
     (("cheats-backup") (file-stream-read-int file)) ;; TODO - Don't remove this, parsing code can't handle unexpected keys
     (("memcard-subtitles?") (set! (-> obj memcard-subtitles?) (file-stream-read-symbol file)))
-    (("hint-subtitles?") (set! (-> obj hint-subtitles?) (file-stream-read-symbol file)))
+    (("hint-subtitles?") (file-stream-read-symbol file))
     (("music-unlocked")
       (dotimes (i (/ (align64 (-> obj music-unlocked length)) 64))
         (bit-array<-int64 (-> obj music-unlocked) (* i 64) (file-stream-read-int file))
@@ -821,7 +821,6 @@
   (format file "  (cheats-purchased #x~x)~%" (-> obj cheats-purchased))
   (format file "  (cheats-unlocked #x~x)~%" (-> obj cheats-unlocked))
   (format file "  (memcard-subtitles? ~A)~%" (-> obj memcard-subtitles?))
-  (format file "  (hint-subtitles? ~A)~%" (-> obj hint-subtitles?))
 
   (format file "  (music-unlocked")
   (dotimes (i (/ (align64 (-> obj music-unlocked length)) 64))

--- a/goal_src/jak2/pc/progress/progress-static-pc.gc
+++ b/goal_src/jak2/pc/progress/progress-static-pc.gc
@@ -341,10 +341,9 @@ This gives us more freedom to write code how we want.
       :name (text-id progress-hint-subtitles)
       :truthy-text (text-id progress-on)
       :falsey-text (text-id progress-off)
-      :get-value-fn (lambda () (-> *pc-settings* hint-subtitles?))
-      :should-disable? (lambda () (not (-> *pc-settings* memcard-subtitles?)))
+      :get-value-fn (lambda () (-> *pc-settings* hinttitles?))
       :on-confirm (lambda ((val symbol))
-        (set! (-> *pc-settings* hint-subtitles?) val)
+        (set! (-> *pc-settings* hinttitles?) val)
         (pc-settings-save))))
 
 (defmacro game-options-pc-subtitle-language ()

--- a/goal_src/jak2/pc/subtitle2.gc
+++ b/goal_src/jak2/pc/subtitle2.gc
@@ -471,8 +471,8 @@
       (set! (-> self font origin y) cur-y)
 
       ;; check if we should actually draw subtitles and do it
-      (when (and (-> *setting-control* user-current subtitle)
-                 (or (-> self movie-mode?) (-> *pc-settings* hint-subtitles?))
+      (when (and (if (-> self movie-mode?) (-> *setting-control* user-current subtitle)
+                                           (-> *pc-settings* hinttitles?))
                  (or *gui-kick-str* (= *master-mode* 'game)))
         (set-action! *gui-control* (gui-action play) (-> self gui-id)
                     (gui-channel none) (gui-action none) (the-as string #f) (the-as (function gui-connection symbol) #f) (the-as process #f))


### PR DESCRIPTION
Re-uses the existing "hinttitles" toggle that's already there, and makes it not depend on if the main subtitles are on or not.