### PR TITLE
jak2: fix consite crash

### DIFF
--- a/goal_src/jak2/engine/gfx/texture/texture-anim.gc
+++ b/goal_src/jak2/engine/gfx/texture/texture-anim.gc
@@ -946,7 +946,7 @@ struct SlimeInput {
      (return #f)
      )
     ((= anim-array *kor-transform-texture-anim-array*)
-     (pc-clut-blender bucket (texture-anim-pc kor-transform) anim-array)
+     ; (pc-clut-blender bucket (texture-anim-pc kor-transform) anim-array)
      (return #f)
      )
     (else


### PR DESCRIPTION
Since #3735, loading consite in Jak 2 crashes due to an assert in the code that handles the PC clut blender DMA. The unused and half-implemented `kor-transform` texture animation doesn't have any blenders as the texture names are commented out in the C++ definition (and it seems that these textures are defined multiple times within different tpages in the same DGO, leading to errors during startup if uncommented), leading to a mismatch between the actual qwc in GOAL and the assumed DMA data size in C++.