### PR TITLE
[jak3] Fix for precd extraction

### DIFF
--- a/decompiler/config/jak3/ntsc_v1/inputs.jsonc
+++ b/decompiler/config/jak3/ntsc_v1/inputs.jsonc
@@ -186,7 +186,7 @@
     "DGO/PRECA.DGO",
     "DGO/PRECB.DGO",
     "DGO/PRECC.DGO",
-    // "DGO/PRECD.DGO",
+    "DGO/PRECD.DGO",
     // title/intro
     "DGO/WIN.DGO", // wasintro
     "DGO/TITLE.DGO",

--- a/decompiler/level_extractor/BspHeader.cpp
+++ b/decompiler/level_extractor/BspHeader.cpp
@@ -1017,7 +1017,8 @@ void PrototypeBucketTie::read_from_file(TypedRef ref,
     for (int i = 0; i < 4; i++) {
       u32 start = index_start[i];
       u32 end = start + frag_count[i];
-      ASSERT(num_color_qwcs <= end);
+      // precd tie has a bug where geo 3's
+      // ASSERT(num_color_qwcs <= end);
       num_color_qwcs = std::max(end, num_color_qwcs);
     }
 

--- a/decompiler/level_extractor/extract_tie.cpp
+++ b/decompiler/level_extractor/extract_tie.cpp
@@ -2753,6 +2753,10 @@ void extract_tie(const level_tools::DrawableTreeInstanceTie* tree,
                  bool dump_level,
                  GameVersion version) {
   for (int geo = 0; geo < GEOM_MAX; ++geo) {
+    // as far as I can tell, this one has bad colors
+    if (debug_name == "PRECD.DGO-2-tie" && geo == 3) {
+      continue;
+    }
     tfrag3::TieTree this_tree;
 
     // sanity check the vis tree (not a perfect check, but this is used in game and should be right)

--- a/goal_src/jak3/game.gp
+++ b/goal_src/jak3/game.gp
@@ -272,7 +272,7 @@
 (cgo-file "preca.gd" common-dep)
 (cgo-file "precb.gd" common-dep)
 (cgo-file "precc.gd" common-dep)
-; (cgo-file "precd.gd" common-dep)
+(cgo-file "precd.gd" common-dep)
 ; ;; title/intro
 (cgo-file "win.gd" common-dep) ;; wasintro
 (cgo-file "title.gd" common-dep)


### PR DESCRIPTION
It looks like one of the tie models in this level has bad color data in the lowest LOD. For now, just skip extracting the lowest lod for this TIE only.