### PR TITLE
Fix crash in ocean-far with invalid DMA size

### DIFF
--- a/common/dma/dma.h
+++ b/common/dma/dma.h
@@ -37,7 +37,7 @@ struct DmaTag {
   DmaTag(u64 value) {
     spr = (value >> 63);
     addr = (value >> 32) & 0x7fffffff;
-    qwc = value & 0xfff;
+    qwc = value & 0xffff;
     kind = Kind((value >> 28) & 0b111);
   }
 


### PR DESCRIPTION
DMA sizes are 16-bits, not 12-bits. This would cause rare crashes when the ocean far renderer uses more than this.

I'm not really sure what the ocean far rendering is doing at this time, but it happens as stuff is loading in.

There's a chance this fixes crashes in jak 2 as well, since we used to see errors that would be explained by this.