### PR TITLE
Fix sprite3_3d.vert on macOS

### DIFF
--- a/game/graphics/opengl_renderer/shaders/sprite3_3d.vert
+++ b/game/graphics/opengl_renderer/shaders/sprite3_3d.vert
@@ -119,7 +119,7 @@ void main() {
     float sp_sin = sin(quat.z);
     float sp_cos = cos(quat.z);
 
-    vec4 xy0_vf19 = xy_array[vert_id + (flags_matrix.x & 15)];
+    vec4 xy0_vf19 = xy_array[vert_id + (flags_matrix.x & 15u)];
     vec4 vf12_rotated = (basis_x * sp_cos) - (basis_y * sp_sin);
     vec4 vf13_rotated_trans = (basis_x * sp_sin) + (basis_y * sp_cos);
 
@@ -141,7 +141,7 @@ void main() {
     float sp_sin = sin(quat.z);
     float sp_cos = cos(quat.z);
 
-    vec4 xy0_vf19 = xy_array[vert_id + (flags_matrix.x & 15)];
+    vec4 xy0_vf19 = xy_array[vert_id + (flags_matrix.x & 15u)];
     vec4 vf12_rotated = (basis_x * sp_cos) - (basis_y * sp_sin);
     vec4 vf13_rotated_trans = (basis_x * sp_sin) + (basis_y * sp_cos);
 


### PR DESCRIPTION
Fixes a regression in #3722.

```
[18:34] [error] Failed to compile vertex shader sprite3_3d:
ERROR: 0:122: '&' does not operate on 'unsigned int' and 'int'
ERROR: 0:129: Use of undeclared identifier 'xy0_vf19'
ERROR: 0:129: Use of undeclared identifier 'xy0_vf19'
ERROR: 0:144: '&' does not operate on 'unsigned int' and 'int'
ERROR: 0:151: Use of undeclared identifier 'xy0_vf19'
ERROR: 0:151: Use of undeclared identifier 'xy0_vf19'
```