### PR TITLE
docs: Remove instructions to add go-task tap to Homebrew.

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,6 @@ xcode-select --install
 #### Intel Based
 
 ```bash
-brew install go-task/tap/go-task
 brew install cmake nasm ninja go-task clang-format
 cmake -B build --preset=Release-macos-clang
 cmake --build build --parallel $((`sysctl -n hw.logicalcpu`))
@@ -257,7 +256,6 @@ cmake --build build --parallel $((`sysctl -n hw.logicalcpu`))
 **Not Supported at This Time**
 
 ```bash
-brew install go-task/tap/go-task
 brew install cmake ninja go-task clang-format
 cmake -B build --preset=Release-macos-clang
 cmake --build build --parallel $((`sysctl -n hw.logicalcpu`))


### PR DESCRIPTION
Homebrew has its own formula for go-task which is up-to-date and working.