### PR TITLE
Create separate x86_64 and ARM64 macOS targets.

### DIFF
--- a/.github/workflows/build-matrix.yaml
+++ b/.github/workflows/build-matrix.yaml
@@ -49,12 +49,12 @@ jobs:
     name: "🍎 MacOS"
     uses: ./.github/workflows/macos-build.yaml
     with:
-      cmakePreset: "Release-macos-clang"
+      cmakePreset: "Release-macos-x86_64-clang"
       cachePrefix: ""
 
   build_macos_arm:
     name: "🍎 MacOS"
     uses: ./.github/workflows/macos-build-arm.yaml
     with:
-      cmakePreset: "Release-macos-rosetta-clang"
+      cmakePreset: "Release-macos-x86_64-clang"
       cachePrefix: ""

--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -74,7 +74,7 @@ jobs:
     name: "🍎 MacOS"
     uses: ./.github/workflows/macos-build.yaml
     with:
-      cmakePreset: "Release-macos-clang-static"
+      cmakePreset: "Release-macos-x86_64-clang-static"
       cachePrefix: "static"
       uploadArtifacts: true
     secrets: inherit
@@ -85,7 +85,7 @@ jobs:
     name: "🍎 MacOS"
     uses: ./.github/workflows/macos-build.yaml
     with:
-      cmakePreset: "Release-macos-rosetta-clang-static"
+      cmakePreset: "Release-macos-x86_64-clang-static"
       cachePrefix: "static"
       uploadArtifacts: true
     secrets: inherit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 project(jak)
 include(CTest)
 
-# Options
-option(BUILD_X86_ON_MACOS "Builds the project for macOS for Rosetta 2" OFF)
-
 # Include third-party modules
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/third-party/cmake/modules/)
 
@@ -123,11 +120,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     
     # pin to AVX for macOS, hopefully all macOS runners have atleast this architecture
     # technically speaking, SSE4 is the cutoff for Apple Silicon so...only a matter of time!
-    if (BUILD_X86_ON_MACOS)
-        message("Targetting x86 on macOS via Rosetta 2 (requires Sequoia)")
-        set(CMAKE_OSX_ARCHITECTURES "x86_64")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
-    elseif(NOT CMAKE_CXX_COMPILER_TARGET STREQUAL "arm64-apple-darwin")
+    if(NOT CMAKE_CXX_COMPILER_TARGET STREQUAL "arm64-apple-darwin")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
     endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -79,6 +79,22 @@
       }
     },
     {
+      "name": "base-macos-arm64",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_APPLE_SILICON_PROCESSOR": "arm64",
+        "CMAKE_OSX_ARCHITECTURES": "arm64"
+      }
+    },
+    {
+      "name": "base-macos-x86_64",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_APPLE_SILICON_PROCESSOR": "x86_64",
+        "CMAKE_OSX_ARCHITECTURES": "x86_64"
+      }
+    },
+    {
       "name": "base-clang",
       "hidden": true,
       "cacheVariables": {
@@ -159,37 +175,33 @@
       "inherits": ["base-linux-release", "base-clang"]
     },
     {
-      "name": "Release-macos-clang",
-      "displayName": "MacOS Release (clang)",
-      "description": "Build with Clang as Release without Debug Symbols",
-      "inherits": ["base-macos-release", "base-clang"]
+      "name": "Release-macos-arm64-clang",
+      "displayName": "MacOS ARM64 Release (clang)",
+      "description": "Build for ARM64 with Clang as Release without Debug Symbols",
+      "inherits": ["base-macos-release", "base-macos-arm64", "base-clang"]
     },
     {
-      "name": "Release-macos-rosetta-clang",
-      "displayName": "MacOS Release Rosetta (clang)",
-      "description": "Build with Clang as Release without Debug Symbols",
-      "inherits": ["base-macos-release", "base-clang"],
-      "cacheVariables": {
-        "BUILD_X86_ON_MACOS": "ON"
-      }
+      "name": "Release-macos-x86_64-clang",
+      "displayName": "MacOS x86_64 Release (clang)",
+      "description": "Build for x86_64 with Clang as Release without Debug Symbols",
+      "inherits": ["base-macos-release", "base-macos-x86_64", "base-clang"]
     },
     {
-      "name": "Release-macos-clang-static",
-      "displayName": "MacOS Static Release (clang)",
-      "description": "Build with Clang as Release without Debug Symbols but statically linked",
-      "inherits": ["base-macos-release", "base-clang"],
+      "name": "Release-macos-arm64-clang-static",
+      "displayName": "MacOS ARM64 Static Release (clang)",
+      "description": "Build for ARM64 with Clang as Release without Debug Symbols but statically linked",
+      "inherits": ["base-macos-release", "base-macos-arm64", "base-clang"],
       "cacheVariables": {
         "STATICALLY_LINK": "true",
         "ZYDIS_BUILD_SHARED_LIB": "OFF"
       }
     },
     {
-      "name": "Release-macos-rosetta-clang-static",
-      "displayName": "MacOS Rosetta Static Release (clang)",
-      "description": "Build with Clang as Release without Debug Symbols but statically linked, requires MacOS Sequoia",
-      "inherits": ["base-macos-release", "base-clang"],
+      "name": "Release-macos-x86_64-clang-static",
+      "displayName": "MacOS x86_64 Static Release (clang)",
+      "description": "Build for x86_64 with Clang as Release without Debug Symbols but statically linked, requires MacOS Sequoia",
+      "inherits": ["base-macos-release", "base-macos-x86_64", "base-clang"],
       "cacheVariables": {
-        "BUILD_X86_ON_MACOS": "ON",
         "STATICALLY_LINK": "true",
         "ZYDIS_BUILD_SHARED_LIB": "OFF"
       }

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Our objectives are:
 
 We support both Linux and Windows on x86-64.
 
-> We do not support, or plan to support the ARM architecture.  This means that this will not run on devices such as an M1 Mac or a mobile device.
+> We do not support, or plan to support the ARM architecture.  This means that this will not run on devices such as a mobile device.
 
 ### Current Status
 
@@ -235,7 +235,7 @@ Then build the entire project as `Windows Release (clang)`. You can also press C
 
 ### MacOS
 
-> NOTE: At this time you can only run the game on macOS if you have an Intel processor.
+> NOTE: Running the game requires an Apple Silicon Mac running macOS Sequoia, or an Intel Mac.
 
 Ensure that you have Xcode command line tools installed (this installs things like Apple Clang).  If you don't, you can run the following command:
 
@@ -243,21 +243,25 @@ Ensure that you have Xcode command line tools installed (this installs things li
 xcode-select --install
 ```
 
-#### Intel Based
+On Apple Silicon, Rosetta 2 also must be installed:
+
+```bash
+softwareupdate --install-rosetta
+```
+
+#### Building for x86_64
 
 ```bash
 brew install cmake nasm ninja go-task clang-format
-cmake -B build --preset=Release-macos-clang
+cmake -B build --preset=Release-macos-x86_64-clang
 cmake --build build --parallel $((`sysctl -n hw.logicalcpu`))
 ```
 
-#### Apple Silicon
-
-**Not Supported at This Time**
+#### Building for ARM64 (experimental, unsupported)
 
 ```bash
 brew install cmake ninja go-task clang-format
-cmake -B build --preset=Release-macos-clang
+cmake -B build --preset=Release-macos-arm64-clang
 cmake --build build --parallel $((`sysctl -n hw.logicalcpu`))
 ```
 

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -1,10 +1,7 @@
 # Set a more convenient ARM flag
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" AND (NOT BUILD_X86_ON_MACOS))
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
     set(ARM64_ARCH TRUE)
     message(STATUS "ARM64 architecture detected")
-elseif()
-    set(ARM64_ARCH FALSE)
-    message(STATUS "Forcefully targetting x86 via Rosetta 2")
 else()
     set(ARM64_ARCH FALSE)
     message(STATUS "Non-ARM64 architecture detected")


### PR DESCRIPTION
Create explicit x86_64 and ARM64 macOS build targets, so it's clear that the CI is building x86_64 binaries (on both Intel and ARM64 build machines). Also, use the `CMAKE_APPLE_SILICON_PROCESSOR` CMake variable (which sets `CMAKE_SYSTEM_PROCESSOR`) so `BUILD_X86_ON_MACOS` is not necessary.

And update the README.