### PR TITLE
[jak3] Fix overlord soundbank unload, fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         -Wall \
         -Wno-c++11-narrowing \
         -Wno-c++98-compat \
+        -Wno-deprecated-this-capture \
+        -Wno-missing-field-initializers \
+        -Wno-sign-compare \
+        -Wno-ignored-qualifiers \
         -O3 \
         -D_CRT_SECURE_NO_WARNINGS")
 
@@ -56,7 +60,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         # Note: this is only _reserved_ memory, not necessarily _committed_ memory
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LDFLAGS} -Xlinker /STACK:16000000")
     else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb -g -Wextra")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb -g")
     endif()
 
     # additional c++ and linker flags for release mode for our projects

--- a/common/formatter/formatter_tree.cpp
+++ b/common/formatter/formatter_tree.cpp
@@ -143,7 +143,7 @@ void FormatterTree::construct_formatter_tree_recursive(const std::string& source
   }
   for (size_t i = 0; i < ts_node_child_count(curr_node); i++) {
     const auto child_node = ts_node_child(curr_node, i);
-    auto debug_child = ts_node_string(child_node);
+    [[maybe_unused]] auto debug_child = ts_node_string(child_node);
     const auto contents = get_source_code(source, child_node);
     bool skip_node = false;
     for (const auto& skippable_content : skippable_nodes) {

--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -166,7 +166,8 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
         prof().set_enable(record_events);
       }
       ImGui::SameLine();
-      ImGui::Text("%s", fmt::format("({}/{})", prof().get_next_idx(), prof().get_max_events()).c_str());
+      ImGui::Text("%s",
+                  fmt::format("({}/{})", prof().get_next_idx(), prof().get_max_events()).c_str());
       ImGui::InputInt("Event Buffer Size", &max_event_buffer_size);
       if (ImGui::Button("Resize")) {
         prof().update_event_buffer_size(max_event_buffer_size);

--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -166,7 +166,7 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
         prof().set_enable(record_events);
       }
       ImGui::SameLine();
-      ImGui::Text(fmt::format("({}/{})", prof().get_next_idx(), prof().get_max_events()).c_str());
+      ImGui::Text("%s", fmt::format("({}/{})", prof().get_next_idx(), prof().get_max_events()).c_str());
       ImGui::InputInt("Event Buffer Size", &max_event_buffer_size);
       if (ImGui::Button("Resize")) {
         prof().update_event_buffer_size(max_event_buffer_size);

--- a/game/graphics/opengl_renderer/foreground/Generic2_DMA.cpp
+++ b/game/graphics/opengl_renderer/foreground/Generic2_DMA.cpp
@@ -598,12 +598,12 @@ void Generic2::process_dma_prim(DmaFollower& dma, u32 next_bucket) {
     }
     if (up1.vifcode0().kind == VifCode::Kind::FLUSHA) {
       while (dma.current_tag_offset() != next_bucket) {
-        auto it = dma.read_and_advance();
+        [[maybe_unused]] auto it = dma.read_and_advance();
       }
       break;
     }
     auto up2 = dma.read_and_advance();
-    auto call = dma.read_and_advance();
+    [[maybe_unused]] auto call = dma.read_and_advance();
 
     // up1 is a 12 qw upload for control:
     // up2 is vertex upload.

--- a/game/kernel/jak2/kmachine.cpp
+++ b/game/kernel/jak2/kmachine.cpp
@@ -424,7 +424,7 @@ int InitMachine() {
  * Shutdown the runtime.
  */
 int ShutdownMachine() {
-  Msg(6, "kernel: machine shutdown (reason %d)\n", MasterExit);
+  Msg(6, "kernel: machine shutdown (reason %d)\n", (int)MasterExit);
 
   StopIOP();
   ShutdownSound();

--- a/game/kernel/jak3/kmachine.cpp
+++ b/game/kernel/jak3/kmachine.cpp
@@ -294,7 +294,7 @@ int InitMachine() {
 }
 
 int ShutdownMachine() {
-  Msg(6, "kernel: machine shutdown (reason %d)\n", MasterExit);
+  Msg(6, "kernel: machine shutdown (reason %d)\n", (int)MasterExit);
 
   StopIOP();
   ShutdownSound();

--- a/game/kernel/jak3/kmachine_extras.cpp
+++ b/game/kernel/jak3/kmachine_extras.cpp
@@ -202,8 +202,8 @@ u32 alloc_vagdir_names(u32 heap_sym) {
     for (size_t i = 0; i < g_VagDir.num_entries; ++i) {
       char vagname_temp[9];
       u64 packed = *(u64*)g_VagDir.entries[i].words;
-      auto name = unpack_vag_name_jak3(packed).data();
-      memcpy(vagname_temp, name, 8);
+      auto name = unpack_vag_name_jak3(packed);
+      memcpy(vagname_temp, name.data(), 8);
       for (int j = 0; j < 8; ++j) {
         vagname_temp[j] = tolower(vagname_temp[j]);
       }

--- a/game/mips2c/jak3_functions/shadow.cpp
+++ b/game/mips2c/jak3_functions/shadow.cpp
@@ -219,7 +219,6 @@ namespace shadow_xform_verts {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   // nop                                            // sll r0, r0, 0
   c->lw(v1, 68, a1);                                // lw v1, 68(a1)
   // nop                                            // sll r0, r0, 0
@@ -382,7 +381,6 @@ namespace shadow_calc_dual_verts {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   // nop                                            // sll r0, r0, 0
   c->lw(v1, 16, a1);                                // lw v1, 16(a1)
   // nop                                            // sll r0, r0, 0
@@ -596,7 +594,6 @@ struct Cache {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   get_fake_spad_addr2(v1, cache.fake_scratchpad_data, 0, c);// lui v1, 28672
   c->lw(a3, 44, a1);                                // lw a3, 44(a1)
   // nop                                            // sll r0, r0, 0
@@ -687,7 +684,6 @@ namespace shadow_scissor_top {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   // nop                                            // sll r0, r0, 0
   c->lw(a2, 44, a1);                                // lw a2, 44(a1)
   // nop                                            // sll r0, r0, 0
@@ -770,8 +766,6 @@ struct Cache {
 
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
-  bool bc = false;
-  u32 call_addr = 0;
   c->load_symbol2(v1, cache.math_camera);           // lw v1, *math-camera*(s7)
   c->mov64(v1, v1);                                 // or v1, v1, r0
   c->lqc2(vf7, 364, v1);                            // lqc2 vf7, 364(v1)
@@ -838,7 +832,6 @@ namespace shadow_find_facing_single_tris {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   c->daddiu(sp, sp, -64);                           // daddiu sp, sp, -64
   c->sd(ra, 0, sp);                                 // sd ra, 0(sp)
   c->sq(s4, 16, sp);                                // sq s4, 16(sp)
@@ -1146,7 +1139,6 @@ namespace shadow_find_single_edges {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   c->lw(a2, 16, a1);                                // lw a2, 16(a1)
   c->lh(a3, 14, a0);                                // lh a3, 14(a0)
   c->mov64(v1, a2);                                 // or v1, a2, r0
@@ -1250,7 +1242,6 @@ namespace shadow_find_facing_double_tris {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   c->daddiu(sp, sp, -16);                           // daddiu sp, sp, -16
   c->sd(ra, 0, sp);                                 // sd ra, 0(sp)
   c->lh(a2, 16, a0);                                // lh a2, 16(a0)
@@ -1536,7 +1527,6 @@ namespace shadow_find_double_edges {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   c->lw(a2, 16, a1);                                // lw a2, 16(a1)
   c->lh(a3, 18, a0);                                // lh a3, 18(a0)
   c->mov64(v1, a2);                                 // or v1, a2, r0
@@ -1650,7 +1640,6 @@ struct Cache {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   c->load_symbol2(v1, cache.shadow_data);           // lw v1, *shadow-data*(s7)
   c->mov64(v1, v1);                                 // or v1, v1, r0
   c->lh(a0, 8, a0);                                 // lh a0, 8(a0)
@@ -1841,7 +1830,6 @@ struct Cache {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   c->load_symbol2(v1, cache.shadow_data);           // lw v1, *shadow-data*(s7)
   c->mov64(a3, v1);                                 // or a3, v1, r0
   c->lw(v1, 20, a1);                                // lw v1, 20(a1)
@@ -1924,7 +1912,6 @@ struct Cache {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   c->load_symbol2(v1, cache.shadow_data);           // lw v1, *shadow-data*(s7)
   c->mov64(a3, v1);                                 // or a3, v1, r0
   c->lw(v1, 24, a1);                                // lw v1, 24(a1)
@@ -2011,7 +1998,6 @@ struct Cache {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   c->load_symbol2(v1, cache.shadow_data);           // lw v1, *shadow-data*(s7)
   c->mov64(a3, v1);                                 // or a3, v1, r0
   c->lh(a1, 12, a0);                                // lh a1, 12(a0)
@@ -2094,7 +2080,6 @@ struct Cache {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   c->load_symbol2(v1, cache.shadow_data);           // lw v1, *shadow-data*(s7)
   c->mov64(a3, v1);                                 // or a3, v1, r0
   c->lh(v1, 16, a0);                                // lh v1, 16(a0)
@@ -2175,7 +2160,6 @@ struct Cache {
 u64 execute(void* ctxt) {
   auto* c = (ExecutionContext*)ctxt;
   bool bc = false;
-  u32 call_addr = 0;
   c->load_symbol2(v1, cache.shadow_data);           // lw v1, *shadow-data*(s7)
   c->mov64(a3, v1);                                 // or a3, v1, r0
   c->lw(v1, 28, a1);                                // lw v1, 28(a1)

--- a/game/overlord/jak3/iso.cpp
+++ b/game/overlord/jak3/iso.cpp
@@ -1738,7 +1738,7 @@ EIsoStatus CopyData(ISO_LoadCommon* cmd, CopyKind kind) {
                 snd_BankLoadFromIOPPartialEx(buffer->m_pCurrentData, len, bank_info->m_nSpuMemLoc,
                                              bank_info->m_nSpuMemSize);
                 if (cmd->progress_bytes + len == cmd->length_to_copy) {
-                  snd_BankLoadFromIOPPartialEx_Completion();
+                  bank_info->snd_handle = snd_BankLoadFromIOPPartialEx_Completion();
                   snd_ResolveBankXREFS();
                   // TODO: this also set field_0x28... is that needed??
                 }

--- a/game/overlord/jak3/rpc_interface.h
+++ b/game/overlord/jak3/rpc_interface.h
@@ -157,7 +157,7 @@ enum class SoundCommand : u16 {
   SET_REVERB = 23,
   SET_EAR_TRANS = 24,
   SHUTDOWN = 25,
-  // LIST_SOUNDS = 26,
+  LIST_SOUNDS = 26,
   UNLOAD_MUSIC = 27,
   SET_FPS = 28,
   // BOOT_LOAD = 29,

--- a/game/overlord/jak3/sbank.cpp
+++ b/game/overlord/jak3/sbank.cpp
@@ -26,6 +26,15 @@ void jak3_overlord_init_globals_sbank() {
   gBanks[7] = &gLevel2hBank;
 }
 
+// added
+void PrintBanks() {
+  printf("Loaded Banks\n");
+  for (int i = 0; i < kNumBanks; i++) {
+    printf(" [%d] %s %s (%d/%d)\n", i, gBanks[i]->m_name1, gBanks[i]->m_name2, gBanks[i]->in_use,
+           gBanks[i]->loaded);
+  }
+}
+
 void InitBanks() {
   for (int i = 0; i < kNumBanks; i++) {
     auto* bank = gBanks[i];

--- a/game/overlord/jak3/sbank.h
+++ b/game/overlord/jak3/sbank.h
@@ -25,5 +25,6 @@ void jak3_overlord_init_globals_sbank();
 void InitBanks();
 SoundBankInfo* LookupBank(const char* name);
 SoundBankInfo* AllocateBankName(const char* name, u32 mode);
+void PrintBanks();
 extern SoundBankInfo* gBanks[8];
 }  // namespace jak3

--- a/game/overlord/jak3/srpc.cpp
+++ b/game/overlord/jak3/srpc.cpp
@@ -578,6 +578,12 @@ void* RPC_Loader(unsigned int, void* msg, int size) {
         }
       } break;
 
+      // added
+      case SoundCommand::LIST_SOUNDS: {
+        PrintBanks();
+        PrintSounds();
+      } break;
+
       default:
         ovrld_log(LogCategory::WARN, "[RPC Loader] Unsupported Loader {}",
                   (int)((const Rpc_Player_Base_Cmd*)m_ptr)->command);

--- a/game/overlord/jak3/ssound.cpp
+++ b/game/overlord/jak3/ssound.cpp
@@ -245,6 +245,13 @@ void InitSound() {
   InitVagStreamList(&g_NewStreamsList, 4, "new");
 }
 
+void PrintSounds() {
+  for (auto& sound : gSounds) {
+    printf("SOUND %d %s\n", sound.id, sound.name.data);
+    printf(" still playing? %d\n", snd_SoundIsStillPlaying(sound.sound_handle));
+  }
+}
+
 SoundInfo* LookupSound(int id) {
   if (id == 0) {
     return nullptr;

--- a/game/overlord/jak3/ssound.h
+++ b/game/overlord/jak3/ssound.h
@@ -43,6 +43,7 @@ void SetPlaybackMode(s32 mode);
 void SetCurve(int curve_idx, u32, u32, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t);
 u32 CalculateFalloffVolume(s32* trans, u32 vol, u32 fo_curve, u32 fo_min, u32 fo_max, u32*, u32*);
 s32 CalculateAngle(s32* trans, u32 fo_curve, u32);
+void PrintSounds();
 
 extern u32 g_anStreamVoice[6];
 extern VolumePair g_aPanTable[361];

--- a/game/sound/sndshim.cpp
+++ b/game/sound/sndshim.cpp
@@ -241,11 +241,12 @@ void snd_BankLoadFromIOPPartialEx_Start() {
 void snd_BankLoadFromIOPPartialEx(const u8* data, u32 length, u32 spu_mem_loc, u32 spu_mem_size) {
   sbk_data.insert(sbk_data.end(), data, data + length);
 }
-void snd_BankLoadFromIOPPartialEx_Completion() {
+snd::BankHandle snd_BankLoadFromIOPPartialEx_Completion() {
   ASSERT(started);
   started = false;
-  player->LoadBank(std::span(sbk_data));
+  auto ret = player->LoadBank(std::span(sbk_data));
   sbk_data.clear();
+  return ret;
 }
 
 s32 snd_GetVoiceStatus(s32 voice) {

--- a/game/sound/sndshim.h
+++ b/game/sound/sndshim.h
@@ -73,7 +73,7 @@ snd::BankHandle snd_BankLoadEx(const char* filepath,
 
 void snd_BankLoadFromIOPPartialEx_Start();
 void snd_BankLoadFromIOPPartialEx(const u8* data, u32 length, u32 spu_mem_loc, u32 spu_mem_size);
-void snd_BankLoadFromIOPPartialEx_Completion();
+snd::BankHandle snd_BankLoadFromIOPPartialEx_Completion();
 
 s32 snd_GetVoiceStatus(s32 voice);
 s32 snd_GetFreeSPUDMA();


### PR DESCRIPTION
Fix compiler warnings, and a bug where the `snd_handle` of `SoundBankInfo` was never set, leading to sound banks never unloading.

The game relies on unloading soundbanks to make sure certain sounds don't play, like the blue gun 1 fire noise when using blue gun 2.