### PR TITLE
[jak3] workaround for intro crash on screen filter

### DIFF
--- a/goal_src/jak3/game.gp
+++ b/goal_src/jak3/game.gp
@@ -549,7 +549,7 @@
    "$OUT/iso/5COMMON.TXT"
    "$OUT/iso/6COMMON.TXT"
    "$OUT/iso/7COMMON.TXT"
-   "$OUT/iso/0SUBTI2.TXT"
+   "$OUT/iso/0SUBTI3.TXT"
    )
  )
 
@@ -560,7 +560,7 @@
 
 (group "engine"
        "$OUT/iso/0COMMON.TXT"
-       "$OUT/iso/0SUBTI2.TXT"
+       "$OUT/iso/0SUBTI3.TXT"
        "$OUT/iso/KERNEL.CGO"
        "$OUT/iso/GAME.CGO"
        "$OUT/iso/VAGDIR.AYB"

--- a/goal_src/jak3/levels/desert/desert-dust-storm.gc
+++ b/goal_src/jak3/levels/desert/desert-dust-storm.gc
@@ -718,7 +718,15 @@
          (set! (-> a2-8 quad) (-> *time-of-day-context* current-fog fog-color quad))
          (set! (-> a2-8 w) (* 128.0 f0-48))
          (set! (-> this enabled-screen-filter?) #t)
-         (setup *screen-filter* a2-8 a2-8 10000.0 (bucket-id generic-sprite-1) #x20000 #x30003 #t)
+         (setup *screen-filter* a2-8 a2-8 10000.0
+                ;;(bucket-id generic-sprite-1)
+                ;; og:preserve-this
+                ;; Modified to put this into a nearby bucket with same settings
+                ;; that uses DirectRenderer in the C++ renderer.
+                ;; otherwise, it goes to the Generic renderer, which doesn't know how to
+                ;; handle drawing through Direct.
+                (bucket-id tex-hud-pris2)
+                 #x20000 #x30003 #t)
          )
        )
      )


### PR DESCRIPTION
Simple workaround to put an effect in a different bucket. I don't think there's a difference in the result, but this is just easier to handle on the PC renderer side.