### PR TITLE
Remove 128 character buffer causing long filenames to crash gk

### DIFF
--- a/game/kernel/jak1/kmachine.cpp
+++ b/game/kernel/jak1/kmachine.cpp
@@ -391,14 +391,12 @@ u64 kopen(u64 fs, u64 name, u64 mode) {
   file_stream->name = name;
   file_stream->flags = 0;
   lg::print("****** CALL TO kopen() ******\n");
-  char buffer[128];
   // sprintf(buffer, "host:%s", Ptr<String>(name)->data());
-  sprintf(buffer, "%s", Ptr<String>(name)->data());
   if (!strcmp(info(Ptr<Symbol>(mode))->str->data(), "read")) {
-    file_stream->file = sceOpen(buffer, SCE_RDONLY);
+    file_stream->file = sceOpen(Ptr<String>(name)->data(), SCE_RDONLY);
   } else {
     // 0x602
-    file_stream->file = sceOpen(buffer, SCE_TRUNC | SCE_CREAT | SCE_WRONLY);
+    file_stream->file = sceOpen(Ptr<String>(name)->data(), SCE_TRUNC | SCE_CREAT | SCE_WRONLY);
   }
 
   return fs;

--- a/game/kernel/jak2/kmachine.cpp
+++ b/game/kernel/jak2/kmachine.cpp
@@ -505,19 +505,17 @@ u64 kopen(u64 fs, u64 name, u64 mode) {
   file_stream->name = name;
   file_stream->flags = 0;
   lg::print("****** CALL TO kopen() ******\n");
-  char buffer[128];
   // sprintf(buffer, "host:%s", Ptr<String>(name)->data());
-  sprintf(buffer, "%s", Ptr<String>(name)->data());
   if (!strcmp(symbol_name_cstr(*Ptr<Symbol4<u8>>(mode)), "read")) {
     // 0x1
-    file_stream->file = sceOpen(buffer, SCE_RDONLY);
+    file_stream->file = sceOpen(Ptr<String>(name)->data(), SCE_RDONLY);
   } else if (!strcmp(symbol_name_cstr(*Ptr<Symbol4<u8>>(mode)), "append")) {
     // new in jak 2!
     // 0x202
-    file_stream->file = sceOpen(buffer, SCE_CREAT | SCE_WRONLY);
+    file_stream->file = sceOpen(Ptr<String>(name)->data(), SCE_CREAT | SCE_WRONLY);
   } else {
     // 0x602
-    file_stream->file = sceOpen(buffer, SCE_TRUNC | SCE_CREAT | SCE_WRONLY);
+    file_stream->file = sceOpen(Ptr<String>(name)->data(), SCE_TRUNC | SCE_CREAT | SCE_WRONLY);
   }
 
   return fs;

--- a/game/kernel/jak3/kmachine.cpp
+++ b/game/kernel/jak3/kmachine.cpp
@@ -324,19 +324,17 @@ u64 kopen(u64 fs, u64 name, u64 mode) {
   file_stream->name = name;
   file_stream->flags = 0;
   lg::print("****** CALL TO kopen() ******\n");
-  char buffer[128];
   // sprintf(buffer, "host:%s", Ptr<String>(name)->data());
-  sprintf(buffer, "%s", Ptr<String>(name)->data());
   if (!strcmp(sym_to_cstring(Ptr<Symbol4<u8>>(mode)), "read")) {
     // 0x1
-    file_stream->file = ee::sceOpen(buffer, SCE_RDONLY);
+    file_stream->file = ee::sceOpen(Ptr<String>(name)->data(), SCE_RDONLY);
   } else if (!strcmp(sym_to_cstring(Ptr<Symbol4<u8>>(mode)), "append")) {
     // new in jak 2!
     // 0x202
-    file_stream->file = ee::sceOpen(buffer, SCE_CREAT | SCE_WRONLY);
+    file_stream->file = ee::sceOpen(Ptr<String>(name)->data(), SCE_CREAT | SCE_WRONLY);
   } else {
     // 0x602
-    file_stream->file = ee::sceOpen(buffer, SCE_TRUNC | SCE_CREAT | SCE_WRONLY);
+    file_stream->file = ee::sceOpen(Ptr<String>(name)->data(), SCE_TRUNC | SCE_CREAT | SCE_WRONLY);
   }
 
   return fs;


### PR DESCRIPTION
Several users have reported that ArchipelaGOAL is not launching properly, even when using the OpenGOAL Launcher. The window pops up with a black screen, and then quits. The only way they can run it is if they double click gk.exe. 

This comes down to the Launcher providing gk.exe with the `config_path` parameter, which leads the program to find `archipelagoal-settings.gc`. Here is an example from me:

```
D:\Applications\Games\OpenGOAL\features\jak1\mods\JakMods\_settings\archipelagoal\OpenGOAL\jak1\settings/Mods/archipelagoal-settings.gc
```

If a user's base OpenGOAL install directory is long enough, this path becomes longer than 128 characters. This overflows the character buffer in `kopen` which is used to open file streams. If you're only slightly over the limit like myself, at 135 characters, you may not have noticed a problem. But some users have paths a little longer, like 168 characters, and they report the issue is consistent.

Water111 suggested we remove the 128 character buffer and use the filename data directly. This fix requires no changes to the Launcher, just to the kernel, and every mod could stand to benefit from this fix.