### PR TITLE
jak3: fix ragdolls settling too early

### DIFF
--- a/decompiler/config/jak3/all-types.gc
+++ b/decompiler/config/jak3/all-types.gc
@@ -23125,7 +23125,7 @@
     (disable-for-duration (_type_ time-frame) none) ;; 16
     (ragdoll-proc-method-17 (_type_ ragdoll-edit-info) none) ;; 17
     (ragdoll-proc-method-18 (_type_ ragdoll-edit-info) none) ;; 18
-    (ragdoll-proc-method-19 (_type_) none) ;; 19
+    (ragdoll-proc-method-19 (_type_) symbol) ;; 19
     )
   )
 

--- a/goal_src/jak3/engine/physics/ragdoll-h.gc
+++ b/goal_src/jak3/engine/physics/ragdoll-h.gc
@@ -218,7 +218,7 @@
     (disable-for-duration (_type_ time-frame) none)
     (ragdoll-proc-method-17 (_type_ ragdoll-edit-info) none)
     (ragdoll-proc-method-18 (_type_ ragdoll-edit-info) none)
-    (ragdoll-proc-method-19 (_type_) none)
+    (ragdoll-proc-method-19 (_type_) symbol)
     )
   )
 

--- a/goal_src/jak3/engine/physics/ragdoll.gc
+++ b/goal_src/jak3/engine/physics/ragdoll.gc
@@ -1567,13 +1567,11 @@
   (none)
   )
 
-;; WARN: Return type mismatch symbol vs none.
 (defmethod ragdoll-proc-method-19 ((this ragdoll-proc))
   (if (nonzero? (-> this ragdoll))
       (logtest? (-> this ragdoll ragdoll-flags) (ragdoll-flag rf2))
       #t
       )
-  (none)
   )
 
 (defstate idle (ragdoll-proc)

--- a/goal_src/jak3/engine/target/flut/flut-racer.gc
+++ b/goal_src/jak3/engine/target/flut/flut-racer.gc
@@ -512,8 +512,7 @@
       (set! (-> s5-0 danger-level) 0.5)
       (set! (-> s5-0 notify-radius) 491520.0)
       (set! (-> s5-0 decay-rate) 0.0)
-      ;; og:preserve-this not-yet-implemented
-      ; (add-danger *traffic-engine* s5-0)
+      (add-danger *traffic-engine* s5-0)
       )
     (let ((s5-1 (new 'stack-no-clear 'vector)))
       (vector-normalize!

--- a/goal_src/jak3/game.gp
+++ b/goal_src/jak3/game.gp
@@ -105,10 +105,10 @@
 (cgo-file "wasseem.gd" common-dep)
 (cgo-file "wca.gd" common-dep)
 (cgo-file "wcb.gd" common-dep)
-(cgo-file "wasleapr.gd" common-dep)
 (cgo-file "wcaseem.gd" common-dep)
 (cgo-file "wascast.gd" common-dep)
 (cgo-file "cwi.gd" common-dep) ;; ctywide
+(cgo-file "wasleapr.gd" common-dep)
 (cgo-file "wasall.gd" common-dep)
 (cgo-file "desresc.gd" common-dep)
 (cgo-file "wsd.gd" common-dep) ;; wasdoors (garage)

--- a/test/decompiler/reference/jak3/engine/physics/ragdoll-h_REF.gc
+++ b/test/decompiler/reference/jak3/engine/physics/ragdoll-h_REF.gc
@@ -294,7 +294,7 @@
     (disable-for-duration (_type_ time-frame) none)
     (ragdoll-proc-method-17 (_type_ ragdoll-edit-info) none)
     (ragdoll-proc-method-18 (_type_ ragdoll-edit-info) none)
-    (ragdoll-proc-method-19 (_type_) none)
+    (ragdoll-proc-method-19 (_type_) symbol)
     )
   )
 
@@ -334,3 +334,7 @@
 
 ;; failed to figure out what this is:
 0
+
+
+
+

--- a/test/decompiler/reference/jak3/engine/physics/ragdoll_REF.gc
+++ b/test/decompiler/reference/jak3/engine/physics/ragdoll_REF.gc
@@ -1616,13 +1616,11 @@
   )
 
 ;; definition for method 19 of type ragdoll-proc
-;; WARN: Return type mismatch symbol vs none.
 (defmethod ragdoll-proc-method-19 ((this ragdoll-proc))
   (if (nonzero? (-> this ragdoll))
       (logtest? (-> this ragdoll ragdoll-flags) (ragdoll-flag rf2))
       #t
       )
-  (none)
   )
 
 ;; failed to figure out what this is:
@@ -1748,3 +1746,7 @@
       )
   (go-virtual idle)
   )
+
+
+
+

--- a/test/decompiler/reference/jak3/levels/common/enemy/darkprec/dp-bipedal_REF.gc
+++ b/test/decompiler/reference/jak3/levels/common/enemy/darkprec/dp-bipedal_REF.gc
@@ -2164,7 +2164,7 @@
         )
     )
   :code (behavior ()
-    (local-vars (v1-31 object) (v1-72 symbol))
+    (local-vars (v1-31 symbol) (v1-72 symbol))
     (cond
       ((handle->process (-> self ragdoll-proc))
        (ja-channel-push! 1 0)

--- a/test/decompiler/reference/jak3/levels/common/enemy/grunt_REF.gc
+++ b/test/decompiler/reference/jak3/levels/common/enemy/grunt_REF.gc
@@ -1790,7 +1790,7 @@
 (defstate knocked-recover (grunt)
   :virtual #t
   :code (behavior ()
-    (local-vars (v1-49 object))
+    (local-vars (v1-49 symbol))
     (ja-channel-push! 1 0)
     (let ((gp-0 (-> (the-as ragdoll-proc (handle->process (-> self ragdoll-proc))) ragdoll)))
       (when gp-0


### PR DESCRIPTION
`none` methods strike again

Fixes #3774 