### PR TITLE
ci: update minimum macOS supported version to Ventura (13)

### DIFF
--- a/.github/workflows/macos-build-arm.yaml
+++ b/.github/workflows/macos-build-arm.yaml
@@ -27,8 +27,8 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.14
         with:
           variant: sccache
-          key: macos-12-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
-          restore-keys: macos-12-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          key: macos-15-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
+          restore-keys: macos-15-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
           max-size: 1000M
 
       - name: CMake Generation

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     name: Intel
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 120
 
     steps:
@@ -41,8 +41,8 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.14
         with:
           variant: sccache
-          key: macos-12-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
-          restore-keys: macos-12-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          key: macos-13-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
+          restore-keys: macos-13-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
           max-size: 1000M
 
       - name: CMake Generation


### PR DESCRIPTION
macOS 12 has been end of life for 2 months, GitHub is removing support for the images very soon (within a week or so).  

https://endoflife.date/macos