### PR TITLE
custom models: ignore invalid envmap material

### DIFF
--- a/common/util/gltf_util.cpp
+++ b/common/util/gltf_util.cpp
@@ -684,19 +684,12 @@ bool material_has_envmap(const tinygltf::Material& mat) {
   return mat.extensions.contains("KHR_materials_specular");
 }
 
-bool envmap_is_valid(const tinygltf::Material& mat, bool die) {
+bool envmap_is_valid(const tinygltf::Material& mat) {
   if (material_has_envmap(mat) && mat.pbrMetallicRoughness.metallicRoughnessTexture.index < 0) {
-    std::string error = fmt::format(
-        "Material \"{}\" has specular property set, but is missing a metallic roughness texture! "
-        "Check "
-        "that the Specular IOR level for the material is at the default of 0.5 if this is "
-        "unintended.",
-        mat.name);
-    if (die) {
-      lg::die(error);
-    } else {
-      lg::error(error);
-    }
+    lg::warn(fmt::format(
+        "Material \"{}\" has specular property set, but is missing a metallic roughness texture, "
+        "ignoring envmap!",
+        mat.name));
     return false;
   }
   return true;

--- a/common/util/gltf_util.h
+++ b/common/util/gltf_util.h
@@ -126,7 +126,7 @@ struct EnvmapSettings {
 
 EnvmapSettings envmap_settings_from_gltf(const tinygltf::Material& mat);
 bool material_has_envmap(const tinygltf::Material& mat);
-bool envmap_is_valid(const tinygltf::Material& mat, bool die);
+bool envmap_is_valid(const tinygltf::Material& mat);
 
 /*!
  * Find the index of the skin for this model. Returns nullopt if there is no skin, the index of the

--- a/decompiler/level_extractor/merc_replacement.cpp
+++ b/decompiler/level_extractor/merc_replacement.cpp
@@ -17,7 +17,6 @@ void extract(const std::string& name,
   std::map<int, tfrag3::MercDraw> draw_by_material;
   int mesh_count = 0;
   int prim_count = 0;
-  bool has_envmaps = false;
   int joints = 3;
   auto skin_idx = find_single_skin(model, all_nodes);
   if (skin_idx) {
@@ -80,6 +79,7 @@ void extract(const std::string& name,
 
   tfrag3::MercEffect e;
   tfrag3::MercEffect envmap_eff;
+  envmap_eff.has_envmap = false;
   out.new_model.name = name;
   out.new_model.max_bones = joints;
   out.new_model.max_draws = 0;
@@ -161,11 +161,9 @@ void extract(const std::string& name,
 
   for (const auto& [mat_idx, d_] : draw_by_material) {
     const auto& mat = model.materials[mat_idx];
-    if (!material_has_envmap(mat)) {
+    if (!material_has_envmap(mat) || !envmap_is_valid(mat)) {
       process_normal_draw(e, mat_idx, d_);
     } else {
-      envmap_is_valid(mat, true);
-      has_envmaps = true;
       envmap_eff.has_envmap = true;
       process_envmap_draw(envmap_eff, mat_idx, d_);
     }
@@ -175,7 +173,7 @@ void extract(const std::string& name,
   if (!e.all_draws.empty()) {
     out.new_model.effects.push_back(e);
   }
-  if (has_envmaps) {
+  if (envmap_eff.has_envmap) {
     out.new_model.effects.push_back(envmap_eff);
   }
 

--- a/goalc/build_actor/common/MercExtract.cpp
+++ b/goalc/build_actor/common/MercExtract.cpp
@@ -17,7 +17,6 @@ void extract(const std::string& name,
   std::map<int, tfrag3::MercDraw> draw_by_material;
   int mesh_count = 0;
   int prim_count = 0;
-  bool has_envmaps = false;
   int joints = 3;
   auto skin_idx = find_single_skin(model, all_nodes);
   if (skin_idx) {
@@ -92,6 +91,7 @@ void extract(const std::string& name,
 
   tfrag3::MercEffect e;
   tfrag3::MercEffect envmap_eff;
+  envmap_eff.has_envmap = false;
   out.new_model.name = name;
   out.new_model.max_bones = joints;
   out.new_model.max_draws = 0;
@@ -173,11 +173,9 @@ void extract(const std::string& name,
 
   for (const auto& [mat_idx, d_] : draw_by_material) {
     const auto& mat = model.materials[mat_idx];
-    if (!gltf_util::material_has_envmap(mat)) {
+    if (!gltf_util::material_has_envmap(mat) || !gltf_util::envmap_is_valid(mat)) {
       process_normal_draw(e, mat_idx, d_);
     } else {
-      gltf_util::envmap_is_valid(mat, false);
-      has_envmaps = true;
       envmap_eff.has_envmap = true;
       process_envmap_draw(envmap_eff, mat_idx, d_);
     }
@@ -187,7 +185,7 @@ void extract(const std::string& name,
   if (!e.all_draws.empty()) {
     out.new_model.effects.push_back(e);
   }
-  if (has_envmaps) {
+  if (envmap_eff.has_envmap) {
     out.new_model.effects.push_back(envmap_eff);
   }
 


### PR DESCRIPTION
If a model has a material with specular properties, but is missing a roughness texture, warn and treat it as a normal draw instead of erroring out.