### PR TITLE
ci: hopefully fix MacOS CI in preparation for release

### DIFF
--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -86,7 +86,7 @@ jobs:
     uses: ./.github/workflows/macos-build.yaml
     with:
       cmakePreset: "Release-macos-x86_64-clang-static"
-      cachePrefix: "static"
+      cachePrefix: "static-arm"
       uploadArtifacts: true
     secrets: inherit
 
@@ -150,13 +150,13 @@ jobs:
       - name: Prepare ARM macOS Build Assets
         run: |
           mkdir -p ./ci-artifacts/macos-arm
-          ./.github/scripts/releases/extract_build_unix.sh ./ci-artifacts/macos-arm ./ci-artifacts/opengoal-macos-arm-static ./
+          ./.github/scripts/releases/extract_build_unix.sh ./ci-artifacts/macos-arm ./ci-artifacts/opengoal-macos-static-arm ./
           pushd ci-artifacts/macos-arm
           TAG_VAL=${{ needs.cut_release.outputs.new_tag }}
           tar czf ../final/opengoal-macos-arm-${TAG_VAL}.tar.gz .
           popd
-          chmod +x ./ci-artifacts/opengoal-macos-arm-static/lsp/lsp
-          cp ./ci-artifacts/opengoal-macos-arm-static/lsp/lsp ./ci-artifacts/final/opengoal-lsp-macos-arm-${TAG_VAL}.bin
+          chmod +x ./ci-artifacts/opengoal-macos-static-arm/lsp/lsp
+          cp ./ci-artifacts/opengoal-macos-static-arm/lsp/lsp ./ci-artifacts/final/opengoal-lsp-macos-arm-${TAG_VAL}.bin
 
       - name: Upload Assets
         env:


### PR DESCRIPTION
Folder names were in common with the normal intel x86 build, the release wasn't going to work.  Hopefully with these changes it will but, still technically untested.  Don't have time to do so tonight.