### PR TITLE
jak3: fix cloth disappearing after 600 orbs

### DIFF
--- a/goal_src/jak3/engine/common-obs/cloth-art-h.gc
+++ b/goal_src/jak3/engine/common-obs/cloth-art-h.gc
@@ -135,6 +135,9 @@
 
 (defmacro static-cloth-params (ag-name args)
  `(let ((parms (new 'static 'cloth-params)))
+    (false! (-> parms alt-tex-name))
+    (false! (-> parms alt-tex-name2))
+    (false! (-> parms alt-tex-name3))
     ,@(apply (lambda (x) (if (and (eq? (car x) 'mesh) (not (integer? (cadr x))))
                            `(set! (-> parms ,(car x)) ,(art-elt-index ag-name (cadr x)))
                            `(set! (-> parms ,(car x)) ,(cadr x))


### PR DESCRIPTION
After collecting 600 orbs, cloth systems that didn't have any `alt-tex-name`s defined would vanish because the `static-cloth-params` macro doesn't default them to `#f`.