### PR TITLE
Add option to hide the imgui bar with a click event

### DIFF
--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -200,8 +200,7 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
       ImGui::PushStyleColor(ImGuiCol_Header, ImGui::GetStyleColorVec4(ImGuiCol_MenuBarBg));
       ImGui::PushStyleColor(ImGuiCol_HeaderHovered,
                             ImGui::GetStyleColorVec4(ImGuiCol_HeaderHovered));
-      ImGui::PushStyleColor(ImGuiCol_HeaderActive,
-                            ImGui::GetStyleColorVec4(ImGuiCol_HeaderActive));
+      ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGui::GetStyleColorVec4(ImGuiCol_HeaderActive));
 
       if (ImGui::Selectable(button_text.c_str(), false, ImGuiSelectableFlags_DontClosePopups,
                             ImVec2(button_width, button_height))) {

--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -188,10 +188,28 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
     }
 
     if (!Gfx::g_debug_settings.ignore_hide_imgui) {
-      ImGui::Text("%s", fmt::format("Toggle toolbar with {}",
-                                    sdl_util::get_keyboard_button_name(
-                                        Gfx::g_debug_settings.hide_imgui_key, InputModifiers()))
-                            .c_str());
+      std::string button_text =
+          fmt::format("Click here or Press {} to hide Toolbar",
+                      sdl_util::get_keyboard_button_name(Gfx::g_debug_settings.hide_imgui_key,
+                                                         InputModifiers()));
+
+      ImVec2 text_size = ImGui::CalcTextSize(button_text.c_str());
+      float button_width = text_size.x + ImGui::GetStyle().FramePadding.x * 2;
+      float button_height = text_size.y + ImGui::GetStyle().FramePadding.y * 2;
+
+      ImGui::PushStyleColor(ImGuiCol_Header,
+                            ImGui::GetStyleColorVec4(ImGuiCol_MenuBarBg));
+      ImGui::PushStyleColor(ImGuiCol_HeaderHovered,
+                            ImGui::GetStyleColorVec4(ImGuiCol_HeaderHovered));
+      ImGui::PushStyleColor(ImGuiCol_HeaderActive,
+                            ImGui::GetStyleColorVec4(ImGuiCol_HeaderActive));
+
+      if (ImGui::Selectable(button_text.c_str(), false, ImGuiSelectableFlags_DontClosePopups,
+                            ImVec2(button_width, button_height))) {
+        std::shared_ptr<GfxDisplay> display = Display::GetMainDisplay();
+        display->set_imgui_visible(false);
+      }
+      ImGui::PopStyleColor(3);
     }
   }
   ImGui::EndMainMenuBar();

--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -197,12 +197,9 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
       float button_width = text_size.x + ImGui::GetStyle().FramePadding.x * 2;
       float button_height = text_size.y + ImGui::GetStyle().FramePadding.y * 2;
 
-      ImGui::PushStyleColor(ImGuiCol_Header,
-                            ImGui::GetStyleColorVec4(ImGuiCol_MenuBarBg));
-      ImGui::PushStyleColor(ImGuiCol_HeaderHovered,
-                            ImGui::GetStyleColorVec4(ImGuiCol_HeaderHovered));
-      ImGui::PushStyleColor(ImGuiCol_HeaderActive,
-                            ImGui::GetStyleColorVec4(ImGuiCol_HeaderActive));
+      ImGui::PushStyleColor(ImGuiCol_Header, ImGui::GetStyleColorVec4(ImGuiCol_MenuBarBg));
+      ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGui::GetStyleColorVec4(ImGuiCol_HeaderHovered));
+      ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGui::GetStyleColorVec4(ImGuiCol_HeaderActive));
 
       if (ImGui::Selectable(button_text.c_str(), false, ImGuiSelectableFlags_DontClosePopups,
                             ImVec2(button_width, button_height))) {

--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -198,8 +198,10 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
       float button_height = text_size.y + ImGui::GetStyle().FramePadding.y * 2;
 
       ImGui::PushStyleColor(ImGuiCol_Header, ImGui::GetStyleColorVec4(ImGuiCol_MenuBarBg));
-      ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGui::GetStyleColorVec4(ImGuiCol_HeaderHovered));
-      ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGui::GetStyleColorVec4(ImGuiCol_HeaderActive));
+      ImGui::PushStyleColor(ImGuiCol_HeaderHovered,
+                            ImGui::GetStyleColorVec4(ImGuiCol_HeaderHovered));
+      ImGui::PushStyleColor(ImGuiCol_HeaderActive,
+                            ImGui::GetStyleColorVec4(ImGuiCol_HeaderActive));
 
       if (ImGui::Selectable(button_text.c_str(), false, ImGuiSelectableFlags_DontClosePopups,
                             ImVec2(button_width, button_height))) {


### PR DESCRIPTION
Should cover edge cases where the bar is displayed and a keyboard type device is not connected to the system (Steam deck/touch input based device instead).

While it should probably be impossible to display the bar in the first place on such devices it apparently isnt -> https://www.reddit.com/r/jakanddaxter/comments/1h4mht1/how_to_remove_grey_bar_at_top_on_steamdeck/

And even ignoring the whole steamdeck/no keyboard thing adding another way to hide it that is visible on the bar should help reduce people asking about how to hide it. (And hopefully help people who dont ask/dont know where to ask!)


https://github.com/user-attachments/assets/7f132781-675c-451e-8b39-2a78fa098b9e

