### PR TITLE
[jak3] Fix issue where some vag streams never queue

### DIFF
--- a/game/overlord/jak3/stream.cpp
+++ b/game/overlord/jak3/stream.cpp
@@ -220,7 +220,6 @@ void* RPC_PLAY(unsigned int, void* msg_in, int size) {
               priority = priority + -1;
             }
           }
-          s = s + 1;
         }
         SignalSema(g_EEStreamsList.sema);
       } break;


### PR DESCRIPTION
Accidentally incrementing `s` twice in the loop, so queued streams in slot 1, and 3 were skipped by the overlord.
This would usually cause the audio to never start playing because the game would wait for the audio to successfully get queued.