### PR TITLE
fix(kernel): fixed the order of kernel versions in logging statement

### DIFF
--- a/game/kernel/jak1/kscheme.cpp
+++ b/game/kernel/jak1/kscheme.cpp
@@ -1758,9 +1758,9 @@ s32 InitHeapAndSymbol() {
     if (!kernel_version || ((kernel_version >> 0x13) != KERNEL_VERSION_MAJOR)) {
       lg::error(
           "Kernel version mismatch! Compiled C kernel version is {}.{} but"
-          "the goal kernel is {}.{}",
-          KERNEL_VERSION_MAJOR, KERNEL_VERSION_MINOR, kernel_version >> 0x13,
-          (kernel_version >> 3) & 0xffff);
+          " the goal kernel is {}.{}",
+          kernel_version >> 0x13, (kernel_version >> 3) & 0xffff, KERNEL_VERSION_MAJOR,
+          KERNEL_VERSION_MINOR);
       return -1;
     } else {
       lg::info("Got correct kernel version {}.{}, loaded in {:.2} ms", kernel_version >> 0x13,

--- a/game/kernel/jak2/kscheme.cpp
+++ b/game/kernel/jak2/kscheme.cpp
@@ -1759,9 +1759,9 @@ int InitHeapAndSymbol() {
     if (!kernel_version || ((kernel_version >> 0x13) != KERNEL_VERSION_MAJOR)) {
       lg::error(
           "Kernel version mismatch! Compiled C kernel version is {}.{} but"
-          "the goal kernel is {}.{}",
-          KERNEL_VERSION_MAJOR, KERNEL_VERSION_MINOR, kernel_version >> 0x13,
-          (kernel_version >> 3) & 0xffff);
+          " the goal kernel is {}.{}",
+          kernel_version >> 0x13, (kernel_version >> 3) & 0xffff, KERNEL_VERSION_MAJOR,
+          KERNEL_VERSION_MINOR);
       return -1;
     } else {
       lg::info("Got correct kernel version {}.{}", kernel_version >> 0x13,

--- a/game/kernel/jak3/kscheme.cpp
+++ b/game/kernel/jak3/kscheme.cpp
@@ -1923,8 +1923,8 @@ int InitHeapAndSymbol() {
       lg::error(
           "Kernel version mismatch! Compiled C kernel version is {}.{} but"
           " the goal kernel is {}.{}",
-          KERNEL_VERSION_MAJOR, KERNEL_VERSION_MINOR, kernel_version >> 0x13,
-          (kernel_version >> 3) & 0xffff);
+          kernel_version >> 0x13, (kernel_version >> 3) & 0xffff, KERNEL_VERSION_MAJOR,
+          KERNEL_VERSION_MINOR);
       return -1;
     } else {
       lg::info("Got correct kernel version {}.{}", kernel_version >> 0x13,


### PR DESCRIPTION
Corrected the order of the c kernel versions.

> [17:23] [error] Kernel version mismatch! Compiled C kernel version is 2.0 but the goal kernel is 0.0

But looking into the code 2.0 is defined for goal. 
<img width="618" alt="image" src="https://github.com/user-attachments/assets/f1de262f-b053-479c-afcb-a48d6b16f5a1" />

There is still an issue that the kernel version cannot be read on macos (arm) (Reading as 0.0) but I have not found a solution for that yet.