### PR TITLE
[jak3] Avoid language 255 issue

### DIFF
--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -6,6 +6,7 @@
 #include "game/graphics/display.h"
 #include "game/graphics/gfx.h"
 #include "game/graphics/screenshot.h"
+#include "game/overlord/jak3/dma.h"
 #include "game/system/hid/sdl_util.h"
 
 #include "fmt/core.h"
@@ -104,6 +105,7 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
       ImGui::MenuItem("Profiler", nullptr, &m_draw_profiler);
       ImGui::MenuItem("Small Profiler", nullptr, &small_profiler);
       ImGui::MenuItem("Loader", nullptr, &m_draw_loader);
+      ImGui::MenuItem("Overlord", nullptr, &m_draw_overlord);
       if (ImGui::MenuItem("Reboot In Debug Mode!")) {
         want_reboot_in_debug = true;
       }
@@ -214,5 +216,20 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
 
   if (m_draw_frame_time) {
     m_frame_timer.draw_window(dma_stats);
+  }
+
+  if (should_draw_overlord_debug()) {
+    draw_overlord_debug_menu();
+  }
+}
+
+void OpenGlDebugGui::draw_overlord_debug_menu() {
+  ImGui::Begin("Overlord");
+
+  for (int stream_idx = 0; stream_idx < 6; stream_idx++) {
+    auto& stream = jak3::g_overlord_stream_memory.infos[stream_idx];
+
+    ImGui::Text("%30s [%3d] | %30s [%3d]", stream[0].name.chars, stream[0].idx,
+                stream[1].name.chars, stream[1].idx);
   }
 }

--- a/game/graphics/opengl_renderer/debug_gui.h
+++ b/game/graphics/opengl_renderer/debug_gui.h
@@ -50,6 +50,7 @@ class OpenGlDebugGui {
   bool should_draw_subtitle_editor() const { return master_enable && m_subtitle_editor; }
   bool should_draw_filters_menu() const { return master_enable && m_filters_menu; }
   bool should_draw_loader_menu() const { return master_enable && m_draw_loader; }
+  bool should_draw_overlord_debug() const { return master_enable && m_draw_overlord; }
 
   bool should_advance_frame() { return m_frame_timer.should_advance_frame(); }
   bool should_gl_finish() const { return m_frame_timer.do_gl_finish; }
@@ -72,11 +73,13 @@ class OpenGlDebugGui {
   bool master_enable = false;
 
  private:
+  void draw_overlord_debug_menu();
   FrameTimeRecorder m_frame_timer;
   bool m_draw_frame_time = false;
   bool m_draw_profiler = false;
   bool m_draw_debug = false;
   bool m_draw_loader = false;
+  bool m_draw_overlord = false;
   bool m_subtitle_editor = false;
   bool m_filters_menu = false;
   bool m_want_screenshot = false;

--- a/game/overlord/jak3/dma.h
+++ b/game/overlord/jak3/dma.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "game/overlord/jak3/rpc_interface.h"
-
 #include "common/common_types.h"
+
+#include "game/overlord/jak3/rpc_interface.h"
 
 namespace jak3 {
 void jak3_overlord_init_globals_dma();

--- a/game/overlord/jak3/dma.h
+++ b/game/overlord/jak3/dma.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "game/overlord/jak3/rpc_interface.h"
+
 #include "common/common_types.h"
 
 namespace jak3 {
@@ -29,4 +31,18 @@ struct DmaQueueEntry {
   u32 num_isobuffered_chunks = 0;
 };
 void dma_intr_hack();
+
+struct OverlordStreamMemory {
+  struct Info {
+    SoundStreamName name;
+    int idx = 0;
+  };
+  Info infos[6][2];
+
+  OverlordStreamMemory();
+  void update_name(const char* input, int stream, int side);
+};
+
+extern OverlordStreamMemory g_overlord_stream_memory;
+
 }  // namespace jak3

--- a/goal_src/jak3/pc/pckernel.gc
+++ b/goal_src/jak3/pc/pckernel.gc
@@ -249,7 +249,13 @@
   )
 
 (defmethod get-game-language ((obj pc-settings-jak3))
-  (get-current-language)
+  ;; if the language is unintialized, return the default
+  (let ((lang (get-current-language)))
+    (if (= lang 255)
+        (scf-get-language)
+        lang
+        )
+    )
   )
 
 


### PR DESCRIPTION
In Jak 3, the default PC settings file would have a language of 255 because it runs before the first settings update. This would cause the game to crash the second time it is started.

I also added this simple imgui window to see the names of streams in the "SPU" memory, which has been useful for debugging
![image](https://github.com/user-attachments/assets/0a9d6af7-c423-4d8a-a461-faf45e350f33)
