### PR TITLE
[graphics] Improve some camera math

### DIFF
--- a/game/graphics/opengl_renderer/shaders/merc2.vert
+++ b/game/graphics/opengl_renderer/shaders/merc2.vert
@@ -56,17 +56,6 @@ maddz.xyzw vf26, vf28, vf25
 ```
 */
 void main() {
-  //  vec4 transformed = -perspective3.xyzw;
-  //  transformed += -perspective0 * position_in.x;
-  //  transformed += -perspective1 * position_in.y;
-  //  transformed += -perspective2 * position_in.z;
-
-
-  //  vec4 transformed = -hmat3.xyzw;
-  //  transformed += -hmat0 * position_in.x;
-  //  transformed += -hmat1 * position_in.y;
-  //  transformed += -hmat2 * position_in.z;
-
   vec4 p = vec4(position_in, 1);
   vec4 vtx_pos = -bones[mats[0]].X * p * weights_in[0];
   vec3 rotated_nrm = bones[mats[0]].R * normal_in * weights_in[0];

--- a/game/graphics/opengl_renderer/shaders/tfrag3.vert
+++ b/game/graphics/opengl_renderer/shaders/tfrag3.vert
@@ -5,6 +5,8 @@ layout (location = 1) in vec3 tex_coord_in;
 layout (location = 2) in int time_of_day_index;
 
 uniform vec4 hvdf_offset;
+uniform vec4 cam_trans;
+uniform mat4 pc_camera;
 uniform mat4 camera;
 uniform float fog_constant;
 uniform float fog_min;
@@ -31,32 +33,18 @@ void main() {
 
   // the itof0 is done in the preprocessing step.  now we have floats.
 
-  // Step 3, the camera transform
-  vec4 transformed = -camera[3];
-  transformed -= camera[0] * position_in.x;
-  transformed -= camera[1] * position_in.y;
-  transformed -= camera[2] * position_in.z;
 
-  // compute Q
-  float Q = fog_constant / transformed.w;
+  // Step 3, the camera transform
+  vec3 vert = position_in - cam_trans.xyz;
+  vec4 transformed = -pc_camera[3];
+  transformed.w = 0;
+  transformed -= pc_camera[0] * vert.x;
+  transformed -= pc_camera[1] * vert.y;
+  transformed -= pc_camera[2] * vert.z;
 
   // do fog!
   fogginess = 255 - clamp(-transformed.w + hvdf_offset.w, fog_min, fog_max);
 
-  // perspective divide!
-  transformed.xyz *= Q;
-  // offset
-  transformed.xyz += hvdf_offset.xyz;
-  // correct xy offset
-  transformed.xy -= (2048.);
-  // correct z scale
-  transformed.z /= (8388608);
-  transformed.z -= 1;
-  // correct xy scale
-  transformed.x /= (256);
-  transformed.y /= -(128);
-  // hack
-  transformed.xyz *= transformed.w;
   // scissoring area adjust
   transformed.y *= SCISSOR_ADJUST * HEIGHT_SCALE;
   gl_Position = transformed;


### PR DESCRIPTION
I finally went through and worked out the math for the camera matrix, and improved how it works for PC rendering. I was able to finally avoid the double perspective divide issue, which I always thought would cause accuracy issues.

This will help tfrag, tie (no envmap), shrub, and hfrag have less z-fighting in cases where the camera and the thing you're looking at are pretty close, but the entire level is far from the origin - like jak 3 temple.  I was able to modify the camera matrix so we don't have to do all the weird scaling/addition in the shader. 

Here's a screenshot from the temple oracle checkpoint, cropped from 4k. This used to have a lot of fighting issues.

![image](https://github.com/user-attachments/assets/4e11157f-ccf5-4f14-98a9-4a0b34da0cd2)

It doesn't help issues where the thing you're looking at is very far away (jak 1 mountains, some jak 2 city stuff). It also doesn't help with jak's skirt/scarf, since those use a different renderer.

There's definitely more to do here, but this is a good starting point and proof that I can at least figure out the math.

