### PR TITLE
[jak3] Fix cloth nans

### DIFF
--- a/game/mips2c/mips2c_private.h
+++ b/game/mips2c/mips2c_private.h
@@ -1029,7 +1029,14 @@ struct ExecutionContext {
   }
 
   void vrsqrt(int src0, BC bc0, int src1, BC bc1) {
-    Q = vf_src(src0).f[(int)bc0] / std::sqrt(std::abs(vf_src(src1).f[(int)bc1]));
+    const float s = std::sqrt(std::abs(vf_src(src1).f[(int)bc1]));
+    if (s == 0) {
+      // avoid propagating NaN's in Jak 3's cloth stuff, which sometimes runs the update method
+      // before doing setup.
+      Q = 0;
+    } else {
+      Q = vf_src(src0).f[(int)bc0] / s;
+    }
   }
 
   void vsqrt(int src, BC bc) { Q = std::sqrt(std::abs(vf_src(src).f[(int)bc])); }


### PR DESCRIPTION
Kind of silly fix.

The cloth update function sometimes runs before the "setup" is done (`need-setup` is set), which divides by zero in a bunch of places. This fix prevents NaNs from spreading during this time.