### PR TITLE
ci: update to ubuntu `22.04`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,6 @@ BasedOnStyle: Chromium
 ColumnLimit: 100
 SortIncludes: true
 IncludeBlocks: Regroup
-AllowShortFunctionsOnASingleLine: InlineOnly
 IncludeCategories:
   - Regex: '^<[a-zA-Z_\-\.]+>'
     Priority: 1

--- a/.clang-format
+++ b/.clang-format
@@ -3,6 +3,7 @@ BasedOnStyle: Chromium
 ColumnLimit: 100
 SortIncludes: true
 IncludeBlocks: Regroup
+AllowShortFunctionsOnASingleLine: InlineOnly
 IncludeCategories:
   - Regex: '^<[a-zA-Z_\-\.]+>'
     Priority: 1

--- a/.github/workflows/compiler-output-check.yaml
+++ b/.github/workflows/compiler-output-check.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Compare
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     steps:
@@ -29,8 +29,8 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           variant: sccache
-          key: linux-ubuntu-20.04--Release-linux-clang-static-${{ github.sha }}
-          restore-keys: linux-ubuntu-20.04--Release-linux-clang-static
+          key: linux-ubuntu-22.04--Release-linux-clang-static-${{ github.sha }}
+          restore-keys: linux-ubuntu-22.04--Release-linux-clang-static
           max-size: 1000M
 
       - name: CMake Generation (master)

--- a/.github/workflows/inform-pages-repo.yaml
+++ b/.github/workflows/inform-pages-repo.yaml
@@ -12,7 +12,7 @@ jobs:
   gen-docs:
     name: Generate Documentation
     if: github.repository == 'open-goal/jak-project'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     env: # overrides: https://github.com/mbitsnbites/buildcache/blob/master/doc/configuration.md
       BUILDCACHE_MAX_CACHE_SIZE: 1000000000 # 1gb
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Buildcache
         uses: mikehardy/buildcache-action@v2.1.0
         with:
-          cache_key: linux-ubuntu-20.04--Release-linux-clang
+          cache_key: linux-ubuntu-22.04--Release-linux-clang
           buildcache_tag: v0.28.1
 
       - name: CMake Generation

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   formatting:
     name: 📝 Formatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - name: Checkout Repository

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -18,20 +18,18 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      # wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-      # sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main'
-      # sudo apt install clang-format-15
-      # --clang-format-executable $(which clang-format-15)
       - name: Get Package Dependencies
         run: |
           sudo apt update
-          sudo apt install clang-format
-          clang-format -version
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main'
+          sudo apt install clang-format-18
+          clang-format-18 -version
 
       - name: Check Clang-Formatting
         run: |
           chmod +x ./third-party/run-clang-format/run-clang-format.py
-          ./third-party/run-clang-format/run-clang-format.py -r common decompiler game goalc test tools lsp --color always
+          ./third-party/run-clang-format/run-clang-format.py -r common decompiler game goalc test tools lsp --color always --clang-format-executable $(which clang-format-18)
 
   required-checks:
     name: 📝 Required Checks

--- a/.github/workflows/linux-build-clang.yaml
+++ b/.github/workflows/linux-build-clang.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     name: Clang
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     steps:
@@ -46,8 +46,8 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           variant: sccache
-          key: linux-ubuntu-20.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
-          restore-keys: linux-ubuntu-20.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          key: linux-ubuntu-22.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
+          restore-keys: linux-ubuntu-22.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
           max-size: 1000M
 
       - name: CMake Generation

--- a/.github/workflows/linux-build-gcc.yaml
+++ b/.github/workflows/linux-build-gcc.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: GCC
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     steps:
@@ -37,8 +37,8 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           variant: sccache
-          key: linux-ubuntu-20.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
-          restore-keys: linux-ubuntu-20.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
+          key: linux-ubuntu-22.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}-${{ github.sha }}
+          restore-keys: linux-ubuntu-22.04-${{ inputs.cachePrefix }}-${{ inputs.cmakePreset }}
           max-size: 1000M
 
       - name: CMake Generation

--- a/common/formatter/formatter_tree.h
+++ b/common/formatter/formatter_tree.h
@@ -46,7 +46,7 @@ class FormatterTreeNode {
 
   FormatterTreeNode() = default;
   FormatterTreeNode(const std::string& source, const TSNode& node);
-  FormatterTreeNode(const Metadata& _metadata) : metadata(_metadata){};
+  FormatterTreeNode(const Metadata& _metadata) : metadata(_metadata) {};
 
   bool is_list() const { return !token.has_value(); }
   std::string token_str() const {

--- a/common/global_profiler/GlobalProfiler.h
+++ b/common/global_profiler/GlobalProfiler.h
@@ -47,7 +47,7 @@ class GlobalProfiler {
 };
 
 struct ScopedEvent {
-  ScopedEvent(GlobalProfiler* _prof) : prof(_prof){};
+  ScopedEvent(GlobalProfiler* _prof) : prof(_prof) {};
   ScopedEvent(const ScopedEvent&) = delete;
   ScopedEvent& operator=(const ScopedEvent&) = delete;
   GlobalProfiler* prof = nullptr;

--- a/common/goos/TextDB.h
+++ b/common/goos/TextDB.h
@@ -41,7 +41,7 @@ class SourceText {
   // want
   virtual bool terminate_compiler_error() { return true; }
 
-  virtual ~SourceText(){};
+  virtual ~SourceText() {};
 
  protected:
   void build_offsets();

--- a/common/repl/config.h
+++ b/common/repl/config.h
@@ -29,7 +29,7 @@ void from_json(const json& j, KeyBind& obj);
 // TODO - per-game config
 struct Config {
   GameVersion game_version;
-  Config(GameVersion _game_version) : game_version(_game_version){};
+  Config(GameVersion _game_version) : game_version(_game_version) {};
 
   // this is the default REPL configuration
   int nrepl_port = 8181;

--- a/decompiler/config/jak3/ntsc_v1/type_casts.jsonc
+++ b/decompiler/config/jak3/ntsc_v1/type_casts.jsonc
@@ -3160,9 +3160,7 @@
     [27, "a0", "process-focusable"],
     [30, "a0", "process-focusable"]
   ],
-  "(method 20 enemy)": [
-    [[0, 30], "v0", "search-info-flag"]
-  ],
+  "(method 20 enemy)": [[[0, 30], "v0", "search-info-flag"]],
   "(method 59 enemy)": [
     [57, "a0", "process-focusable"],
     [60, "a0", "process-focusable"]
@@ -3217,9 +3215,7 @@
     [67, "s3", "process-drawable"],
     [68, "a1", "collide-shape"]
   ],
-  "(method 68 enemy)": [
-    [[0, 50], "v0", "enemy-aware"]
-  ],
+  "(method 68 enemy)": [[[0, 50], "v0", "enemy-aware"]],
   "(method 82 enemy)": [
     [80, "v1", "process-drawable"],
     [122, "v1", "attack-info"],
@@ -9798,9 +9794,7 @@
     [229, "v1", "ff-squad-control"],
     [319, "a1", "ff-squad-control"]
   ],
-  "(method 252 crimson-guard)": [
-    [[0, 223], "s5", "process-focusable"]
-  ],
+  "(method 252 crimson-guard)": [[[0, 223], "s5", "process-focusable"]],
   "(method 51 ff-squad-control)": [
     [13, "v1", "connection"],
     [14, "v1", "collide-shape"],

--- a/decompiler/config/jak3/ntsc_v1/var_names.jsonc
+++ b/decompiler/config/jak3/ntsc_v1/var_names.jsonc
@@ -175,14 +175,14 @@
   },
   "(method 9 align-control)": {
     "vars": {
-      "s5-0":"num-chans",
-      "s4-0":"chan-idx",
-      "a0-4":"chan",
-      "v1-7":"frame-group",
-      "a0-9":"root-chan",
-      "v1-18":"root-frame-group",
-      "f0-0":"root-frame-num",
-      "a0-10":"disable?"
+      "s5-0": "num-chans",
+      "s4-0": "chan-idx",
+      "a0-4": "chan",
+      "v1-7": "frame-group",
+      "a0-9": "root-chan",
+      "v1-18": "root-frame-group",
+      "f0-0": "root-frame-num",
+      "a0-10": "disable?"
     }
   },
   "(method 9 process)": {
@@ -192,7 +192,7 @@
     "args": ["this", "ent"]
   },
   "(method 106 bot)": {
-    "vars": {"v1-3": ["v1-3", "process-focusable"]}
+    "vars": { "v1-3": ["v1-3", "process-focusable"] }
   },
   "(method 0 clock)": {
     "args": ["allocation", "type-to-make", "index"]

--- a/decompiler/util/data_decompile.h
+++ b/decompiler/util/data_decompile.h
@@ -135,7 +135,7 @@ struct ArrayFieldDecompMeta {
   ArrayFieldDecompMeta(TypeSpec _element_type,
                        int _bytes_per_element,
                        Kind _kind = Kind::REF_TO_INLINE_ARR)
-      : element_type(_element_type), bytes_per_element(_bytes_per_element), kind(_kind){};
+      : element_type(_element_type), bytes_per_element(_bytes_per_element), kind(_kind) {};
 };
 
 extern const std::unordered_map<

--- a/game/system/hid/devices/input_device.h
+++ b/game/system/hid/devices/input_device.h
@@ -14,7 +14,7 @@ class InputDevice {
   std::shared_ptr<game_settings::InputSettings> m_settings;
 
  public:
-  virtual ~InputDevice(){};
+  virtual ~InputDevice() {};
 
   virtual void process_event(const SDL_Event& event,
                              const CommandBindingGroups& commands,

--- a/game/system/hid/devices/keyboard.h
+++ b/game/system/hid/devices/keyboard.h
@@ -20,7 +20,7 @@ struct ActiveKeyboardAction {
 
 class KeyboardDevice : public InputDevice {
  public:
-  KeyboardDevice(){};
+  KeyboardDevice() {};
   KeyboardDevice(std::shared_ptr<game_settings::InputSettings> settings);
   ~KeyboardDevice() {}
 

--- a/game/system/hid/devices/mouse.h
+++ b/game/system/hid/devices/mouse.h
@@ -21,7 +21,7 @@ class MouseDevice : public InputDevice {
     bool mouse5 = false;
   };
 
-  MouseDevice(){};
+  MouseDevice() {};
   MouseDevice(std::shared_ptr<game_settings::InputSettings> settings);
   ~MouseDevice() {}
 

--- a/game/system/hid/input_bindings.h
+++ b/game/system/hid/input_bindings.h
@@ -183,14 +183,14 @@ void from_json(const json& j, InputModifiers& obj);
 /// should make him move towards the camera.
 struct InputBinding {
   InputBinding() = default;
-  InputBinding(int index) : pad_data_index(index){};
+  InputBinding(int index) : pad_data_index(index) {};
   InputBinding(int index, const std::optional<InputModifiers> _modifiers) : pad_data_index(index) {
     if (_modifiers) {
       modifiers = _modifiers.value();
     }
   };
   InputBinding(int index, bool _minimum_in_range)
-      : pad_data_index(index), minimum_in_range(_minimum_in_range){};
+      : pad_data_index(index), minimum_in_range(_minimum_in_range) {};
   InputBinding(int index, bool _minimum_in_range, const std::optional<InputModifiers> _modifiers)
       : pad_data_index(index), minimum_in_range(_minimum_in_range) {
     if (_modifiers) {
@@ -262,7 +262,7 @@ struct InputBindingGroups {
       : device_type(_device_type),
         analog_axii(_analog_axii),
         button_axii(_button_axii),
-        buttons(_buttons){};
+        buttons(_buttons) {};
 
   // TODO - make these private
   InputDeviceType device_type;
@@ -345,7 +345,7 @@ struct CommandBinding {
   enum Source { CONTROLLER, KEYBOARD, MOUSE };
 
   CommandBinding(const u32 _host_key, std::function<void()> _command)
-      : host_key(_host_key), command(_command){};
+      : host_key(_host_key), command(_command) {};
   u32 host_key;
   std::function<void()> command;
   InputModifiers modifiers;

--- a/lsp/protocol/common_types.h
+++ b/lsp/protocol/common_types.h
@@ -29,7 +29,7 @@ struct Range {
   Position m_start;
   Position m_end;
 
-  Range(){};
+  Range() {};
   Range(Position start, Position end);
   // point constructor
   Range(uint32_t line, uint32_t character);

--- a/lsp/state/workspace.cpp
+++ b/lsp/state/workspace.cpp
@@ -19,8 +19,8 @@ extern const TSLanguage* tree_sitter_opengoal();
 
 const TSLanguage* g_opengoalLang = tree_sitter_opengoal();
 
-Workspace::Workspace(){};
-Workspace::~Workspace(){};
+Workspace::Workspace() {};
+Workspace::~Workspace() {};
 
 bool Workspace::is_initialized() {
   return m_initialized;

--- a/lsp/state/workspace.h
+++ b/lsp/state/workspace.h
@@ -37,7 +37,7 @@ struct OGGlobalIndex {
 
 class WorkspaceOGFile {
  public:
-  WorkspaceOGFile(){};
+  WorkspaceOGFile() {};
   WorkspaceOGFile(const LSPSpec::DocumentUri& uri,
                   const std::string& content,
                   const GameVersion& game_version);
@@ -62,7 +62,7 @@ class WorkspaceOGFile {
 
 class WorkspaceIRFile {
  public:
-  WorkspaceIRFile(){};
+  WorkspaceIRFile() {};
   WorkspaceIRFile(const std::string& content);
   // TODO - make private
   int32_t version;
@@ -91,14 +91,14 @@ class WorkspaceIRFile {
 class WorkspaceAllTypesFile {
  public:
   WorkspaceAllTypesFile()
-      : m_dts(std::make_unique<decompiler::DecompilerTypeSystem>(GameVersion::Jak1)){};
+      : m_dts(std::make_unique<decompiler::DecompilerTypeSystem>(GameVersion::Jak1)) {};
   WorkspaceAllTypesFile(const LSPSpec::DocumentUri& uri,
                         const GameVersion version,
                         const fs::path file_path)
       : m_game_version(version),
         m_uri(uri),
         m_dts(std::make_unique<decompiler::DecompilerTypeSystem>(m_game_version)),
-        m_file_path(file_path){};
+        m_file_path(file_path) {};
 
   GameVersion m_game_version;
   LSPSpec::DocumentUri m_uri;

--- a/test/offline/framework/file_management.h
+++ b/test/offline/framework/file_management.h
@@ -13,7 +13,7 @@ struct OfflineTestSourceFile {
       : path(_path),
         containing_dgo(_containing_dgo),
         name_in_dgo(_name_in_dgo),
-        unique_name(_unique_name){};
+        unique_name(_unique_name) {};
   fs::path path;
   std::string containing_dgo;
   std::string name_in_dgo;
@@ -24,7 +24,7 @@ struct OfflineTestArtFile {
   OfflineTestArtFile(std::string _containing_dgo,
                      std::string _name_in_dgo,
                      std::string _unique_name)
-      : containing_dgo(_containing_dgo), name_in_dgo(_name_in_dgo), unique_name(_unique_name){};
+      : containing_dgo(_containing_dgo), name_in_dgo(_name_in_dgo), unique_name(_unique_name) {};
   std::string containing_dgo;
   std::string name_in_dgo;
   std::string unique_name;

--- a/test/offline/framework/orchestration.h
+++ b/test/offline/framework/orchestration.h
@@ -81,7 +81,7 @@ class OfflineTestThreadStatus {
  public:
   enum class Stage { IDLE, PREPARING, DECOMPILING, COMPARING, COMPILING, FAILED, FINISHED };
 
-  OfflineTestThreadStatus(const OfflineTestConfig& _config) : config(_config){};
+  OfflineTestThreadStatus(const OfflineTestConfig& _config) : config(_config) {};
 
   Stage stage = Stage::IDLE;
   uint32_t total_steps = 0;


### PR DESCRIPTION
Ubuntu 20.04 is hitting it's next EOL stage in april https://endoflife.date/ubuntu
And it's being removed from github actions in april to go along with that https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

Getting ahead of this before we have random failures, I'll update the launcher along with this change for this month.

On the bright side, we can finally update clang-format!