### PR TITLE
Fix 'Destroy cargo in port' mission subtitle

### DIFF
--- a/game/assets/jak2/subtitle/subtitle_lines_cs-CZ.json
+++ b/game/assets/jak2/subtitle/subtitle_lines_cs-CZ.json
@@ -6410,7 +6410,7 @@
     ],
     "krew002": [
       "Excellent work, Jak. Even I am impressed.",
-      "I should keep unscrupulous Krimzon Guards",
+      "That should keep those unscrupulous Krimzon Guards",
       "out of our business.",
       "What's the world coming to when you can't buy off",
       "a few guards with bribes?"

--- a/game/assets/jak2/subtitle/subtitle_lines_en-GB.json
+++ b/game/assets/jak2/subtitle/subtitle_lines_en-GB.json
@@ -6410,7 +6410,7 @@
     ],
     "krew002": [
       "Excellent work, Jak. Even I am impressed.",
-      "I should keep unscrupulous Krimzon Guards",
+      "That should keep those unscrupulous Krimzon Guards",
       "out of our business.",
       "What's the world coming to when you can't buy off",
       "a few guards with bribes?"

--- a/game/assets/jak2/subtitle/subtitle_lines_en-US.json
+++ b/game/assets/jak2/subtitle/subtitle_lines_en-US.json
@@ -6410,7 +6410,7 @@
     ],
     "krew002": [
       "Excellent work, Jak. Even I am impressed.",
-      "I should keep unscrupulous Krimzon Guards",
+      "That should keep those unscrupulous Krimzon Guards",
       "out of our business.",
       "What's the world coming to when you can't buy off",
       "a few guards with bribes?"

--- a/game/assets/jak2/subtitle/subtitle_lines_gl-ES.json
+++ b/game/assets/jak2/subtitle/subtitle_lines_gl-ES.json
@@ -6410,7 +6410,7 @@
     ],
     "krew002": [
       "Excellent work, Jak. Even I am impressed.",
-      "I should keep unscrupulous Krimzon Guards",
+      "That should keep those unscrupulous Krimzon Guards",
       "out of our business.",
       "What's the world coming to when you can't buy off",
       "a few guards with bribes?"

--- a/game/assets/jak2/subtitle/subtitle_lines_hr-HR.json
+++ b/game/assets/jak2/subtitle/subtitle_lines_hr-HR.json
@@ -6410,7 +6410,7 @@
     ],
     "krew002": [
       "Excellent work, Jak. Even I am impressed.",
-      "I should keep unscrupulous Krimzon Guards",
+      "That should keep those unscrupulous Krimzon Guards",
       "out of our business.",
       "What's the world coming to when you can't buy off",
       "a few guards with bribes?"

--- a/game/assets/jak2/subtitle/subtitle_lines_is-IS.json
+++ b/game/assets/jak2/subtitle/subtitle_lines_is-IS.json
@@ -6410,7 +6410,7 @@
     ],
     "krew002": [
       "Excellent work, Jak. Even I am impressed.",
-      "I should keep unscrupulous Krimzon Guards",
+      "That should keep those unscrupulous Krimzon Guards",
       "out of our business.",
       "What's the world coming to when you can't buy off",
       "a few guards with bribes?"

--- a/game/assets/jak2/subtitle/subtitle_lines_ja-JP.json
+++ b/game/assets/jak2/subtitle/subtitle_lines_ja-JP.json
@@ -6410,7 +6410,7 @@
     ],
     "krew002": [
       "Excellent work, Jak. Even I am impressed.",
-      "I should keep unscrupulous Krimzon Guards",
+      "That should keep those unscrupulous Krimzon Guards",
       "out of our business.",
       "What's the world coming to when you can't buy off",
       "a few guards with bribes?"

--- a/game/assets/jak2/subtitle/subtitle_lines_lt-LT.json
+++ b/game/assets/jak2/subtitle/subtitle_lines_lt-LT.json
@@ -6410,7 +6410,7 @@
     ],
     "krew002": [
       "Excellent work, Jak. Even I am impressed.",
-      "I should keep unscrupulous Krimzon Guards",
+      "That should keep those unscrupulous Krimzon Guards",
       "out of our business.",
       "What's the world coming to when you can't buy off",
       "a few guards with bribes?"

--- a/game/assets/jak2/subtitle/subtitle_lines_no-NO.json
+++ b/game/assets/jak2/subtitle/subtitle_lines_no-NO.json
@@ -6410,7 +6410,7 @@
     ],
     "krew002": [
       "Excellent work, Jak. Even I am impressed.",
-      "I should keep unscrupulous Krimzon Guards",
+      "That should keep those unscrupulous Krimzon Guards",
       "out of our business.",
       "What's the world coming to when you can't buy off",
       "a few guards with bribes?"

--- a/game/assets/jak2/subtitle/subtitle_lines_pt-PT.json
+++ b/game/assets/jak2/subtitle/subtitle_lines_pt-PT.json
@@ -6410,7 +6410,7 @@
     ],
     "krew002": [
       "Excellent work, Jak. Even I am impressed.",
-      "I should keep unscrupulous Krimzon Guards",
+      "That should keep those unscrupulous Krimzon Guards",
       "out of our business.",
       "What's the world coming to when you can't buy off",
       "a few guards with bribes?"

--- a/game/assets/jak2/subtitle/subtitle_lines_sv-SE.json
+++ b/game/assets/jak2/subtitle/subtitle_lines_sv-SE.json
@@ -6410,7 +6410,7 @@
     ],
     "krew002": [
       "Excellent work, Jak. Even I am impressed.",
-      "I should keep unscrupulous Krimzon Guards",
+      "That should keep those unscrupulous Krimzon Guards",
       "out of our business.",
       "What's the world coming to when you can't buy off",
       "a few guards with bribes?"


### PR DESCRIPTION
Noticed this while playing and figured I'd raise a quick PR. Upon completion of the 'Destroy cargo in port' mission Krew's subtitle says:

> **_I_** should keep unscrupulous Krimzon Guard out of our business

What it should say is:

> **_That_** should keep **_those_** unscrupulous Krimzon Guard out of our business

[Video/audio](https://youtu.be/X0Ghezd1el0?feature=shared&t=178)  and [full game script](https://jakanddaxter.fandom.com/wiki/Jak_II_script) for reference.

(Keep up the great work! This is a wonderful project.)