### PR TITLE
Extract levels+collision to `decompiler_out` (adjacent to textures+audio)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -144,6 +144,9 @@ tasks:
   rip-collision:
     cmds:
       - "{{.DECOMP_BIN_RELEASE_DIR}}/decompiler \"./decompiler/config/{{.DECOMP_CONFIG}}\" \"./iso_data\" \"./decompiler_out\" --version \"{{.DECOMP_CONFIG_VERSION}}\" --config-override '{\"decompile_code\": false, \"levels_extract\": true, \"extract_collision\": true, \"rip_collision\": true}'"
+  rip-audio:
+    cmds:
+      - "{{.DECOMP_BIN_RELEASE_DIR}}/decompiler \"./decompiler/config/{{.DECOMP_CONFIG}}\" \"./iso_data\" \"./decompiler_out\" --version \"{{.DECOMP_CONFIG_VERSION}}\" --config-override '{\"decompile_code\": false, \"levels_extract\": true, \"rip_streamed_audio\": true}'"
   # TOOLS
   analyze-ee-memory:
     cmds:

--- a/decompiler/config/jak1/jak1_config.jsonc
+++ b/decompiler/config/jak1/jak1_config.jsonc
@@ -112,12 +112,12 @@
 
   // turn this on to extract level background graphics data as .fr3 files in out/<game>/fr3
   "levels_extract": true,
-  // turn this on if you want extracted levels to be saved out as .glb files in glb_out/<game>
+  // turn this on if you want extracted levels to be saved out as .glb files in decompiler_out/<game>/levels
   "rip_levels": false,
   // should we also extract collision meshes to the .fr3 files?
   // these can be displayed in-game with the OpenGOAL collision renderer
   "extract_collision": true,
-  // turn this on if you want extracted level collision to be saved as .obj files in debug_out/<game>
+  // turn this on if you want extracted level collision to be saved as .obj files in decompiler_out/<game>/collision
   "rip_collision": false,
   // save game textures as .png files to decompiler_out/<game>/textures
   "save_texture_pngs": false,

--- a/decompiler/config/jak2/jak2_config.jsonc
+++ b/decompiler/config/jak2/jak2_config.jsonc
@@ -118,12 +118,12 @@
 
   // turn this on to extract level background graphics data as .fr3 files in out/<game>/fr3
   "levels_extract": true,
-  // turn this on if you want extracted levels to be saved out as .glb files in glb_out/<game>
+  // turn this on if you want extracted levels to be saved out as .glb files in decompiler_out/<game>/levels
   "rip_levels": false,
   // should we also extract collision meshes to the .fr3 files?
   // these can be displayed in-game with the OpenGOAL collision renderer
   "extract_collision": true,
-  // turn this on if you want extracted level collision to be saved as .obj files in debug_out/<game>
+  // turn this on if you want extracted level collision to be saved as .obj files in decompiler_out/<game>/collision
   "rip_collision": false,
   // save game textures as .png files to decompiler_out/<game>/textures
   "save_texture_pngs": false,

--- a/decompiler/config/jak3/jak3_config.jsonc
+++ b/decompiler/config/jak3/jak3_config.jsonc
@@ -117,12 +117,12 @@
 
   // turn this on to extract level background graphics data as .fr3 files in out/<game>/fr3
   "levels_extract": false,
-  // turn this on if you want extracted levels to be saved out as .glb files in glb_out/<game>
+  // turn this on if you want extracted levels to be saved out as .glb files in decompiler_out/<game>/levels
   "rip_levels": false,
   // should we also extract collision meshes to the .fr3 files?
   // these can be displayed in-game with the OpenGOAL collision renderer
   "extract_collision": true,
-  // turn this on if you want extracted level collision to be saved as .obj files in debug_out/<game>
+  // turn this on if you want extracted level collision to be saved as .obj files in decompiler_out/<game>/collision
   "rip_collision": false,
   // save game textures as .png files to decompiler_out/<game>/textures
   "save_texture_pngs": false,

--- a/decompiler/level_extractor/extract_collide_frags.cpp
+++ b/decompiler/level_extractor/extract_collide_frags.cpp
@@ -195,7 +195,7 @@ std::string debug_dump_to_obj(const std::vector<CollideListItem>& list) {
       faces.emplace_back(f.verts[0] + f_off, f.verts[1] + f_off, f.verts[2] + f_off);
     }
     for (u32 t = 0; t < item.unpacked.vu0_buffer.size(); t++) {
-      verts.push_back(item.unpacked.vu0_buffer[t] / 65536);
+      verts.push_back(item.unpacked.vu0_buffer[t] / 4096);
     }
   }
 
@@ -262,7 +262,7 @@ void extract_collide_frags(const level_tools::DrawableTreeCollideFragment* tree,
   if (config.rip_collision) {
     auto debug_out = debug_dump_to_obj(all_frags);
     auto file_path = file_util::get_file_path(
-        {fmt::format("debug_out/{}", config.game_name), fmt::format("collide-{}.obj", debug_name)});
+        {fmt::format("decompiler_out/{}/collision", config.game_name), fmt::format("collide-{}.obj", debug_name)});
     file_util::create_dir_if_needed_for_file(file_path);
     file_util::write_text_file(file_path, debug_out);
   }
@@ -510,7 +510,7 @@ void extract_collide_frags(const level_tools::CollideHash& chash,
     // for now debug_dump_to_obj isn't smart and doesn't hash these to save space or anything
     auto debug_out = debug_dump_to_obj(out.collision.vertices);
     auto file_path = file_util::get_file_path(
-        {fmt::format("debug_out/{}", config.game_name), fmt::format("collide-{}.obj", debug_name)});
+        {fmt::format("decompiler_out/{}/collision", config.game_name), fmt::format("collide-{}.obj", debug_name)});
     file_util::create_dir_if_needed_for_file(file_path);
     file_util::write_text_file(file_path, debug_out);
   }

--- a/decompiler/level_extractor/extract_level.cpp
+++ b/decompiler/level_extractor/extract_level.cpp
@@ -339,8 +339,8 @@ void extract_common(const ObjectFileDB& db,
       compressed.data(), compressed.size());
 
   if (config.rip_levels) {
-    auto file_path = file_util::get_jak_project_dir() / "glb_out" /
-                     game_version_names[config.game_version] / "common";
+    auto file_path = file_util::get_jak_project_dir() / "decompiler_out" /
+                     game_version_names[config.game_version] / "levels" / "common";
     save_level_foreground_as_gltf(tfrag_level, art_group_data, file_path);
   }
 }
@@ -376,13 +376,13 @@ void extract_from_level(const ObjectFileDB& db,
                                compressed.data(), compressed.size());
 
   if (config.rip_levels) {
-    auto back_file_path = file_util::get_jak_project_dir() / "glb_out" /
-                          game_version_names[config.game_version] / level_data.level_name /
+    auto back_file_path = file_util::get_jak_project_dir() / "decompiler_out" /
+                          game_version_names[config.game_version] / "levels"/ level_data.level_name /
                           fmt::format("{}-background.glb", level_data.level_name);
     file_util::create_dir_if_needed_for_file(back_file_path);
     save_level_background_as_gltf(level_data, back_file_path);
-    auto fore_file_path = file_util::get_jak_project_dir() / "glb_out" /
-                          game_version_names[config.game_version] / level_data.level_name;
+    auto fore_file_path = file_util::get_jak_project_dir() / "decompiler_out" /
+                          game_version_names[config.game_version] / "levels" / level_data.level_name;
     save_level_foreground_as_gltf(level_data, art_group_data, fore_file_path);
   }
   file_util::write_text_file(entities_folder / fmt::format("{}-actors.json", level_data.level_name),


### PR DESCRIPTION
should make it nice and easy to jump to the decompiler_out/<game> folder in the launcher and show the user all their exported things.

also adds a taskfile command for ripping audio.

and fixes jak1 collision extract scaling. I [previously fixed this for jak2/3](https://github.com/open-goal/jak-project/pull/3292#discussion_r1442595308) but never fixed for jak1 apparently

before:
![image](https://github.com/user-attachments/assets/ce3e3c59-e3d7-4fc2-b83b-c938fdb3bb02)

after:
![image](https://github.com/user-attachments/assets/bcc65ffb-b5ff-484e-8f60-d1913e239294)

