### PR TITLE
Fix pagination for non-dynamic popup menus (speedrun menu)

### DIFF
--- a/goal_src/jak2/pc/util/popup-menu.gc
+++ b/goal_src/jak2/pc/util/popup-menu.gc
@@ -136,7 +136,7 @@
                                 font-ctx
                                 buf
                                 (= (+ i start-index) current-index))
-            (draw-entry (-> (-> this menu-states (-> this curr-state-index) entries) i) font-ctx buf (= (+ i start-index) current-index)))
+            (draw-entry (-> (-> this menu-states (-> this curr-state-index) entries) (+ i start-index)) font-ctx buf (= (+ i start-index) current-index)))
           (set! (-> font-ctx origin y) (+ 15.0 (-> font-ctx origin y))))
         (when (< end-index entry-count)
           (clear *pc-encoded-temp-string*)

--- a/goal_src/jak3/pc/util/popup-menu.gc
+++ b/goal_src/jak3/pc/util/popup-menu.gc
@@ -135,7 +135,7 @@
                                 font-ctx
                                 buf
                                 (= (+ i start-index) current-index))
-            (draw-entry (-> (-> this menu-states (-> this curr-state-index) entries) i) font-ctx buf (= (+ i start-index) current-index)))
+            (draw-entry (-> (-> this menu-states (-> this curr-state-index) entries) (+ i start-index)) font-ctx buf (= (+ i start-index) current-index)))
           (set! (-> font-ctx origin y) (+ 15.0 (-> font-ctx origin y))))
         (when (< end-index entry-count)
           (clear *pc-encoded-temp-string*)


### PR DESCRIPTION
Was testing out adding ILs to the speedrun menu and noticed this wasn't working properly

(video before the changes)
https://github.com/user-attachments/assets/e1e7f443-60d2-4b15-bc27-a20cbe4442d6

