### PR TITLE
goalc: don't assume DGO/CGOs are within the ObjectDB when building levels

### DIFF
--- a/.vs/launch.vs.json
+++ b/.vs/launch.vs.json
@@ -381,7 +381,7 @@
       "projectTarget": "extractor.exe (bin\\extractor.exe)",
       "name": "Tools - Extractor - Full",
       "args": [
-        "\"E:\\ISOs\\Jak\\Jak 1.iso\""
+        "D:\\ISOs\\Jak\\Temp\\bad.iso"
       ]
     },
     {

--- a/goalc/build_level/jak1/build_level.cpp
+++ b/goalc/build_level/jak1/build_level.cpp
@@ -191,6 +191,9 @@ bool run_build_level(const std::string& input_file,
       for (auto& dgo : config.dgo_names) {
         // remove "DGO/" prefix
         const auto& dgo_name = dgo.substr(4);
+        ASSERT_MSG(
+            db.obj_files_by_dgo.contains(dgo_name),
+            fmt::format("{} DGO expected to be part of the ObjectDB but it is not!", dgo_name));
         const auto& files = db.obj_files_by_dgo.at(dgo_name);
         auto art_groups =
             find_art_groups(processed_art_groups,


### PR DESCRIPTION
Follow-up later on improving the validation of the extractor (that may require testing with all iso versions), but this is just some simple safe-guarding code that will improve the error messaging, instead of just a vague invalid map error.

![Screenshot 2025-03-30 165334](https://github.com/user-attachments/assets/a195d248-4ed5-4c02-80f4-4170d3ff1e48)
