### PR TITLE
g/j2: change and initialize jak 2 subtitles correctly

### DIFF
--- a/goal_src/jak2/pc/pckernel.gc
+++ b/goal_src/jak2/pc/pckernel.gc
@@ -318,11 +318,13 @@
   "initial initialize method to be run after allocating"
   (set! (-> obj music-unlocked) (new 'global 'bit-array (-> *music-player-tracks* length)))
   ((method-of-type pc-settings initialize) obj)
+  ;; any post-operations that need to be done after loading
   (set! (-> *setting-control* user-default sfx-volume) (-> obj memcard-volume-sfx))
   (set! (-> *setting-control* user-default music-volume) (-> obj memcard-volume-music))
   (set! (-> *setting-control* user-default dialog-volume) (-> obj memcard-volume-dialog))
   (set! (-> *setting-control* user-default vibration) (-> obj memcard-vibration?))
   (set! (-> *setting-control* user-default subtitle) (-> obj memcard-subtitles?))
+  (set! (-> *setting-control* user-default subtitle-language) (the-as language-enum (-> obj subtitle-language)))
   obj)
 
 (defmethod set-game-setting! ((obj pc-settings-jak2) (setting symbol) (value symbol))
@@ -750,7 +752,6 @@
 
 (defmethod handle-input-settings ((obj pc-settings-jak2) (file file-stream))
   "handle the text parsing input for the 'settings' group"
-
   ((method-of-type pc-settings handle-input-settings) obj file)
   (case-str *pc-temp-string*
     (("fast-airlock?") (set! (-> obj fast-airlock?) (file-stream-read-symbol file)))

--- a/goal_src/jak2/pc/progress/progress-static-pc.gc
+++ b/goal_src/jak2/pc/progress/progress-static-pc.gc
@@ -400,6 +400,7 @@ This gives us more freedom to write code how we want.
       :get-item-index-fn (lambda () (-> *pc-settings* subtitle-language))
       :on-confirm (lambda ((index int) (the-progress progress))
           (set! (-> *pc-settings* subtitle-language) (the-as pc-language index))
+          (set! (-> *setting-control* user-default subtitle-language) (the-as language-enum index))
           (pc-settings-save))))
 
 (defmacro game-options-pc-sound-language ()


### PR DESCRIPTION
Fixes #3906

Wasn't an issue on Jak 1 because that game had no original subtitles, but jak 2's subtitles still go through their original code, which uses the `*setting-control*` object.  This is a regression from when i recently added all languages to the menu options.

- Update the setting at runtime
- Update the setting at initialization time

This may be an issue in Jak 3 as well if the code was copied over.  We'll fix it when we get there.

![image](https://github.com/user-attachments/assets/19a796a7-a3f3-4872-98f8-7fcbe91b3ec1)
![image](https://github.com/user-attachments/assets/356f751a-5406-41f3-b616-97ece2782a88)

