### PR TITLE
g/jak2: don't try to print subtitles that don't exist (non-base language)

### DIFF
--- a/common/serialization/subtitles/subtitles_v2.h
+++ b/common/serialization/subtitles/subtitles_v2.h
@@ -124,7 +124,6 @@ class GameSubtitleBank {
   std::optional<std::string> m_file_base_path;
 
   std::map<std::string, GameSubtitleSceneInfo> m_base_scenes;
-  std::map<std::string, GameSubtitleSceneInfo> m_lang_scenes;
   std::map<std::string, GameSubtitleSceneInfo> m_scenes;
   bool scene_exists(const std::string& name) const { return m_scenes.find(name) != m_scenes.end(); }
   GameSubtitleSceneInfo new_scene_from_meta(

--- a/goal_src/jak2/engine/scene/scene.gc
+++ b/goal_src/jak2/engine/scene/scene.gc
@@ -728,7 +728,11 @@
         ;; og:preserve-this send a movie-no-subtitle message so the pc subtitle system at least knows there's a movie playing
         (#when PC_PORT
             (if (= (-> self type) scene-player)
-                (send-event (ppointer->process *subtitle2*) 'movie-no-subtitle (-> (the scene-player self) anim name) #f (ja-aframe-num 0))))
+                (send-event (ppointer->process *subtitle2*) 'movie-no-subtitle (-> (the scene-player self) anim name) #f (ja-aframe-num 0)))
+            ;; if this isn't a default language -- get out before you crash!
+            (when (> (the-as int (-> *setting-control* user-current subtitle-language))
+                     (the-as int (language-enum uk-english)))
+              (return #f)))
         (let ((gp-0 (res-lump-struct (-> v1-9 extra) 'subtitle-range (array subtitle-range))))
           (when gp-0
             (let ((f30-0 (ja-aframe-num 0))

--- a/goal_src/jak2/pc/pckernel.gc
+++ b/goal_src/jak2/pc/pckernel.gc
@@ -817,7 +817,7 @@
   (format file "  (minimap-force-north ~A)~%" (-> obj minimap-force-north))
   (format file "  (hires-clouds? ~A)~%" (-> obj hires-clouds?))
   (format file "  (text-language ~D)~%" (-> obj text-language))
-  (format file "  (subtitle-language ~D)~%" (-> obj text-language))
+  (format file "  (subtitle-language ~D)~%" (-> obj subtitle-language))
   (format file "  (controller-led-status? ~A)~%" (-> obj controller-led-status?))
   (format file "  (controller-swap-r1-r2? ~A)~%" (-> obj controller-swap-r1-r2?))
   (format file "  (speedrunner-mode-custom-bind ~D)~%" (-> obj speedrunner-mode-custom-bind))


### PR DESCRIPTION
Fixes #3909 

Long standing issue in Jak 2's subtitles, it's actually kinda incredible that finnish didn't run into this problem.  Later in this code it accesses the subtitle based on the language-id, and finnish is always out of bounds -- but it never caused a catastrophic issue.

Polish on the otherhand is much more out of bounds and always causes an access violation / crash.

Jak 2's subtitle code has no fallback (ie. use english if not translated) for cutscenes, since they are not defined in the base file like in Jak 1.  This means that an untranslated language will render no subtitles during cutscenes.  Translations are welcome!.

Tested a cutscene in:
- english 
- italian (base game with subtitles)
- finnish (new language, actually is translated)
- polish (new language, not translated)