### PR TITLE
game: ensure SDL subsystems are cleaned up prior to quitting SDL

### DIFF
--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -377,6 +377,14 @@ GLDisplay::~GLDisplay() {
   // Cleanup SDL
   SDL_GL_DestroyContext(m_gl_context);
   SDL_DestroyWindow(m_window);
+  // cleanup SDL related sub-systems before we quit SDL
+  if (m_display_manager) {
+    m_display_manager.reset();
+  }
+  if (m_input_manager) {
+    m_input_manager.reset();
+  }
+  // now quit SDL
   SDL_Quit();
   if (m_main) {
     gl_exit();

--- a/game/system/hid/devices/game_controller.cpp
+++ b/game/system/hid/devices/game_controller.cpp
@@ -253,6 +253,7 @@ void GameController::close_device() {
   if (m_device_handle) {
     clear_trigger_effect(dualsense_effects::TriggerEffectOption::BOTH);
     SDL_CloseGamepad(m_device_handle);
+    m_device_handle = NULL;
   }
 }
 


### PR DESCRIPTION
For dualsense controllers, when the game exits we explicitly clear any trigger effects.  This was happening after SDL was already terminated, so the hardware handles were already lost.

From a practical standpoint though, this mostly just cleans up logs.