### PR TITLE
Fixed typo in US English subs.

### DIFF
--- a/game/assets/jak2/subtitle/subtitle_lines_en-US.json
+++ b/game/assets/jak2/subtitle/subtitle_lines_en-US.json
@@ -2721,7 +2721,7 @@
       "That's it! You did it!"
     ],
     "ds305": [
-      "Shoot the switch to change the coveyor belt's",
+      "Shoot the switch to change the conveyor belt's",
       "direction!"
     ],
     "ds306": [


### PR DESCRIPTION
Coveyor -> Conveyor