### PR TITLE
macos: fix dynamically linked library in static release

### DIFF
--- a/.github/workflows/build-matrix.yaml
+++ b/.github/workflows/build-matrix.yaml
@@ -51,6 +51,7 @@ jobs:
     with:
       cmakePreset: "Release-macos-x86_64-clang"
       cachePrefix: ""
+    secrets: inherit
 
   build_macos_arm:
     name: "🍎 MacOS"
@@ -58,3 +59,4 @@ jobs:
     with:
       cmakePreset: "Release-macos-x86_64-clang"
       cachePrefix: ""
+    secrets: inherit

--- a/.github/workflows/macos-build-arm.yaml
+++ b/.github/workflows/macos-build-arm.yaml
@@ -9,6 +9,10 @@ on:
       cachePrefix:
         required: true
         type: string
+      uploadArtifacts:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -43,11 +47,23 @@ jobs:
       - name: Build Project
         run: cmake --build build --parallel $((`sysctl -n hw.logicalcpu`))
 
+      - name: List libraries of gk
+        run: otool -L ./build/game/gk
+
       - name: Run Tests
         run: ./test.sh
 
+      - name: Prepare artifacts
+        if: ${{ inputs.uploadArtifacts }}
+        run: |
+          strip ./build/goalc/goalc
+          strip ./build/decompiler/extractor
+          strip ./build/game/gk
+          strip ./build/lsp/lsp
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
+        if: ${{ inputs.uploadArtifacts }}
         with:
           name: opengoal-macos-arm-${{ inputs.cachePrefix }}
           if-no-files-found: error

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -57,6 +57,9 @@ jobs:
       - name: Build Project
         run: cmake --build build --parallel $((`sysctl -n hw.logicalcpu`))
 
+      - name: List libraries of gk
+        run: otool -L ./build/game/gk
+
       - name: Run Tests
         run: ./test.sh
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,9 @@ include_directories(SYSTEM third-party/inja)
 # TODO - probably integrate with ZSTD since we have it already
 set(CURL_USE_LIBSSH2 OFF)
 set(CURL_ZLIB OFF)
+# suddenly became enabled on macOS atleast, only needed for unicode URLs
+# wasn't being properly statically linked
+set(USE_LIBIDN2 OFF)
 if(WIN32)
     set(CURL_USE_SCHANNEL ON) # native Windows SSL support
 elseif(APPLE)


### PR DESCRIPTION
libidn2 which is a potential part of libcurl seemingly slipped into the latest release (0.2.25) and it was dynamically linked.

This causes issues:
```
dyld[95648]: Library not loaded: /usr/local/opt/libidn2/lib/libidn2.0.dylib
  Referenced from: <9DA6EC1D-F99A-3233-8264-AAEA87F07743> /Users/tyler/Downloads/opengoal-macos-arm-v0.2.25/gk
  Reason: tried: '/usr/local/opt/libidn2/lib/libidn2.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/opt/libidn2/lib/libidn2.0.dylib' (no such file), '/usr/local/opt/libidn2/lib/libidn2.0.dylib' (no such file)
zsh: abort      ./g
```

My theory for why is that the underlying image changed (now has this library) and so the cmake detected that and started building with it.

The simple fix is to just disable it, as we don't need it.  If we do eventually, I can figure out how to ensure it's properly compiled.