### PR TITLE
Properly set window size when switching from borderless/fullscreen -> windowed mode

### DIFF
--- a/game/kernel/common/kmachine.cpp
+++ b/game/kernel/common/kmachine.cpp
@@ -496,19 +496,19 @@ u32 pc_get_display_mode() {
   }
 }
 
-void pc_set_display_mode(u32 symptr) {
+void pc_set_display_mode(u32 symptr, u64 window_width, u64 window_height) {
   if (!Display::GetMainDisplay()) {
     return;
   }
   if (symptr == g_pc_port_funcs.intern_from_c("windowed").offset || symptr == s7.offset) {
     Display::GetMainDisplay()->get_display_manager()->enqueue_set_window_display_mode(
-        game_settings::DisplaySettings::DisplayMode::Windowed);
+        game_settings::DisplaySettings::DisplayMode::Windowed, window_width, window_height);
   } else if (symptr == g_pc_port_funcs.intern_from_c("borderless").offset) {
     Display::GetMainDisplay()->get_display_manager()->enqueue_set_window_display_mode(
-        game_settings::DisplaySettings::DisplayMode::Borderless);
+        game_settings::DisplaySettings::DisplayMode::Borderless, window_width, window_height);
   } else if (symptr == g_pc_port_funcs.intern_from_c("fullscreen").offset) {
     Display::GetMainDisplay()->get_display_manager()->enqueue_set_window_display_mode(
-        game_settings::DisplaySettings::DisplayMode::Fullscreen);
+        game_settings::DisplaySettings::DisplayMode::Fullscreen, window_width, window_height);
   }
 }
 

--- a/game/system/hid/display_manager.cpp
+++ b/game/system/hid/display_manager.cpp
@@ -238,8 +238,8 @@ void DisplayManager::set_display_mode(game_settings::DisplaySettings::DisplayMod
         if (!SDL_SetWindowSize(m_window, window_width, window_height)) {
           sdl_util::log_error("unable to change window size");
         }
-        // if we are changing from fullscreen/borderless back to windowed - make sure it's not annoyingly at the edge
-        // of the screen
+        // if we are changing from fullscreen/borderless back to windowed - make sure it's not
+        // annoyingly at the edge of the screen
         if (m_display_settings.display_mode !=
                 game_settings::DisplaySettings::DisplayMode::Windowed &&
             !SDL_SetWindowPosition(m_window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED)) {

--- a/game/system/hid/display_manager.cpp
+++ b/game/system/hid/display_manager.cpp
@@ -24,7 +24,7 @@ DisplayManager::DisplayManager(SDL_Window* window) : m_window(window) {
     m_display_settings.load_settings();
     // Adjust window / monitor position
     initialize_window_position_from_settings();
-    set_display_mode(m_display_settings.display_mode);
+    set_display_mode(m_display_settings.display_mode, m_window_width, m_window_height);
   }
 }
 
@@ -139,7 +139,8 @@ void DisplayManager::process_ee_events() {
         set_window_size(std::get<int>(evt.param1), std::get<int>(evt.param2));
         break;
       case EEDisplayEventType::SET_DISPLAY_MODE:
-        set_display_mode(std::get<game_settings::DisplaySettings::DisplayMode>(evt.param1));
+        set_display_mode(std::get<game_settings::DisplaySettings::DisplayMode>(evt.param1),
+                         std::get<int>(evt.param2), std::get<int>(evt.param3));
         break;
       case EEDisplayEventType::SET_DISPLAY_ID:
         set_display_id(std::get<int>(evt.param1));
@@ -216,22 +217,34 @@ void DisplayManager::set_window_size(int width, int height) {
 }
 
 void DisplayManager::enqueue_set_window_display_mode(
-    game_settings::DisplaySettings::DisplayMode mode) {
+    game_settings::DisplaySettings::DisplayMode mode,
+    const int window_width,
+    const int window_height) {
   const std::lock_guard<std::mutex> lock(event_queue_mtx);
-  ee_event_queue.push({EEDisplayEventType::SET_DISPLAY_MODE, mode, {}});
+  ee_event_queue.push({EEDisplayEventType::SET_DISPLAY_MODE, mode, window_width, window_height});
 }
 
-void DisplayManager::set_display_mode(game_settings::DisplaySettings::DisplayMode mode) {
-  lg::info("[DISPLAY] Setting to display mode: {}", static_cast<int>(mode));
+void DisplayManager::set_display_mode(game_settings::DisplaySettings::DisplayMode mode,
+                                      const int window_width,
+                                      const int window_height) {
+  lg::info("[DISPLAY] Setting to display mode: {}, with window_size: {},{}", static_cast<int>(mode),
+           window_width, window_height);
   // https://wiki.libsdl.org/SDL3/SDL_SetWindowFullscreen
   int result = 0;
   switch (mode) {
     case game_settings::DisplaySettings::DisplayMode::Windowed:
       if (SDL_SetWindowFullscreen(m_window, false)) {
-        lg::info("[DISPLAY] windowed mode - resizing window to {}x{}", m_window_width,
-                 m_window_height);
-        if (!SDL_SetWindowSize(m_window, m_window_width, m_window_height)) {
+        lg::info("[DISPLAY] windowed mode - resizing window to {}x{}", window_width, window_height);
+        if (!SDL_SetWindowSize(m_window, window_width, window_height)) {
           sdl_util::log_error("unable to change window size");
+        }
+        // if we are changing from fullscreen/borderless back to windowed - make sure it's not annoyingly at the edge
+        // of the screen
+        if (m_display_settings.display_mode !=
+                game_settings::DisplaySettings::DisplayMode::Windowed &&
+            !SDL_SetWindowPosition(m_window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED)) {
+          sdl_util::log_error(fmt::format("unable to move window to center"));
+          break;
         }
       } else {
         sdl_util::log_error("unable to change window to windowed mode");
@@ -312,7 +325,7 @@ void DisplayManager::toggle_display_mode() {
     case game_settings::DisplaySettings::DisplayMode::Borderless:
       lg::info("Fullscreen/Borderless\n");
       lg::info("Switching to Windowed mode...\n");
-      enqueue_set_window_display_mode(game_settings::DisplaySettings::DisplayMode::Windowed);
+      enqueue_set_window_display_mode(game_settings::DisplaySettings::DisplayMode::Windowed, 0, 0);
       break;
 
     case game_settings::DisplaySettings::DisplayMode::Windowed:
@@ -326,7 +339,10 @@ void DisplayManager::toggle_display_mode() {
       } else {
         lg::info("Switching to unknown preferred mode...\n");
       }
-      enqueue_set_window_display_mode(m_previous_fullscreen_display_mode);
+      // TODO - we'd have to track the intended window size, that info is stored in the GOAL
+      // settings right now so clean this and a few other things up eventually when those settings
+      // are extracted out of there for now, just use the default window size.
+      enqueue_set_window_display_mode(m_previous_fullscreen_display_mode, 640, 480);
       break;
 
     default:
@@ -347,7 +363,8 @@ void DisplayManager::set_display_id(int display_id) {
   }
   m_display_settings.display_id = display_id;
   if (get_display_mode() != game_settings::DisplaySettings::DisplayMode::Windowed) {
-    set_display_mode((game_settings::DisplaySettings::DisplayMode)m_display_settings.display_mode);
+    set_display_mode((game_settings::DisplaySettings::DisplayMode)m_display_settings.display_mode,
+                     0, 0);
   }
   m_display_settings.save_settings();
 }
@@ -377,7 +394,7 @@ void DisplayManager::update_curr_display_info() {
     return;
   }
   m_display_settings.display_id = display_index;
-  lg::info("[DISPLAY] current display idndex is {}", m_display_settings.display_id);
+  lg::info("[DISPLAY] current display index is {}", m_display_settings.display_id);
   SDL_GetWindowSizeInPixels(m_window, &m_window_width, &m_window_height);
   SDL_GetWindowPosition(m_window, &m_window_xpos, &m_window_ypos);
   // Update the scale of the display as well

--- a/game/system/hid/display_manager.h
+++ b/game/system/hid/display_manager.h
@@ -52,7 +52,8 @@ class DisplayManager {
   struct EEDisplayEvent {
     EEDisplayEventType type;
     std::variant<bool, int, game_settings::DisplaySettings::DisplayMode> param1;
-    std::variant<bool, int, game_settings::DisplaySettings::DisplayMode> param2;
+    std::variant<bool, int> param2;
+    std::variant<int> param3;
   };
 
  public:
@@ -88,7 +89,9 @@ class DisplayManager {
 
   // Mutators
   void enqueue_set_window_size(int width, int height);
-  void enqueue_set_window_display_mode(game_settings::DisplaySettings::DisplayMode mode);
+  void enqueue_set_window_display_mode(game_settings::DisplaySettings::DisplayMode mode,
+                                       const int window_width,
+                                       const int window_height);
   void toggle_display_mode();
   void enqueue_set_display_id(int display_id);
 
@@ -134,6 +137,8 @@ class DisplayManager {
   void update_resolutions();
 
   void set_window_size(int width, int height);
-  void set_display_mode(game_settings::DisplaySettings::DisplayMode mode);
+  void set_display_mode(game_settings::DisplaySettings::DisplayMode mode,
+                        const int window_width,
+                        const int window_height);
   void set_display_id(int display_id);
 };

--- a/goal_src/jak1/kernel-defs.gc
+++ b/goal_src/jak1/kernel-defs.gc
@@ -520,7 +520,7 @@
 
 (define-extern pc-set-display-id! (function int none))
 
-(define-extern pc-set-display-mode! (function symbol none))
+(define-extern pc-set-display-mode! (function symbol int int none))
 
 (define-extern pc-get-num-resolutions (function symbol int))
 

--- a/goal_src/jak1/pc/debug/default-menu-pc.gc
+++ b/goal_src/jak1/pc/debug/default-menu-pc.gc
@@ -508,9 +508,9 @@
                                                                                ,(lambda ()
                                                                                  (set-aspect! *pc-settings* (-> *pc-settings* aspect-custom-x) (-> *pc-settings* aspect-custom-y)))))
                                                                (menu "Fullscreen"
-                                                                     (function "Windowed" #f ,(lambda () (pc-set-display-mode! 'windowed)))
-                                                                     (function "Fullscreen" #f ,(lambda () (pc-set-display-mode! 'fullscreen)))
-                                                                     (function "Borderless" #f ,(lambda () (pc-set-display-mode! 'borderless))))
+                                                                     (function "Windowed" #f ,(lambda () (pc-set-display-mode! 'windowed (-> *pc-settings* window-width) (-> *pc-settings* window-height))))
+                                                                     (function "Fullscreen" #f ,(lambda () (pc-set-display-mode! 'fullscreen 0 0)))
+                                                                     (function "Borderless" #f ,(lambda () (pc-set-display-mode! 'borderless 0 0))))
                                                                (menu "Sizes"
                                                                      (function "640 x 480" #f ,(lambda () (set-window-size! *pc-settings* 640 480)))
                                                                      (function "640 x 360" #f ,(lambda () (set-window-size! *pc-settings* 640 360)))

--- a/goal_src/jak1/pc/progress-pc.gc
+++ b/goal_src/jak1/pc/progress-pc.gc
@@ -2731,9 +2731,9 @@
               (((game-option-type display-mode))
                ;; same thing.
                (case (-> *progress-carousell* int-backup)
-                 ((0) (pc-set-display-mode! 'windowed))
-                 ((1) (pc-set-display-mode! 'fullscreen))
-                 ((2) (pc-set-display-mode! 'borderless))))
+                 ((0) (pc-set-display-mode! 'windowed (-> *pc-settings* window-width) (-> *pc-settings* window-height)))
+                 ((1) (pc-set-display-mode! 'fullscreen 0 0))
+                 ((2) (pc-set-display-mode! 'borderless 0 0))))
               (((game-option-type msaa))
                (case (-> *progress-carousell* int-backup)
                  ((0) (set! (-> *pc-settings* gfx-msaa) 1))

--- a/goal_src/jak2/kernel-defs.gc
+++ b/goal_src/jak2/kernel-defs.gc
@@ -237,7 +237,7 @@
 (define-extern pc-set-window-size! (function int int none))
 (define-extern pc-get-display-id (function int))
 (define-extern pc-set-display-id! (function int none))
-(define-extern pc-set-display-mode! (function symbol none))
+(define-extern pc-set-display-mode! (function symbol int int none))
 (define-extern pc-get-num-resolutions (function symbol int))
 (define-extern pc-get-resolution (function int symbol (pointer int64) (pointer int64) none))
 (define-extern pc-is-supported-resolution? (function int int symbol))

--- a/goal_src/jak2/pc/debug/default-menu-pc.gc
+++ b/goal_src/jak2/pc/debug/default-menu-pc.gc
@@ -855,9 +855,9 @@
             (function "Custom" #f ,(lambda () (set-aspect! *pc-settings* (-> *pc-settings* aspect-custom-x) (-> *pc-settings* aspect-custom-y))))
             )
          (menu "Fullscreen"
-            (function "Windowed" #f ,(lambda () (pc-set-display-mode! 'windowed)))
-            (function "Fullscreen" #f ,(lambda () (pc-set-display-mode! 'fullscreen)))
-            (function "Borderless" #f ,(lambda () (pc-set-display-mode! 'borderless)))
+            (function "Windowed" #f ,(lambda () (pc-set-display-mode! 'windowed (-> *pc-settings* window-width) (-> *pc-settings* window-height))))
+            (function "Fullscreen" #f ,(lambda () (pc-set-display-mode! 'fullscreen 0 0)))
+            (function "Borderless" #f ,(lambda () (pc-set-display-mode! 'borderless 0 0)))
             )
          (menu "Sizes"
             (function "640 x 480" (640 480) dm-size-pick-func)

--- a/goal_src/jak2/pc/progress/progress-static-pc.gc
+++ b/goal_src/jak2/pc/progress/progress-static-pc.gc
@@ -576,9 +576,9 @@ This gives us more freedom to write code how we want.
           (('borderless) 2)))
       :on-confirm (lambda ((index int) (the-progress progress))
         (case index
-          ((0) (pc-set-display-mode! 'windowed))
-          ((1) (pc-set-display-mode! 'fullscreen))
-          ((2) (pc-set-display-mode! 'borderless)))))
+          ((0) (pc-set-display-mode! 'windowed (-> *pc-settings* window-width) (-> *pc-settings* window-height)))
+          ((1) (pc-set-display-mode! 'fullscreen 0 0))
+          ((2) (pc-set-display-mode! 'borderless 0 0)))))
     (new 'static 'menu-generic-carousel-option
       :name (text-id progress-aspect-ratio)
       :items (new 'static 'boxed-array :type text-id

--- a/goal_src/jak3/kernel-defs.gc
+++ b/goal_src/jak3/kernel-defs.gc
@@ -237,7 +237,7 @@
 (define-extern pc-set-window-size! (function int int none))
 (define-extern pc-get-display-id (function int))
 (define-extern pc-set-display-id! (function int none))
-(define-extern pc-set-display-mode! (function symbol none))
+(define-extern pc-set-display-mode! (function symbol int int none))
 (define-extern pc-get-num-resolutions (function symbol int))
 (define-extern pc-get-resolution (function int symbol (pointer int64) (pointer int64) none))
 (define-extern pc-is-supported-resolution? (function int int symbol))

--- a/goal_src/jak3/pc/debug/default-menu-pc.gc
+++ b/goal_src/jak3/pc/debug/default-menu-pc.gc
@@ -837,9 +837,9 @@
             (function "Custom" #f ,(lambda () (set-aspect! *pc-settings* (-> *pc-settings* aspect-custom-x) (-> *pc-settings* aspect-custom-y))))
             )
          (menu "Fullscreen"
-            (function "Windowed" #f ,(lambda () (pc-set-display-mode! 'windowed)))
-            (function "Fullscreen" #f ,(lambda () (pc-set-display-mode! 'fullscreen)))
-            (function "Borderless" #f ,(lambda () (pc-set-display-mode! 'borderless)))
+            (function "Windowed" #f ,(lambda () (pc-set-display-mode! 'windowed (-> *pc-settings* window-width) (-> *pc-settings* window-height))))
+            (function "Fullscreen" #f ,(lambda () (pc-set-display-mode! 'fullscreen 0 0)))
+            (function "Borderless" #f ,(lambda () (pc-set-display-mode! 'borderless 0 0)))
             )
          (menu "Sizes"
             (function "640 x 480" (640 480) dm-size-pick-func)

--- a/goal_src/jak3/pc/progress/progress-static-pc.gc
+++ b/goal_src/jak3/pc/progress/progress-static-pc.gc
@@ -675,9 +675,9 @@ This gives us more freedom to write code how we want.
           (('borderless) 2)))
       :on-confirm (lambda ((index int) (the-progress progress))
         (case index
-          ((0) (pc-set-display-mode! 'windowed))
-          ((1) (pc-set-display-mode! 'fullscreen))
-          ((2) (pc-set-display-mode! 'borderless)))))
+          ((0) (pc-set-display-mode! 'windowed (-> *pc-settings* window-width) (-> *pc-settings* window-height)))
+          ((1) (pc-set-display-mode! 'fullscreen 0 0))
+          ((2) (pc-set-display-mode! 'borderless 0 0)))))
     (new 'static 'menu-generic-carousel-option
       :name (text-id progress-graphics-aspect-ratio)
       :items (new 'static 'boxed-array :type text-id


### PR DESCRIPTION
Prior to SDL3, borderless windows were kinda a hack, they cleaned all of that up.  The side-effect of that is that the C++ code keeps track of the current window size (it does this for framebuffer sizing, but also to set the size of the window).

This is now an issue because SDL is properly firing events when you change to borderless mode, so our window size gets updated to the size of the entire monitor.  When you switch to windowed mode from borderless, it now seems like it didn't work (it did, its just still taking up the entire screen).

This could be better cleaned up if more settings are extracted out of GOAL and put into C++ so they can be managed and accessed where they belong.  But for now, this is a minimally invasive fix.

Fixes #3917