### PR TITLE
default button pressure to 0

### DIFF
--- a/game/system/hid/input_bindings.h
+++ b/game/system/hid/input_bindings.h
@@ -96,7 +96,7 @@ struct PadData {
 
   std::array<bool, 16> button_data = {false, false, false, false, false, false, false, false,
                                       false, false, false, false, false, false, false, false};
-  std::array<u8, 12> pressure_data = {255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255};
+  std::array<u8, 12> pressure_data = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
   // Normal Buttons
   bool select() const { return button_data.at(static_cast<int>(ButtonIndex::SELECT)); };


### PR DESCRIPTION
This should solve the issue where buttons are held down until you push them the same time. This would cause the cars in jak 3 to not move until you pushed square/circle and "released" the brake.