### PR TITLE
[jak3] Fix disabling nav

### DIFF
--- a/goal_src/jak3/levels/desert/chase/desert-chase.gc
+++ b/goal_src/jak3/levels/desert/chase/desert-chase.gc
@@ -1227,7 +1227,9 @@
           (send-event gp-0 'ai-set-target-speed f30-0)
           )
         )
-      (send-event gp-0 'ai-ignore-nav-mesh)
+      ;; og:preserve-this
+      ;; original game bug.
+      (send-event gp-0 'ai-ignore-nav-mesh #t)
       )
     )
   0

--- a/goal_src/jak3/levels/desert/hover/scorpion-gun.gc
+++ b/goal_src/jak3/levels/desert/hover/scorpion-gun.gc
@@ -1677,7 +1677,8 @@
       (let ((a0-4 (vehicle-spawn (vehicle-type v-scorpion) gp-0)))
         (when a0-4
           (set! (-> self scorp) (process->handle a0-4))
-          (send-event (handle->process (-> self scorp)) 'ai-ignore-nav-mesh)
+          ;; og:preserve-this original game bug.
+          (send-event (handle->process (-> self scorp)) 'ai-ignore-nav-mesh #t)
           )
         )
       )


### PR DESCRIPTION
This needs a parameter, otherwise it was reading some uninitialized value. In some cases, the uninitialized value would leave the nav stuff on, and the marauders would go crazy trying to avoid each other.