### PR TITLE
game: default MSAA to off

### DIFF
--- a/game/graphics/gfx.h
+++ b/game/graphics/gfx.h
@@ -65,7 +65,7 @@ struct GfxGlobalSettings {
   int game_res_h = 480;
 
   // multi-sampled anti-aliasing sample count. 1 = disabled.
-  int msaa_samples = 2;
+  int msaa_samples = 1;
 
   // current renderer
   const GfxRendererModule* renderer;

--- a/game/graphics/opengl_renderer/OpenGLRenderer.h
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.h
@@ -26,7 +26,7 @@ struct RenderOptions {
   bool draw_filters_window = false;
 
   // internal rendering settings - The OpenGLRenderer will internally use this resolution/format.
-  int msaa_samples = 2;
+  int msaa_samples = 1;
   int game_res_w = 640;
   int game_res_h = 480;
 

--- a/goal_src/jak1/pc/pckernel-h.gc
+++ b/goal_src/jak1/pc/pckernel-h.gc
@@ -67,7 +67,7 @@
 
 (defconstant PC_MIN_HEIGHT 240)
 
-(defconstant PC_DEFAULT_MSAA 2)
+(defconstant PC_DEFAULT_MSAA 1)
 
 ;; how many entries the music log has. the game only has 21 tracks but let's have more space for no reason.
 (defconstant PC_MUSIC_LOG_LENGTH 30)


### PR DESCRIPTION
There's a suspicion that MSAA might be what causes the black screen problem for some users, additionally this can cause perf issues for people with really bad PCs so this is probably a better default.

Needs testing before merging, i think this is all inclusive though.