### PR TITLE
[jak1] Fix speedrun mode bug where loading a save is counted as new run

### DIFF
--- a/goal_src/jak1/engine/game/game-save.gc
+++ b/goal_src/jak1/engine/game/game-save.gc
@@ -16,6 +16,7 @@
 
 ;; Having two state machines, one in C++ and one in GOAL is kind of a questionable and confusing design.
 
+(define-extern mark-speedrun-started (function none))
 ;; DECOMP BEGINS
 
 ;; version identifier
@@ -607,6 +608,9 @@
       (set! save-data
             (the-as game-save-tag
                     (&+ (the-as pointer save-data) (logand -16 (+ (* (the-as int (-> save-data elt-size)) (-> save-data elt-count)) 31)))))))
+  ;; og:preserve-this make sure loading a save doesn't reset speedrun state
+  (when (and (-> *pc-settings* speedrunner-mode?) (zero? (-> save new-game)))
+    (mark-speedrun-started))
   ;; if we're a new game, set our checkpoint.
   (when (nonzero? (-> save new-game))
     (set-continue! this "game-start")

--- a/goal_src/jak1/pc/features/speedruns.gc
+++ b/goal_src/jak1/pc/features/speedruns.gc
@@ -385,6 +385,10 @@
   (set! (-> *speedrun-info* should-display?) #f)
   (none))
 
+(defun mark-speedrun-started ()
+  (true! (-> *speedrun-info* has-started?))
+  (none))
+
 (defun speedrun-mode-update ()
   "A per frame update for speedrunning related stuff"
   (when (-> *pc-settings* speedrunner-mode?)
@@ -397,7 +401,7 @@
                ;; target has landed on ground/water, or we're about to enter target-hit-ground state
                (or (logtest? (-> *target* control status) (cshape-moving-flags onground onsurf on-water))
                    (= (-> *target* next-state name) 'target-hit-ground)))
-      (true! (-> *speedrun-info* has-started?))
+      (mark-speedrun-started)
       ;; spawn a process that resets autosplitter after suspending for 1 frame
       (process-spawn-function process
         (lambda ()


### PR DESCRIPTION
Fixes a small bug introduced in #3902. 

Without this change, whenever you load a save it is treated as if you started a new game and resets the autosplitter back to 0s.