### PR TITLE
[build actor] Fix displaying actor materials

### DIFF
--- a/goalc/build_actor/common/MercExtract.cpp
+++ b/goalc/build_actor/common/MercExtract.cpp
@@ -14,7 +14,7 @@ void extract(const std::string& name,
              u32 tex_offset) {
   ASSERT(out.new_vertices.empty());
 
-  std::map<int, tfrag3::MercDraw> draw_by_material;
+  std::map<std::pair<int, int>, tfrag3::MercDraw> draw_by_material;
   int mesh_count = 0;
   int prim_count = 0;
   int joints = 3;
@@ -77,7 +77,7 @@ void extract(const std::string& name,
         }
 
         // real draw details will be filled out in the next loop.
-        auto& draw = draw_by_material[prim.material];
+        auto& draw = draw_by_material[{prim.material, n.node_idx}];
         draw.mode = gltf_util::make_default_draw_mode();  // todo rm
         draw.tree_tex_id = 0;                             // todo rm
         draw.num_triangles += prim_indices.size() / 3;
@@ -96,8 +96,8 @@ void extract(const std::string& name,
   out.new_model.max_bones = joints;
   out.new_model.max_draws = 0;
 
-  for (const auto& [mat_idx, d_] : draw_by_material) {
-    const auto& mat = model.materials[mat_idx];
+  for (const auto& [key, d_] : draw_by_material) {
+    int mat_idx = key.first;
     if (mat_idx < 0 || !gltf_util::material_has_envmap(model.materials[mat_idx]) ||
         !gltf_util::envmap_is_valid(model.materials[mat_idx])) {
       gltf_util::process_normal_merc_draw(model, out, tex_offset, e, mat_idx, d_);


### PR DESCRIPTION
Known issue confirmed by Hat Kid shortly after the release of the build actor tool as something that came up during testing.

There is a problem which is you can't go over 255 vertices or faces in a single collision primitive. The solution then is to split a single object into two different primitives.

To do this, you need to separate an object in Blender into two separate objects. However, this causes issues because you can't share the same material across two different Blender objects. If you do, any subsequent uses of the same material show up invisible because they get skipped during the build process as they were presumed to already have been built.

This simple fix adds an additional check to check materials AND objects when building materials.

This is a pretty important fix, as there's no way to get around the 255 hex limit, so at that point you have no choice but to separate objects into two separate Blender objects. At this point, it doesn't make sense to not be able to share the same material across two different objects.

Before this PR:

<video controls src="https://github.com/user-attachments/assets/fabcd951-d855-4d52-8ed0-0aeea0b75414"></video>

After this PR:

<video controls src="https://github.com/user-attachments/assets/3e3b7d53-e4ed-43bb-aef1-08cc147d44c0"></video>
