### PR TITLE
[jak1] Don't update cell/orb/fly autosplit counters during blackout

### DIFF
--- a/goal_src/jak1/pc/features/autosplit.gc
+++ b/goal_src/jak1/pc/features/autosplit.gc
@@ -17,14 +17,14 @@
   `(set! (-> *autosplit-info-jak1* ,field-name) (if (task-complete? *game-info* (game-task ,task-name)) 1 0)))
 
 (defun update-autosplit-info-jak1 ()
-  ;; general statistics
-  (set! (-> *autosplit-info-jak1* num-power-cells) (the int (-> *game-info* fuel)))
-  (set! (-> *autosplit-info-jak1* num-orbs) (the int (-> *game-info* money-total)))
-  (set! (-> *autosplit-info-jak1* num-scout-flies) (the int (-> *game-info* buzzer-total)))
-  ;; per-level orb/fly counts
   ;; when we are blacked out in loads the value of these are temporarily 0, and that messes with the auto splitter.
   (let ((in-blackout? (>= (-> *game-info* blackout-time) (current-time))))
     (when (not in-blackout?)
+      ;; general statistics
+      (set! (-> *autosplit-info-jak1* num-power-cells) (the int (-> *game-info* fuel)))
+      (set! (-> *autosplit-info-jak1* num-orbs) (the int (-> *game-info* money-total)))
+      (set! (-> *autosplit-info-jak1* num-scout-flies) (the int (-> *game-info* buzzer-total)))
+      ;; per-level orb/fly counts
       (set! (-> *autosplit-info-jak1* training-num-orbs) (-> *game-info* money-per-level (level-task-data-index training)))
       (set! (-> *autosplit-info-jak1* village1-num-orbs) (-> *game-info* money-per-level (level-task-data-index village1)))
       (set! (-> *autosplit-info-jak1* beach-num-orbs) (-> *game-info* money-per-level (level-task-data-index beach)))


### PR DESCRIPTION
Similar issue to the orbs-per-level counts, while loading a save (in blackout) these values are reset to 0 briefly. This can cause extra autosplits (see https://github.com/open-goal/speedrunning/pull/25)