### PR TITLE
jak3: fix `was-pre-game` crash and `egg-spider` bbush

### DIFF
--- a/game/graphics/texture/jak1_tpage_dir.h
+++ b/game/graphics/texture/jak1_tpage_dir.h
@@ -5,4 +5,4 @@
 #include "common/common_types.h"
 
 const std::vector<u32>& get_jak1_tpage_dir();
-constexpr u32 EXTRA_PC_PORT_TEXTURE_COUNT = 64;
+constexpr u32 EXTRA_PC_PORT_TEXTURE_COUNT = 128;

--- a/goal_src/jak3/levels/desert/des-bush.gc
+++ b/goal_src/jak3/levels/desert/des-bush.gc
@@ -1514,8 +1514,8 @@
              )
         ;; og:preserve-this fix hud kill counter
         (set! (-> *game-info* score) (the float (the int v1-7)))
-        ;; og:preserve-this fix original game bug
-        (if (>= v1-7 (-> self goal-score))
+        ;; og:preserve-this fix original game bug and add check for spider-manager process
+        (if (and (-> v1-5 extra process) (>= v1-7 (-> self goal-score)))
             (send-event self 'complete)
             )
         )

--- a/goal_src/jak3/levels/wascity/defend/was-pre-game.gc
+++ b/goal_src/jak3/levels/wascity/defend/was-pre-game.gc
@@ -2368,7 +2368,8 @@
       ((not (task-node-closed? (game-task-node wascity-pre-game-bronze)))
        (when (>= f30-0 (game-info-method-31 *game-info* 1 1))
          (sound-play-by-spec (static-sound-spec "skill-pickup" :group 0 :fo-curve 1) (new-sound-id) (the-as vector #t))
-         (script-eval '(birth-pickup ("power-game-2" "screen") skill FACT_SUPER_SKILL_INC flags (suck-in)))
+         ;; og:preserve-this changed string from "power-game-2"
+         (script-eval '(birth-pickup ("was-pre-game-2" "screen") skill FACT_SUPER_SKILL_INC flags (suck-in)))
          (task-node-close! (game-task-node wascity-pre-game-bronze) 'event)
          (set! (-> *game-info* goal) (game-info-method-31 *game-info* 1 2))
          (let ((v1-39 (the-as hud (handle->process (-> this hud-goal)))))
@@ -2387,7 +2388,8 @@
       ((not (task-node-closed? (game-task-node wascity-pre-game-silver)))
        (when (>= f30-0 (game-info-method-31 *game-info* 1 2))
          (sound-play-by-spec (static-sound-spec "skill-pickup" :group 0 :fo-curve 1) (new-sound-id) (the-as vector #t))
-         (script-eval '(birth-pickup ("power-game-2" "screen") skill FACT_SUPER_SKILL_INC flags (suck-in)))
+         ;; og:preserve-this changed string from "power-game-2"
+         (script-eval '(birth-pickup ("was-pre-game-2" "screen") skill FACT_SUPER_SKILL_INC flags (suck-in)))
          (task-node-close! (game-task-node wascity-pre-game-silver) 'event)
          (set! (-> *game-info* goal) (game-info-method-31 *game-info* 1 3))
          (let ((v1-53 (the-as hud (handle->process (-> this hud-goal)))))
@@ -2406,7 +2408,8 @@
       ((not (task-node-closed? (game-task-node wascity-pre-game-gold)))
        (when (>= f30-0 (game-info-method-31 *game-info* 1 3))
          (sound-play-by-spec (static-sound-spec "skill-pickup" :group 0 :fo-curve 1) (new-sound-id) (the-as vector #t))
-         (script-eval '(birth-pickup ("power-game-2" "screen") skill FACT_SUPER_SKILL_INC flags (suck-in)))
+         ;; og:preserve-this changed string from "power-game-2"
+         (script-eval '(birth-pickup ("was-pre-game-2" "screen") skill FACT_SUPER_SKILL_INC flags (suck-in)))
          (task-node-close! (game-task-node wascity-pre-game-gold) 'event)
          (send-event (handle->process (-> this hud-goal)) 'hide-and-die)
          )


### PR DESCRIPTION
Fixes #3997: The script for the orb that is spawned when getting a medal in the satellite game was using the wrong entity name.
Fixes #3998: The `spider-manager` process was invalid for one frame, causing the score to be set to the value of `#f`, winning the game instantly.

Also doubled the PC port texture count, which should hopefully fix the crash that happens when playing the game all the way through to the end of the Destroy Dark Eco Tanks mission in one sitting.