### PR TITLE
ci: don't explicitly install `cmake` anymore for macOS builds

### DIFF
--- a/.github/workflows/macos-build-arm.yaml
+++ b/.github/workflows/macos-build-arm.yaml
@@ -25,7 +25,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Package Dependencies
-        run: brew install cmake ninja nasm
+        env:
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+          HOMEBREW_NO_ANALYTICS: 1
+        run: |
+          if ! brew install ninja nasm; then
+            brew update
+            brew install ninja nasm
+          fi
 
       - name: Setup sccache
         uses: hendrikmuhs/ccache-action@v1.2.18

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -35,7 +35,14 @@ jobs:
           fetch-tags: true
 
       - name: Install Package Dependencies
-        run: brew install cmake nasm ninja
+        env:
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+          HOMEBREW_NO_ANALYTICS: 1
+        run: |
+          if ! brew install ninja nasm; then
+            brew update
+            brew install ninja nasm
+          fi
 
       - name: Setup sccache
         uses: hendrikmuhs/ccache-action@v1.2.18


### PR DESCRIPTION
Something has changed, hopefully the system installed cmake plays nice

<img width="623" height="304" alt="image" src="https://github.com/user-attachments/assets/30b9506f-eb7c-4dca-b4bd-5276b1d351e1" />
