### PR TITLE
[jak1] Fix lavatube oranges autosplit

### DIFF
--- a/goal_src/jak1/pc/features/autosplit.gc
+++ b/goal_src/jak1/pc/features/autosplit.gc
@@ -260,8 +260,9 @@
   (autosplit-flag-task-complete! res-ogre-secret ogre-secret)
   (autosplit-flag-task-complete! res-lavatube-end lavatube-end)
   (autosplit-flag-task-complete! res-lavatube-buzzer lavatube-buzzer)
-  (autosplit-flag-task-complete! res-lavatube-balls lavatube-balls)
-  (autosplit-flag-task-complete! res-intro intro)
+  ;; oranges are special, they don't get marked complete in task-perm-list in normal gameplay
+  (set! (-> *autosplit-info-jak1* res-lavatube-balls)
+        (if (task-closed? (game-task lavatube-balls) (task-status need-resolution)) 1 0))  (autosplit-flag-task-complete! res-intro intro)
   ;; other misc tasks
   (set! (-> *autosplit-info-jak1* int-finalboss-movies)
         (if (task-closed? (game-task finalboss-movies) (task-status need-introduction)) 1 0))

--- a/goal_src/jak1/pc/features/autosplit.gc
+++ b/goal_src/jak1/pc/features/autosplit.gc
@@ -262,7 +262,8 @@
   (autosplit-flag-task-complete! res-lavatube-buzzer lavatube-buzzer)
   ;; oranges are special, they don't get marked complete in task-perm-list in normal gameplay
   (set! (-> *autosplit-info-jak1* res-lavatube-balls)
-        (if (task-closed? (game-task lavatube-balls) (task-status need-resolution)) 1 0))  (autosplit-flag-task-complete! res-intro intro)
+        (if (task-closed? (game-task lavatube-balls) (task-status need-resolution)) 1 0))
+  (autosplit-flag-task-complete! res-intro intro)
   ;; other misc tasks
   (set! (-> *autosplit-info-jak1* int-finalboss-movies)
         (if (task-closed? (game-task finalboss-movies) (task-status need-introduction)) 1 0))


### PR DESCRIPTION
Not sure if/how this ever worked. The old code splits if you mark the task complete from the debug menu, but not from normal gameplay. 

`autosplit-flag-task-complete!` checks if the `task-perm-list` has the `real-complete` flag. Other than the debug menu and couple special cases, it looks like `task-perm-list` entries only get marked `real-complete` here when we get a fuel-cell
https://github.com/open-goal/jak-project/blob/aad1b53ce31ab0ef4c20ad7f6311cdda84f5c2bf/goal_src/jak1/engine/game/game-info.gc#L287-L300

Fixes one of the issues in #4021