### PR TITLE
jak2: progress: fix duplicate "Right Analog Stick Left" in keybind list

### DIFF
--- a/goal_src/jak2/pc/progress/progress-static-pc.gc
+++ b/goal_src/jak2/pc/progress/progress-static-pc.gc
@@ -344,7 +344,7 @@ This gives us more freedom to write code how we want.
       (progress-new-generic-link-to-keybind-details-page (text-id progress-reassign-binds-keyboard)
           :should-disable? (lambda () (not (pc-get-keyboard-enabled?)))
           :device-type keyboard
-          :entries (l-analog-up l-analog-down l-analog-left l-analog-right r-analog-up r-analog-down r-analog-left r-analog-left r-analog-right
+          :entries (l-analog-up l-analog-down l-analog-left l-analog-right r-analog-up r-analog-down r-analog-left r-analog-right
                     select l3 r3 start dpad-up dpad-right dpad-down dpad-left l2 r2 l1 r1 triangle circle cross square)
           :confirm ((text-id progress-restore-defaults) (lambda () (pc-reset-bindings-to-defaults! 0 1))))
       (progress-new-generic-link-to-keybind-details-page (text-id progress-reassign-binds-mouse)


### PR DESCRIPTION
Fixes #4023 

This fixes a duplicated entry in the Jak 2 keybind details page where
"Right Analog Stick Left" appears twice.

File: goal_src/jak2/pc/progress/progress-static-pc.gc
Change: corrected the :entries list to include r-analog-right once
and removed the duplicate r-analog-left, resulting in the 8 expected
analog directions (L and R sticks).

Repro: Options → Input → Reassign Binds → Keyboard (Jak 2)
Before: Right stick shows duplicate "Left"
After: Right stick shows Left/Right correctly