### PR TITLE
[jak3] Add zoom blur and color filter effect

### DIFF
--- a/decompiler/config/jak3/all-types.gc
+++ b/decompiler/config/jak3/all-types.gc
@@ -1966,7 +1966,7 @@
   :size-assert         #x1c
   :flag-assert         #xa0000001c
   (:methods
-    (evaluate! "Set the x and y component of the vector to the current point on the curve." 
+    (evaluate! "Set the x and y component of the vector to the current point on the curve."
                (_type_ vector) vector) ;; 9
     )
   )
@@ -3525,7 +3525,7 @@
   (bucket0 0)
   (bucket1 1)
   (bucket2 2) ;; pc vis stuff
-  (bucket3 3) ;; blit?
+  (blit 3)
   (tex-lcom-sky-pre 4)
   (sky 5) ;; sky
   (bucket6 6) ;; ocean
@@ -4156,7 +4156,7 @@
   (merc-lcom-water 564)
   (gmerc-lcom-water 565)
   (gmerc2-lcom-water 566) ;; default for prim
-  (bucket567 567)
+  (anti-alias 567)
 
   (tex-sprite 568)
   (generic-sprite-1 569) ;; ;prim
@@ -4254,7 +4254,7 @@
   (rn33)
   (rn34)
   (rn35)
-  (rn36)
+  (depth-cue)
   (rn37)
   )
 ;; ---vu1-user-h:vu1-renderer-mask
@@ -11778,7 +11778,7 @@
    (line-tmpl                dma-gif-packet :inline :offset-assert 160)
    (scan-tmpl                dma-gif-packet :inline :offset-assert 192)
    (color                    vector4w       :inline :offset-assert 224)
-   (line-color               uint64                 :offset-assert 240)
+   (line-color               gs-rgbaq               :offset-assert 240)
    (scan-colors              vector4w    15 :inline :offset-assert 256) ;; guessed by decompiler
    (zoom-blur-pos            vector         :inline :offset-assert 496)
    (zoom-blur-count          int32                  :offset-assert 512)
@@ -11803,18 +11803,26 @@
   :size-assert         #x24c
   :flag-assert         #x1b0000024c
   (:methods
-    (blit-displays-work-method-9 (_type_ dma-buffer int int int) none) ;; 9
-    (blit-displays-work-method-10 (_type_ dma-buffer int int int) none) ;; 10
-    (blit-displays-work-method-11 (_type_ dma-buffer int) none) ;; 11
+    (blit-standard "Draw a full-width quad of the given height to copy from raster to display buffer"
+                   (_type_ dma-buffer int int int) none) ;; 9
+    (blit-slow-time
+      "Draw a full-screen triangle fan to copy from raster to display buffer.
+       The fan is centered in the center of the screen.
+       This applies a gradient of alpha from 192 at the center to arg3 at the corners."
+      (_type_ dma-buffer int int int) none) ;; 10
+    (draw-sprite-color (_type_ dma-buffer int) none) ;; 11
     (draw-letterbox (_type_ dma-buffer float int float) none) ;; 12
-    (blit-displays-work-method-13 (_type_ dma-buffer int int int) none) ;; 13
-    (blit-displays-work-method-14 (_type_ dma-buffer vector) none) ;; 14
-    (blit-displays-work-method-15 (_type_ dma-buffer) none) ;; 15
+    (draw-antialias
+      "Draw the raster buffer on top of itself, with a half-pixel offset.
+       This is used as an antialiasing effect."
+      (_type_ dma-buffer int int int) none) ;; 13
+    (draw-color-filter (_type_ dma-buffer vector) none) ;; 14
+    (fx-to-raster-flipped (_type_ dma-buffer) none) ;; 15
     (draw-zoom-blur (_type_ dma-buffer int) none) ;; 16
     (setup-zoom-blur-2d (_type_ vector int float symbol) none) ;; 17
-    (setup-brightness-and-contrast (_type_ dma-buffer float float) none) ;; 18
+    (draw-brightness-and-contrast (_type_ dma-buffer float float) none) ;; 18
     (do-blit-displays (_type_) none) ;; 19 (called from main.gc)
-    (draw-sky (_type_ dma-buffer) none) ;; 20
+    (blit-menu-mode (_type_ dma-buffer) none) ;; 20
     (get-menu-mode (_type_) symbol) ;; 21
     (get-screen-copied (_type_) symbol) ;; 22
     (get-horizontal-flip-flag (_type_) symbol) ;; 23
@@ -19737,8 +19745,8 @@
    The prejoint is the parent for all joints, so it causes all bones to move.
    The align joint has no children, but the convention is that moving align will
    cause the entire process-drawable's root to move, effectively moving the entire character.
-   Most of the time, this is the preferable way to move a character as part of an animation - 
-   it will update their velocity and when the animation ends or is canceled, 
+   Most of the time, this is the preferable way to move a character as part of an animation -
+   it will update their velocity and when the animation ends or is canceled,
    the offset in position from playing the animation will stay. For example, if Jak punches,
    his velocity will increase due to the animated align in the punch animation.
    To implement this, the align-control computes the relative transform between align frames.
@@ -42018,7 +42026,7 @@
     (rnd-int-excluding-masked "Get a random int in the range. Exclude a value n by setting the n-th bit of the mask."(_type_ int int) int) ;; 131
     (rnd-time-frame "Get a random time frame." (_type_ time-frame time-frame) time-frame) ;; 132
     (rnd-chance? "Returns true with the given probability." (_type_ float) symbol) ;; 133
-    (rnd-chance-for-idle? 
+    (rnd-chance-for-idle?
       "Like rnd-chance, but is more likely to return true when the game is close to not fitting in frame rate.
        This makes enemies start idling more if the game isn't running fast enough." (_type_ float) symbol) ;; 134
     (enemy-method-135 (_type_) none) ;; 135
@@ -42166,7 +42174,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-extern *enemy-dummy-shadow-control* shadow-control)
-(define-extern get-penetrate-using-from-attack-event "Given an attack event to an enemy, return the penetrate that should be applied to the enemy" 
+(define-extern get-penetrate-using-from-attack-event "Given an attack event to an enemy, return the penetrate that should be applied to the enemy"
                (function process-drawable event-message-block penetrate))
 (define-extern enemy-setup-gem "Determine if the enemy should have a gem and set drawing masks/particles as needed." (function object :behavior enemy))
 (define-extern enemy-init-by-other "Function to initialize an enemy from a parent process." (function process-drawable enemy-init-by-other-params object :behavior enemy))

--- a/decompiler/config/jak3/ntsc_v1/type_casts.jsonc
+++ b/decompiler/config/jak3/ntsc_v1/type_casts.jsonc
@@ -11298,7 +11298,9 @@
     [[844, 847], "a0", "dma-gif-packet"],
     [[921, 924], "v1", "dma-gif-packet"]
   ],
-  "(method 9 blit-displays-work)": [[[2, 36], "v1", "(inline-array vector4w)"]],
+  "(method 9 blit-displays-work)": [
+    [[2, 36], "v1", "(inline-array vector4w)"]
+  ],
   "(method 10 blit-displays-work)": [
     [[2, 141], "v1", "(inline-array vector4w)"]
   ],

--- a/game/graphics/opengl_renderer/BlitDisplays.cpp
+++ b/game/graphics/opengl_renderer/BlitDisplays.cpp
@@ -117,6 +117,9 @@ void BlitDisplays::do_copy_back(SharedRenderState* render_state, ScopedProfilerN
 
 void BlitDisplays::do_zoom_blur(SharedRenderState* render_state, ScopedProfilerNode& prof) {
   const float texels = m_zoom_blur.texels;
+  // this is computing texture coordinates that zoom by texels, and offset by pos
+  // the reason to limit only in non-2d is not understood.
+
   float xmin, xmax, ymin, ymax;
   if (m_zoom_blur.is_2d) {
     const float f2_0 = (texels / 512.f) * m_zoom_blur.pos.x();

--- a/game/graphics/opengl_renderer/BlitDisplays.cpp
+++ b/game/graphics/opengl_renderer/BlitDisplays.cpp
@@ -19,6 +19,7 @@ void BlitDisplays::init_textures(TexturePool& texture_pool, GameVersion version)
     default:
       ASSERT_NOT_REACHED();
   }
+
   m_copier = std::make_unique<FramebufferCopier>();
   TextureInput in;
   in.gpu_texture = m_copier->texture();
@@ -63,6 +64,14 @@ void BlitDisplays::render(DmaFollower& dma,
           // buffer back.
           m_copy_back_pending = true;
         } break;
+        case 0x13: {
+          // copy from render buffer
+          m_blur_old_copier.copy_now(render_state->render_fb_w, render_state->render_fb_h,
+                                     render_state->render_fb);
+
+          memcpy(&m_zoom_blur, data.data, sizeof(PcZoomBlur));
+          m_zoom_blur_pending = true;
+        } break;
       }
     }
   }
@@ -88,7 +97,7 @@ void BlitDisplays::render(DmaFollower& dma,
   render_state->stencil_dirty = false;
 }
 
-void BlitDisplays::do_copy_back(SharedRenderState* render_state) {
+void BlitDisplays::do_copy_back(SharedRenderState* render_state, ScopedProfilerNode& prof) {
   if (m_copy_back_pending) {
     if (render_state->render_fb_w == m_copier->width() &&
         render_state->render_fb_h == m_copier->height()) {
@@ -96,7 +105,61 @@ void BlitDisplays::do_copy_back(SharedRenderState* render_state) {
                               render_state->render_fb);
     }
     m_copy_back_pending = false;
+  } else if (m_zoom_blur_pending) {
+    do_zoom_blur(render_state, prof);
+    m_zoom_blur_pending = false;
   }
+}
+
+void BlitDisplays::do_zoom_blur(SharedRenderState* render_state, ScopedProfilerNode& prof) {
+  const float texels = m_zoom_blur.texels;
+  float xmin, xmax, ymin, ymax;
+  if (m_zoom_blur.is_2d) {
+    const float f2_0 = (texels / 512.f) * m_zoom_blur.pos.x();
+    const float f0_6 = 512.f - (texels - f2_0);
+    const float f3_1 = (texels / 416.f) * m_zoom_blur.pos.y();
+    const float f1_4 = 416.f - (texels - f3_1);
+
+    xmin = f2_0 / 512.f;
+    xmax = (f0_6 - 1.f) / 512.f;
+    ymin = f3_1 / 416.f;
+    ymax = (f1_4 - 1.f) / 416.f;
+
+  } else {
+    const float f1_10 = (texels / 512.f) * m_zoom_blur.pos.x();
+    const float f2_8 = std::max(0.f, std::min(f1_10, texels));
+    const float f0_22 = 512.f - (texels - f2_8);
+    const float f3_4 = (texels / 416.f) * m_zoom_blur.pos.y();
+    const float f3_6 = std::max(0.f, std::min(f3_4, texels));
+    const float f1_16 = 416.f - (texels - f3_6);
+
+    xmin = f2_8 / 512.f;
+    xmax = (f0_22 - 1.f) / 512.f;
+    ymin = f3_6 / 416.f;
+    ymax = (f1_16 - 1.f) / 416.f;
+  }
+
+  m_blur_new_copier.copy_now(render_state->render_fb_w, render_state->render_fb_h,
+                             render_state->render_fb);
+
+  // clear screen
+  glBindFramebuffer(GL_FRAMEBUFFER, render_state->render_fb);
+  glClearColor(0.0, 0.0, 0.0, 0.0);
+  glClear(GL_COLOR_BUFFER_BIT);
+
+  // GL Setup
+  glDisable(GL_DEPTH_TEST);
+  glEnable(GL_BLEND);
+  glBindTexture(GL_TEXTURE_2D, m_blur_old_copier.texture());
+
+  // zoom blur draw
+  m_fullscreen_tex_draw.draw(m_zoom_blur.color.cast<float>() / 128.f, math::Vector2f{xmin, ymin},
+                             math::Vector2f{xmax, ymax}, render_state, prof);
+
+  // screen draw
+  glBindTexture(GL_TEXTURE_2D, m_blur_new_copier.texture());
+  m_fullscreen_tex_draw.draw(math::Vector4f{1.f, 1.f, 1.f, m_zoom_blur.alpha_current},
+                             math::Vector2f{0, 0}, math::Vector2f{1, 1}, render_state, prof);
 }
 
 void BlitDisplays::draw_debug_window() {

--- a/game/graphics/opengl_renderer/BlitDisplays.h
+++ b/game/graphics/opengl_renderer/BlitDisplays.h
@@ -23,6 +23,7 @@ class BlitDisplays : public BucketRenderer {
   void draw_debug_window() override;
   void do_copy_back(SharedRenderState* render_state, ScopedProfilerNode& prof);
   void do_zoom_blur(SharedRenderState* render_state, ScopedProfilerNode& prof);
+  void apply_color_filter(SharedRenderState* render_state, ScopedProfilerNode& prof);
 
  private:
   std::unique_ptr<FramebufferCopier> m_copier;
@@ -32,6 +33,9 @@ class BlitDisplays : public BucketRenderer {
   u32 m_tbp;
   bool m_copy_back_pending = false;
   bool m_zoom_blur_pending = false;
+  bool m_color_filter_pending = false;
+  math::Vector4f m_color_filter;
   PcZoomBlur m_zoom_blur;
   FullScreenTexDraw m_fullscreen_tex_draw;
+  FullScreenDraw m_color_draw;
 };

--- a/game/graphics/opengl_renderer/BlitDisplays.h
+++ b/game/graphics/opengl_renderer/BlitDisplays.h
@@ -4,6 +4,14 @@
 #include "game/graphics/opengl_renderer/opengl_utils.h"
 #include "game/graphics/texture/TexturePool.h"
 
+struct PcZoomBlur {
+  math::Vector4f pos;
+  math::Vector4<int32_t> color;
+  uint32_t is_2d;
+  int32_t texels;
+  float alpha_current;
+};
+
 /*!
  * The BlitDisplays renderer does various blitting and effects on the previous frame
  */
@@ -13,11 +21,17 @@ class BlitDisplays : public BucketRenderer {
   void render(DmaFollower& dma, SharedRenderState* render_state, ScopedProfilerNode& prof) override;
   void init_textures(TexturePool& texture_pool, GameVersion) override;
   void draw_debug_window() override;
-  void do_copy_back(SharedRenderState* render_state);
+  void do_copy_back(SharedRenderState* render_state, ScopedProfilerNode& prof);
+  void do_zoom_blur(SharedRenderState* render_state, ScopedProfilerNode& prof);
 
  private:
   std::unique_ptr<FramebufferCopier> m_copier;
+  FramebufferCopier m_blur_old_copier;
+  FramebufferCopier m_blur_new_copier;
   GpuTexture* m_gpu_tex;
   u32 m_tbp;
   bool m_copy_back_pending = false;
+  bool m_zoom_blur_pending = false;
+  PcZoomBlur m_zoom_blur;
+  FullScreenTexDraw m_fullscreen_tex_draw;
 };

--- a/game/graphics/opengl_renderer/DirectRenderer.cpp
+++ b/game/graphics/opengl_renderer/DirectRenderer.cpp
@@ -500,8 +500,8 @@ void DirectRenderer::update_gl_blend() {
       m_ogl.color_mult = 0.5;
     } else {
       // unsupported blend: a 0 b 2 c 2 d 1
-      lg::error("unsupported blend: a {} b {} c {} d {}", (int)state.a, (int)state.b, (int)state.c,
-                (int)state.d);
+      lg::error("unsupported blend (direct): a {} b {} c {} d {}", (int)state.a, (int)state.b,
+                (int)state.c, (int)state.d);
       //      ASSERT(false);
     }
   }

--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -1426,6 +1426,11 @@ void OpenGLRenderer::dispatch_buckets_jak3(DmaFollower dma,
       auto p = prof.make_scoped_child("collision-draw");
       m_collide_renderer.render(&m_render_state, p);
     }
+
+    if (bucket_id == (int)jak3::BucketId::TEX_HUD_HUD_ALPHA) {
+      auto p = prof.make_scoped_child("color-filter");
+      m_blit_displays->apply_color_filter(&m_render_state, p);
+    }
   }
   vif_interrupt_callback(m_bucket_renderers.size());
 

--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -970,9 +970,9 @@ Fbo make_fbo(int w, int h, int msaa, bool make_zbuf_and_stencil) {
 }
 }  // namespace
 
-void OpenGLRenderer::blit_display() {
+void OpenGLRenderer::blit_display(ScopedProfilerNode& prof) {
   if (m_blit_displays) {
-    m_blit_displays->do_copy_back(&m_render_state);
+    m_blit_displays->do_copy_back(&m_render_state, prof);
   }
 }
 
@@ -1021,7 +1021,7 @@ void OpenGLRenderer::render(DmaFollower dma, const RenderOptions& settings) {
   {
     g_current_renderer = "blit-display";
     auto prof = m_profiler.root()->make_scoped_child("blit-display");
-    blit_display();
+    blit_display(prof);
   }
 
   // apply effects done with PCRTC registers

--- a/game/graphics/opengl_renderer/OpenGLRenderer.h
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.h
@@ -79,7 +79,7 @@ class OpenGLRenderer {
   void dispatch_buckets_jak3(DmaFollower dma, ScopedProfilerNode& prof, bool sync_after_buckets);
 
   void do_pcrtc_effects(float alp, SharedRenderState* render_state, ScopedProfilerNode& prof);
-  void blit_display();
+  void blit_display(ScopedProfilerNode& prof);
   void init_bucket_renderers_jak1();
   void init_bucket_renderers_jak2();
   void init_bucket_renderers_jak3();

--- a/game/graphics/opengl_renderer/Shader.cpp
+++ b/game/graphics/opengl_renderer/Shader.cpp
@@ -132,6 +132,7 @@ ShaderLibrary::ShaderLibrary(GameVersion version) {
   at(ShaderId::HFRAG_MONTAGE) = {"hfrag_montage", version};
   at(ShaderId::PLAIN_TEXTURE) = {"plain_texture", version};
   at(ShaderId::TIE_WIND) = {"tie_wind", version};
+  at(ShaderId::SIMPLE_TEXTURE) = {"simple_texture", version};
 
   for (auto& shader : m_shaders) {
     ASSERT_MSG(shader.okay(), "error compiling shader");

--- a/game/graphics/opengl_renderer/Shader.h
+++ b/game/graphics/opengl_renderer/Shader.h
@@ -65,6 +65,7 @@ enum class ShaderId {
   HFRAG_MONTAGE = 38,
   PLAIN_TEXTURE = 39,
   TIE_WIND = 40,
+  SIMPLE_TEXTURE = 41,
   MAX_SHADERS
 };
 

--- a/game/graphics/opengl_renderer/opengl_utils.h
+++ b/game/graphics/opengl_renderer/opengl_utils.h
@@ -79,6 +79,23 @@ class FullScreenDraw {
   GLuint m_vertex_buffer;
 };
 
+class FullScreenTexDraw {
+ public:
+  FullScreenTexDraw();
+  ~FullScreenTexDraw();
+  FullScreenTexDraw(const FullScreenTexDraw&) = delete;
+  FullScreenTexDraw& operator=(const FullScreenTexDraw&) = delete;
+  void draw(const math::Vector4f& color,
+            const math::Vector2f& tex0,
+            const math::Vector2f& tex1,
+            SharedRenderState* render_state,
+            ScopedProfilerNode& prof);
+
+ private:
+  GLuint m_vao;
+  GLuint m_vertex_buffer;
+};
+
 class FramebufferCopier {
  public:
   FramebufferCopier();

--- a/game/graphics/opengl_renderer/shaders/simple_texture.frag
+++ b/game/graphics/opengl_renderer/shaders/simple_texture.frag
@@ -1,0 +1,10 @@
+#version 410 core
+
+out vec4 out_color;
+in vec2 tex;
+uniform vec4 color;
+uniform sampler2D tex_T0;
+
+void main() {
+  out_color = texture(tex_T0, tex) * color;
+}

--- a/game/graphics/opengl_renderer/shaders/simple_texture.vert
+++ b/game/graphics/opengl_renderer/shaders/simple_texture.vert
@@ -1,0 +1,25 @@
+#version 410 core
+
+layout (location = 0) in int index_in;
+layout (location = 1) in vec4 color_in;
+
+uniform vec2 tex_coord_0;
+uniform vec2 tex_coord_1;
+
+out vec2 tex;
+
+void main() {
+  if (index_in == 0) {
+    gl_Position = vec4(-1, -1, 0, 1.0);
+    tex = tex_coord_0;
+  } else if (index_in == 1) {
+    gl_Position = vec4(-1, 1, 0, 1.0);
+    tex = vec2(tex_coord_0.x, tex_coord_1.y);
+  } else if (index_in == 2) {
+    gl_Position = vec4(1, -1, 0, 1);
+    tex = vec2(tex_coord_1.x, tex_coord_0.y);
+  } else {
+    gl_Position = vec4(1, 1, 0, 1);
+    tex = vec2(tex_coord_1.x, tex_coord_1.y);
+  }
+}

--- a/goal_src/jak3/engine/gfx/background/subdivide.gc
+++ b/goal_src/jak3/engine/gfx/background/subdivide.gc
@@ -219,7 +219,7 @@
 
 (define GSH_ENABLE #f)
 
-(define GSH_BUCKET (bucket-id bucket3))
+(define GSH_BUCKET (bucket-id blit))
 
 (define GSH_WHICH_STAT 1)
 

--- a/goal_src/jak3/engine/gfx/blit-displays-h.gc
+++ b/goal_src/jak3/engine/gfx/blit-displays-h.gc
@@ -5,6 +5,9 @@
 ;; name in dgo: blit-displays-h
 ;; dgos: GAME
 
+(declare-type blit-displays-work structure)
+(define-extern *blit-displays-work* blit-displays-work)
+
 ;; DECOMP BEGINS
 
 (deftype blit-displays-work (structure)
@@ -16,7 +19,7 @@
    (line-tmpl                 dma-gif-packet  :inline)
    (scan-tmpl                 dma-gif-packet  :inline)
    (color                     vector4w        :inline)
-   (line-color                uint64)
+   (line-color                gs-rgbaq)
    (scan-colors               vector4w        15 :inline)
    (zoom-blur-pos             vector          :inline)
    (zoom-blur-count           int32)
@@ -38,18 +41,18 @@
    (slow-time                 float)
    )
   (:methods
-    (blit-displays-work-method-9 (_type_ dma-buffer int int int) none)
-    (blit-displays-work-method-10 (_type_ dma-buffer int int int) none)
-    (blit-displays-work-method-11 (_type_ dma-buffer int) none)
+    (blit-standard (_type_ dma-buffer int int int) none)
+    (blit-slow-time (_type_ dma-buffer int int int) none)
+    (draw-sprite-color (_type_ dma-buffer int) none)
     (draw-letterbox (_type_ dma-buffer float int float) none)
-    (blit-displays-work-method-13 (_type_ dma-buffer int int int) none)
-    (blit-displays-work-method-14 (_type_ dma-buffer vector) none)
-    (blit-displays-work-method-15 (_type_ dma-buffer) none)
+    (draw-antialias (_type_ dma-buffer int int int) none)
+    (draw-color-filter (_type_ dma-buffer vector) none)
+    (fx-to-raster-flipped (_type_ dma-buffer) none)
     (draw-zoom-blur (_type_ dma-buffer int) none)
     (setup-zoom-blur-2d (_type_ vector int float symbol) none)
-    (setup-brightness-and-contrast (_type_ dma-buffer float float) none)
+    (draw-brightness-and-contrast (_type_ dma-buffer float float) none)
     (do-blit-displays (_type_) none)
-    (draw-sky (_type_ dma-buffer) none)
+    (blit-menu-mode (_type_ dma-buffer) none)
     (get-menu-mode (_type_) symbol)
     (get-screen-copied (_type_) symbol)
     (get-horizontal-flip-flag (_type_) symbol)
@@ -86,5 +89,3 @@
   (set! (-> this horizontal-flip-flag) arg0)
   arg0
   )
-
-(define-extern *blit-displays-work* blit-displays-work)

--- a/goal_src/jak3/engine/gfx/blit-displays.gc
+++ b/goal_src/jak3/engine/gfx/blit-displays.gc
@@ -5,83 +5,36 @@
 ;; name in dgo: blit-displays
 ;; dgos: GAME
 
-;; just a stub for now.
-(define-extern draw-color-bars (function blit-displays-work none))
+;; Background on the VRAM.
+;; the PS2 has 4 MB of VRAM.
+;; the "TBP" register addresses VRAM with 256 byte (64 word).
+;; the full VRAM of the PS2 (4 MB) is 16384 TBP pages (#x4000)
+;; The "FBP" register addresses with 8192 byte units. (32 times the TBP value)
 
-(define *blit-displays-work* (new 'static 'blit-displays-work
-                               :adgif-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x1000000000008005 #xe)
-                                 )
-                               :sprite-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x41 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x41 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x408b400000008010 #x5353)
-                                 )
-                               :contrast-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x41 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x41 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x40ab400000008010 #x5353)
-                                 )
-                               :sprite-slow-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x50ab400000008001 #x53531)
-                                 )
-                               :draw-slow-time-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x13 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x13 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x30aec00000008006 #x531)
-                                 )
-                               :line-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x41 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x41 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x2020c00000008020 #x55)
-                                 )
-                               :scan-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x4c :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x4c :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x5020c0000000800f #x55551)
-                                 )
-                               :color (new 'static 'vector4w :x #x80 :y #x80 :z #x80 :w #x80)
-                               :line-color #x3f80000000000000
-                               :scan-colors (new 'static 'inline-array vector4w 15
-                                 (new 'static 'vector4w :y 1 :z 1)
-                                 (new 'static 'vector4w :y 1 :z 1)
-                                 (new 'static 'vector4w :y 1 :z 1)
-                                 (new 'static 'vector4w :y 1 :z 1)
-                                 (new 'static 'vector4w :x 1 :y 3 :z 2)
-                                 (new 'static 'vector4w :x 1 :y 4 :z 3)
-                                 (new 'static 'vector4w :x 2 :y 6 :z 5)
-                                 (new 'static 'vector4w :x 3 :y 8 :z 7)
-                                 (new 'static 'vector4w :x 5 :y 11 :z 10)
-                                 (new 'static 'vector4w :x 6 :y 14 :z 13)
-                                 (new 'static 'vector4w :x 9 :y 20 :z 17)
-                                 (new 'static 'vector4w :x 13 :y 27 :z 21)
-                                 (new 'static 'vector4w :x 17 :y 36 :z 24)
-                                 (new 'static 'vector4w :x 22 :y 45 :z 28)
-                                 (new 'static 'vector4w :x 32 :y 63 :z 32)
-                                 )
-                               :menu-mode #f
-                               :screen-copied #f
-                               :horizontal-flip-flag #f
-                               )
-        )
+;; The first #xf80 are the texture pool, used for normal textures of levels, etc.
+;; It's possible for other code to temporarily use this VRAM too.
+;; From #xf80 to #x11d1 are various "dynamic" textures used for effects, etc.
+
+;; the fx buffer is at FBP = #x26 or TBP = #x4c0
+
+;; The "display-fbp" is 0xa4 (NTSC) = TBP of #x1480. This is the location for the
+;; frame that's being displayed on the TV.
+
+;; The z-buffer is at ZBP = #x130 = TBP of #x2600
+
+;; By default, the framebuffer used during rasterization is FBP = #x198 = TBP of #x3300.
+;; This is the frame that is being written to by triangle drawing.
+
+;; The bucket order is roughly
+
+;; bucket3
+;; normal drawing
+;; bucket567
+;; sprite/prim/shadow2,3
+;; warp
+;; debug menu (585)
+
+;; The brightness/contrast effect is done in place on the rasterization buffer, at the very end.
 
 (defun pc-upload-raw-texture ((dma-buf dma-buffer) (image-data pointer) (width int) (height int) (tbp int))
   "Added function in the PC port to create a 'raw' texture (no clut)"
@@ -101,82 +54,149 @@
 
 ;; DECOMP BEGINS
 
-(define *blit-displays-work* (new 'static 'blit-displays-work
-                               :adgif-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x1000000000008005 #xe)
-                                 )
-                               :sprite-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x41 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x41 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x408b400000008010 #x5353)
-                                 )
-                               :contrast-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x41 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x41 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x40ab400000008010 #x5353)
-                                 )
-                               :sprite-slow-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x50ab400000008001 #x53531)
-                                 )
-                               :draw-slow-time-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x13 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x13 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x30aec00000008006 #x531)
-                                 )
-                               :line-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x41 :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x41 :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x2020c00000008020 #x55)
-                                 )
-                               :scan-tmpl (new 'static 'dma-gif-packet
-                                 :dma-vif (new 'static 'dma-packet
-                                   :dma (new 'static 'dma-tag :qwc #x4c :id (dma-tag-id cnt))
-                                   :vif1 (new 'static 'vif-tag :imm #x4c :cmd (vif-cmd direct) :msk #x1)
-                                   )
-                                 :gif (new 'static 'array uint64 2 #x5020c0000000800f #x55551)
-                                 )
-                               :color (new 'static 'vector4w :x #x80 :y #x80 :z #x80 :w #x80)
-                               :line-color #x3f80000000000000
-                               :scan-colors (new 'static 'inline-array vector4w 15
-                                 (new 'static 'vector4w :y 1 :z 1)
-                                 (new 'static 'vector4w :y 1 :z 1)
-                                 (new 'static 'vector4w :y 1 :z 1)
-                                 (new 'static 'vector4w :y 1 :z 1)
-                                 (new 'static 'vector4w :x 1 :y 3 :z 2)
-                                 (new 'static 'vector4w :x 1 :y 4 :z 3)
-                                 (new 'static 'vector4w :x 2 :y 6 :z 5)
-                                 (new 'static 'vector4w :x 3 :y 8 :z 7)
-                                 (new 'static 'vector4w :x 5 :y 11 :z 10)
-                                 (new 'static 'vector4w :x 6 :y 14 :z 13)
-                                 (new 'static 'vector4w :x 9 :y 20 :z 17)
-                                 (new 'static 'vector4w :x 13 :y 27 :z 21)
-                                 (new 'static 'vector4w :x 17 :y 36 :z 24)
-                                 (new 'static 'vector4w :x 22 :y 45 :z 28)
-                                 (new 'static 'vector4w :x 32 :y 63 :z 32)
-                                 )
-                               :menu-mode #f
-                               :screen-copied #f
-                               :horizontal-flip-flag #f
-                               )
+(define *blit-displays-work*
+  (new 'static 'blit-displays-work
+    :adgif-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
         )
+      :gif0 (new 'static 'gif-tag64 :nloop #x5 :eop #x1 :nreg #x1)
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id a+d))
+      )
+    :sprite-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x41 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x41 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x10
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :fst #x1)
+        :nreg #x4
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id uv)
+        :regs1 (gif-reg-id xyz2)
+        :regs2 (gif-reg-id uv)
+        :regs3 (gif-reg-id xyz2)
+        )
+      )
+    :contrast-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x41 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x41 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x10
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1 :fst #x1)
+        :nreg #x4
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id uv)
+        :regs1 (gif-reg-id xyz2)
+        :regs2 (gif-reg-id uv)
+        :regs3 (gif-reg-id xyz2)
+        )
+      )
+    :sprite-slow-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x6 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x6 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x1
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type sprite) :tme #x1 :abe #x1 :fst #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id uv)
+        :regs2 (gif-reg-id xyz2)
+        :regs3 (gif-reg-id uv)
+        :regs4 (gif-reg-id xyz2)
+        )
+      )
+    :draw-slow-time-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x13 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x13 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x6
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type tri-fan) :iip #x1 :tme #x1 :abe #x1 :fst #x1)
+        :nreg #x3
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id rgbaq) :regs1 (gif-reg-id uv) :regs2 (gif-reg-id xyz2))
+      )
+    :line-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x41 :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x41 :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #x20
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type line) :abe #x1)
+        :nreg #x2
+        )
+      :gif1 (new 'static 'gif-tag-regs :regs0 (gif-reg-id xyz2) :regs1 (gif-reg-id xyz2))
+      )
+    :scan-tmpl (new 'static 'dma-gif-packet
+      :dma-vif (new 'static 'dma-packet
+        :dma (new 'static 'dma-tag :qwc #x4c :id (dma-tag-id cnt))
+        :vif1 (new 'static 'vif-tag :imm #x4c :cmd (vif-cmd direct) :msk #x1)
+        )
+      :gif0 (new 'static 'gif-tag64
+        :nloop #xf
+        :eop #x1
+        :pre #x1
+        :prim (new 'static 'gs-prim :prim (gs-prim-type line) :abe #x1)
+        :nreg #x5
+        )
+      :gif1 (new 'static 'gif-tag-regs
+        :regs0 (gif-reg-id rgbaq)
+        :regs1 (gif-reg-id xyz2)
+        :regs2 (gif-reg-id xyz2)
+        :regs3 (gif-reg-id xyz2)
+        :regs4 (gif-reg-id xyz2)
+        )
+      )
+    :color (new 'static 'vector4w :x #x80 :y #x80 :z #x80 :w #x80)
+    :line-color (new 'static 'gs-rgbaq :q 1.0)
+    :scan-colors (new 'static 'inline-array vector4w 15
+      (new 'static 'vector4w :y 1 :z 1)
+      (new 'static 'vector4w :y 1 :z 1)
+      (new 'static 'vector4w :y 1 :z 1)
+      (new 'static 'vector4w :y 1 :z 1)
+      (new 'static 'vector4w :x 1 :y 3 :z 2)
+      (new 'static 'vector4w :x 1 :y 4 :z 3)
+      (new 'static 'vector4w :x 2 :y 6 :z 5)
+      (new 'static 'vector4w :x 3 :y 8 :z 7)
+      (new 'static 'vector4w :x 5 :y 11 :z 10)
+      (new 'static 'vector4w :x 6 :y 14 :z 13)
+      (new 'static 'vector4w :x 9 :y 20 :z 17)
+      (new 'static 'vector4w :x 13 :y 27 :z 21)
+      (new 'static 'vector4w :x 17 :y 36 :z 24)
+      (new 'static 'vector4w :x 22 :y 45 :z 28)
+      (new 'static 'vector4w :x 32 :y 63 :z 32)
+      )
+    :menu-mode #f
+    :screen-copied #f
+    :horizontal-flip-flag #f
+    )
+  )
 
-(defmethod blit-displays-work-method-9 ((this blit-displays-work) (arg0 dma-buffer) (arg1 int) (arg2 int) (arg3 int))
+(defmethod blit-standard ((this blit-displays-work) (arg0 dma-buffer) (arg1 int) (arg2 int) (arg3 int))
+  "Draw a full-width quad of the given height to copy from raster to display buffer"
   (let ((v1-0 (the-as object (-> arg0 base))))
     (set! (-> (the-as (inline-array vector4w) v1-0) 0 quad) (-> this sprite-slow-tmpl dma-vif quad))
     (set! (-> (the-as (inline-array vector4w) v1-0) 1 quad) (-> this sprite-slow-tmpl quad 1))
@@ -191,7 +211,10 @@
   (none)
   )
 
-(defmethod blit-displays-work-method-10 ((this blit-displays-work) (arg0 dma-buffer) (arg1 int) (arg2 int) (arg3 int))
+(defmethod blit-slow-time ((this blit-displays-work) (arg0 dma-buffer) (arg1 int) (arg2 int) (arg3 int))
+  "Draw a full-screen triangle fan to copy from raster to display buffer.
+   The fan is centered in the center of the screen.
+   This applies a gradient of alpha from 192 at the center to arg3 at the corners."
   (let ((v1-0 (the-as object (-> arg0 base))))
     (set! (-> (the-as (inline-array vector4w) v1-0) 0 quad) (-> this draw-slow-time-tmpl dma-vif quad))
     (set! (-> (the-as (inline-array vector4w) v1-0) 1 quad) (-> this draw-slow-time-tmpl quad 1))
@@ -219,7 +242,7 @@
   (none)
   )
 
-(defmethod blit-displays-work-method-11 ((this blit-displays-work) (arg0 dma-buffer) (arg1 int))
+(defmethod draw-sprite-color ((this blit-displays-work) (arg0 dma-buffer) (arg1 int))
   (let ((v1-0 (the-as object (-> arg0 base))))
     (set! (-> (the-as (inline-array vector4w) v1-0) 0 quad) (-> this sprite-slow-tmpl dma-vif quad))
     (set! (-> (the-as (inline-array vector4w) v1-0) 1 quad) (-> this sprite-slow-tmpl quad 1))
@@ -271,7 +294,9 @@
   (none)
   )
 
-(defmethod blit-displays-work-method-13 ((this blit-displays-work) (arg0 dma-buffer) (arg1 int) (arg2 int) (arg3 int))
+(defmethod draw-antialias ((this blit-displays-work) (arg0 dma-buffer) (arg1 int) (arg2 int) (arg3 int))
+  "Draw the raster buffer on top of itself, with a half-pixel offset.
+   This is used as an antialiasing effect."
   (set-display-gs-state arg0 408 512 416 0 0)
   (dma-buffer-add-gs-set arg0 (rgbaq (new 'static 'gs-rgbaq :r #x80 :g #x80 :b #x80 :a #x80 :q 1.0)))
   (let ((v1-3 (the-as object (-> arg0 base))))
@@ -295,7 +320,7 @@
   (none)
   )
 
-(defmethod blit-displays-work-method-14 ((this blit-displays-work) (arg0 dma-buffer) (arg1 vector))
+(defmethod draw-color-filter ((this blit-displays-work) (arg0 dma-buffer) (arg1 vector))
   (set-display-gs-state arg0 408 512 416 0 0)
   (dma-buffer-add-gs-set arg0
                          (test-1 (new 'static 'gs-test :ate #x1 :afail #x3 :zte #x1 :ztst (gs-ztest always)))
@@ -334,7 +359,7 @@
   (none)
   )
 
-(defmethod blit-displays-work-method-15 ((this blit-displays-work) (arg0 dma-buffer))
+(defmethod fx-to-raster-flipped ((this blit-displays-work) (arg0 dma-buffer))
   (set-display-gs-state arg0 408 512 416 0 0)
   (dma-buffer-add-gs-set arg0
                          (test-1 (new 'static 'gs-test :ate #x1 :afail #x3 :zte #x1 :ztst (gs-ztest always)))
@@ -490,7 +515,29 @@
   (none)
   )
 
-(defmethod setup-brightness-and-contrast ((this blit-displays-work) (arg0 dma-buffer) (arg1 float) (arg2 float))
+(deftype pc-zoom-blur (structure)
+  ((pos           vector   :inline)
+   (color         vector4w :inline)
+   (is-2d?        int32)
+   (texels        int32)
+   (alpha-current float)
+   )
+  )
+
+(defun add-pc-zoom-blur ((dma-buf dma-buffer))
+  (dma-buffer-add-cnt-vif2
+    dma-buf
+    3
+    (new 'static 'vif-tag :cmd (vif-cmd pc-port) :imm #x13)
+    (new 'static 'vif-tag)
+    )
+  (let ((ret (-> dma-buf base)))
+    (&+! (-> dma-buf base) (* 16 3))
+    (the pc-zoom-blur ret)
+    )
+  )
+
+(defmethod draw-brightness-and-contrast ((this blit-displays-work) (arg0 dma-buffer) (arg1 float) (arg2 float))
   (set-display-gs-state arg0 408 512 416 0 0)
   (let ((s4-1 (fmax 0.0 (fmin 1.0 arg2)))
         (s3-1 (fmax 0.0 (fmin 1.0 arg1)))
@@ -548,45 +595,59 @@
   (none)
   )
 
-;; TODO new jak3 effects
 (defmethod do-blit-displays ((this blit-displays-work))
   (set! (-> this slow-time) (- 1.0 (-> *setting-control* user-current slow-time)))
+  
+  ;; in-place draw on rasterization buffer to apply brightness and contrast. Added to almost
+  ;; the last bucket, so it applies to HUD too.
   (let ((v1-3 (-> *setting-control* user-current)))
     (when (or (!= (-> v1-3 contrast) 0.5) (!= (-> v1-3 brightness) 0.5))
       (with-dma-buffer-add-bucket ((s4-0 (-> *display* frames (-> *display* on-screen) global-buf))
                                    (bucket-id debug-menu)
                                    )
-        (setup-brightness-and-contrast this s4-0 (-> v1-3 brightness) (-> v1-3 contrast))
+        (draw-brightness-and-contrast this s4-0 (-> v1-3 brightness) (-> v1-3 contrast))
         (reset-display-gs-state *display* s4-0)
         )
       )
     )
+  
+  ;; The count-down is used to delay blitting while rendering settings are propagating through
+  ;; the engine. When count-down reaches 0, the changes have propagated to the raster buffer.
+  ;; While counting down, the display buffer isn't updated.
   (when (zero? (-> this count-down))
     (cond
+      ;; if menu mode has activated, take a picture of the screen and disable almost all renderers.
+      ;; generic is kept on since it renders the menu itself.
       ((and (-> this menu-mode) (not (-> this screen-copied)))
+       
+       ;; capture the raster buffer! Instead of blitting to the display buffer, copy to the "fx buffer"
+       ;; note that this runs in the blit bucket (bucket 3) and so it contains the raster buffer
+       ;; from the previous frame that we'd normally copy to the display buffer.
        (with-dma-buffer-add-bucket ((s4-1 (-> *display* frames (-> *display* on-screen) global-buf))
-                                    (bucket-id bucket3)
+                                    (bucket-id blit)
                                     )
          (fx-copy-buf s4-1)
          )
+       ;; backup which renderers were enabled
        (set! (-> this vu1-enable-user-menu) (-> *display* vu1-enable-user-menu))
-       ;; og:preserve-this
+       
+       ;; og:preserve-this, was generic in the original
+       ;; only render merc
        (set! (-> *display* vu1-enable-user-menu) (vu1-renderer-mask merc))
        (set! (-> *display* vu1-enable-user) (vu1-renderer-mask merc))
        (set! (-> this texture-enable-user-menu) (the-as uint (-> *texture-pool* texture-enable-user-menu)))
        (set! (-> *texture-pool* texture-enable-user-menu) (texture-enable-mask shrub water hud))
        (set! (-> *texture-pool* texture-enable-user) (texture-enable-mask shrub water hud))
+       ;; activate a countdown as the renderers disable.
        (set! (-> this count-down) (the-as uint 3))
        (set! (-> this screen-copied) #t)
+       ;; progress menu can start coming out now.
        (set! (-> this progress-interp) 0.0)
        (set! (-> this progress-interp-dest) 1.0)
        (set! (-> this progress-interp-speed) 0.033333335)
-       (#when PC_PORT
-         (when (-> *pc-settings* fast-progress?)
-           (*! (-> this progress-interp-speed) (-> *pc-cheat-state* progress-speed))
-           )
-         )
        )
+      
+      ;; menu mode has deactivated, re-enable renderers and wait 3 frames
       ((and (not (get-menu-mode this)) (get-screen-copied this))
        (set! (-> *display* vu1-enable-user-menu) (-> this vu1-enable-user-menu))
        (set! (-> *texture-pool* texture-enable-user-menu)
@@ -597,56 +658,76 @@
        )
       )
     )
-  ; (when (and (-> *setting-control* user-current render) (>= (the-as uint 1) (-> this count-down)))
-  ;   (when (and (get-horizontal-flip-flag this) (not (get-menu-mode this)))
-  ;     (with-dma-buffer-add-bucket ((s4-2 (-> *display* frames (-> *display* on-screen) global-buf))
-  ;                                  (bucket-id debug-no-zbuf1)
-  ;                                  )
-  ;       (fx-copy-buf s4-2)
-  ;       (blit-displays-work-method-15 this s4-2)
-  ;       (reset-display-gs-state *display* s4-2)
-  ;       )
-  ;     )
-  ;   (when (logtest? (vu1-renderer-mask rn36) (-> *display* vu1-enable-user))
-  ;     (when (not *display-color-bars*)
-  ;       (with-dma-buffer-add-bucket ((s4-3 (-> *display* frames (-> *display* on-screen) global-buf))
-  ;                                    (bucket-id bucket567)
-  ;                                    )
-  ;         (dma-buffer-add-gs-set s4-3
-  ;                                (test-1 (new 'static 'gs-test :ate #x1 :afail #x3 :zte #x1 :ztst (gs-ztest always)))
-  ;                                (alpha-1 (new 'static 'gs-alpha))
-  ;                                (tex0-1 (new 'static 'gs-tex0 :tbp0 #x3300 :tbw #x8 :tw #x9 :th #x9 :tcc #x1))
-  ;                                (tex1-1 (new 'static 'gs-tex1 :mmag #x1 :mmin #x1))
-  ;                                (clamp-1 (new 'static 'gs-clamp :wms (gs-tex-wrap-mode clamp) :wmt (gs-tex-wrap-mode clamp)))
-  ;                                (texflush 0)
-  ;                                )
-  ;         (if (or (zero? *screen-shot-work*) (= (-> *screen-shot-work* count) -1))
-  ;             (blit-displays-work-method-13 this s4-3 0 6656 8)
-  ;             )
-  ;         (reset-display-gs-state *display* s4-3)
-  ;         )
-  ;       )
-  ;     )
-  ;   )
-  ; (let ((f0-9 (-> this slow-time))
-  ;       (a2-6 (-> *time-of-day-context* filter))
-  ;       (s5-4 (new 'stack-no-clear 'vector))
-  ;       )
-  ;   (set-vector! s5-4 1.0 1.0 1.5 1.0)
-  ;   (vector4-lerp! s5-4 s5-4 a2-6 f0-9)
-  ;   (when (and (or (!= (-> s5-4 x) 1.0) (!= (-> s5-4 y) 1.0) (!= (-> s5-4 z) 1.0)) (not (get-menu-mode this)))
-  ;     (with-dma-buffer-add-bucket ((s3-0 (-> *display* frames (-> *display* on-screen) global-buf))
-  ;                                  (bucket-id tex-hud-hud-alpha)
-  ;                                  )
-  ;       (blit-displays-work-method-14 this s3-0 s5-4)
-  ;       (reset-display-gs-state *display* s3-0)
-  ;       )
-  ;     )
-  ;   )
+  
+  (when (and (-> *setting-control* user-current render) (>= (the-as uint 1) (-> this count-down)))
+    ;; handle horizontal flip by copying to fx buf, then copying back.
+    ;; this is done before any HUD/text rendering.
+    (when (and (get-horizontal-flip-flag this) (not (get-menu-mode this)))
+      (with-dma-buffer-add-bucket ((s4-2 (-> *display* frames (-> *display* on-screen) global-buf))
+                                   (bucket-id debug-no-zbuf1)
+                                   )
+        (fx-copy-buf s4-2)
+        (fx-to-raster-flipped this s4-2)
+        (reset-display-gs-state *display* s4-2)
+        )
+      )
+
+    
+    ;; draw "depth-cue" or a simple attempt at anti-aliasing. This happens before particles, and
+    ;; simply redraws the entire raster buffer, in place, with a half-pixel offset.
+    ;; you might be wondering how this is a safe thing to do, reading and writing from the same texture.
+    ;; I guess they just tested it and found that it worked.
+    ;; og:preserve-this disabled anti-aliasing
+    #|
+    (when (logtest? (vu1-renderer-mask depth-cue) (-> *display* vu1-enable-user))
+      (when (not *display-color-bars*)
+        (with-dma-buffer-add-bucket ((s4-3 (-> *display* frames (-> *display* on-screen) global-buf))
+                                     (bucket-id anti-alias)
+                                     )
+          (dma-buffer-add-gs-set s4-3
+                                 (test-1 (new 'static 'gs-test :ate #x1 :afail #x3 :zte #x1 :ztst (gs-ztest always)))
+                                 (alpha-1 (new 'static 'gs-alpha))
+                                 (tex0-1 (new 'static 'gs-tex0 :tbp0 #x3300 :tbw #x8 :tw #x9 :th #x9 :tcc #x1))
+                                 (tex1-1 (new 'static 'gs-tex1 :mmag #x1 :mmin #x1))
+                                 (clamp-1 (new 'static 'gs-clamp :wms (gs-tex-wrap-mode clamp) :wmt (gs-tex-wrap-mode clamp)))
+                                 (texflush 0)
+                                 )
+          (if (or (zero? *screen-shot-work*) (= (-> *screen-shot-work* count) -1))
+              (draw-antialias this s4-3 0 6656 8)
+              )
+          (reset-display-gs-state *display* s4-3)
+          )
+        )
+      )
+    |#
+    )
+  
+  
+  ;; apply color filter, if enabled. This is again drawn in-place in the raster buffer, before text, but
+  ;; after particles.
+  (let ((f0-9 (-> this slow-time))
+        (a2-6 (-> *time-of-day-context* filter))
+        (s5-4 (new 'stack-no-clear 'vector))
+        )
+    (set-vector! s5-4 1.0 1.0 1.5 1.0)
+    (vector4-lerp! s5-4 s5-4 a2-6 f0-9)
+    (when (and (or (!= (-> s5-4 x) 1.0) (!= (-> s5-4 y) 1.0) (!= (-> s5-4 z) 1.0)) (not (get-menu-mode this)))
+      (with-dma-buffer-add-bucket ((s3-0 (-> *display* frames (-> *display* on-screen) global-buf))
+                                   (bucket-id tex-hud-hud-alpha)
+                                   )
+        (draw-color-filter this s3-0 s5-4)
+        (reset-display-gs-state *display* s3-0)
+        )
+      )
+    )
+
+  ;; main copying function
   (cond
     ((and (-> *setting-control* user-current render) (zero? (-> this count-down)))
+     ;; run in the blit bucket of the next frame. This relies on the blit being fast enough to finish
+     ;; before the actual image starts being displayed on screen.
      (with-dma-buffer-add-bucket ((s4-5 (-> *display* frames (-> *display* on-screen) global-buf))
-                                  (bucket-id bucket3)
+                                  (bucket-id blit)
                                   )
        (dma-buffer-add-gs-set s4-5
                               (dthe (new 'static 'gs-dthe))
@@ -672,30 +753,83 @@
                                   )
            (cond
              ((or (zero? (-> this zoom-blur-texels)) (or (= (-> this zoom-blur-alpha-target) 1.0) (paused?)))
+              ;; zoom-blur is disabled.
               (let ((f0-14 (-> this slow-time))
                     (f30-0 1.0)
                     )
                 (if (!= f0-14 1.0)
                     (set! f30-0 (lerp 0.05 1.0 f0-14))
                     )
+                ;; destination is the display buffer
                 (set-display-gs-state s4-5 (-> s0-0 display-fbp) 640 s2-0 (shl #xff00 16) 0)
+                ;; draw either normal or slow-time effect.
+                ;; currently this slow-time effect is ignored by the BlitDisplays renderer
                 (if (= f30-0 1.0)
-                    (blit-displays-work-method-9 this s4-5 416 s2-0 128)
-                    (blit-displays-work-method-10 this s4-5 416 s2-0 (the int (* 128.0 f30-0)))
+                    (blit-standard this s4-5 416 s2-0 128)
+                    (blit-slow-time this s4-5 416 s2-0 (the int (* 128.0 f30-0)))
                     )
                 )
               )
              (else
+               ;; zoom-blur is enabled.
+               ;; At the start: display holds the last frame (possibly blurry)
+               ;; display is copied to FX
+               ;; FX is copied to display, with alpha = 1 (overwriting it), but with distortion
+               ;; raster is copied over display, with alpha
+               
+               ;; so the final output is:
+               ;; previous output, with distortion applied
+               ;; plus new frame with alpha applied
+               
+               ;; destination is the FX buffer (38 = #x26)
                (set-display-gs-state s4-5 38 512 416 (shl #xff00 16) 0)
+               
+               ;; source is the display buffer
                (dma-buffer-add-gs-set s4-5
                                       (tex0-1 (new 'static 'gs-tex0 :tbw #xa :tw #xa :th #x9 :tbp0 (* (-> s0-0 display-fbp) 32)))
                                       )
-               (blit-displays-work-method-11 this s4-5 s2-0)
+               
+               ;; copy from raster to FX
+               (draw-sprite-color this s4-5 s2-0)
+               
+               ;; PC Port Added Zoom Blur
+               (let ((zblur (add-pc-zoom-blur s4-5)))
+                 (vector-copy! (-> zblur pos) (-> this zoom-blur-pos))
+                 
+                 ;; if using 3D zoom blur, the blur is in world,
+                 ;; so we need to project it to a point on the screen
+                 (when (not (-> this zoom-blur-2d))
+                   (let ((projected (new-stack-vector0)))
+                     (transform-point-vector! projected (-> this zoom-blur-pos))
+                     (if (< (-> projected z) 0.0)
+                         (vector-negate! projected projected)
+                         )
+                     (+! (-> projected x) -1792.0)
+                     (+! (-> projected y) -1840.0)
+                     (vector-copy! (-> zblur pos) projected)
+                     )
+                   
+                   )
+                 (vector-copy! (-> zblur color) (-> this color))
+                 (set! (-> zblur is-2d?) (if (-> this zoom-blur-2d) 1 0))
+                 (set! (-> zblur texels) (-> this zoom-blur-texels))
+                 (set! (-> zblur alpha-current) (-> this zoom-blur-alpha-current))
+                 )
+               
+               ;; End
+               
+               ;; destination is the display buffer now
                (set-display-gs-state s4-5 s1-0 640 s2-0 (shl #xff00 16) 0)
+               ;; source is the FX buffer
                (dma-buffer-add-gs-set s4-5 (tex0-1 (new 'static 'gs-tex0 :tbp0 #x4c0 :tbw #x8 :tw #x9 :th #x9)))
+               ;; draw distorted stuff to display buffer               
                (draw-zoom-blur this s4-5 s2-0)
+               ;; read from raster buffer
                (dma-buffer-add-gs-set s4-5 (tex0-1 (new 'static 'gs-tex0 :tbp0 #x3300 :tbw #x8 :tw #x9 :th #x9)))
-               (blit-displays-work-method-9 this s4-5 416 s2-0 (the int (* 128.0 (-> this zoom-blur-alpha-current))))
+               ;; draw over the display with the raster, using alpha arg
+               (blit-standard this s4-5 416 s2-0 (the int (* 128.0 (-> this zoom-blur-alpha-current))))
+               
+               ;; draw letterbox if needed
                (when (or (!= (-> *setting-control* user-current letterbox) 0.0)
                          (< (-> *display* base-clock frame-counter) (-> *game-info* letterbox-time))
                          )
@@ -717,11 +851,12 @@
                )
              )
            )
+         
+         ;; draw the scanline effect
+         ;; currently this effect is ignored by the BlitDisplays renderer
          (when (!= (-> *setting-control* user-current scanlines) 0.0)
            (let ((v1-213 (the int (* 128.0 (-> *setting-control* user-current scanlines)))))
-             (set! (-> this line-color)
-                   (logior (logand (-> this line-color) (the-as uint #xffffffff00ffffff)) (shr (shl v1-213 56) 32))
-                   )
+             (set! (-> this line-color a) v1-213)
              (dotimes (a0-120 15)
                (set! (-> this scan-colors a0-120 w) v1-213)
                )
@@ -780,7 +915,7 @@
      )
     (else
       (with-dma-buffer-add-bucket ((s4-6 (-> *display* frames (-> *display* on-screen) global-buf))
-                                   (bucket-id bucket3)
+                                   (bucket-id blit)
                                    )
         (reset-display-gs-state *display* s4-6)
         )
@@ -790,7 +925,7 @@
       (+! (-> this count-down) -1)
       ;; og:preserve-this
       (with-dma-buffer-add-bucket ((buf (-> *display* frames (-> *display* on-screen) global-buf))
-                                   (bucket-id bucket3)
+                                   (bucket-id blit)
                                    )
         (dma-buffer-add-cnt-vif2 buf 0 (new 'static 'vif-tag :cmd (vif-cmd pc-port) :imm #x11) ;; kind - do nothing
                                  (new 'static 'vif-tag :cmd (vif-cmd pc-port)))
@@ -800,7 +935,9 @@
   (none)
   )
 
-(defmethod draw-sky ((this blit-displays-work) (arg0 dma-buffer))
+(defmethod blit-menu-mode ((this blit-displays-work) (arg0 dma-buffer))
+  "Called from the sky renderer when in menu mode.
+   Instead of clearing the screen, this combines the captured screen plus the rendered screen."
   (let ((f0-0 (-> this progress-interp))
         (v1-0 *time-of-day-context*)
         )

--- a/goal_src/jak3/engine/gfx/blit-displays.gc
+++ b/goal_src/jak3/engine/gfx/blit-displays.gc
@@ -359,6 +359,7 @@
   (none)
   )
 
+
 (defmethod fx-to-raster-flipped ((this blit-displays-work) (arg0 dma-buffer))
   (set-display-gs-state arg0 408 512 416 0 0)
   (dma-buffer-add-gs-set arg0
@@ -537,6 +538,19 @@
     )
   )
 
+(defun add-pc-color-filter ((dma-buf dma-buffer))
+  (dma-buffer-add-cnt-vif2
+    dma-buf
+    1
+    (new 'static 'vif-tag :cmd (vif-cmd pc-port) :imm #x14)
+    (new 'static 'vif-tag)
+    )
+  (let ((ret (-> dma-buf base)))
+    (&+! (-> dma-buf base) (* 16 1))
+    (the vector ret)
+    )
+  )
+
 (defmethod draw-brightness-and-contrast ((this blit-displays-work) (arg0 dma-buffer) (arg1 float) (arg2 float))
   (set-display-gs-state arg0 408 512 416 0 0)
   (let ((s4-1 (fmax 0.0 (fmin 1.0 arg2)))
@@ -597,7 +611,7 @@
 
 (defmethod do-blit-displays ((this blit-displays-work))
   (set! (-> this slow-time) (- 1.0 (-> *setting-control* user-current slow-time)))
-  
+
   ;; in-place draw on rasterization buffer to apply brightness and contrast. Added to almost
   ;; the last bucket, so it applies to HUD too.
   (let ((v1-3 (-> *setting-control* user-current)))
@@ -610,7 +624,7 @@
         )
       )
     )
-  
+
   ;; The count-down is used to delay blitting while rendering settings are propagating through
   ;; the engine. When count-down reaches 0, the changes have propagated to the raster buffer.
   ;; While counting down, the display buffer isn't updated.
@@ -619,7 +633,7 @@
       ;; if menu mode has activated, take a picture of the screen and disable almost all renderers.
       ;; generic is kept on since it renders the menu itself.
       ((and (-> this menu-mode) (not (-> this screen-copied)))
-       
+
        ;; capture the raster buffer! Instead of blitting to the display buffer, copy to the "fx buffer"
        ;; note that this runs in the blit bucket (bucket 3) and so it contains the raster buffer
        ;; from the previous frame that we'd normally copy to the display buffer.
@@ -630,7 +644,7 @@
          )
        ;; backup which renderers were enabled
        (set! (-> this vu1-enable-user-menu) (-> *display* vu1-enable-user-menu))
-       
+
        ;; og:preserve-this, was generic in the original
        ;; only render merc
        (set! (-> *display* vu1-enable-user-menu) (vu1-renderer-mask merc))
@@ -646,7 +660,7 @@
        (set! (-> this progress-interp-dest) 1.0)
        (set! (-> this progress-interp-speed) 0.033333335)
        )
-      
+
       ;; menu mode has deactivated, re-enable renderers and wait 3 frames
       ((and (not (get-menu-mode this)) (get-screen-copied this))
        (set! (-> *display* vu1-enable-user-menu) (-> this vu1-enable-user-menu))
@@ -658,7 +672,7 @@
        )
       )
     )
-  
+
   (when (and (-> *setting-control* user-current render) (>= (the-as uint 1) (-> this count-down)))
     ;; handle horizontal flip by copying to fx buf, then copying back.
     ;; this is done before any HUD/text rendering.
@@ -672,7 +686,7 @@
         )
       )
 
-    
+
     ;; draw "depth-cue" or a simple attempt at anti-aliasing. This happens before particles, and
     ;; simply redraws the entire raster buffer, in place, with a half-pixel offset.
     ;; you might be wondering how this is a safe thing to do, reading and writing from the same texture.
@@ -701,8 +715,8 @@
       )
     |#
     )
-  
-  
+
+
   ;; apply color filter, if enabled. This is again drawn in-place in the raster buffer, before text, but
   ;; after particles.
   (let ((f0-9 (-> this slow-time))
@@ -712,11 +726,15 @@
     (set-vector! s5-4 1.0 1.0 1.5 1.0)
     (vector4-lerp! s5-4 s5-4 a2-6 f0-9)
     (when (and (or (!= (-> s5-4 x) 1.0) (!= (-> s5-4 y) 1.0) (!= (-> s5-4 z) 1.0)) (not (get-menu-mode this)))
+
       (with-dma-buffer-add-bucket ((s3-0 (-> *display* frames (-> *display* on-screen) global-buf))
-                                   (bucket-id tex-hud-hud-alpha)
+                                   ;;(bucket-id tex-hud-hud-alpha)
+                                   (bucket-id blit)
+
                                    )
-        (draw-color-filter this s3-0 s5-4)
-        (reset-display-gs-state *display* s3-0)
+        (vector-copy! (add-pc-color-filter s3-0) s5-4)
+        ;; (draw-color-filter this s3-0 s5-4)
+        ;; (reset-display-gs-state *display* s3-0)
         )
       )
     )
@@ -776,26 +794,26 @@
                ;; display is copied to FX
                ;; FX is copied to display, with alpha = 1 (overwriting it), but with distortion
                ;; raster is copied over display, with alpha
-               
+
                ;; so the final output is:
                ;; previous output, with distortion applied
                ;; plus new frame with alpha applied
-               
+
                ;; destination is the FX buffer (38 = #x26)
                (set-display-gs-state s4-5 38 512 416 (shl #xff00 16) 0)
-               
+
                ;; source is the display buffer
                (dma-buffer-add-gs-set s4-5
                                       (tex0-1 (new 'static 'gs-tex0 :tbw #xa :tw #xa :th #x9 :tbp0 (* (-> s0-0 display-fbp) 32)))
                                       )
-               
+
                ;; copy from raster to FX
                (draw-sprite-color this s4-5 s2-0)
-               
+
                ;; PC Port Added Zoom Blur
                (let ((zblur (add-pc-zoom-blur s4-5)))
                  (vector-copy! (-> zblur pos) (-> this zoom-blur-pos))
-                 
+
                  ;; if using 3D zoom blur, the blur is in world,
                  ;; so we need to project it to a point on the screen
                  (when (not (-> this zoom-blur-2d))
@@ -808,27 +826,27 @@
                      (+! (-> projected y) -1840.0)
                      (vector-copy! (-> zblur pos) projected)
                      )
-                   
+
                    )
                  (vector-copy! (-> zblur color) (-> this color))
                  (set! (-> zblur is-2d?) (if (-> this zoom-blur-2d) 1 0))
                  (set! (-> zblur texels) (-> this zoom-blur-texels))
                  (set! (-> zblur alpha-current) (-> this zoom-blur-alpha-current))
                  )
-               
+
                ;; End
-               
+
                ;; destination is the display buffer now
                (set-display-gs-state s4-5 s1-0 640 s2-0 (shl #xff00 16) 0)
                ;; source is the FX buffer
                (dma-buffer-add-gs-set s4-5 (tex0-1 (new 'static 'gs-tex0 :tbp0 #x4c0 :tbw #x8 :tw #x9 :th #x9)))
-               ;; draw distorted stuff to display buffer               
+               ;; draw distorted stuff to display buffer
                (draw-zoom-blur this s4-5 s2-0)
                ;; read from raster buffer
                (dma-buffer-add-gs-set s4-5 (tex0-1 (new 'static 'gs-tex0 :tbp0 #x3300 :tbw #x8 :tw #x9 :th #x9)))
                ;; draw over the display with the raster, using alpha arg
                (blit-standard this s4-5 416 s2-0 (the int (* 128.0 (-> this zoom-blur-alpha-current))))
-               
+
                ;; draw letterbox if needed
                (when (or (!= (-> *setting-control* user-current letterbox) 0.0)
                          (< (-> *display* base-clock frame-counter) (-> *game-info* letterbox-time))
@@ -851,7 +869,7 @@
                )
              )
            )
-         
+
          ;; draw the scanline effect
          ;; currently this effect is ignored by the BlitDisplays renderer
          (when (!= (-> *setting-control* user-current scanlines) 0.0)

--- a/goal_src/jak3/engine/gfx/foreground/foreground.gc
+++ b/goal_src/jak3/engine/gfx/foreground/foreground.gc
@@ -155,7 +155,7 @@
                        (bucket-id-16 gmerc-l3-tfrag)
                        (bucket-id-16 tex-l3-tfrag)
                        (bucket-id-16 gmerc2-l3-tfrag)
-                       (bucket-id-16 bucket3)
+                       (bucket-id-16 blit)
                        (bucket-id-16 merc-l3-pris)
                        (bucket-id-16 emerc-l3-pris)
                        (bucket-id-16 gmerc-l3-pris)

--- a/goal_src/jak3/engine/gfx/hw/display-h.gc
+++ b/goal_src/jak3/engine/gfx/hw/display-h.gc
@@ -146,7 +146,7 @@ At any point in time, there are 3 frames in progress:
                                            rn32
                                            rn33
                                            rn34
-                                           rn36
+                                           depth-cue
                                            )
           )
     (set! (-> gp-0 vu1-enable-user) (vu1-renderer-mask
@@ -182,7 +182,7 @@ At any point in time, there are 3 frames in progress:
                                       rn32
                                       rn33
                                       rn34
-                                      rn36
+                                      depth-cue
                                       )
           )
     gp-0

--- a/goal_src/jak3/engine/gfx/sky/sky-tng.gc
+++ b/goal_src/jak3/engine/gfx/sky/sky-tng.gc
@@ -743,7 +743,7 @@
        (with-dma-buffer-add-bucket ((s5-2 (-> *display* frames (-> *display* on-screen) global-buf))
                                     (bucket-id sky)
                                     )
-         (draw-sky *blit-displays-work* s5-2)
+         (blit-menu-mode *blit-displays-work* s5-2)
          )
        )
       (else

--- a/goal_src/jak3/engine/gfx/vu1-user-h.gc
+++ b/goal_src/jak3/engine/gfx/vu1-user-h.gc
@@ -29,7 +29,7 @@
   (bucket0 0)
   (bucket1 1)
   (bucket2 2) ;; pc vis stuff
-  (bucket3 3) ;; blit?
+  (blit 3)
   (tex-lcom-sky-pre 4)
   (sky 5) ;; sky
   (bucket6 6) ;; ocean
@@ -660,7 +660,7 @@
   (merc-lcom-water 564)
   (gmerc-lcom-water 565)
   (gmerc2-lcom-water 566) ;; default for prim
-  (bucket567 567)
+  (anti-alias 567)
 
   (tex-sprite 568)
   (generic-sprite-1 569) ;; ;prim
@@ -733,7 +733,7 @@
   (rn33)
   (rn34)
   (rn35)
-  (rn36)
+  (depth-cue)
   (rn37)
   )
 ;; ---vu1-renderer-mask

--- a/test/decompiler/reference/jak3/engine/anim/aligner-h_REF.gc
+++ b/test/decompiler/reference/jak3/engine/anim/aligner-h_REF.gc
@@ -8,8 +8,8 @@ The animation format has two special parent-like joints: prejoint and align.
 The prejoint is the parent for all joints, so it causes all bones to move.
 The align joint has no children, but the convention is that moving align will
 cause the entire process-drawable's root to move, effectively moving the entire character.
-Most of the time, this is the preferable way to move a character as part of an animation - 
-it will update their velocity and when the animation ends or is canceled, 
+Most of the time, this is the preferable way to move a character as part of an animation -
+it will update their velocity and when the animation ends or is canceled,
 the offset in position from playing the animation will stay. For example, if Jak punches,
 his velocity will increase due to the animated align in the punch animation.
 To implement this, the align-control computes the relative transform between align frames.

--- a/test/decompiler/reference/jak3/engine/gfx/background/subdivide_REF.gc
+++ b/test/decompiler/reference/jak3/engine/gfx/background/subdivide_REF.gc
@@ -232,7 +232,7 @@
 (define GSH_ENABLE #f)
 
 ;; definition for symbol GSH_BUCKET, type bucket-id
-(define GSH_BUCKET (bucket-id bucket3))
+(define GSH_BUCKET (bucket-id blit))
 
 ;; definition for symbol GSH_WHICH_STAT, type int
 (define GSH_WHICH_STAT 1)

--- a/test/decompiler/reference/jak3/engine/gfx/blit-displays-h_REF.gc
+++ b/test/decompiler/reference/jak3/engine/gfx/blit-displays-h_REF.gc
@@ -11,7 +11,7 @@
    (line-tmpl                 dma-gif-packet  :inline)
    (scan-tmpl                 dma-gif-packet  :inline)
    (color                     vector4w        :inline)
-   (line-color                uint64)
+   (line-color                gs-rgbaq)
    (scan-colors               vector4w        15 :inline)
    (zoom-blur-pos             vector          :inline)
    (zoom-blur-count           int32)
@@ -33,18 +33,18 @@
    (slow-time                 float)
    )
   (:methods
-    (blit-displays-work-method-9 (_type_ dma-buffer int int int) none)
-    (blit-displays-work-method-10 (_type_ dma-buffer int int int) none)
-    (blit-displays-work-method-11 (_type_ dma-buffer int) none)
+    (blit-standard (_type_ dma-buffer int int int) none)
+    (blit-slow-time (_type_ dma-buffer int int int) none)
+    (draw-sprite-color (_type_ dma-buffer int) none)
     (draw-letterbox (_type_ dma-buffer float int float) none)
-    (blit-displays-work-method-13 (_type_ dma-buffer int int int) none)
-    (blit-displays-work-method-14 (_type_ dma-buffer vector) none)
-    (blit-displays-work-method-15 (_type_ dma-buffer) none)
+    (draw-antialias (_type_ dma-buffer int int int) none)
+    (draw-color-filter (_type_ dma-buffer vector) none)
+    (fx-to-raster-flipped (_type_ dma-buffer) none)
     (draw-zoom-blur (_type_ dma-buffer int) none)
     (setup-zoom-blur-2d (_type_ vector int float symbol) none)
-    (setup-brightness-and-contrast (_type_ dma-buffer float float) none)
+    (draw-brightness-and-contrast (_type_ dma-buffer float float) none)
     (do-blit-displays (_type_) none)
-    (draw-sky (_type_ dma-buffer) none)
+    (blit-menu-mode (_type_ dma-buffer) none)
     (get-menu-mode (_type_) symbol)
     (get-screen-copied (_type_) symbol)
     (get-horizontal-flip-flag (_type_) symbol)
@@ -128,7 +128,3 @@
 
 ;; failed to figure out what this is:
 0
-
-
-
-

--- a/test/decompiler/reference/jak3/engine/gfx/blit-displays_REF.gc
+++ b/test/decompiler/reference/jak3/engine/gfx/blit-displays_REF.gc
@@ -53,7 +53,7 @@
                                  :gif (new 'static 'array uint64 2 #x5020c0000000800f #x55551)
                                  )
                                :color (new 'static 'vector4w :x #x80 :y #x80 :z #x80 :w #x80)
-                               :line-color #x3f80000000000000
+                               :line-color (new 'static 'gs-rgbaq :q 1.0)
                                :scan-colors (new 'static 'inline-array vector4w 15
                                  (new 'static 'vector4w :y 1 :z 1)
                                  (new 'static 'vector4w :y 1 :z 1)
@@ -80,7 +80,8 @@
 ;; definition for method 9 of type blit-displays-work
 ;; INFO: Used lq/sq
 ;; WARN: Return type mismatch int vs none.
-(defmethod blit-displays-work-method-9 ((this blit-displays-work) (arg0 dma-buffer) (arg1 int) (arg2 int) (arg3 int))
+(defmethod blit-standard ((this blit-displays-work) (arg0 dma-buffer) (arg1 int) (arg2 int) (arg3 int))
+  "Draw a full-width quad of the given height to copy from raster to display buffer"
   (let ((v1-0 (the-as object (-> arg0 base))))
     (set! (-> (the-as (inline-array vector4w) v1-0) 0 quad) (-> this sprite-slow-tmpl dma-vif quad))
     (set! (-> (the-as (inline-array vector4w) v1-0) 1 quad) (-> this sprite-slow-tmpl quad 1))
@@ -98,7 +99,10 @@
 ;; definition for method 10 of type blit-displays-work
 ;; INFO: Used lq/sq
 ;; WARN: Return type mismatch int vs none.
-(defmethod blit-displays-work-method-10 ((this blit-displays-work) (arg0 dma-buffer) (arg1 int) (arg2 int) (arg3 int))
+(defmethod blit-slow-time ((this blit-displays-work) (arg0 dma-buffer) (arg1 int) (arg2 int) (arg3 int))
+  "Draw a full-screen triangle fan to copy from raster to display buffer.
+   The fan is centered in the center of the screen.
+   This applies a gradient of alpha from 192 at the center to arg3 at the corners."
   (let ((v1-0 (the-as object (-> arg0 base))))
     (set! (-> (the-as (inline-array vector4w) v1-0) 0 quad) (-> this draw-slow-time-tmpl dma-vif quad))
     (set! (-> (the-as (inline-array vector4w) v1-0) 1 quad) (-> this draw-slow-time-tmpl quad 1))
@@ -129,7 +133,7 @@
 ;; definition for method 11 of type blit-displays-work
 ;; INFO: Used lq/sq
 ;; WARN: Return type mismatch int vs none.
-(defmethod blit-displays-work-method-11 ((this blit-displays-work) (arg0 dma-buffer) (arg1 int))
+(defmethod draw-sprite-color ((this blit-displays-work) (arg0 dma-buffer) (arg1 int))
   (let ((v1-0 (the-as object (-> arg0 base))))
     (set! (-> (the-as (inline-array vector4w) v1-0) 0 quad) (-> this sprite-slow-tmpl dma-vif quad))
     (set! (-> (the-as (inline-array vector4w) v1-0) 1 quad) (-> this sprite-slow-tmpl quad 1))
@@ -187,7 +191,9 @@
 ;; definition for method 13 of type blit-displays-work
 ;; INFO: Used lq/sq
 ;; WARN: Return type mismatch int vs none.
-(defmethod blit-displays-work-method-13 ((this blit-displays-work) (arg0 dma-buffer) (arg1 int) (arg2 int) (arg3 int))
+(defmethod draw-antialias ((this blit-displays-work) (arg0 dma-buffer) (arg1 int) (arg2 int) (arg3 int))
+  "Draw the raster buffer on top of itself, with a half-pixel offset.
+   This is used as an antialiasing effect."
   (set-display-gs-state arg0 408 512 416 0 0)
   (dma-buffer-add-gs-set arg0 (rgbaq (new 'static 'gs-rgbaq :r #x80 :g #x80 :b #x80 :a #x80 :q 1.0)))
   (let ((v1-3 (the-as object (-> arg0 base))))
@@ -214,7 +220,7 @@
 ;; definition for method 14 of type blit-displays-work
 ;; INFO: Used lq/sq
 ;; WARN: Return type mismatch int vs none.
-(defmethod blit-displays-work-method-14 ((this blit-displays-work) (arg0 dma-buffer) (arg1 vector))
+(defmethod draw-color-filter ((this blit-displays-work) (arg0 dma-buffer) (arg1 vector))
   (set-display-gs-state arg0 408 512 416 0 0)
   (dma-buffer-add-gs-set arg0
                          (test-1 (new 'static 'gs-test :ate #x1 :afail #x3 :zte #x1 :ztst (gs-ztest always)))
@@ -256,7 +262,7 @@
 ;; definition for method 15 of type blit-displays-work
 ;; INFO: Used lq/sq
 ;; WARN: Return type mismatch int vs none.
-(defmethod blit-displays-work-method-15 ((this blit-displays-work) (arg0 dma-buffer))
+(defmethod fx-to-raster-flipped ((this blit-displays-work) (arg0 dma-buffer))
   (set-display-gs-state arg0 408 512 416 0 0)
   (dma-buffer-add-gs-set arg0
                          (test-1 (new 'static 'gs-test :ate #x1 :afail #x3 :zte #x1 :ztst (gs-ztest always)))
@@ -421,7 +427,7 @@
 ;; definition for method 18 of type blit-displays-work
 ;; INFO: Used lq/sq
 ;; WARN: Return type mismatch int vs none.
-(defmethod setup-brightness-and-contrast ((this blit-displays-work) (arg0 dma-buffer) (arg1 float) (arg2 float))
+(defmethod draw-brightness-and-contrast ((this blit-displays-work) (arg0 dma-buffer) (arg1 float) (arg2 float))
   (set-display-gs-state arg0 408 512 416 0 0)
   (let ((s4-1 (fmax 0.0 (fmin 1.0 arg2)))
         (s3-1 (fmax 0.0 (fmin 1.0 arg1)))
@@ -489,7 +495,7 @@
       (with-dma-buffer-add-bucket ((s4-0 (-> *display* frames (-> *display* on-screen) global-buf))
                                    (bucket-id debug-menu)
                                    )
-        (setup-brightness-and-contrast this s4-0 (-> v1-3 brightness) (-> v1-3 contrast))
+        (draw-brightness-and-contrast this s4-0 (-> v1-3 brightness) (-> v1-3 contrast))
         (reset-display-gs-state *display* s4-0)
         )
       )
@@ -498,7 +504,7 @@
     (cond
       ((and (-> this menu-mode) (not (-> this screen-copied)))
        (with-dma-buffer-add-bucket ((s4-1 (-> *display* frames (-> *display* on-screen) global-buf))
-                                    (bucket-id bucket3)
+                                    (bucket-id blit)
                                     )
          (fx-copy-buf s4-1)
          )
@@ -530,14 +536,14 @@
                                    (bucket-id debug-no-zbuf1)
                                    )
         (fx-copy-buf s4-2)
-        (blit-displays-work-method-15 this s4-2)
+        (fx-to-raster-flipped this s4-2)
         (reset-display-gs-state *display* s4-2)
         )
       )
-    (when (logtest? (vu1-renderer-mask rn36) (-> *display* vu1-enable-user))
+    (when (logtest? (vu1-renderer-mask depth-cue) (-> *display* vu1-enable-user))
       (when (not *display-color-bars*)
         (with-dma-buffer-add-bucket ((s4-3 (-> *display* frames (-> *display* on-screen) global-buf))
-                                     (bucket-id bucket567)
+                                     (bucket-id anti-alias)
                                      )
           (dma-buffer-add-gs-set s4-3
                                  (test-1 (new 'static 'gs-test :ate #x1 :afail #x3 :zte #x1 :ztst (gs-ztest always)))
@@ -548,7 +554,7 @@
                                  (texflush 0)
                                  )
           (if (or (zero? *screen-shot-work*) (= (-> *screen-shot-work* count) -1))
-              (blit-displays-work-method-13 this s4-3 0 6656 8)
+              (draw-antialias this s4-3 0 6656 8)
               )
           (reset-display-gs-state *display* s4-3)
           )
@@ -565,7 +571,7 @@
       (with-dma-buffer-add-bucket ((s3-0 (-> *display* frames (-> *display* on-screen) global-buf))
                                    (bucket-id tex-hud-hud-alpha)
                                    )
-        (blit-displays-work-method-14 this s3-0 s5-4)
+        (draw-color-filter this s3-0 s5-4)
         (reset-display-gs-state *display* s3-0)
         )
       )
@@ -573,7 +579,7 @@
   (cond
     ((and (-> *setting-control* user-current render) (zero? (-> this count-down)))
      (with-dma-buffer-add-bucket ((s4-5 (-> *display* frames (-> *display* on-screen) global-buf))
-                                  (bucket-id bucket3)
+                                  (bucket-id blit)
                                   )
        (dma-buffer-add-gs-set s4-5
                               (dthe (new 'static 'gs-dthe))
@@ -607,8 +613,8 @@
                     )
                 (set-display-gs-state s4-5 (-> s0-0 display-fbp) 640 s2-0 (shl #xff00 16) 0)
                 (if (= f30-0 1.0)
-                    (blit-displays-work-method-9 this s4-5 416 s2-0 128)
-                    (blit-displays-work-method-10 this s4-5 416 s2-0 (the int (* 128.0 f30-0)))
+                    (blit-standard this s4-5 416 s2-0 128)
+                    (blit-slow-time this s4-5 416 s2-0 (the int (* 128.0 f30-0)))
                     )
                 )
               )
@@ -617,12 +623,12 @@
                (dma-buffer-add-gs-set s4-5
                                       (tex0-1 (new 'static 'gs-tex0 :tbw #xa :tw #xa :th #x9 :tbp0 (* (-> s0-0 display-fbp) 32)))
                                       )
-               (blit-displays-work-method-11 this s4-5 s2-0)
+               (draw-sprite-color this s4-5 s2-0)
                (set-display-gs-state s4-5 s1-0 640 s2-0 (shl #xff00 16) 0)
                (dma-buffer-add-gs-set s4-5 (tex0-1 (new 'static 'gs-tex0 :tbp0 #x4c0 :tbw #x8 :tw #x9 :th #x9)))
                (draw-zoom-blur this s4-5 s2-0)
                (dma-buffer-add-gs-set s4-5 (tex0-1 (new 'static 'gs-tex0 :tbp0 #x3300 :tbw #x8 :tw #x9 :th #x9)))
-               (blit-displays-work-method-9 this s4-5 416 s2-0 (the int (* 128.0 (-> this zoom-blur-alpha-current))))
+               (blit-standard this s4-5 416 s2-0 (the int (* 128.0 (-> this zoom-blur-alpha-current))))
                (when (or (!= (-> *setting-control* user-current letterbox) 0.0)
                          (< (-> *display* base-clock frame-counter) (-> *game-info* letterbox-time))
                          )
@@ -646,9 +652,7 @@
            )
          (when (!= (-> *setting-control* user-current scanlines) 0.0)
            (let ((v1-213 (the int (* 128.0 (-> *setting-control* user-current scanlines)))))
-             (set! (-> this line-color)
-                   (logior (logand (-> this line-color) (the-as uint #xffffffff00ffffff)) (shr (shl v1-213 56) 32))
-                   )
+             (set! (-> this line-color a) v1-213)
              (dotimes (a0-120 15)
                (set! (-> this scan-colors a0-120 w) v1-213)
                )
@@ -707,7 +711,7 @@
      )
     (else
       (with-dma-buffer-add-bucket ((s4-6 (-> *display* frames (-> *display* on-screen) global-buf))
-                                   (bucket-id bucket3)
+                                   (bucket-id blit)
                                    )
         (reset-display-gs-state *display* s4-6)
         )
@@ -723,7 +727,7 @@
 ;; definition for method 20 of type blit-displays-work
 ;; INFO: Used lq/sq
 ;; WARN: Return type mismatch int vs none.
-(defmethod draw-sky ((this blit-displays-work) (arg0 dma-buffer))
+(defmethod blit-menu-mode ((this blit-displays-work) (arg0 dma-buffer))
   (let ((f0-0 (-> this progress-interp))
         (v1-0 *time-of-day-context*)
         )

--- a/test/decompiler/reference/jak3/engine/gfx/foreground/foreground_REF.gc
+++ b/test/decompiler/reference/jak3/engine/gfx/foreground/foreground_REF.gc
@@ -137,7 +137,7 @@
                        (bucket-id-16 gmerc-l3-tfrag)
                        (bucket-id-16 tex-l3-tfrag)
                        (bucket-id-16 gmerc2-l3-tfrag)
-                       (bucket-id-16 bucket3)
+                       (bucket-id-16 blit)
                        (bucket-id-16 merc-l3-pris)
                        (bucket-id-16 emerc-l3-pris)
                        (bucket-id-16 gmerc-l3-pris)

--- a/test/decompiler/reference/jak3/engine/gfx/hw/display-h_REF.gc
+++ b/test/decompiler/reference/jak3/engine/gfx/hw/display-h_REF.gc
@@ -189,7 +189,7 @@
                                            rn32
                                            rn33
                                            rn34
-                                           rn36
+                                           depth-cue
                                            )
           )
     (set! (-> gp-0 vu1-enable-user) (vu1-renderer-mask
@@ -225,7 +225,7 @@
                                       rn32
                                       rn33
                                       rn34
-                                      rn36
+                                      depth-cue
                                       )
           )
     gp-0

--- a/test/decompiler/reference/jak3/engine/gfx/sky/sky-tng_REF.gc
+++ b/test/decompiler/reference/jak3/engine/gfx/sky/sky-tng_REF.gc
@@ -791,7 +791,7 @@
        (with-dma-buffer-add-bucket ((s5-2 (-> *display* frames (-> *display* on-screen) global-buf))
                                     (bucket-id sky)
                                     )
-         (draw-sky *blit-displays-work* s5-2)
+         (blit-menu-mode *blit-displays-work* s5-2)
          )
        )
       (else


### PR DESCRIPTION
Add the zoom blur effect, used by cutscene effects and a few weapons:

https://github.com/user-attachments/assets/8d231b34-faf8-4b88-a636-edf2b5477ff9

And color filtering

https://github.com/user-attachments/assets/67db5933-4b29-4c77-ad56-5025cbefa328

There's still two blit-displays not covered: scanlines and the light jak slow motion effect.