### PR TITLE
[jak3] fix bomb and war factory ocean culling

### DIFF
--- a/game/graphics/opengl_renderer/TextureAnimatorDefs.cpp
+++ b/game/graphics/opengl_renderer/TextureAnimatorDefs.cpp
@@ -1263,11 +1263,11 @@ void TextureAnimator::setup_texture_anims_jak3() {
     flames.channel_masks[3] = false;
 
     FixedAnimDef hemi_gradient_flames_dest;
-    hemi_gradient_flames_dest.tex_name = "hemi-gradient-dest";
+    hemi_gradient_flames_dest.tex_name = "hemi-gradient-flames-dest";
     hemi_gradient_flames_dest.color = math::Vector4<u8>{0, 0, 0, 0x80};
     hemi_gradient_flames_dest.override_size = math::Vector2<int>(64, 64);
 
-    auto& flames0 = hemi_gradient_dest.layers.emplace_back();
+    auto& flames0 = hemi_gradient_flames_dest.layers.emplace_back();
     flames0.tex_name = "hemi-gradient-flames";
     flames0.end_time = 600.f;
     flames0.set_blend_b2_d1();

--- a/goal_src/jak3/engine/draw/drawable.gc
+++ b/goal_src/jak3/engine/draw/drawable.gc
@@ -49,6 +49,59 @@
     )
   )
 
+;; og:preserve-this
+(defun sphere-cull-for-ocean ((arg0 vector))
+  "Is the given sphere in the view frustum?
+  PC-port ocean version"
+  (local-vars (v1-0 uint128) (v1-1 uint128) (v1-2 uint128))
+  (rlet ((acc :class vf)
+         (vf0 :class vf)
+         (vf10 :class vf)
+         (vf16 :class vf)
+         (vf17 :class vf)
+         (vf18 :class vf)
+         (vf19 :class vf)
+         (vf9 :class vf)
+         )
+        ;; og:preserve-this modified for PC: these register would be loaded by the draw method of bsp.
+        (cond
+          ((-> *time-of-day-context* use-camera-other)
+           (let ((at-0 *math-camera*))
+             (.lvf vf16 (&-> at-0 plane-other 0 quad))
+             (.lvf vf17 (&-> at-0 plane-other 1 quad))
+             (.lvf vf18 (&-> at-0 plane-other 2 quad))
+             (.lvf vf19 (&-> at-0 plane-other 3 quad))
+             )
+           )
+          (else
+            (let ((at-0 *math-camera*))
+              (.lvf vf16 (&-> at-0 plane 0 quad))
+              (.lvf vf17 (&-> at-0 plane 1 quad))
+              (.lvf vf18 (&-> at-0 plane 2 quad))
+              (.lvf vf19 (&-> at-0 plane 3 quad))
+              )
+            )
+          )
+
+        (init-vf0-vector)
+        (.lvf vf10 (&-> arg0 quad))
+        (.mul.x.vf acc vf16 vf10)
+        (.add.mul.y.vf acc vf17 vf10 acc)
+        (.add.mul.z.vf acc vf18 vf10 acc)
+        (.sub.mul.w.vf vf9 vf19 vf0 acc)
+
+        ;; checking to see if we are inside all 4 planes.
+
+        ;; using the inside part of the sphere
+        (.add.w.vf vf9 vf9 vf10)
+        (.mov v1-0 vf9)
+        (.pcgtw v1-1 0 v1-0)
+        (.ppach v1-2 (the-as uint128 0) v1-1)
+        (zero? (the-as int v1-2))
+        )
+  )
+
+
 ;; ERROR: Bad vector register dependency: vf20
 ;; ERROR: Bad vector register dependency: vf21
 ;; ERROR: Bad vector register dependency: vf22

--- a/goal_src/jak3/engine/gfx/ocean/ocean-mid.gc
+++ b/goal_src/jak3/engine/gfx/ocean/ocean-mid.gc
@@ -1002,7 +1002,7 @@
         (while (>= s1-0 s2-0)
           (set! (-> sv-36 x) (+ 196608.0 (* 393216.0 (the float s2-0)) (-> this start-corner x)))
           (set! (-> sv-36 z) (+ 196608.0 (* 393216.0 (the float s4-0)) (-> this start-corner z)))
-          (when (sphere-cull sv-36)
+          (when (sphere-cull-for-ocean sv-36) ;; og:preserve-this
             (cond
               ((= s4-0 sv-34)
                (ocean-mid-add-upload-top this arg0 s4-0 s2-0)
@@ -1101,7 +1101,7 @@
             (set! (-> s3-0 y) f28-0)
             (set! (-> s3-0 z) (+ f26-0 (the float (* #x300000 s2-0))))
             (set! (-> s3-0 r) 2224365.2)
-            (when (sphere-cull s3-0)
+            (when (sphere-cull-for-ocean s3-0) ;; og:preserve-this
               (cond
                 ((< sv-48 0)
                  )

--- a/goal_src/jak3/engine/gfx/ocean/ocean-transition.gc
+++ b/goal_src/jak3/engine/gfx/ocean/ocean-transition.gc
@@ -651,7 +651,7 @@
           (while (>= s1-0 s2-0)
             (set! (-> sv-36 x) (+ 49152.0 (* 98304.0 (the float s2-0)) (-> this start-corner x)))
             (set! (-> sv-36 z) (+ 49152.0 (* 98304.0 (the float s4-0)) (-> this start-corner z)))
-            (when (sphere-cull sv-36)
+            (when (sphere-cull-for-ocean sv-36) ;; og:preserve-this
               (if (not (ocean-trans-camera-masks-bit? this s4-0 s2-0))
                   (ocean-trans-add-upload this arg0 s4-0 s2-0)
                   )
@@ -741,7 +741,7 @@
             (when (ocean-mid-camera-masks-bit? this s4-0 s2-0)
               (set! (-> sv-36 x) (+ 196608.0 (* 393216.0 (the float s2-0)) (-> this start-corner x)))
               (set! (-> sv-36 z) (+ 196608.0 (* 393216.0 (the float s4-0)) (-> this start-corner z)))
-              (if (sphere-cull sv-36)
+              (if (sphere-cull-for-ocean sv-36) ;; og:preserve-this
                   (ocean-make-trans-camera-masks this s4-0 s2-0 (- s4-0 sv-34) (- s2-0 sv-32))
                   )
               )


### PR DESCRIPTION
Fix textures on the bomb (just a simple typo fix):
<img width="1638" height="1067" alt="2025-10-05_18-22" src="https://github.com/user-attachments/assets/d31fedd4-b4f3-4e65-8457-a67068b137be" />

Fix issue with ocean culling when in the war factory. In this level, the make the background rotate by defining a different camera matrix. We need to use that matrix when culling the ocean, since it rotates too. This is different on PC because the original game stashed the camera frustum planes in some vf registers for background drawing. 

<img width="1638" height="671" alt="image" src="https://github.com/user-attachments/assets/feb5f931-e71f-411e-8a29-e8d970f70078" />

