### PR TITLE
[jak3] Decouple dust storm particles & push vector from FPS

### DIFF
--- a/goal_src/jak2/kernel/gkernel-h.gc
+++ b/goal_src/jak2/kernel/gkernel-h.gc
@@ -160,7 +160,7 @@
    (mask                       process-mask) ;; mask for ticking
    (clock-ratio                float) ;; how fast to run. 1.0 = realtime.
    (accum                      float) ;; fractional time for frame-counter (time-frame units)
-   (integral-accum             float) ;; fractional time for integral (time-frame untis)
+   (integral-accum             float) ;; fractional time for integral (time-frame units)
    (frame-counter              time-frame) ;; how much time has gone by since reset (time-frame units)
    (old-frame-counter          time-frame) ;; the frame-counter on the last engine iteration
    (integral-frame-counter     uint64) ;; how many vsyncs have gone by since reset

--- a/goal_src/jak3/levels/desert/desert-dust-storm.gc
+++ b/goal_src/jak3/levels/desert/desert-dust-storm.gc
@@ -66,6 +66,7 @@
   (set! (-> self wind-sound) (new-sound-id))
   (set! (-> self dust-storm-clock-scalar) 1.0)
   (set! (-> self is-intro?) #f)
+  (#when PC_PORT (set! (-> *duststorm-helper* sparticle-time) (- (-> self clock frame-counter) (seconds 1)))) ;; og:preserve-this fix particles spawning every frame no matter what
   (if (= arg1 'track)
       (go-virtual track)
       (go-virtual hold-pos)
@@ -519,10 +520,23 @@
         )
       (set! (-> *part-id-table* 1421 init-specs 2 initial-valuef) 61440.0)
       (set! (-> *part-id-table* 1422 init-specs 2 initial-valuef) 61440.0)
-      (if (-> this is-intro?)
-          (launch-particles (-> *part-id-table* 1422) s3-0)
-          (launch-particles (-> *part-id-table* 1421) s3-0)
+      (#cond
+        (PC_PORT
+          (when (>= (- (-> this clock frame-counter) (-> *duststorm-helper* sparticle-time)) 5) ;; og:preserve-this fix particles spawning every frame no matter what (we know 5 ticks = 1/60 frame)
+            (set! (-> *duststorm-helper* sparticle-time) (-> this clock frame-counter))
+            (if (-> this is-intro?)
+                (launch-particles (-> *part-id-table* 1422) s3-0)
+                (launch-particles (-> *part-id-table* 1421) s3-0)
+                )
+            )
           )
+        (#t
+          (if (-> this is-intro?)
+              (launch-particles (-> *part-id-table* 1422) s3-0)
+              (launch-particles (-> *part-id-table* 1421) s3-0)
+              )
+          )
+        )
       )
     )
   (none)
@@ -573,10 +587,23 @@
         (set! (-> *part-id-table* 1421 init-specs 2 initial-valuef) (lerp 20480.0 61440.0 f30-4))
         (set! (-> *part-id-table* 1422 init-specs 2 initial-valuef) (lerp 20480.0 61440.0 f30-4))
         )
-      (if (-> this is-intro?)
-          (launch-particles (-> *part-id-table* 1422) s4-0)
-          (launch-particles (-> *part-id-table* 1421) s4-0)
+      (#cond
+        (PC_PORT
+          (when (>= (- (-> this clock frame-counter) (-> *duststorm-helper* sparticle-time)) 5) ;; og:preserve-this fix particles spawning every frame no matter what (we know 5 ticks = 1/60 frame)
+            (set! (-> *duststorm-helper* sparticle-time) (-> this clock frame-counter))
+            (if (-> this is-intro?)
+                (launch-particles (-> *part-id-table* 1422) s4-0)
+                (launch-particles (-> *part-id-table* 1421) s4-0)
+                )
+            )
           )
+        (#t
+          (if (-> this is-intro?)
+              (launch-particles (-> *part-id-table* 1422) s4-0)
+              (launch-particles (-> *part-id-table* 1421) s4-0)
+              )
+          )
+        )
       )
     )
   (none)
@@ -680,7 +707,7 @@
             (send-event
               *target*
               'push-trans
-              (vector-float*! (new 'stack-no-clear 'vector) *duststorm-wind-vec* (/ (the float *duststorm-wind-vel*) 50))
+              (vector-float*! (new 'stack-no-clear 'vector) *duststorm-wind-vec* (* (/ (the float *duststorm-wind-vel*) 50) 60 (seconds-per-frame))) ;; og:preserve-this normalize speed to per-sec instead of per-frame
               (seconds 0.11)
               )
             )

--- a/goal_src/jak3/pc/pckernel-impl.gc
+++ b/goal_src/jak3/pc/pckernel-impl.gc
@@ -140,6 +140,16 @@
    )
   )
 
+
+;; duststorm fixes helper
+(deftype desert-dust-storm-helper (structure)
+  ((sparticle-time    time-frame)
+   )
+  )
+
+(define *duststorm-helper* (new 'static 'desert-dust-storm-helper))
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; resets
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
The dust storm will now always behave as if it was at 60 FPS. Particles only spawn every 1/60th of a second and the push vector is converted as if it was originally equivalent to 1/60th of a second.