### PR TITLE
Fix strange scene-player initial blackout being bad for non-zero `artist-base`

### DIFF
--- a/goal_src/jak3/engine/scene/scene.gc
+++ b/goal_src/jak3/engine/scene/scene.gc
@@ -1597,7 +1597,7 @@
           )
       )
     (when (and (-> self scene) (nonzero? (-> self skel active-channels)))
-      (when (and (< (ja-aframe-num 0) 2.0)
+      (when (and (< (ja-aframe-num 0) (+ (-> self skel root-channel 0 frame-group artist-base) 2.0)) ;; og:preserve-this account for scenes that have a non-zero artist-base (e.g. mh tower res)
                  (< (-> *display* base-clock frame-counter) (-> *game-info* blackout-time))
                  (logtest? (-> self skel status) (joint-control-status valid-spooled-frame))
                  )


### PR DESCRIPTION
This fixes the metal head tower resolution cutscene having an awkward amount of blackout at the start unless the framerate dipped to at least (most?) 33FPS, since its frame num starts in the negative. There may be other cutscenes that start at negative or higher than zero, but I don't know of any (did not check thoroughly as that's boring as hell).

I don't really understand what the purpose of this check is in the first place to be honest.