### PR TITLE
jak2, jak3: fix high fps vehicle smush

### DIFF
--- a/goal_src/jak2/levels/city/traffic/vehicle/vehicle.gc
+++ b/goal_src/jak2/levels/city/traffic/vehicle/vehicle.gc
@@ -905,7 +905,8 @@
         (cond
           ((logtest? (do-push-aways s5-0) (collide-spec jak))
            (+! (-> this overlap-player-counter) 1)
-           (when (< (the-as uint 60) (-> this overlap-player-counter))
+           ;; og:preserve-this changed for high fps
+           (when (< (the uint (/ 60.0 DISPLAY_FPS_RATIO)) (-> this overlap-player-counter))
              (send-event
                *target*
                'attack-invinc

--- a/goal_src/jak3/levels/city/ctyport-obs.gc
+++ b/goal_src/jak3/levels/city/ctyport-obs.gc
@@ -325,7 +325,8 @@
       (cond
         ((logtest? (do-push-aways s5-0) (collide-spec jak))
          (+! (-> this overlap-player-counter) 1)
-         (when (< (the-as uint 60) (-> this overlap-player-counter))
+         ;; og:preserve-this changed for high fps
+         (when (< (the uint (/ 60.0 DISPLAY_FPS_RATIO)) (-> this overlap-player-counter))
            (send-event
              *target*
              'attack-invinc

--- a/goal_src/jak3/levels/desert/wvehicle/wvehicle.gc
+++ b/goal_src/jak3/levels/desert/wvehicle/wvehicle.gc
@@ -182,7 +182,8 @@
         (cond
           ((logtest? (do-push-aways s5-0) (collide-spec jak))
            (+! (-> this overlap-player-counter) 1)
-           (when (< (the-as uint 60) (-> this overlap-player-counter))
+           ;; og:preserve-this changed for high fps
+           (when (< (the uint (/ 60.0 DISPLAY_FPS_RATIO)) (-> this overlap-player-counter))
              (send-event
                *target*
                'attack-invinc

--- a/goal_src/jak3/levels/factory/car/hvehicle.gc
+++ b/goal_src/jak3/levels/factory/car/hvehicle.gc
@@ -333,7 +333,8 @@
       (cond
         ((logtest? (do-push-aways s5-0) (collide-spec jak))
          (+! (-> this overlap-player-counter) 1)
-         (when (< (the-as uint 60) (-> this overlap-player-counter))
+         ;; og:preserve-this changed for high fps
+         (when (< (the uint (/ 60.0 DISPLAY_FPS_RATIO)) (-> this overlap-player-counter))
            (send-event
              *target*
              'attack-invinc


### PR DESCRIPTION
Prevents instantly killing Jak when exiting some vehicles at high FPS.