### PR TITLE
[jak3] Some autosplit changes

### DIFF
--- a/goal_src/jak3/levels/desert/boss/terraformer-head.gc
+++ b/goal_src/jak3/levels/desert/boss/terraformer-head.gc
@@ -2202,6 +2202,10 @@
   :virtual #t
   :event terraformer-head-always-handler
   :enter (behavior ()
+    ;; og:preserve-this
+    (#when PC_PORT
+      (when (= (-> self hit-points) 0.0)
+        (set! (-> *autosplit-info-jak3* errol-dead?) 1)))
     (terraformer-head-play-speech 3 self)
     (let ((gp-0 (get-trans self 3)))
       (cond
@@ -2605,9 +2609,6 @@
   :trans (behavior ()
     (cond
       ((= (-> self hit-points) 0.0)
-       ;; og:preserve-this
-       (#when PC_PORT
-         (set! (-> *autosplit-info-jak3* errol-dead?) 1))
        (let ((a1-0 (new 'stack-no-clear 'event-message-block)))
          (set! (-> a1-0 from) (process->ppointer self))
          (set! (-> a1-0 num-params) 0)

--- a/goal_src/jak3/pc/features/autosplit-h.gc
+++ b/goal_src/jak3/pc/features/autosplit-h.gc
@@ -153,6 +153,14 @@
    (res-desert-bbush-destroy-interceptors uint8)
    ;; TODO misc other task-nodes
    (arena-fight-1-throne                  uint8) ;; after arena 1 cutscene
+   (nest-eggs-tunnel                      uint8) ;; % warp for cave skip
+   (int-temple-climb                      uint8) ;; entering templex courtyard
+   (temple-defend-door-4                  uint8) ;; % warp for full temple skip
+   (palace-ruins-patrol-stadium           uint8) ;; % warp for palace ruins (no oob restricted)
+   (int-city-bbush-get-to-26              uint8) ;; start bbush outside mineboss exit (no oob unrestricted/easier any%+heromode palace ruins)
+   (int-city-bbush-get-to-31              uint8) ;; start bbush in new haven (harder any%+hero mode palace ruins)
+   (int-city-bbush-get-to-28              uint8) ;; start bbush closest to palace ruins (no oob restricted palace ruins)
+   (desert-final-boss-walker              uint8) ;; terraformer
    ;; TODO - orbs in level X
    ;; end marker just to make things look nice in a memory view
    (end-marker                            uint8 4))

--- a/goal_src/jak3/pc/features/autosplit.gc
+++ b/goal_src/jak3/pc/features/autosplit.gc
@@ -236,6 +236,15 @@
   (autosplit-flag-task-complete! res-desert-bbush-destroy-interceptors desert-bbush-destroy-interceptors)
   ;; misc other tasks
   (autosplit-flag-task-node-closed! arena-fight-1-throne arena-fight-1-throne) ;; after arena 1 cutscene
+  (autosplit-flag-task-node-closed! nest-eggs-tunnel nest-eggs-tunnel) ;; % warp for cave skip
+  (autosplit-flag-task-node-closed! int-temple-climb temple-climb-introduction) ;; entering templex courtyard
+  (autosplit-flag-task-node-closed! temple-defend-door-4 temple-defend-door-4) ;; % warp for full temple skip
+  (autosplit-flag-task-node-closed! palace-ruins-patrol-stadium palace-ruins-patrol-stadium) ;; % warp for palace ruins (no oob restricted)
+  (autosplit-flag-task-node-closed! int-city-bbush-get-to-26 city-bbush-get-to-26-introduction) ;; start bbush outside mineboss exit (no oob unrestricted/easier any%+heromode palace ruins)
+  (autosplit-flag-task-node-closed! int-city-bbush-get-to-31 city-bbush-get-to-31-introduction) ;; start bbush in new haven (harder any%+hero mode palace ruins)
+  (autosplit-flag-task-node-closed! int-city-bbush-get-to-28 city-bbush-get-to-28-introduction) ;; start bbush closest to palace ruins (no oob restricted palace ruins)
+  (autosplit-flag-task-node-closed! desert-final-boss-walker desert-final-boss-walker) ;; terraformer
+
   ;; debug only, draw stuff to the screen so i don't have to stare at a memory editor
   (if AUTOSPLITTER_DEBUG (debug-draw this)))
 


### PR DESCRIPTION
Adds some additional autosplit points that I think will be useful. 

Also tweaks the `errol-dead?` condition to update immediately on the final hit (there's a sec or so of animation before it returns to `initial-state`, where it was being updated previously)

Corresponding autosplitter updates: https://github.com/open-goal/speedrunning/pull/27