### PR TITLE
[jak3] Fix temple % warp split

### DIFF
--- a/goal_src/jak3/pc/features/autosplit-h.gc
+++ b/goal_src/jak3/pc/features/autosplit-h.gc
@@ -155,7 +155,7 @@
    (arena-fight-1-throne                  uint8) ;; after arena 1 cutscene
    (nest-eggs-tunnel                      uint8) ;; % warp for cave skip
    (int-temple-climb                      uint8) ;; entering templex courtyard
-   (temple-defend-door-4                  uint8) ;; % warp for full temple skip
+   (int-temple-defend                     uint8) ;; % warp for full temple skip (use intro instead of defend-door-4 since that's un-closed by restart mission)
    (palace-ruins-patrol-stadium           uint8) ;; % warp for palace ruins (no oob restricted)
    (int-city-bbush-get-to-26              uint8) ;; start bbush outside mineboss exit (no oob unrestricted/easier any%+heromode palace ruins)
    (int-city-bbush-get-to-31              uint8) ;; start bbush in new haven (harder any%+hero mode palace ruins)

--- a/goal_src/jak3/pc/features/autosplit.gc
+++ b/goal_src/jak3/pc/features/autosplit.gc
@@ -238,7 +238,7 @@
   (autosplit-flag-task-node-closed! arena-fight-1-throne arena-fight-1-throne) ;; after arena 1 cutscene
   (autosplit-flag-task-node-closed! nest-eggs-tunnel nest-eggs-tunnel) ;; % warp for cave skip
   (autosplit-flag-task-node-closed! int-temple-climb temple-climb-introduction) ;; entering templex courtyard
-  (autosplit-flag-task-node-closed! temple-defend-door-4 temple-defend-door-4) ;; % warp for full temple skip
+  (autosplit-flag-task-node-closed! int-temple-defend temple-defend-introduction) ;; % warp for full temple skip (use intro instead of defend-door-4 since that's un-closed by restart mission)
   (autosplit-flag-task-node-closed! palace-ruins-patrol-stadium palace-ruins-patrol-stadium) ;; % warp for palace ruins (no oob restricted)
   (autosplit-flag-task-node-closed! int-city-bbush-get-to-26 city-bbush-get-to-26-introduction) ;; start bbush outside mineboss exit (no oob unrestricted/easier any%+heromode palace ruins)
   (autosplit-flag-task-node-closed! int-city-bbush-get-to-31 city-bbush-get-to-31-introduction) ;; start bbush in new haven (harder any%+hero mode palace ruins)


### PR DESCRIPTION
I realized this `temple-defend-door-4` was getting triggered twice, once during the temple skip % warp, then again when entering palace ruins % warp (because it's un-closed by a restart mission, since the overall `temple-defend` task isn't closed). `temple-defend-introduction` remains closed after the restart mission, so works better here.