### PR TITLE
[jak3] Fix audio language setting

### DIFF
--- a/goal_src/jak3/pc/progress/progress-static-pc.gc
+++ b/goal_src/jak3/pc/progress/progress-static-pc.gc
@@ -484,7 +484,7 @@ This gives us more freedom to write code how we want.
 
 (defmacro game-options-pc-sound-language ()
   `(new 'static 'menu-generic-carousel-option
-      :name (text-id progress-language)
+      :name (text-id progress-audio-language)
       :items (new 'static 'boxed-array :type text-id
                   (text-id progress-language-english)
                   (text-id progress-language-french)
@@ -499,9 +499,9 @@ This gives us more freedom to write code how we want.
                   (text-id progress-language-dutch)
                   (text-id progress-language-english-uk)
                   )
-      :get-item-index-fn (lambda () (-> *setting-control* user-default language))
+      :get-item-index-fn (lambda () (-> *setting-control* user-default audio-language))
       :on-confirm (lambda ((index int) (the-progress progress))
-          (set! (-> *setting-control* user-default language) (the-as language-enum index)))))
+          (set! (-> *setting-control* user-default audio-language) (the-as language-enum index)))))
 
 (defmacro game-options-pc-text-language ()
   `(new 'static 'menu-generic-carousel-option
@@ -536,6 +536,7 @@ This gives us more freedom to write code how we want.
                   )
       :get-item-index-fn (lambda () (-> *pc-settings* text-language))
       :on-confirm (lambda ((index int) (the-progress progress))
+          (set! (-> *setting-control* user-default language) (the-as language-enum index))
           (set! (-> *pc-settings* text-language) (the-as pc-language index))
           ;; NOTE - this doesn't actually work (naughty dog tried it too in their progress code)
           (load-level-text-files (the-as int (-> *pc-settings* text-language)))


### PR DESCRIPTION
Rename `Language` to `Audio Language` in the menu, and connect it to `audio-language` instead of `language`.

After this change, we have:
<img width="559" height="322" alt="image" src="https://github.com/user-attachments/assets/d928a91b-6184-4bde-b147-aa08f22b02d2" />


where 

- Subtitle Language controls `subtitle-language` on both PC settings and the normal setting control (unchanged)
- Audio Language controls `audio-language` on setting-control
- Text Language controls `text-language` on PC settings and `language` on setting control. The game looks at `(-> *setting-control* user-default language)` to determine text scaling sometimes, so I think it's good for this to set both.