### PR TITLE
jak1: fix high fps menu sliders

### DIFF
--- a/goal_src/jak1/pc/progress-pc.gc
+++ b/goal_src/jak1/pc/progress-pc.gc
@@ -2300,11 +2300,11 @@
                    ;; slider is selected
                    (cond
                      ((>= (-> (the-as (pointer float) (-> options (-> obj option-index) value-to-modify)))
-                          (+ (-> options (-> obj option-index) slider-step-size) (-> options (-> obj option-index) param1)))
+                          (+ (* (-> options (-> obj option-index) slider-step-size) DISPLAY_FPS_RATIO) (-> options (-> obj option-index) param1)))
                       ;; we're 1 above minimum, so reduce by 1
                       (set! (-> (the-as (pointer float) (-> options (-> obj option-index) value-to-modify)))
                             (- (-> (the-as (pointer float) (-> options (-> obj option-index) value-to-modify)))
-                               (-> options (-> obj option-index) slider-step-size)))
+                               (* (-> options (-> obj option-index) slider-step-size) DISPLAY_FPS_RATIO)))
                       (set! sound? #t))
                      ((< (-> options (-> obj option-index) param1)
                          ;; not at least 1 above minimum, just set to minimum (why not just use max or something!!)
@@ -2384,10 +2384,10 @@
                 (case (-> options (-> obj option-index) option-type)
                   (((game-option-type slider))
                    (cond
-                     ((>= (- (-> options (-> obj option-index) param2) (-> options (-> obj option-index) slider-step-size))
+                     ((>= (- (-> options (-> obj option-index) param2) (* (-> options (-> obj option-index) slider-step-size) DISPLAY_FPS_RATIO))
                           (-> (the-as (pointer float) (-> options (-> obj option-index) value-to-modify))))
                       (set! (-> (the-as (pointer float) (-> options (-> obj option-index) value-to-modify)))
-                            (+ (-> options (-> obj option-index) slider-step-size)
+                            (+ (* (-> options (-> obj option-index) slider-step-size) DISPLAY_FPS_RATIO)
                                (-> (the-as (pointer float) (-> options (-> obj option-index) value-to-modify)))))
                       (set! sound? #t))
                      ((< (-> (the-as (pointer float) (-> options (-> obj option-index) value-to-modify)))


### PR DESCRIPTION
Menu sliders are very slippery at high FPS and make it touchy and difficult to select precisely:

https://github.com/user-attachments/assets/3c9b9ae5-0c1f-4a3a-bb18-1bfae5396b6d

