### PR TITLE
Prevent array OOB access for traffic-height-map

### DIFF
--- a/goal_src/jak2/levels/city/common/height-map.gc
+++ b/goal_src/jak2/levels/city/common/height-map.gc
@@ -103,7 +103,8 @@
          (a1-7
            (the-as
              (pointer int8)
-             (+ (+ (min a2-0 (+ v1-0 -2)) (* (min a1-1 (+ a3-0 -2)) v1-0) 0) (the-as int (the-as pointer (-> this data))))
+             ;; og:preserve-this prevent array out-of-bounds access
+             (+ (+ (min (max 0 a2-0) (+ v1-0 -2)) (* (min (max 0 a1-1) (+ a3-0 -2)) v1-0) 0) (the-as int (the-as pointer (-> this data))))
              )
            )
          (f3-3 (the float (-> a1-7 0)))

--- a/goal_src/jak3/levels/city/common/height-map.gc
+++ b/goal_src/jak3/levels/city/common/height-map.gc
@@ -95,7 +95,8 @@
          (a1-7
            (the-as
              (pointer int8)
-             (+ (+ (min a2-0 (+ v1-0 -2)) (* (min a1-1 (+ a3-0 -2)) v1-0) 0) (the-as int (the-as pointer (-> this data))))
+             ;; og:preserve-this prevent array out-of-bounds access
+             (+ (+ (min (max 0 a2-0) (+ v1-0 -2)) (* (min (max 0 a1-1) (+ a3-0 -2)) v1-0) 0) (the-as int (the-as pointer (-> this data))))
              )
            )
          (f3-3 (the float (-> a1-7 0)))


### PR DESCRIPTION
If the `arg0` vector has extreme values, `a2-0` and `a1-1` can end up being negative, which leads to out-of-bounds access when using these values to read from the `xz-height-map`'s `data` array, and crashes the game (you can pretty easily reproduce this in jak 3 by overcharging the "superfasthoverbikeglitch")

The `min` here already makes sure these values don't go too high, but doesn't cover the case when they go negative.

As I understand it, this `data` in the `*traffic-height-map*` functions as a 2d array, bucketing x/z coordinates into heights for the vehicle.