### PR TITLE
[jak2/jak3] Wait to reset autosplitter until after blackout

### DIFF
--- a/goal_src/jak1/pc/features/speedruns.gc
+++ b/goal_src/jak1/pc/features/speedruns.gc
@@ -169,7 +169,7 @@
   ;; turn on speedrun verification display and flip flag for setting up speedrun after initialize!
   (true! (-> *speedrun-info* should-display?))
   (true! (-> *speedrun-info* needs-post-blackout-setup?))
-  ;; reset has-started? flag so we can flip it back to #t when jak touches ground
+  ;; reset has-started? flag so we can flip it back to #t when jak touches ground/out of blackout
   (false! (-> *speedrun-info* has-started?))
   ;; start new game with specified category, if any (otherwise we're resetting current category)
   (if category (set! (-> *speedrun-info* category) category))

--- a/goal_src/jak2/engine/game/game-save.gc
+++ b/goal_src/jak2/engine/game/game-save.gc
@@ -5,6 +5,8 @@
 ;; name in dgo: game-save
 ;; dgos: ENGINE, GAME
 
+(define-extern mark-speedrun-started (function none))
+
 ;; NOTE - for default-menu
 (declare-type auto-save process)
 (define-extern auto-save-command (function symbol int int process-tree symbol (pointer auto-save)))
@@ -1178,6 +1180,9 @@
             )
       )
     )
+  ;; og:preserve-this make sure loading a save doesn't reset speedrun state
+  (when (and (-> *pc-settings* speedrunner-mode?) (zero? (-> arg0 new-game)))
+    (mark-speedrun-started))
   (when (nonzero? (-> arg0 new-game))
     (case (-> arg0 new-game)
       ((2)

--- a/goal_src/jak2/pc/features/speedruns-h.gc
+++ b/goal_src/jak2/pc/features/speedruns-h.gc
@@ -100,6 +100,7 @@
 
 (deftype speedrun-info (structure)
   ((category speedrun-category)
+   (has-started? symbol)
    (active-custom-category speedrun-custom-category)
    (dump-custom-category speedrun-custom-category)
    (display-run-info? symbol)

--- a/goal_src/jak2/pc/features/speedruns.gc
+++ b/goal_src/jak2/pc/features/speedruns.gc
@@ -65,10 +65,10 @@
   (none))
 
 (defmethod start-run! ((this speedrun-info))
-  ;; randomize game id so the autosplitter knows to restart
-  (reset! *autosplit-info-jak2*)
   ;; turn on speedrun verification display
-  (set! (-> this display-run-info?) #t)
+  (true! (-> this display-run-info?))
+  ;; reset has-started? flag so we can flip it back to #t when jak touches ground/out of blackout
+  (false! (-> *speedrun-info* has-started?))
   (send-event (ppointer->process *speedrun-manager*) 'start-run)
   ;; ensure any required settings are enabled
   (enforce-settings! this)
@@ -393,6 +393,10 @@
   (go-virtual idle)
   (none))
 
+(defun mark-speedrun-started ()
+  (true! (-> *speedrun-info* has-started?))
+  (none))
+
 (defmethod update! ((this speedrun-info))
   "A per frame update for speedrunning related stuff"
   ;; Ensure the speedrunner menu process is enabled or destroyed
@@ -404,6 +408,21 @@
     (deactivate (-> *speedrun-manager* 0)))
   ;; do speedrunner mode things
   (when (-> *pc-settings* speedrunner-mode?)
+    ;; Check if run/autosplitter should be started (out of blackout and player has control of jak)
+    (when (and (not (-> *speedrun-info* has-started?))
+               *target*
+               ;; not in blackout
+               (>= (-> *display* base-clock frame-counter) (-> *game-info* blackout-time))
+               (!= (-> *setting-control* user-current bg-a-force) 1.0)
+               ;; target has landed on ground/water, or we're about to enter target-hit-ground state
+               (or (logtest? (-> *target* control status) (collide-status on-ground on-surface on-water))
+                   (= (-> *target* next-state name) 'target-hit-ground)))
+      (mark-speedrun-started)
+      ;; spawn a process that resets autosplitter after suspending for 1 frame
+      (process-spawn-function process
+        (lambda ()
+          (suspend)
+          (reset! *autosplit-info-jak2*))))
     ;; Update auto-splitter struct
     (update! *autosplit-info-jak2*)
     ;; see if we should stop drawing the run info (when you escape the fortress!)

--- a/goal_src/jak3/engine/game/game-save.gc
+++ b/goal_src/jak3/engine/game/game-save.gc
@@ -5,6 +5,8 @@
 ;; name in dgo: game-save
 ;; dgos: GAME
 
+(define-extern mark-speedrun-started (function none))
+
 ;; +++game-save-elt
 (defenum game-save-elt
   :type uint16
@@ -1788,6 +1790,9 @@
             )
       )
     )
+  ;; og:preserve-this make sure loading a save doesn't reset speedrun state
+  (when (and (-> *pc-settings* speedrunner-mode?) (zero? (-> arg0 new-game)))
+    (mark-speedrun-started))
   (when (nonzero? (-> arg0 new-game))
     (case (-> arg0 new-game)
       ((2)

--- a/goal_src/jak3/pc/features/speedruns-h.gc
+++ b/goal_src/jak3/pc/features/speedruns-h.gc
@@ -100,6 +100,7 @@
 
 (deftype speedrun-info (structure)
   ((category                            speedrun-category)
+   (has-started? symbol)
    (active-custom-category              speedrun-custom-category)
    (dump-custom-category                speedrun-custom-category)
    (display-run-info?                   symbol)

--- a/goal_src/jak3/pc/features/speedruns.gc
+++ b/goal_src/jak3/pc/features/speedruns.gc
@@ -143,10 +143,10 @@
                 darkeco))
 
 (defmethod start-run! ((this speedrun-info))
-  ;; randomize game id so the autosplitter knows to restart
-  (reset! *autosplit-info-jak3*)
   ;; turn on speedrun verification display
   (true! (-> this display-run-info?))
+  ;; reset has-started? flag so we can flip it back to #t when jak touches ground/out of blackout
+  (false! (-> *speedrun-info* has-started?))
   (send-event (ppointer->process *speedrun-manager*) 'start-run)
   ;; ensure any required settings are enabled
   (enforce-settings! this)
@@ -634,6 +634,10 @@
   (set! (-> *speedrun-info* waiting-to-record-practice-attempt?) #f)
   (go-virtual idle))
 
+(defun mark-speedrun-started ()
+  (true! (-> *speedrun-info* has-started?))
+  (none))
+
 (defmethod update! ((this speedrun-info))
   "A per frame update for speedrunning related stuff"
   ;; Ensure the speedrunner menu process is enabled or destroyed
@@ -643,6 +647,21 @@
     (deactivate (-> *speedrun-manager* 0)))
   ;; do speedrunner mode things
   (when (-> *pc-settings* speedrunner-mode?)
+    ;; Check if run/autosplitter should be started (out of blackout and player has control of jak)
+    (when (and (not (-> *speedrun-info* has-started?))
+               *target*
+               ;; not in blackout
+               (>= (-> *display* base-clock frame-counter) (-> *game-info* blackout-time))
+               (!= (-> *setting-control* user-current bg-a-force) 1.0)
+               ;; target has landed on ground/water, or we're about to enter target-hit-ground state
+               (or (logtest? (-> *target* control status) (collide-status on-ground on-surface on-water))
+                   (= (-> *target* next-state name) 'target-hit-ground)))
+      (mark-speedrun-started)
+      ;; spawn a process that resets autosplitter after suspending for 1 frame
+      (process-spawn-function process
+        (lambda ()
+          (suspend)
+          (reset! *autosplit-info-jak3*))))
     ;; Update auto-splitter struct
     (update! *autosplit-info-jak3*)
     ;; see if we should stop drawing the run info (when you finish arena training)


### PR DESCRIPTION
Based on [similar changes we made awhile back for jak1](https://github.com/open-goal/jak-project/pull/3902) - this way runners don't need to figure out the -0.3s offset or whatever, and it won't vary based on where they reset from.