### PR TITLE
[jak1] MP ILs - dont spawn the column that klaww breaks during cutscene

### DIFF
--- a/goal_src/jak1/levels/ogre/ogreboss.gc
+++ b/goal_src/jak1/levels/ogre/ogreboss.gc
@@ -794,7 +794,10 @@
 (defstate ogreboss-idle (ogreboss)
   :enter
     (behavior ()
-      (when (zero? (-> self try-count))
+      (when (#if PC_PORT
+              ;; og:preserve-this skip intro cutscene (and breakable column spawning) for Mountain Pass IL speedruns
+              (and (zero? (-> self try-count)) (not (and PC_PORT (is-speedrun-category? 'il-ogre))))
+              (zero? (-> self try-count)))
         (let ((gp-0 (manipy-spawn (-> self root trans) (-> self entity) *ogreboss-column-sg* #f :to self)))
           (set! (-> self column) (ppointer->handle gp-0))
           (send-event (ppointer->process gp-0) 'anim-mode 'loop)


### PR DESCRIPTION
Small thing I only noticed from the Gordon & Daxter mod since you skip klaww and go through where this column spawns.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2ea74b77-47db-4783-8917-d0b616dd1820" />
