### PR TITLE
[jak2/jak3] Unbreak split boxes debug option

### DIFF
--- a/goal_src/jak2/engine/level/region.gc
+++ b/goal_src/jak2/engine/level/region.gc
@@ -85,7 +85,7 @@
 
 (defmethod debug-draw-region ((this drawable-region-prim) (arg0 int))
   (#when PC_PORT
-    (when (and *debug-region-hide-empty* (not (or (-> this region on-enter) (-> this region on-exit) (-> this region on-inside))))
+    (when (and *debug-region-hide-empty* (nonzero? (-> this region)) (not (or (-> this region on-enter) (-> this region on-exit) (-> this region on-inside))))
       ;; no scripts to run means the region is "empty" so do not render (unless enabled)
       (return 0)))
   (local-vars (sv-32 vector2h) (sv-36 vector))
@@ -247,7 +247,7 @@ otherwise, add the [[drawable-region-sphere]] to `region-start-prim-list` and in
 
 (defmethod debug-draw-region ((this drawable-region-sphere) (arg0 int))
   (#when PC_PORT
-    (when (and *debug-region-hide-empty* (not (or (-> this region on-enter) (-> this region on-exit) (-> this region on-inside))))
+    (when (and *debug-region-hide-empty* (nonzero? (-> this region)) (not (or (-> this region on-enter) (-> this region on-exit) (-> this region on-inside))))
       ;; no scripts to run means the region is "empty" so do not render (unless enabled)
       (return 0)))
   (let ((t9-0 (method-of-type drawable-region-prim debug-draw-region)))
@@ -294,7 +294,7 @@ otherwise, add the [[drawable-region-sphere]] to `region-start-prim-list` and in
 
 (defmethod debug-draw-region ((this drawable-region-face) (arg0 int))
   (#when PC_PORT
-    (when (and *debug-region-hide-empty* (not (or (-> this region on-enter) (-> this region on-exit) (-> this region on-inside))))
+    (when (and *debug-region-hide-empty* (nonzero? (-> this region)) (not (or (-> this region on-enter) (-> this region on-exit) (-> this region on-inside))))
       ;; no scripts to run means the region is "empty" so do not render (unless enabled)
       (return 0)))
   (when (zero? arg0)
@@ -421,7 +421,7 @@ otherwise, add the [[drawable-region-sphere]] to `region-start-prim-list` and in
 
 (defmethod debug-draw-region ((this drawable-region-volume) (arg0 int))
   (#when PC_PORT
-    (when (and *debug-region-hide-empty* (not (or (-> this region on-enter) (-> this region on-exit) (-> this region on-inside))))
+    (when (and *debug-region-hide-empty* (nonzero? (-> this region)) (not (or (-> this region on-enter) (-> this region on-exit) (-> this region on-inside))))
       ;; no scripts to run means the region is "empty" so do not render (unless enabled)
       (return 0)))
   (let ((t9-0 (method-of-type drawable-region-prim debug-draw-region)))

--- a/goal_src/jak3/engine/level/region.gc
+++ b/goal_src/jak3/engine/level/region.gc
@@ -203,7 +203,7 @@
 
 (defmethod debug-draw-region ((this drawable-region-sphere) (arg0 int))
   (#when PC_PORT
-    (when (and *debug-region-hide-empty* (not (or (-> this region on-enter) (-> this region on-exit) (-> this region on-inside))))
+    (when (and *debug-region-hide-empty* (nonzero? (-> this region)) (not (or (-> this region on-enter) (-> this region on-exit) (-> this region on-inside))))
       ;; no scripts to run means the region is "empty" so do not render (unless enabled)
       (return 0)))
   (let ((t9-0 (method-of-type drawable-region-prim debug-draw-region)))
@@ -242,7 +242,7 @@
 
 (defmethod debug-draw-region ((this drawable-region-face) (arg0 int))
   (#when PC_PORT
-    (when (and *debug-region-hide-empty* (not (or (-> this region on-enter) (-> this region on-exit) (-> this region on-inside))))
+    (when (and *debug-region-hide-empty* (nonzero? (-> this region)) (not (or (-> this region on-enter) (-> this region on-exit) (-> this region on-inside))))
       ;; no scripts to run means the region is "empty" so do not render (unless enabled)
       (return 0)))
   (when (zero? arg0)


### PR DESCRIPTION
The `Split Boxes` option in jak2/3 currently crashes as soon as you select it because of the `*debug-region-hide-empty*` code added in openGOAL. The split boxes aren't true regions, but they reuse the `debug-draw-region` functions, and crash trying to access `(-> this region on-enter)`.

<img width="2160" height="1620" alt="image" src="https://github.com/user-attachments/assets/e8753fcc-8234-40fa-9278-d2dca4dff71a" />
yay split boxes