### PR TITLE
[jak3] Scale sandstorm push effect to better match PS2

### DIFF
--- a/goal_src/jak3/levels/desert/desert-dust-storm.gc
+++ b/goal_src/jak3/levels/desert/desert-dust-storm.gc
@@ -707,7 +707,7 @@
             (send-event
               *target*
               'push-trans
-              (vector-float*! (new 'stack-no-clear 'vector) *duststorm-wind-vec* (* (/ (the float *duststorm-wind-vel*) 50) 60 (seconds-per-frame))) ;; og:preserve-this normalize speed to per-sec instead of per-frame
+              (vector-float*! (new 'stack-no-clear 'vector) *duststorm-wind-vec* (* *duststorm-wind-vel* (seconds-per-frame))) ;; og:preserve-this normalize speed to per-sec instead of per-frame, and nerf to better match PS2 fps
               (seconds 0.11)
               )
             )


### PR DESCRIPTION
Took @ManDude 's suggestion to make the sandstorm's push effect on Jak slightly less aggressive, to better match the effect on PS2 where it never hits 60fps. This was especially noticeable in finalboss. Tested at higher FPS as well