### PR TITLE
crowdin: reference jak 3 files

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -26,3 +26,20 @@ files:
       - "en-GB"
       - "fi"
       - "fi-Fi"
+  - source: /game/assets/jak3/text/game_custom_text_en-US.json
+    translation: /game/assets/jak3/text/game_custom_text_%locale%.json
+  - source: /game/assets/jak3/subtitle/subtitle_lines_en-US.json
+    translation: /game/assets/jak3/subtitle/subtitle_lines_%locale%.json
+    excluded_target_languages:
+      - "fr-FR"
+      - "de-DE"
+      - "es-ES"
+      - "it"
+      - "it-IT"
+      - "ja-JP"
+      - "ko"
+      - "en-GB"
+      - "fi"
+      - "fi-Fi"
+      - "ru-RU"
+      - "pt-PT"


### PR DESCRIPTION
Hopefully the excluded languages are correct, it's a bit hard to tell without testing since there seems to be some languages/localization in the original game that was abandoned / not complete.

So some of these (depending on the version you use as well) may only be partially done in the final games and will require translation -- which is a perfect job for a translator to investigate.