### PR TITLE
[jak3] Update progress code to use DPROCESS_STACK_SIZE

### DIFF
--- a/goal_src/jak3/engine/ui/progress/progress.gc
+++ b/goal_src/jak3/engine/ui/progress/progress.gc
@@ -12,7 +12,7 @@
 
 (kmemopen global "progress-data")
 
-(define *progress-stack* (the-as (pointer uint8) (malloc 'global #x3800)))
+(define *progress-stack* (the-as (pointer uint8) (malloc 'global DPROCESS_STACK_SIZE)))
 
 (define *progress-process* (the-as (pointer progress) #f))
 
@@ -493,7 +493,7 @@
         (set-menu-mode *blit-displays-work* #t)
         )
       (set! *progress-process*
-            (process-spawn progress arg1 :name "progress" :to arg0 :stack (&-> *progress-stack* 14336))
+            (process-spawn progress arg1 :name "progress" :to arg0 :stack (&-> *progress-stack* DPROCESS_STACK_SIZE))
             )
       (set-master-mode 'progress)
       )


### PR DESCRIPTION
Mirroring [changes from jak2](https://github.com/open-goal/jak-project/commit/ba12d804f7a6bed6e3c3dd7b6928bce5c02edb86#diff-a2dfc3363ae440ca32fdf57325fdbcd942fc0155877df70f12c447b9924d54a4), this was actually causing crashes when opening Mission menu in modbase