### PR TITLE
jak3: remove `-debug` from critical load-game logging function

### DIFF
--- a/.vs/launch.vs.json
+++ b/.vs/launch.vs.json
@@ -227,6 +227,20 @@
     {
       "type": "default",
       "project": "CMakeLists.txt",
+      "projectTarget": "gk.exe (bin\\gk.exe)",
+      "name": "Game - Jak 3 - Runtime (release)",
+      "args": [
+        "-v",
+        "--game",
+        "jak3",
+        "--",
+        "-boot",
+        "-fakeiso"
+      ]
+    },
+    {
+      "type": "default",
+      "project": "CMakeLists.txt",
       "projectTarget": "goalc.exe (bin\\goalc.exe)",
       "name": "REPL - Jak 1",
       "args": [

--- a/goal_src/jak3/engine/game/game-save.gc
+++ b/goal_src/jak3/engine/game/game-save.gc
@@ -114,7 +114,7 @@
 
 ;; DECOMP BEGINS
 
-(defun-debug game-save-elt->string ((arg0 game-save-elt))
+(defun game-save-elt->string ((arg0 game-save-elt))
   (case arg0
     (((game-save-elt video-mode))
      "video-mode"


### PR DESCRIPTION
Closes #4183

Jak 2 didn't have this logging call so its fine, but jak 3 added this which is a nice idea.  TLDR - there's some settings we stopped loading from the memcard as the source of truth, this function (`load-game...`) skips said portions of the save file and in jak 3, includes a helpful log message.

It constructed that log message by calling a `defun-debug` function, which means that in retail mode, that function is gone, instead of that being a straight forward crash, it returns garbage, which is passed to `format`, which causes the crash.  Fix is simple, make it a non-debug function so it's always available.

Feels like something that could be improved about `goalc` but, be-careful with debug only functions is the take away.

This would seem to impact any save file that wrote these related tags (and thus, triggered the logging code) but it might also be semi-random with how unlucky you get with the returned garbage addr