### PR TITLE
Adjust projectile focus fix to also work on semi-solid targets + fix tracking issues with dm-tentacles

### DIFF
--- a/goal_src/jak3/engine/collide/find-nearest.gc
+++ b/goal_src/jak3/engine/collide/find-nearest.gc
@@ -102,7 +102,7 @@
                     (let* ((s2-1 (get-trans (the-as process-focusable s3-0) 3))
                            (f30-0 (- (vector-vector-distance (-> gp-0 point) s2-1) (-> s2-1 w)))
                            )
-                      (when (#if PC_PORT  (and (nonzero? (-> s0-0 root-prim prim-core collide-as)) (or (not (-> *pc-settings* fix-projectile-focus)) (logtest? (collide-action solid) (-> s0-0 root-prim prim-core action))))
+                      (when (#if PC_PORT  (and (nonzero? (-> s0-0 root-prim prim-core collide-as)) (or (not (-> *pc-settings* fix-projectile-focus)) (logtest? (collide-action solid semi-solid) (-> s0-0 root-prim prim-core action))))
                                           (nonzero? (-> s0-0 root-prim prim-core collide-as)))
                         (let ((s0-1 (search-info-flag)))
                           0.0

--- a/goal_src/jak3/engine/target/gun/gun-util.gc
+++ b/goal_src/jak3/engine/target/gun/gun-util.gc
@@ -6,7 +6,7 @@
 ;; dgos: GAME
 
 (defmacro pc-check-focus-fix (focusable)
-  `(#if PC_PORT (or (not (-> *pc-settings* fix-projectile-focus)) (logtest? (collide-action solid) (-> ,focusable root root-prim prim-core action))) #t))
+  `(#if PC_PORT (or (not (-> *pc-settings* fix-projectile-focus)) (logtest? (collide-action solid semi-solid) (-> ,focusable root root-prim prim-core action))) #t))
 
 ;; DECOMP BEGINS
 

--- a/goal_src/jak3/levels/desert/boss/deswalk-obs.gc
+++ b/goal_src/jak3/levels/desert/boss/deswalk-obs.gc
@@ -1245,8 +1245,17 @@
     (dm-tentacle-adjust-collision 12 0)
     (logclear! (-> self flags) (dm-tentacle-flag dt7))
     (set! (-> self hit-points) 10.0)
+    (#when PC_PORT ;; og:preserve-this fix dead tentacles being targetable
+        (set! (-> self root root-prim prim-core action) (collide-action solid)))
     )
   :code sleep-code
+  :post (behavior ()
+    (#when PC_PORT ;; og:preserve-this fix dead tentacles being targetable
+      (if (or (not (-> *pc-settings* fix-projectile-focus)))
+          (set! (-> self root root-prim prim-core action) (collide-action solid))
+          (set! (-> self root root-prim prim-core action) (collide-action)))
+      )
+    )
   )
 
 (defstate strike (dm-tentacle)


### PR DESCRIPTION
Fixes #4177 

Also additionally fixes the setting not doing anything to the terraformer tentacles. Tentacles are no longer considered 'solid' when dead while the setting is on.