### PR TITLE
[jak3] Fix some things relating to resetting speedruns

### DIFF
--- a/goal_src/jak3/engine/ui/progress/progress.gc
+++ b/goal_src/jak3/engine/ui/progress/progress.gc
@@ -228,7 +228,12 @@
 
 (defun progress-intro-start ()
   (set! (-> *game-info* mode) 'play)
-  (initialize! *game-info* 'game (the-as game-save #f) "intro-start" (the-as resetter-spec #f))
+  ;; og:preserve-this start speedrun from title screen
+  (cond
+    ((= (-> *pc-settings* speedrunner-mode?) #t)
+      (start-run! *speedrun-info*))
+    (else
+      (initialize! *game-info* 'game (the-as game-save #f) "intro-start" (the-as resetter-spec #f))))
   (set-master-mode 'game)
   0
   )

--- a/goal_src/jak3/levels/wascity/wasall-obs.gc
+++ b/goal_src/jak3/levels/wascity/wasall-obs.gc
@@ -348,6 +348,11 @@
 (defstate attacking-0 (tentacle)
   :virtual #t
   :event tentacle-attack-handler
+  ;; og:preserve-this make sure tentacle-loop sound isn't orphaned and looping forever
+  :exit (behavior ()
+    (when (and (!= (-> self next-state name) 'attacking-1) (!= (-> self next-state name) 'kill-player))
+      (sound-stop (-> self sound-id-loop)))
+    )
   :trans (behavior ()
     (set! (-> self sound-id-attack)
           (add-process *gui-control* self (gui-channel background) (gui-action queue) "tentacle" -99.0 0)
@@ -452,6 +457,8 @@
     (if *target*
         (send-event *target* 'end-mode 'bot)
         )
+    ;; og:preserve-this make sure tentacle-loop sound isn't orphaned and looping forever
+    (sound-stop (-> self sound-id-loop))
     )
   :code (behavior ()
     (ja-channel-push! 1 0)

--- a/goal_src/jak3/pc/features/speedruns.gc
+++ b/goal_src/jak3/pc/features/speedruns.gc
@@ -670,8 +670,10 @@
           (reset! *autosplit-info-jak3*))))
     ;; Update auto-splitter struct
     (update! *autosplit-info-jak3*)
-    ;; see if we should stop drawing the run info (when you finish arena training)
-    (when (and (!= (-> this category) (speedrun-category custom)) (task-complete? *game-info* (game-task arena-training-1)))
+    ;; see if we should stop drawing the run info (when you finish arena training, but also make sure at least 10s have passed)
+    (when (and (!= (-> this category) (speedrun-category custom))
+               (task-complete? *game-info* (game-task arena-training-1))
+               (time-elapsed? (-> this run-started-at) (seconds 10)))
       (false! (-> this display-run-info?)))
     ;; Draw info to the screen
     (when (and (not (-> *speedrun-info* practicing?)) (-> this display-run-info?))
@@ -786,6 +788,6 @@
           (reset! (-> *speedrun-info* active-practice-objective)))
         (when (and (-> *speedrun-info* display-run-info?)
                    (= (-> *speedrun-info* category) (speedrun-category custom))
-                   (time-elapsed? (-> *speedrun-info* run-started-at) (seconds 15)))
+                   (time-elapsed? (-> *speedrun-info* run-started-at) (seconds 10)))
           (false! (-> *speedrun-info* display-run-info?)))
         (suspend))))


### PR DESCRIPTION
addresses:
- starting new game from title screen with speedrun mode on -> shows intro cutscene, doesn't start autosplitter, verification text not shown
  - resetting run during intro cutscene leaves weird desert state across training course (not an issue if we fix^)
- reset in hero mode after completing training course -> verification text not shown
- resetting during tentacle grab leaves the water bubble sound playing forever