### PR TITLE
[jak2/jak3] Fix off by one bug in trick display

### DIFF
--- a/goal_src/jak2/engine/target/board/target-board.gc
+++ b/goal_src/jak2/engine/target/board/target-board.gc
@@ -46,7 +46,7 @@
   (when (not (-> this combo-in-progress?))
     (set! (-> this combo-in-progress?) #t)
     (reset-combo! this))
-  (when (< (-> this num-tricks-in-combo) 15)
+  (when (< (-> this num-tricks-in-combo) 16)
     (set! (-> this tricks-in-combo (-> this num-tricks-in-combo)) trick)
     (set! (-> this num-tricks-in-combo) (inc (-> this num-tricks-in-combo)))
     (set! (-> this points-in-combo) (+ (-> this points-in-combo) points)))

--- a/goal_src/jak3/engine/target/board/target-board.gc
+++ b/goal_src/jak3/engine/target/board/target-board.gc
@@ -26,7 +26,7 @@
   (when (not (-> this combo-in-progress?))
     (set! (-> this combo-in-progress?) #t)
     (reset-combo! this))
-  (when (< (-> this num-tricks-in-combo) 15)
+  (when (< (-> this num-tricks-in-combo) 16)
     (set! (-> this tricks-in-combo (-> this num-tricks-in-combo)) trick)
     (set! (-> this num-tricks-in-combo) (inc (-> this num-tricks-in-combo)))
     (set! (-> this points-in-combo) (+ (-> this points-in-combo) points)))


### PR DESCRIPTION
fixes #3150 

the scoring system counts up to 16 (point-scoring) tricks, but the opengoal-secret display system was ignoring the 16th one, causing score discrepancies