### PR TITLE
[jak3] Prevent NaN propagation in spydroid attack state

### DIFF
--- a/goal_src/jak3/levels/common/enemy/spydroid.gc
+++ b/goal_src/jak3/levels/common/enemy/spydroid.gc
@@ -745,6 +745,9 @@
         (when a0-2
           (let ((s5-0 (new 'stack-no-clear 'vector)))
             (vector-copy! s5-0 (get-trans a0-2 3))
+            ;; og:preserve-this prevent NaN propagation - if bullseye-joint (3) returns NaNs, fall back to root trans (0)
+            (when (is-nan? (-> s5-0 x))
+              (vector-copy! s5-0 (get-trans a0-2 0)))
             (vector-! gp-0 s5-0 (-> self root trans))
             )
           )


### PR DESCRIPTION
Another patch to prevent NaN propagation. Still doesn't address the root cause of the NaNs, but should fix some mission behavior.

In some cases, crimson-guards will [return NaN vectors for their `bullseye-joint`](https://github.com/open-goal/jak-project/blob/1dff57182004f058848b26f0f8bfbb111a96e480/goal_src/jak3/engine/ai/enemy.gc#L178-L183). I suspect the root cause of these NaNs may be related to the guards missing their torsos

<img width="1202" height="692" alt="image" src="https://github.com/user-attachments/assets/c1a91266-cd50-44f9-80cb-de9b9415d36b" />

In the [spydroid's `attack` state](https://github.com/open-goal/jak-project/blob/1dff57182004f058848b26f0f8bfbb111a96e480/goal_src/jak3/levels/common/enemy/spydroid.gc#L743-L772), this NaN value will end up propagating to the spydroid's position.

This in turn causes issues like the infinite looping addressed in #4225. Or another issue in "Defend HQ From Attack" - every spydroid spawned by the task manager can end up with NaN positions. The spydroids will be nowhere to be seen, but the task-manager still considers them alive and won't spawn any other KG enemies.