### PR TITLE
[jak3] Fix Daxter's death quotes scenes not playing

### DIFF
--- a/decompiler/config/jak3/ntsc_v1/stack_structures.jsonc
+++ b/decompiler/config/jak3/ntsc_v1/stack_structures.jsonc
@@ -195,8 +195,9 @@
   "(code target-hit)": [[16, "vector"]],
   "apply-pos-from-entity": [[208, "collide-query"]],
   "target-death-main": [
-    [16, "event-message-block"],
-    [96, ["array", "level", 1]]
+    [16, "event-message-block"]
+    // this wrong stack cast was the reason Daxter's death quotes scenes didn't work
+    //[96, ["array", "level", 1]]
   ],
   "find-nearest-focusable": [[48, "vector"]],
   "target-gun-joint-pre0": [

--- a/goal_src/jak3/engine/target/target-death.gc
+++ b/goal_src/jak3/engine/target/target-death.gc
@@ -1905,7 +1905,9 @@
         (send-event self 'blend-shape #t)
         (apply-settings *setting-control*)
         (flag-setup)
-        (let ((sv-96 (the-as level #f)))
+        ;; og:preserve-this - fix daxter death quotes scenes not playing
+        ;(let ((sv-96 (the-as level #f)))
+        (let ((sv-96 (level-get-target-inside *level*)))
           (art-group-get-by-name *level* "daxter-highres" (new 'stack-no-clear 'array 'level 1))
           (let ((s4-1 (if (and sv-96 (nonzero? (-> sv-96 entity)) (> (-> sv-96 entity length) 0))
                           (-> sv-96 entity data 0 entity)

--- a/goal_src/jak3/engine/target/target-death.gc
+++ b/goal_src/jak3/engine/target/target-death.gc
@@ -1905,10 +1905,8 @@
         (send-event self 'blend-shape #t)
         (apply-settings *setting-control*)
         (flag-setup)
-        ;; og:preserve-this - fix daxter death quotes scenes not playing
-        ;(let ((sv-96 (the-as level #f)))
-        (let ((sv-96 (level-get-target-inside *level*)))
-          (art-group-get-by-name *level* "daxter-highres" (new 'stack-no-clear 'array 'level 1))
+        (let ((sv-96 (the-as level #f)))
+          (art-group-get-by-name *level* "daxter-highres" (& sv-96))
           (let ((s4-1 (if (and sv-96 (nonzero? (-> sv-96 entity)) (> (-> sv-96 entity length) 0))
                           (-> sv-96 entity data 0 entity)
                           )

--- a/test/decompiler/reference/jak3/engine/target/target-death_REF.gc
+++ b/test/decompiler/reference/jak3/engine/target/target-death_REF.gc
@@ -1949,7 +1949,7 @@
         (apply-settings *setting-control*)
         (flag-setup)
         (let ((sv-96 (the-as level #f)))
-          (art-group-get-by-name *level* "daxter-highres" (new 'stack-no-clear 'array 'level 1))
+          (art-group-get-by-name *level* "daxter-highres" (& sv-96))
           (let ((s4-1 (if (and sv-96 (nonzero? (-> sv-96 entity)) (> (-> sv-96 entity length) 0))
                           (-> sv-96 entity data 0 entity)
                           )


### PR DESCRIPTION
This PR fixes a bug in `target-death.gc` that was causing Daxter's death quotes scenes to not play in OpenGoal. 

Basically, these scenes weren’t working because `sv-96` was assigned an invalid level, and as a result the `s4-1` check always returned `#f`. So, the `(when s4-1 ...)` block that contains the logic for these scenes was never executed.

<img width="1118" height="911" alt="png1" src="https://github.com/user-attachments/assets/b92505f0-fa9b-4499-a113-b7524265c314" />

## Before the fix:

https://github.com/user-attachments/assets/58e2f412-814b-40ff-ab64-d22054a7232e

## After the fix:

https://github.com/user-attachments/assets/bf6ac0da-1a62-4cb4-b363-20af898dac7f



