### PR TITLE
jak3: fix dark eco vent powerup anim

### DIFF
--- a/goal_src/jak3/engine/common-obs/vent.gc
+++ b/goal_src/jak3/engine/common-obs/vent.gc
@@ -324,7 +324,8 @@
       (if (and (time-elapsed? (-> self pickup-time) (seconds 0.1))
                (not (logtest? (-> self fact options) (actor-option no-reaction)))
                )
-          (send-event proc 'powerup)
+          ;; og:preserve-this this was called without any event args
+          (send-event proc 'powerup (pickup-type eco-pill-light) (-> *FACT-bank* eco-full-inc))
           )
       (set-time! (-> self pickup-time))
       #f
@@ -527,7 +528,8 @@
       (if (and (time-elapsed? (-> self pickup-time) (seconds 0.1))
                (not (logtest? (-> self fact options) (actor-option no-reaction)))
                )
-          (send-event proc 'powerup)
+          ;; og:preserve-this this was called without any event args
+          (send-event proc 'powerup (pickup-type eco-pill-dark) (-> *FACT-bank* eco-full-inc))
           )
       (set-time! (-> self pickup-time))
       #f


### PR DESCRIPTION
Yet another case of the PS2 getting insanely lucky with buggy ND code, the eco vents send an event to Jak to make him go into the powerup state, but do not pass any event arguments which determine what animation to play and at what speed/start frame. For the dark eco vents, PS2 manages to somehow get the correct value of `7`, but we are not so lucky.

As a side effect of this fix, we also get the originally intended behavior for the light eco vents of playing the full powerup animation from the start at a slower speed, rather than the much shorter one you see on PS2.

Closes #4268 