### PR TITLE
fix: Make port arg usable

### DIFF
--- a/game/main.cpp
+++ b/game/main.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv) {
   app.add_flag("--version", show_version, "Display the built revision");
   app.add_option("-g,--game", game_name, "The game name: 'jak1' or 'jak2'");
   app.add_flag("-v,--verbose", verbose_logging, "Enable verbose logging on stdout");
-  app.add_flag(
+  app.add_option(
       "--port", port_number,
       "Specify port number for listener connection (default is 8112 for Jak 1 and 8113 for Jak 2)");
   app.add_flag("--no-avx2", disable_avx2, "Disable AVX2 for testing");

--- a/game/runtime.cpp
+++ b/game/runtime.cpp
@@ -90,7 +90,7 @@ u8* g_ee_main_mem = nullptr;
 std::thread::id g_main_thread_id = std::thread::id();
 GameVersion g_game_version = GameVersion::Jak1;
 BackgroundWorker g_background_worker;
-int g_server_port = DECI2_PORT;
+int g_server_port = DECI2_PORT - 1 + (int)g_game_version;
 
 namespace {
 
@@ -106,7 +106,7 @@ void deci2_runner(SystemThreadInterface& iface) {
   std::function<bool()> shutdown_callback = [&]() { return iface.get_want_exit(); };
 
   // create and register server
-  Deci2Server server(shutdown_callback, DECI2_PORT - 1 + (int)g_game_version);
+  Deci2Server server(shutdown_callback, g_server_port);
   ee::LIBRARY_sceDeci2_register(&server);
 
   // now its ok to continue with initialization


### PR DESCRIPTION
This fix makes the --port arg usable, so you can override the default port
Useful if you want to bind to multiple instances of the same game at the same time

Example: `/gk -v --port 8130 --game {{.GAME}} -- -boot -fakeiso -debug`