### PR TITLE
[jak2/3] Fix dark/light eco HUD not flashing after save file is X hours old

### DIFF
--- a/goal_src/jak2/engine/ui/hud-classes.gc
+++ b/goal_src/jak2/engine/ui/hud-classes.gc
@@ -187,8 +187,8 @@
   (set-as-offset-from! (-> this sprites 7) (-> this sprites 8 pos) 40 40)
   (set-as-offset-from! (-> this sprites 21) (-> this sprites 8 pos) 25 25)
   (let ((v1-12
-          ;; og:preserve-this use base-clock instead of game-clock so it keeps flashing after file is X hours old
-          (+ (the int (* 127.0 (sin (* 182.04445 (the float (* (-> *display* base-clock frame-counter) 2)))))) 127)
+          ;; og:preserve-this mod by 360 to avoid sine breaking at high float values (fix flash effect breaking after X hours)
+          (+ (the int (* 127.0 (sin (degrees (mod (* (-> *display* game-clock frame-counter) 2) 360))))) 127)
           )
         )
     (set! (-> this sprites 1 color x) v1-12)
@@ -367,8 +367,8 @@
        (set! (-> this sprites 0 scale-x) 1.5)
        (set! (-> this sprites 0 scale-y) 1.5)
        (let ((v1-31
-               ;; og:preserve-this use base-clock instead of game-clock so it keeps flashing after file is X hours old
-               (+ (the int (* 15.0 (sin (* 182.04445 (the float (* (-> *display* base-clock frame-counter) 4)))))) 160)
+               ;; og:preserve-this mod by 360 to avoid sine breaking at high float values (fix flash effect breaking after X hours)
+               (+ (the int (* 15.0 (sin (degrees (mod (* (-> *display* game-clock frame-counter) 4) 360))))) 160)
                )
              )
          (set! (-> this sprites 0 color x) v1-31)

--- a/goal_src/jak2/engine/ui/hud-classes.gc
+++ b/goal_src/jak2/engine/ui/hud-classes.gc
@@ -187,7 +187,8 @@
   (set-as-offset-from! (-> this sprites 7) (-> this sprites 8 pos) 40 40)
   (set-as-offset-from! (-> this sprites 21) (-> this sprites 8 pos) 25 25)
   (let ((v1-12
-          (+ (the int (* 127.0 (sin (* 182.04445 (the float (* (-> *display* game-clock frame-counter) 2)))))) 127)
+          ;; og:preserve-this use base-clock instead of game-clock so it keeps flashing after file is X hours old
+          (+ (the int (* 127.0 (sin (* 182.04445 (the float (* (-> *display* base-clock frame-counter) 2)))))) 127)
           )
         )
     (set! (-> this sprites 1 color x) v1-12)
@@ -366,7 +367,8 @@
        (set! (-> this sprites 0 scale-x) 1.5)
        (set! (-> this sprites 0 scale-y) 1.5)
        (let ((v1-31
-               (+ (the int (* 15.0 (sin (* 182.04445 (the float (* (-> *display* game-clock frame-counter) 4)))))) 160)
+               ;; og:preserve-this use base-clock instead of game-clock so it keeps flashing after file is X hours old
+               (+ (the int (* 15.0 (sin (* 182.04445 (the float (* (-> *display* base-clock frame-counter) 4)))))) 160)
                )
              )
          (set! (-> this sprites 0 color x) v1-31)

--- a/goal_src/jak3/engine/ui/hud-classes.gc
+++ b/goal_src/jak3/engine/ui/hud-classes.gc
@@ -137,7 +137,8 @@
     ((nonzero? (-> this values 5 current))
      (let ((f30-1
              (the float
-                  (+ (the int (* 127.0 (sin (* 182.04445 (the float (-> *display* game-clock frame-counter)))))) 127)
+                  ;; og:preserve-this use base-clock instead of game-clock so it keeps flashing after file is X hours old
+                  (+ (the int (* 127.0 (sin (* 182.04445 (the float (-> *display* base-clock frame-counter)))))) 127)
                   )
              )
            )
@@ -164,7 +165,8 @@
                                                     2
                                                     1
                                                     )
-                                                (-> *display* game-clock frame-counter)
+                                                ;; og:preserve-this use base-clock instead of game-clock so it keeps flashing after file is X hours old
+                                                (-> *display* base-clock frame-counter)
                                                 )
                                        )
                         )

--- a/goal_src/jak3/engine/ui/hud-classes.gc
+++ b/goal_src/jak3/engine/ui/hud-classes.gc
@@ -137,8 +137,8 @@
     ((nonzero? (-> this values 5 current))
      (let ((f30-1
              (the float
-                  ;; og:preserve-this use base-clock instead of game-clock so it keeps flashing after file is X hours old
-                  (+ (the int (* 127.0 (sin (* 182.04445 (the float (-> *display* base-clock frame-counter)))))) 127)
+                  ;; og:preserve-this mod by 360 to avoid sine breaking at high float values (fix flash effect breaking after X hours)
+                  (+ (the int (* 127.0 (sin (degrees (mod (-> *display* game-clock frame-counter) 360))))) 127)
                   )
              )
            )
@@ -161,14 +161,15 @@
              (+ 0.5
                 (* 0.5
                    (sin
-                     (* 182.04445 (the float (* (if (>= (-> this values 2 current) (the int (-> *FACT-bank* darkjak-bomb-min)))
+                     ;; og:preserve-this mod by 360 to avoid sine breaking at high float values (fix flash effect breaking after X hours)
+                     (degrees (mod (* (if (>= (-> this values 2 current) (the int (-> *FACT-bank* darkjak-bomb-min)))
                                                     2
                                                     1
                                                     )
-                                                ;; og:preserve-this use base-clock instead of game-clock so it keeps flashing after file is X hours old
-                                                (-> *display* base-clock frame-counter)
+                                                (-> *display* game-clock frame-counter)
                                                 )
-                                       )
+                                   360
+                                   )
                         )
                      )
                    )


### PR DESCRIPTION
Once `(-> *display* game-clock frame-counter)` gets too large, in the HUD flashing math the `sin` function breaks down at high values. It's effectively reading the number of ticks (times a multiplier) as degrees, so we can modulo that by 360 to avoid breaking `sin`

This applies to both the eco meter and the dark jak icon in jak 2 - the icon stops flashing twice as early because it's multiplied by x4 vs the eco meter x2. 

example:

you can see dark jak icon stops flashing around 2:36:02
https://youtu.be/3V2GneLSY14?t=9362

and dark eco meter stops flashing between 4:30 and 4:37
https://youtu.be/3V2GneLSY14?t=16235
https://youtu.be/3V2GneLSY14?t=16619