### PR TITLE
jak2: add missing inline declaration in `vector*!`

### DIFF
--- a/goal_src/jak2/engine/math/vector.gc
+++ b/goal_src/jak2/engine/math/vector.gc
@@ -62,6 +62,7 @@
 
 (defun vector*! ((arg0 vector) (arg1 vector) (arg2 vector))
   "Elementwise product. Set w = 1"
+  (declare (inline))
   (rlet ((vf0 :class vf)
          (vf4 :class vf)
          (vf5 :class vf)


### PR DESCRIPTION
as per the description of #3846 
"Detect use of vector*!, which is **inlined in jak 2** and jak 3."

This function was missing the inline declaration resulting in the compiled output differing.