### PR TITLE
Support identical imgui controller labels

### DIFF
--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -166,12 +166,18 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
         if (ImGui::TreeNode(label.c_str())) {
           const auto num_controllers =
               Display::GetMainDisplay()->get_input_manager()->get_num_controllers();
+          std::unordered_map<std::string, int> controller_name_counts;
           for (int i = 0; i < num_controllers; i++) {
             const auto controller_name =
                 Display::GetMainDisplay()->get_input_manager()->get_controller_name(i);
+            int count = controller_name_counts[controller_name]++;
+            std::string display_name = controller_name;
+            if (count > 0) {
+              display_name += " (" + std::to_string(count) + ")";
+            }
             auto is_controller_active =
                 Display::GetMainDisplay()->get_input_manager()->get_controller_index(port) == i;
-            if (ImGui::RadioButton(controller_name.c_str(), is_controller_active)) {
+            if (ImGui::RadioButton(display_name.c_str(), is_controller_active)) {
               Display::GetMainDisplay()->get_input_manager()->set_controller_for_port(i, port);
             }
           }

--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -173,7 +173,7 @@ void OpenGlDebugGui::draw(const DmaStats& dma_stats) {
             int count = controller_name_counts[controller_name]++;
             std::string display_name = controller_name;
             if (count > 0) {
-              display_name += " (" + std::to_string(count) + ")";
+              display_name = fmt::format("{} ({})", display_name, count);
             }
             auto is_controller_active =
                 Display::GetMainDisplay()->get_input_manager()->get_controller_index(port) == i;


### PR DESCRIPTION
ImGUI does have ways to make sure the Internal IDs are unique and separate from the display label, however I still thought that appending a count to the end of the name was more clear/understandable.

If you add `ImGui::PushID(i);` Into the loop it appends i to the end of the internal ID without modifying the display label. The other alternative would be to use a syntax like `ImGui::Button((controller_name + "##option1").c_str());` etc....
https://github.com/ocornut/imgui/blob/master/docs/FAQ.md#q-how-can-i-have-multiple-widgets-with-the-same-label


In both cases I think just adding a number that increments communicates that its a different controller cleaner to the user.

Closes #4289
