### PR TITLE
jak3: make actor LOD setting affect lightning quality in elec gates

### DIFF
--- a/goal_src/jak3/levels/common/elec-gate.gc
+++ b/goal_src/jak3/levels/common/elec-gate.gc
@@ -446,6 +446,9 @@
                                             (-> self params min-dist)
                                             )
               )
+          ;; og:preserve-this changed for PC port so lightning can always render from farther than 2 inches away...
+          (#when PC_PORT
+              (if (not (-> *pc-settings* ps2-lod-dist?)) (set! (-> self lightning-quality) 1.0)))
         )
       )
     (let ((gp-1 (+ (the int (* 5.0 (-> self lightning-quality))) 1)))


### PR DESCRIPTION
Carrying this over from Jak 2, where it significantly improved the elec gates' look at a distance.