### PR TITLE
decompiler: `extract_anim` model name remap

### DIFF
--- a/decompiler/level_extractor/extract_anim.cpp
+++ b/decompiler/level_extractor/extract_anim.cpp
@@ -257,11 +257,43 @@ void extract_animations(const ObjectFileData& ag_data,
         frames_ref.byte_offset += 4;
       }
     }
-    // this should catch 99% of cases, but there could be mismatches between
-    // master art names and model names
-    out[master_art_name + "-lod0"].anims.push_back(ja);
-    // out[master_art_name + "-lod1"].anims.push_back(ja);
-    // out[master_art_name + "-lod2"].anims.push_back(ja);
+    // some master art groups and model names do not match, this remaps the model name based on the
+    // animation name prefix for these rare exceptions
+    PerGameVersion<std::vector<std::string>> mdl_name_remap{
+        {},
+        {
+            "collectables-bomb-blast",
+            "collectables-health",
+            "collectables-gem",
+            "collectables-generic-blast",
+            "collectables-generic-ripples",
+            "collectables-skill",
+        },
+        {
+            "collectables-bomb-blast",
+            "collectables-health",
+            "collectables-gem",
+            "collectables-generic-blast",
+            "collectables-generic-ripples",
+            "collectables-skill",
+            "collectables-warp-time",
+        },
+        {},
+    };
+    auto lst = mdl_name_remap[version];
+    auto remap = std::ranges::find_if(lst.begin(), lst.end(), [&](const std::string& prefix) {
+      return ja.name.find(prefix) != std::string::npos;
+    });
+    if (remap != lst.end()) {
+      const auto& mdl_prefix = *remap;
+      out[mdl_prefix + "-lod0"].anims.push_back(ja);
+      // out[mdl_name + "-lod1"].anims.push_back(ja);
+      // out[mdl_name + "-lod2"].anims.push_back(ja);
+    } else {
+      out[master_art_name + "-lod0"].anims.push_back(ja);
+      // out[master_art_name + "-lod1"].anims.push_back(ja);
+      // out[master_art_name + "-lod2"].anims.push_back(ja);
+    }
   }
 }
 }  // namespace decompiler


### PR DESCRIPTION
In some rare cases, the master art group and model names do not match for some animations (`collectables-ag` is a prime example for Jak 2/3, which contains multiple different models).