### PR TITLE
jak1/2/3: fix high fps slowdown

### DIFF
--- a/goal_src/jak1/engine/gfx/hw/display.gc
+++ b/goal_src/jak1/engine/gfx/hw/display.gc
@@ -62,7 +62,7 @@
   (-> this time-ratio))
 
 ;; new constant for use in high FPS scenarios
-(defconstant DISPLAY_FPS_RATIO (/ (-> *display* time-factor) 5.0))
+(defconstant DISPLAY_FPS_RATIO (/ (* (-> *display* time-factor) (-> *display* time-ratio)) 5))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; DISPLAY ENV and DRAW ENV

--- a/goal_src/jak1/engine/gfx/hw/display.gc
+++ b/goal_src/jak1/engine/gfx/hw/display.gc
@@ -62,7 +62,7 @@
   (-> this time-ratio))
 
 ;; new constant for use in high FPS scenarios
-(defconstant DISPLAY_FPS_RATIO (/ (* (-> *display* time-factor) (-> *display* time-ratio)) 5))
+(defconstant DISPLAY_FPS_RATIO (/ (* (-> *display* time-factor) (-> *display* time-ratio)) 5.0))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; DISPLAY ENV and DRAW ENV

--- a/goal_src/jak2/engine/gfx/hw/display.gc
+++ b/goal_src/jak2/engine/gfx/hw/display.gc
@@ -10,7 +10,7 @@
 ;(defconstant DMA_BUFFER_DEBUG_SIZE (* 8 1024 1024)) ;; 8M
 (defconstant DMA_BUFFER_DEBUG_SIZE (* 12 1024 1024)) ;; expand to 12M because we can
 
-(defconstant DISPLAY_FPS_RATIO (/ (-> *display* time-factor) 5.0))
+(defconstant DISPLAY_FPS_RATIO (/ (* (-> *display* time-factor) (-> *display* dog-ratio)) 5))
 
 ;; DECOMP BEGINS
 

--- a/goal_src/jak2/engine/gfx/hw/display.gc
+++ b/goal_src/jak2/engine/gfx/hw/display.gc
@@ -10,7 +10,7 @@
 ;(defconstant DMA_BUFFER_DEBUG_SIZE (* 8 1024 1024)) ;; 8M
 (defconstant DMA_BUFFER_DEBUG_SIZE (* 12 1024 1024)) ;; expand to 12M because we can
 
-(defconstant DISPLAY_FPS_RATIO (/ (* (-> *display* time-factor) (-> *display* dog-ratio)) 5))
+(defconstant DISPLAY_FPS_RATIO (/ (* (-> *display* time-factor) (-> *display* dog-ratio)) 5.0))
 
 ;; DECOMP BEGINS
 

--- a/goal_src/jak3/engine/gfx/hw/display.gc
+++ b/goal_src/jak3/engine/gfx/hw/display.gc
@@ -10,7 +10,7 @@
 (defconstant DMA_BUFFER_DEBUG_SIZE (* 8 1024 1024)) ;; 8M
 ;; (defconstant DMA_BUFFER_DEBUG_SIZE (* 12 1024 1024)) ;; expand to 12M because we can
 
-(defconstant DISPLAY_FPS_RATIO (/ (-> *display* time-factor) 5.0))
+(defconstant DISPLAY_FPS_RATIO (/ (* (-> *display* time-factor) (-> *display* dog-ratio)) 5))
 
 ;; DECOMP BEGINS
 

--- a/goal_src/jak3/engine/gfx/hw/display.gc
+++ b/goal_src/jak3/engine/gfx/hw/display.gc
@@ -10,7 +10,7 @@
 (defconstant DMA_BUFFER_DEBUG_SIZE (* 8 1024 1024)) ;; 8M
 ;; (defconstant DMA_BUFFER_DEBUG_SIZE (* 12 1024 1024)) ;; expand to 12M because we can
 
-(defconstant DISPLAY_FPS_RATIO (/ (* (-> *display* time-factor) (-> *display* dog-ratio)) 5))
+(defconstant DISPLAY_FPS_RATIO (/ (* (-> *display* time-factor) (-> *display* dog-ratio)) 5.0))
 
 ;; DECOMP BEGINS
 


### PR DESCRIPTION
`DISPLAY_FPS_RATIO` shrinks values relative to the higher rate of operations when the framerate is higher.

However, currently it always applies the limit needed for the full framerate, even when the game is not running at full speed.

During slowdown, this causes a slower speed for anything adjusted by `DISPLAY_FPS_RATIO`, compared to everything else in the game.

This small fix incorperates slowdown into `DISPLAY_FPS_RATIO`, syncing the speeds of everything during slowdown and eliminating the strange speedups/slowdowns of things when the game lags.

Tested at various framerates in Jak 1/2/3.

This also has the positive side effect of correctly boosting values during slowdown at regular 60 FPS.