### PR TITLE
jak3: fix zoom blur flashbang in retail

### DIFF
--- a/game/graphics/opengl_renderer/BlitDisplays.cpp
+++ b/game/graphics/opengl_renderer/BlitDisplays.cpp
@@ -167,6 +167,8 @@ void BlitDisplays::do_zoom_blur(SharedRenderState* render_state, ScopedProfilerN
   // GL Setup
   glDisable(GL_DEPTH_TEST);
   glEnable(GL_BLEND);
+  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ZERO);
+  glBlendEquation(GL_FUNC_ADD);
   glBindTexture(GL_TEXTURE_2D, m_blur_old_copier.texture());
 
   // draw old image


### PR DESCRIPTION
When `do_zoom_blur` sets up its draw, it doesn't update the blend settings, so it ends up inheriting the previous values.

In retail mode, the previous draw is from a texture animation, which sets up the blend in a specific way that causes it to draw a white texture over the screen. In debug mode, right before the zoom blur is drawn, the debug text is drawn, which modifies the blend settings to something that makes the blur look as it should.

Closes #4206 