### PR TITLE
[jak3] track-skill: Better check for orbs collected from crate

### DIFF
--- a/goal_src/jak3/pc/debug/pc-debug-methods.gc
+++ b/goal_src/jak3/pc/debug/pc-debug-methods.gc
@@ -143,10 +143,10 @@
                         (format *stdcon* "~S at ~m ~m ~m (~m away)~%" (res-lump-struct e 'name string) (-> e trans x) (-> e trans y) (-> e trans z) (vector-vector-distance start-pos (-> e trans)))
                         )
                       (('crate 'market-crate 'market-sack-a 'market-sack-b 'market-basket-a 'market-basket-b 'wascity-market-crate 'wascity-market-sack-a 'wascity-market-sack-b 'wascity-market-basket-a 'wascity-market-basket-b 'urn-a 'urn-b 'urn-c)
-                        ;; some kind of crate, only track if pickup-type = skill and pickup-amount != collected amount (there is one crate that spawns 2 orbs, one crate that spawns a golden triple orb)
+                        ;; some kind of crate, only track if pickup-type = skill and it doesnt have subtask-complete status
                         (let ((e-info (res-lump-data e 'eco-info (pointer int32) :time 0.0)))
                           (when (and (= (-> e-info 0) (pickup-type skill))
-                                     (!= (-> e-info 1) (-> e extra perm user-int8 1)))
+                                     (not (logtest? (-> e extra perm status) (entity-perm-status subtask-complete))))
                             (add-debug-line #t (bucket-id debug-no-zbuf1) start-pos (-> e trans) (new 'static 'rgba :r #xff :a #x80) #f (the-as rgba -1))
                             (format *stdcon* "~S at ~m ~m ~m (~m away)~%" (res-lump-struct e 'name string) (-> e trans x) (-> e trans y) (-> e trans z) (vector-vector-distance start-pos (-> e trans)))
                             )


### PR DESCRIPTION
The one crate with gold triple orb in temple doesn't update `(-> e extra perm user-int8 1)` the way I was expecting based on how the one crate that drops two orbs behaved. This check fixes that and is a bit simpler