### PR TITLE
[jak2/jak3] Speedrun menu - add Act 2/3, Open Orbs categories

### DIFF
--- a/goal_src/jak2/pc/features/speedruns-h.gc
+++ b/goal_src/jak2/pc/features/speedruns-h.gc
@@ -82,6 +82,11 @@
   ;; Main Categories
   (newgame-normal 0)
   (newgame-heromode 1)
+  ;; e.g. for All Missions Act 2/3
+  (act-2 2)
+  (act-3 3)
+  ;; for All Open Orbs (endgame)
+  (open-orbs-endgame 4)
   ;; TODO - add ILs and such later
   ;; there's no point in adding categories that just start from a new-game and have later restrictions
   ;; because we aren't going to modify the code to make that possible

--- a/goal_src/jak2/pc/features/speedruns.gc
+++ b/goal_src/jak2/pc/features/speedruns.gc
@@ -5,6 +5,8 @@
 
 (define-extern task-close! (function string symbol))
 
+(define-extern *pc-dead-pool* dead-pool)
+
 (define *speedrun-info* (new 'static 'speedrun-info))
 (set! (-> *speedrun-info* active-custom-category) (new 'static 'speedrun-custom-category))
 (set! (-> *speedrun-info* dump-custom-category) (new 'static 'speedrun-custom-category))
@@ -78,6 +80,40 @@
       (initialize! *game-info* 'game (the-as game-save #f) "game-start"))
     (((speedrun-category newgame-heromode))
       (initialize! *game-info* 'game (the-as game-save #f) "game-start-hero"))
+    (((speedrun-category act-2))
+      (set! (-> *game-info* mode) 'debug)
+      (initialize! *game-info* 'game (the game-save #f) (the string #f))
+      (set! (-> *game-info* mode) 'play)
+      ;; unlock Dark Bomb
+      (task-close! "city-oracle-level0-training")
+      ;; finish Protect Site in Dead Town
+      (task-close! "ruins-enemy-resolution")
+      ;; start player in ruins back at start
+      (start 'play (get-continue-by-name *game-info* "ruins-start"))
+      (set-master-mode 'game)
+      )
+    (((speedrun-category act-3))
+      (set! (-> *game-info* mode) 'debug)
+      (initialize! *game-info* 'game (the game-save #f) (the string #f))
+      (set! (-> *game-info* mode) 'play)
+      ;; unlock Dark Bomb
+      (task-close! "city-oracle-level0-training")
+      ;; finish Defeat Baron in Mar's Tomb
+      (task-close! "tomb-boss-resolution")
+      ;; start player in tomb after Baron fight
+      (start 'play (get-continue-by-name *game-info* "tombboss-start"))
+      (set-master-mode 'game)
+      )
+    (((speedrun-category open-orbs-endgame))
+      (set! (-> *game-info* mode) 'debug)
+      (initialize! *game-info* 'game (the game-save #f) (the string #f))
+      (set! (-> *game-info* mode) 'play)
+      ;; start Break Barrier at Nest
+      (task-close! "nest-get-to-gun-introduction")
+      ;; start player at Nest
+      (start 'play (get-continue-by-name *game-info* "nest-start"))
+      (set-master-mode 'game)
+      )
     (((speedrun-category all-cheats-allowed))
       (initialize! *game-info* 'game (the-as game-save #f) "game-start"))
     (((speedrun-category custom))
@@ -106,8 +142,10 @@
   ;;   probably like the game to automatically set the appropriate ones for you
   ;; - If you are playing a category that forbids cheats, you wouldn't want your run invalidated because you forgot
   (case (-> this category)
-    (((speedrun-category newgame-normal) (speedrun-category newgame-heromode))
-      ;; disable any active cheats
+    (((speedrun-category newgame-normal) (speedrun-category newgame-heromode)
+      (speedrun-category act-2) (speedrun-category act-3)
+      (speedrun-category open-orbs-endgame))
+      ;; disable any active PC cheats
       (set! (-> *pc-settings* cheats) (the-as pc-cheats #x0)))
     (((speedrun-category custom))
       (set! (-> *game-info* secrets) (-> *speedrun-info* active-custom-category secrets))
@@ -265,9 +303,19 @@
           (new 'static 'popup-menu-flag :label "Hero mode"
             :on-confirm (lambda () (set-category! *speedrun-info* (speedrun-category newgame-heromode)))
             :is-toggled? (lambda () (= (-> *speedrun-info* category) (speedrun-category newgame-heromode))))
+          (new 'static 'popup-menu-flag :label "Act 2"
+            :on-confirm (lambda () (set-category! *speedrun-info* (speedrun-category act-2)))
+            :is-toggled? (lambda () (= (-> *speedrun-info* category) (speedrun-category act-2))))
+          (new 'static 'popup-menu-flag :label "Act 3"
+            :on-confirm (lambda () (set-category! *speedrun-info* (speedrun-category act-3)))
+            :is-toggled? (lambda () (= (-> *speedrun-info* category) (speedrun-category act-3))))
+          (new 'static 'popup-menu-flag :label "All Open Orbs (Endgame)"
+            :on-confirm (lambda () (set-category! *speedrun-info* (speedrun-category open-orbs-endgame)))
+            :is-toggled? (lambda () (= (-> *speedrun-info* category) (speedrun-category open-orbs-endgame))))
           (new 'static 'popup-menu-flag :label "All cheats allowed"
             :on-confirm (lambda () (set-category! *speedrun-info* (speedrun-category all-cheats-allowed)))
-            :is-toggled? (lambda () (= (-> *speedrun-info* category) (speedrun-category all-cheats-allowed))))))
+            :is-toggled? (lambda () (= (-> *speedrun-info* category) (speedrun-category all-cheats-allowed))))
+          ))
       (new 'static 'popup-menu-dynamic-submenu :label "Custom category select"
         :get-length (lambda () (pc-sr-mode-get-custom-category-amount))
         :get-entry-label (lambda ((index int) (str-dest string)) (pc-sr-mode-get-custom-category-name index str-dest))
@@ -402,7 +450,7 @@
   ;; Ensure the speedrunner menu process is enabled or destroyed
   (when (and (-> *pc-settings* speedrunner-mode?)
              (not *speedrun-manager*))
-    (process-spawn speedrun-manager :init speedrun-manager-init #f :to *entity-pool*))
+    (process-spawn speedrun-manager :init speedrun-manager-init #f :from *pc-dead-pool* :to *pc-pool*))
   (when (and (not (-> *pc-settings* speedrunner-mode?))
              *speedrun-manager*)
     (deactivate (-> *speedrun-manager* 0)))

--- a/goal_src/jak3/pc/features/speedruns-h.gc
+++ b/goal_src/jak3/pc/features/speedruns-h.gc
@@ -81,6 +81,12 @@
   ;; Main Categories
   (newgame-normal 0)
   (newgame-heromode 1)
+  ;; e.g. for All Missions Act 2/3
+  (act-2 2)
+  (act-3 3)
+  ;; e.g. for All Open Orbs (Post Game)
+  (post-game 4)
+  (post-game-heromode 5)
   ;; TODO - add ILs and such later
   ;; there's no point in adding categories that just start from a new-game and have later restrictions
   ;; because we aren't going to modify the code to make that possible

--- a/goal_src/jak3/pc/features/speedruns.gc
+++ b/goal_src/jak3/pc/features/speedruns.gc
@@ -185,6 +185,36 @@
          (set! (-> *game-info* secrets) (the-as game-secrets (-> *pc-settings* speedrunner-mode-hm-secrets)))
          (set! (-> *game-info* purchase-secrets) (the-as game-secrets (-> *pc-settings* speedrunner-mode-hm-secrets)))
          (set! (-> *game-info* features) HERO_MODE_FEATURES))))
+    (((speedrun-category act-2))
+      (start 'play (get-continue-by-name *game-info* (play-task (game-task sewer-met-hum) 'debug 'play)))
+      (set-master-mode 'game))
+    (((speedrun-category act-3))
+      (start 'play (get-continue-by-name *game-info* (play-task (game-task temple-defend) 'debug 'play)))
+      (set-master-mode 'game))
+    (((speedrun-category post-game))
+     (process-spawn-function process
+       (lambda :behavior process ()
+         (set! (-> *game-info* mode) 'debug)
+         (initialize! *game-info* 'game (the game-save #f) (the string #f) (the resetter-spec #f))
+         (set! (-> *game-info* mode) 'play)
+         (task-close! "city-win-introduction")
+         (start 'play (get-continue-by-name *game-info* "wascity-start"))
+         )))
+    (((speedrun-category post-game-heromode))
+     (process-spawn-function process
+       (lambda :behavior process ()
+         (set! (-> *game-info* mode) 'debug)
+         (initialize! *game-info* 'game (the game-save #f) (the string #f) (the resetter-spec #f))
+         (set! (-> *game-info* mode) 'play)
+         (logior! (-> *game-info* secrets) (game-secrets hero-mode))
+         (logior! (-> *game-info* purchase-secrets) (game-secrets hero-mode))
+         (task-close! "city-win-introduction")
+         (start 'play (get-continue-by-name *game-info* "wascity-start"))
+         (until (and *target* (!= (-> *target* next-state name) 'target-continue))
+           (suspend))
+         (set! (-> *game-info* secrets) (the-as game-secrets (-> *pc-settings* speedrunner-mode-hm-secrets)))
+         (set! (-> *game-info* purchase-secrets) (the-as game-secrets (-> *pc-settings* speedrunner-mode-hm-secrets)))
+         (set! (-> *game-info* features) HERO_MODE_FEATURES))))
     (((speedrun-category all-cheats-allowed))
      (process-spawn-function process
        (lambda :behavior process ()
@@ -215,8 +245,10 @@
   ;;   probably like the game to automatically set the appropriate ones for you
   ;; - If you are playing a category that forbids cheats, you wouldn't want your run invalidated because you forgot
   (case (-> this category)
-    (((speedrun-category newgame-normal) (speedrun-category newgame-heromode))
-     ;; disable any active cheats
+    (((speedrun-category newgame-normal) (speedrun-category newgame-heromode)
+      (speedrun-category act-2) (speedrun-category act-3)
+      (speedrun-category post-game) (speedrun-category post-game-heromode))
+     ;; disable any active PC cheats
      (set! (-> *pc-settings* cheats) (pc-cheats)))
     (((speedrun-category custom))
      (set! (-> *game-info* purchase-secrets) (-> *speedrun-info* active-custom-category secrets))
@@ -392,6 +424,42 @@
                       :is-toggled?
                       (lambda ()
                         (= (-> *speedrun-info* category) (speedrun-category newgame-heromode))))
+                 (new 'static
+                      'popup-menu-flag
+                      :label "Act 2"
+                      :on-confirm
+                      (lambda ()
+                        (set-category! *speedrun-info* (speedrun-category act-2)))
+                      :is-toggled?
+                      (lambda ()
+                        (= (-> *speedrun-info* category) (speedrun-category act-2))))
+                 (new 'static
+                      'popup-menu-flag
+                      :label "Act 3"
+                      :on-confirm
+                      (lambda ()
+                        (set-category! *speedrun-info* (speedrun-category act-3)))
+                      :is-toggled?
+                      (lambda ()
+                        (= (-> *speedrun-info* category) (speedrun-category act-3))))
+                 (new 'static
+                      'popup-menu-flag
+                      :label "Post-Game"
+                      :on-confirm
+                      (lambda ()
+                        (set-category! *speedrun-info* (speedrun-category post-game)))
+                      :is-toggled?
+                      (lambda ()
+                        (= (-> *speedrun-info* category) (speedrun-category post-game))))
+                 (new 'static
+                      'popup-menu-flag
+                      :label "Post-Game Hero Mode"
+                      :on-confirm
+                      (lambda ()
+                        (set-category! *speedrun-info* (speedrun-category post-game-heromode)))
+                      :is-toggled?
+                      (lambda ()
+                        (= (-> *speedrun-info* category) (speedrun-category post-game-heromode))))
                  (new 'static
                       'popup-menu-flag
                       :label "All Cheats Allowed"


### PR DESCRIPTION
Adds these speedrun categories which require special setup:
- Jak 2
  - Act 2
  - Act 3
  - All Open Orbs (Endgame)
- Jak 3
  - Act 2
  - Act 3
  - Post-Game
  - Post-Game Hero Mode

https://github.com/open-goal/jak-project/issues/4214