### PR TITLE
i18n: adjust exclusions again

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -14,11 +14,11 @@ files:
       - "ja"
       - "en-GB"
       - "fi"
+      - "ko"
       - "ru"
   - source: /game/assets/jak2/text/game_custom_text_en-US.json
     translation: /game/assets/jak2/text/game_custom_text_%locale%.json
     excluded_target_languages:
-      - "ko"
       - "ru"
   - source: /game/assets/jak2/subtitle/subtitle_lines_en-US.json
     translation: /game/assets/jak2/subtitle/subtitle_lines_%locale%.json


### PR DESCRIPTION
- can't display korean text in jak 1
- shouldn't be excluded from text in jak 2