### PR TITLE
[jak1] Patch autosave/progress lock in speedrun mode

### DIFF
--- a/goal_src/jak1/engine/game/game-save.gc
+++ b/goal_src/jak1/engine/game/game-save.gc
@@ -1166,15 +1166,14 @@
         (send-event (handle->process (-> self notify)) 'notify 'done 1 gp-0))
       (case (-> self mode)
         (('auto-save)
-         (when (= (-> *game-info* auto-save-count) 1)
+         ;; og:preserve-this Don't display the first auto-save warning prompt if speedrunning
+         (when (and (= (-> *game-info* auto-save-count) 1) (not (-> *pc-settings* speedrunner-mode?)))
            (set! (-> self event-hook) (-> (method-of-object self error) event))
            (set! (-> self state-time) (-> *display* real-frame-counter))
            (while (< (- (-> *display* real-frame-counter) (-> self state-time)) (seconds 0.2))
              (if (not (progress-allowed?)) (set! (-> self state-time) (-> *display* real-frame-counter)))
              (suspend))
-           ;; Don't display the auto-save warning prompt if speedrunning
-           (when (= (-> *pc-settings* speedrunner-mode?) #f)
-             (activate-progress *dproc* (progress-screen auto-save))))))))
+           (activate-progress *dproc* (progress-screen auto-save)))))))
 
 (defun auto-save-command ((arg0 symbol) (arg1 int) (arg2 int) (arg3 process-tree))
   (process-spawn auto-save arg0 arg3 arg1 arg2 :stack *kernel-dram-stack*)


### PR DESCRIPTION
We already skip the "first autosave warning" prompt in speedrunner mode, this just moves the check up a bit earlier, where it feels more appropriate imo.

This also prevents a potential softlock from occurring in speedrunner mode only, if you manage to bring up the progress menu while the first autosave occurs/finishes (e.g. by pause buffering 7th scout fly, or one of the citadel sage cells).

In that scenario, the `auto-save` process gets stuck in `done` state in this loop because `progress-allowed?` is false due to the pending powercell cutscene, and so we keep resetting `state-time`:
https://github.com/open-goal/jak-project/blob/d8710bb2f645528e598e2bd799708d9d945f76c6/goal_src/jak1/engine/game/game-save.gc#L1172-L1174
(in normal circumstances, this prevents the autosave prompt from popping up during and shortly after the cell cutscene)

The problem is that the `progress` code has a sort of mirrored check, where it will only `enter!` the next state if there is no `auto-save` process:
https://github.com/open-goal/jak-project/blob/d8710bb2f645528e598e2bd799708d9d945f76c6/goal_src/jak1/pc/progress-pc.gc#L3600-L3609

Here's an example of the locked progress screen, I run some code in the REPL to show the game is still running, and then use a breakpoint and continue to artificially get past the `time-elapsed?` check in the `auto-save` code

https://youtu.be/4eZlQbRq6l8