### PR TITLE
Update `def-actor` to version 8 for jak3

### DIFF
--- a/goal_src/jak2/engine/data/art-h.gc
+++ b/goal_src/jak2/engine/data/art-h.gc
@@ -420,7 +420,7 @@
         )
   )
 
-(defmacro def-actor (name &key (idle #f) &key (lods #f) &key (art (idle-ja)) &key (joints ()) &key (shadow 0) &key bounds &key (longest-edge 0.0) &key (texture-level 0) &key (sort 0) &key (version 7) &key (origin-joint-index 0) &key (shadow-joint-index 0) &key (light-index 0))
+(defmacro def-actor (name &key (idle #f) &key (lods #f) &key (art (idle-ja)) &key (joints ()) &key (shadow 0) &key bounds &key (longest-edge 0.0) &key (texture-level 0) &key (sort 0) &key (version ART_GROUP_FILE_VERSION) &key (origin-joint-index 0) &key (shadow-joint-index 0) &key (light-index 0))
   `(begin
     (def-art-elt ,(string->symbol-format "{}-ag" name) ,(string->symbol-format "{}-lod0-jg" name) 0)
     (def-art-elt ,(string->symbol-format "{}-ag" name) ,(string->symbol-format "{}-lod0-mg" name) 1)

--- a/goal_src/jak3/engine/data/art-h.gc
+++ b/goal_src/jak3/engine/data/art-h.gc
@@ -486,7 +486,7 @@ Each process-drawable has a draw-control."
         )
   )
 
-(defmacro def-actor (name &key (idle #f) &key (lods #f) &key (art (idle-ja)) &key (joints ()) &key (shadow 0) &key bounds &key (longest-edge 0.0) &key (texture-level 0) &key (sort 0) &key (version 8) &key (origin-joint-index 0) &key (shadow-joint-index 0) &key (light-index 0) &key (global-effects 0) &key (clothing ()))
+(defmacro def-actor (name &key (idle #f) &key (lods #f) &key (art (idle-ja)) &key (joints ()) &key (shadow 0) &key bounds &key (longest-edge 0.0) &key (texture-level 0) &key (sort 0) &key (version ART_GROUP_FILE_VERSION) &key (origin-joint-index 0) &key (shadow-joint-index 0) &key (light-index 0) &key (global-effects 0) &key (clothing ()))
   `(begin
     (def-art-elt ,(string->symbol-format "{}-ag" name) ,(string->symbol-format "{}-lod0-jg" name) 0)
     (def-art-elt ,(string->symbol-format "{}-ag" name) ,(string->symbol-format "{}-lod0-mg" name) 1)

--- a/goal_src/jak3/engine/data/art-h.gc
+++ b/goal_src/jak3/engine/data/art-h.gc
@@ -486,7 +486,7 @@ Each process-drawable has a draw-control."
         )
   )
 
-(defmacro def-actor (name &key (idle #f) &key (lods #f) &key (art (idle-ja)) &key (joints ()) &key (shadow 0) &key bounds &key (longest-edge 0.0) &key (texture-level 0) &key (sort 0) &key (version 7) &key (origin-joint-index 0) &key (shadow-joint-index 0) &key (light-index 0) &key (global-effects 0) &key (clothing ()))
+(defmacro def-actor (name &key (idle #f) &key (lods #f) &key (art (idle-ja)) &key (joints ()) &key (shadow 0) &key bounds &key (longest-edge 0.0) &key (texture-level 0) &key (sort 0) &key (version 8) &key (origin-joint-index 0) &key (shadow-joint-index 0) &key (light-index 0) &key (global-effects 0) &key (clothing ()))
   `(begin
     (def-art-elt ,(string->symbol-format "{}-ag" name) ,(string->symbol-format "{}-lod0-jg" name) 0)
     (def-art-elt ,(string->symbol-format "{}-ag" name) ,(string->symbol-format "{}-lod0-mg" name) 1)

--- a/goal_src/jakx/engine/data/art-h.gc
+++ b/goal_src/jakx/engine/data/art-h.gc
@@ -454,7 +454,7 @@ This stores settings like the name of the art-group, shadow/level-of-detail sett
         )
   )
 
-(defmacro def-actor (name &key (idle #f) &key (lods #f) &key (art (idle-ja)) &key (joints ()) &key (shadow 0) &key bounds &key (longest-edge 0.0) &key (texture-level 0) &key (sort 0) &key (version 7) &key (origin-joint-index 0) &key (shadow-joint-index 0) &key (light-index 0) &key (global-effects 0) &key (clothing ()))
+(defmacro def-actor (name &key (idle #f) &key (lods #f) &key (art (idle-ja)) &key (joints ()) &key (shadow 0) &key bounds &key (longest-edge 0.0) &key (texture-level 0) &key (sort 0) &key (version ART_GROUP_FILE_VERSION) &key (origin-joint-index 0) &key (shadow-joint-index 0) &key (light-index 0) &key (global-effects 0) &key (clothing ()))
   `(begin
     (def-art-elt ,(string->symbol-format "{}-ag" name) ,(string->symbol-format "{}-lod0-jg" name) 0)
     (def-art-elt ,(string->symbol-format "{}-ag" name) ,(string->symbol-format "{}-lod0-mg" name) 1)


### PR DESCRIPTION
v7 is copy/paste from jak2
https://github.com/open-goal/jak-project/blob/697337166da69af6515e97c5a9894b8ba2abc93c/goal_src/jak2/engine/data/art-h.gc#L423 https://github.com/open-goal/jak-project/blob/697337166da69af6515e97c5a9894b8ba2abc93c/goal_src/jak2/engine/load/file-io.gc#L109

but jak 3 uses v8
https://github.com/open-goal/jak-project/blob/697337166da69af6515e97c5a9894b8ba2abc93c/goal_src/jak3/engine/load/file-io.gc#L198-L199