### PR TITLE
fix(gfx): send fog CLUT payload inline to end sky flicker

### DIFF
--- a/game/graphics/opengl_renderer/TextureAnimator.cpp
+++ b/game/graphics/opengl_renderer/TextureAnimator.cpp
@@ -1737,7 +1737,7 @@ void TextureAnimator::clear_stale_textures(u64 frame_idx) {
  */
 void TextureAnimator::handle_upload_clut_16_16(const DmaTransfer& tf, const u8* ee_mem) {
   dprintf("[tex anim] upload clut 16 16\n");
-  ASSERT(tf.size_bytes == sizeof(TextureAnimPcUpload));
+  ASSERT(tf.size_bytes >= sizeof(TextureAnimPcUpload));
   auto* upload = (const TextureAnimPcUpload*)(tf.data);
   ASSERT(upload->width == 16);
   ASSERT(upload->height == 16);
@@ -1748,7 +1748,18 @@ void TextureAnimator::handle_upload_clut_16_16(const DmaTransfer& tf, const u8* 
   vram.data.resize(16 * 16 * 4);
   vram.tex_width = upload->width;
   vram.tex_height = upload->height;
-  memcpy(vram.data.data(), ee_mem + upload->data, vram.data.size());
+  if (tf.size_bytes >= sizeof(TextureAnimPcUpload) + vram.data.size()) {
+    // the payload travels inline in the (double-buffered) dma buffer, right after the
+    // upload record. This is required for data the game rewrites every frame (the fog
+    // CLUT): reading it through the EE address races the game thread, which is
+    // concurrently writing the next frame's values, and caused one-frame fog/sky
+    // flickers.
+    memcpy(vram.data.data(), tf.data + sizeof(TextureAnimPcUpload), vram.data.size());
+  } else {
+    // legacy path: an EE address. Only safe for data that is stable while the frame
+    // renders (bigmap, blit-displays).
+    memcpy(vram.data.data(), ee_mem + upload->data, vram.data.size());
+  }
   if (m_tex_looking_for_clut) {
     m_tex_looking_for_clut->cbp = upload->dest;
     m_tex_looking_for_clut = nullptr;

--- a/goal_src/jak2/engine/gfx/texture/texture-anim-funcs.gc
+++ b/goal_src/jak2/engine/gfx/texture/texture-anim-funcs.gc
@@ -236,15 +236,22 @@
     ;; and the clut
     ;(upload-vram-data arg0 (the-as int (-> s5-1 clutdest)) (the-as pointer (-> s5-1 pad 1)) 16 16)
 
-    (pc-texture-anim-flag upload-clut-16-16 arg0 :qwc 1)
+    ;; og:preserve-this - this CLUT is rewritten by the EE every frame (the alpha loop
+    ;; above), so the payload must travel INLINE in the double buffered dma buffer.
+    ;; Passing only its address makes the render thread read memory that the next
+    ;; frame is concurrently rewriting, which caused one-frame fog/sky flickers.
+    ;; qwc = 1 record + 64 (16x16 CLUT, 1024 bytes).
+    (pc-texture-anim-flag upload-clut-16-16 arg0 :qwc 65)
     (let ((upload-record (the texture-anim-pc-upload (-> arg0 base))))
-      (set! (-> upload-record data) (the-as pointer (-> s5-1 pad 1))) ;; the clut16x16 object
+      (set! (-> upload-record data) (the-as pointer (-> s5-1 pad 1))) ;; unused in inline mode
       (set! (-> upload-record width) 16)
       (set! (-> upload-record height) 16)
       (set! (-> upload-record dest) (-> s5-1 clutdest))
       (set! (-> upload-record format) (gs-psm ct32))
       )
     (&+! (-> arg0 base) 16)
+    (mem-copy! (-> arg0 base) (the-as pointer (-> s5-1 pad 1)) 1024)
+    (&+! (-> arg0 base) 1024)
 
     (set! (-> *texture-pool* ids (shr (-> s5-1 clutdest) 6)) (the-as uint 0))
     ;; og:preserve-this just a texflush.

--- a/goal_src/jak3/engine/gfx/texture/texture-anim-funcs.gc
+++ b/goal_src/jak3/engine/gfx/texture/texture-anim-funcs.gc
@@ -151,7 +151,9 @@
       )
     (let ((s5-1 (-> arg1 tex))
           (v1-20 *display*)
-          (a0-26 144)
+          ;; og:preserve-this 144 in the original; grown by 1024 for the inline fog CLUT
+          ;; payload (see below).
+          (a0-26 1168)
           )
       (+! (-> v1-20 mem-reserve-size) a0-26)
       (the-as
@@ -188,15 +190,22 @@
 
             ;; PC port of clut upload
             ;;(upload-vram-data arg0 (the-as int (-> s5-1 clutdest)) (the-as pointer (-> s5-1 pad 1)) 16 16)
-            (pc-texture-anim-flag upload-clut-16-16 arg0 :qwc 1)
+            ;; og:preserve-this - this CLUT is rewritten by the EE every frame (the
+            ;; alpha loop above), so the payload must travel INLINE in the double
+            ;; buffered dma buffer. Passing only its address makes the render thread
+            ;; read memory that the next frame is concurrently rewriting, which caused
+            ;; one-frame fog/sky flickers. qwc = 1 record + 64 (16x16 CLUT, 1024 bytes).
+            (pc-texture-anim-flag upload-clut-16-16 arg0 :qwc 65)
             (let ((upload-record (the texture-anim-pc-upload (-> arg0 base))))
-              (set! (-> upload-record data) (the-as pointer (-> s5-1 pad 1))) ;; the clut16x16 object
+              (set! (-> upload-record data) (the-as pointer (-> s5-1 pad 1))) ;; unused in inline mode
               (set! (-> upload-record width) 16)
               (set! (-> upload-record height) 16)
               (set! (-> upload-record dest) (-> s5-1 clutdest))
               (set! (-> upload-record format) (gs-psm ct32))
               )
             (&+! (-> arg0 base) 16)
+            (mem-copy! (-> arg0 base) (the-as pointer (-> s5-1 pad 1)) 1024)
+            (&+! (-> arg0 base) 1024)
             (set! (-> *texture-pool* ids (shr (-> s5-1 clutdest) 6)) (the-as uint 0))
             ; (let* ((v1-29 arg0)
             ;        (a0-39 (-> v1-29 base))


### PR DESCRIPTION
## Problem

Jak 2 and Jak 3 exhibit a random one-frame sky/fog flicker, most visible on the jak3 title screen: the sky's warm haze layer pops or briefly disappears for exactly one frame at random intervals (typically every 1 to 3 seconds), independent of framerate. Framerate only changes how visible each bad frame is.

## Root cause

The fog texture animation (`real-fog-texture-anim-func` in `texture-anim-funcs.gc`) rewrites its 16x16 CLUT in EE memory **every frame**: a base color fill of all 256 entries followed by the per-entry alpha computation. The PC-port upload record (`upload-clut-16-16`) only carried the CLUT's EE **address**. The render thread memcpy's that memory whenever the tex bucket renders, racing the game thread which is concurrently writing the **next** frame's values. A torn read renders the fog layer (which tints both sky and terrain) with wrong colors for exactly one frame, then self-heals on the next upload.

This was isolated with per-frame instrumentation: with the sky bucket's DMA, the generated cloud texture (all mip levels), texture pool bindings, and GL state all hashed bit-identical on flicker frames, fully serializing the game and render threads eliminated the flicker (2 events vs 104-182 per 2.5 min baseline), which narrowed it to a cross-thread read of live EE memory; the fog CLUT is the only such per-frame-rewritten payload in the sky path.

## Fix

Carry the CLUT payload inline in the double-buffered DMA buffer, immediately after the upload record (qwc 65 = 1 record + 64 quadwords of CLUT). The buffer is per-frame double-buffered, so the renderer always sees a coherent copy with no synchronization needed.

The C++ handler accepts both forms based on transfer size, so the other `upload-clut-16-16` callers (bigmap, blit-displays), whose data is stable while a frame renders, keep the address form unchanged.

## Test plan

- [ ] jak3 title screen at fps 60, vsync off: sky no longer flickers (verified over 3+ minute telemetry captures: large-magnitude one-frame events eliminated; also verified by eye)
- [ ] jak2 compiles and boots (shares the fog anim code; same fix applied)
- [ ] bigmap and progress menu still render correctly (legacy address path)

---

I work off a self-hosted forge, so this GitHub account is quiet; the full investigation telemetry (per-frame DMA and texture content hashes, framebuffer pixel-patch captures, before/after event-rate runs) is available if anyone wants the raw data.

(AI-assisted)