### PR TITLE
fix(merc2): resolve GOAL addresses against EE memory, not the chain

### DIFF
--- a/game/graphics/opengl_renderer/foreground/Merc2.cpp
+++ b/game/graphics/opengl_renderer/foreground/Merc2.cpp
@@ -219,7 +219,6 @@ void Merc2::model_mod_draws(int num_effects,
                             const tfrag3::MercModel* model,
                             const LevelData* lev,
                             const u8* input_data,
-                            const DmaTransfer& setup,
                             ModBuffers* mod_opengl_buffers,
                             MercDebugStats* stats) {
   auto p = scoped_prof("update-verts");
@@ -258,7 +257,7 @@ void Merc2::model_mod_draws(int num_effects,
     // get pointers to the fragment and fragment control data
     u32 goal_addr;
     memcpy(&goal_addr, input_data + 4 * ei, 4);
-    const u8* ee0 = setup.data - setup.data_offset;
+    const u8* ee0 = m_ee_memory;
     const u8* merc_effect = ee0 + goal_addr;
     u16 frag_cnt;
     memcpy(&frag_cnt, merc_effect + 18, 2);
@@ -516,7 +515,7 @@ void Merc2::handle_pc_model(const DmaTransfer& setup,
     // read goal addr of matrix (matrix data isn't known at merc dma time, bones runs after)
     u32 addr;
     memcpy(&addr, &matrix_array[i * 4], 4);
-    const u8* real_addr = setup.data - setup.data_offset + addr;
+    const u8* real_addr = m_ee_memory + addr;
     ASSERT(input_data[i] < MAX_SKEL_BONES);
     // get the matrix data
     memcpy(&skel_matrix_buffer[input_data[i]], real_addr, sizeof(MercMat));
@@ -571,7 +570,7 @@ void Merc2::handle_pc_model(const DmaTransfer& setup,
   if (model_uses_pc_blerc) {
     model_mod_blerc_draws(num_effects, model, lev, mod_opengl_buffers, blerc_weights, stats);
   } else if (model_uses_mod) {  // only if we've enabled, this path is slow.
-    model_mod_draws(num_effects, model, lev, input_data, setup, mod_opengl_buffers, stats);
+    model_mod_draws(num_effects, model, lev, input_data, mod_opengl_buffers, stats);
   }
 
   // stats
@@ -779,6 +778,11 @@ void Merc2::render(DmaFollower& dma,
                    SharedRenderState* render_state,
                    ScopedProfilerNode& prof,
                    MercDebugStats* stats) {
+  // GOAL addresses embedded in merc DMA payloads (bone matrices, mod effect data)
+  // must resolve against EE main memory itself. Reconstructing the base from chain
+  // pointers (data - data_offset) breaks whenever the chain is not the original EE
+  // buffer, e.g. the run_dma_copy snapshot path.
+  m_ee_memory = (const u8*)render_state->ee_main_memory;
   bool hack = stats->collect_debug_model_list;
   *stats = {};
   stats->collect_debug_model_list = hack;

--- a/game/graphics/opengl_renderer/foreground/Merc2.h
+++ b/game/graphics/opengl_renderer/foreground/Merc2.h
@@ -51,6 +51,9 @@ class Merc2 {
 
  private:
   const std::vector<GLuint>* m_anim_slot_array;
+  // EE main memory base, for resolving GOAL addresses embedded in merc DMA payloads.
+  // Set per render() call; must not be derived from chain pointers.
+  const u8* m_ee_memory = nullptr;
   enum MercDataMemory {
     LOW_MEMORY = 0,
     BUFFER_BASE = 442,
@@ -253,7 +256,6 @@ class Merc2 {
                        const tfrag3::MercModel* model,
                        const LevelData* lev,
                        const u8* input_data,
-                       const DmaTransfer& setup,
                        ModBuffers* mod_opengl_buffers,
                        MercDebugStats* stats);
   void model_mod_blerc_draws(int num_effects,


### PR DESCRIPTION
Found while investigating the jak2/jak3 one-frame sky flicker (see the fog CLUT inline payload PR: `#4343`).

## Problem

`Merc2::handle_pc_model` and `Merc2::model_mod_draws` follow GOAL addresses embedded in the merc DMA payload (bone matrices, mod effect and fragment data). To turn those addresses into host pointers they reconstruct the EE memory base from chain pointers:

```cpp
const u8* real_addr = setup.data - setup.data_offset + addr;
```

That arithmetic only works when the chain being rendered is the original EE buffer. With the `run_dma_copy` snapshot path (`pipelines/opengl.cpp`), `setup.data` points into the snapshot vector, so the reconstructed "base" is garbage and the reads land far out of bounds: an access violation inside `handle_pc_model` as soon as a level with merc models loads. This is latent bitrot; it does not affect the default configuration, but it makes the snapshot path unusable and is a trap for any future work that renders from copied chains.

## Fix

Resolve the addresses against `render_state->ee_main_memory`, cached per `render()` call. For the default live-chain path this computes the identical pointer, so behavior is unchanged; for snapshot chains it is correct.

## Test plan

- [ ] Default path: jak3 boots and renders characters normally (identical pointer math)
- [ ] With `run_dma_copy` enabled, the previous crash during the title load no longer occurs

(AI-assisted)