### PR TITLE
fix(sky): accumulate fractional cloud scroll above 120fps (jak2/jak3)

### DIFF
--- a/goal_src/jak2/engine/gfx/sky/sky-tng.gc
+++ b/goal_src/jak2/engine/gfx/sky/sky-tng.gc
@@ -141,6 +141,14 @@ vf31: cam 0 (premultiplied by hmge)
   (none)
   )
 
+;; og:preserve-this sub-integer cloud scroll accumulators for the high-fps fix in
+;; update-time-and-speed below. Deliberately file-scope rather than fields on sky-work:
+;; sky-work is a singleton, so per-instance state is not needed, and leaving the type
+;; alone keeps goal_src and decompiler/config/jak2/all-types.gc in agreement. Adding
+;; fields makes the two disagree and fails Jak2TypeConsistency.
+(define *sky-off-s-frac* 0.0)
+(define *sky-off-t-frac* 0.0)
+
 (defmethod update-time-and-speed ((this sky-work) (arg0 float) (arg1 float))
   "Update based on the given time. Time is used to place suns/moon at the right spot, speed is used to scroll clouds."
   (if (and (level-get-target-inside *level*) (= (-> (level-get-target-inside *level*) info taskname) 'nest))
@@ -149,8 +157,20 @@ vf31: cam 0 (premultiplied by hmge)
   (sky-make-sun-data this 0 arg0)
   (sky-make-sun-data this 1 arg0)
   (sky-make-moon-data this arg0)
-  (+! (-> this off-s) (the int (* -8.0 arg1)))
-  (+! (-> this off-t) (the int (* 2.0 arg1)))
+  ;; og:preserve-this high-fps cloud scroll fix. The original truncated the scaled
+  ;; per-frame step, (the int (* 2.0 arg1)), which reaches 0 above 120fps and freezes the
+  ;; cloud T scroll; the S term survives until above 480fps. Accumulate the fractional
+  ;; part and apply only the whole part each frame, carrying the remainder.
+  (set! *sky-off-s-frac* (+ *sky-off-s-frac* (* -8.0 arg1)))
+  (set! *sky-off-t-frac* (+ *sky-off-t-frac* (* 2.0 arg1)))
+  (let ((si (the int *sky-off-s-frac*))
+        (ti (the int *sky-off-t-frac*))
+        )
+    (+! (-> this off-s) si)
+    (+! (-> this off-t) ti)
+    (set! *sky-off-s-frac* (- *sky-off-s-frac* (the float si)))
+    (set! *sky-off-t-frac* (- *sky-off-t-frac* (the float ti)))
+    )
   (set! (-> this time) arg0)
   0
   (none)

--- a/goal_src/jak3/engine/gfx/sky/sky-tng.gc
+++ b/goal_src/jak3/engine/gfx/sky/sky-tng.gc
@@ -91,6 +91,14 @@
   (none)
   )
 
+;; og:preserve-this sub-integer cloud scroll accumulators for the high-fps fix in
+;; update-time-and-speed below. Deliberately file-scope rather than fields on sky-work:
+;; sky-work is a singleton, so per-instance state is not needed, and leaving the type
+;; alone keeps goal_src and decompiler/config/jak3/all-types.gc in agreement. Adding
+;; fields makes the two disagree and fails Jak3TypeConsistency.
+(define *sky-off-s-frac* 0.0)
+(define *sky-off-t-frac* 0.0)
+
 (defmethod update-time-and-speed ((this sky-work) (arg0 float) (arg1 float))
   "Update cloud sroll and sun/moon position for the time."
   (if (and (level-get-target-inside *level*) (= (-> (level-get-target-inside *level*) info taskname) 'nest))
@@ -99,8 +107,20 @@
   (sky-make-sun-data this 0 arg0)
   (sky-make-sun-data this 1 arg0)
   (sky-make-moon-data this arg0)
-  (+! (-> this off-s) (the int (* -8.0 arg1)))
-  (+! (-> this off-t) (the int (* 2.0 arg1)))
+  ;; og:preserve-this high-fps cloud scroll fix. The original truncated the scaled
+  ;; per-frame step, (the int (* 2.0 arg1)), which reaches 0 above 120fps and freezes the
+  ;; cloud T scroll; the S term survives until above 480fps. Accumulate the fractional
+  ;; part and apply only the whole part each frame, carrying the remainder.
+  (set! *sky-off-s-frac* (+ *sky-off-s-frac* (* -8.0 arg1)))
+  (set! *sky-off-t-frac* (+ *sky-off-t-frac* (* 2.0 arg1)))
+  (let ((si (the int *sky-off-s-frac*))
+        (ti (the int *sky-off-t-frac*))
+        )
+    (+! (-> this off-s) si)
+    (+! (-> this off-t) ti)
+    (set! *sky-off-s-frac* (- *sky-off-s-frac* (the float si)))
+    (set! *sky-off-t-frac* (- *sky-off-t-frac* (the float ti)))
+    )
   (set! (-> this time) arg0)
   0
   (none)


### PR DESCRIPTION
Found while investigating the jak2/jak3 one-frame sky flicker (see `#4343`).

## Problem

`update-time-and-speed` (sky-tng.gc) applies the per-frame cloud scroll as:

```lisp
(+! (-> this off-s) (the int (* -8.0 arg1)))
(+! (-> this off-t) (the int (* 2.0 arg1)))
```

The High FPS Fix scales `arg1` by `DISPLAY_FPS_RATIO`, which resolves to `60 / target-fps`
(`time-factor` is `300 / target-fps`, and `DISPLAY_FPS_RATIO` is `time-factor / 5.0`). So the
two per-frame steps are `(the int (-480 / fps))` and `(the int (120 / fps))`, and both
truncate toward zero, at different framerates:

| fps | `off-t` step | `off-s` step |
| --- | --- | --- |
| 60 | 2 | -8 |
| 120 | 1 | -4 |
| 121 | **0** | -3 |
| 240 | **0** | -2 |
| 480 | 0 | -1 |
| 481 | 0 | **0** |

The T scroll stops strictly above 120fps. The S scroll keeps working until above 480, and
because the smaller per-frame step is offset by proportionally more frames, its net rate
stays correct.

**The symptom is not a stall, which is why it is easy to miss.** At 240fps the cloud layer
still drifts at the right speed, but only along S, so it moves straight instead of
diagonally. Inside `nest`, where `arg1` is multiplied by 10, it does not appear until
roughly 1200fps.

## Fix

Accumulate the scaled step in floats and apply only the whole part each frame, carrying the
remainder. At 60fps the remainder is always zero, so the behaviour is bit-identical to
before: `arg1` is exactly 1.0 and the steps are exactly -8 and 2.

The accumulators are file-scope rather than fields on `sky-work`. `sky-work` is a singleton,
reached only as `*sky-work*`, so per-instance state is not needed, and leaving the type alone
keeps `goal_src` in agreement with `decompiler/config/*/all-types.gc`. Adding fields there
makes the two disagree and fails `Jak2TypeConsistency` and `Jak3TypeConsistency`.

Applies to jak2 and jak3, which share the pattern.

## Test plan

- [x] Arithmetic verified live via the REPL: called with the 240fps ratio (0.25), the original
      produced exactly 0 T movement per call, and the accumulating version the correct
      +0.5/call. That was measured on an earlier revision which stored the accumulators as
      fields; this revision changes only where they live, not the maths.
- [x] Thresholds above derived from `DISPLAY_FPS_RATIO` and `time-factor`, not estimated
- [x] Builds clean and the full unit test suite passes (1523 tests), Linux clang
- [x] `Jak2TypeConsistency` and `Jak3TypeConsistency` pass, which the field-based revision
      did not
- [ ] **Not verified in gameplay at high framerate.** The visible difference is a change of
      drift direction rather than motion versus no motion, so it needs a side-by-side against
      60fps to judge, and I have not done that.

(AI-assisted)
