### PR TITLE
[jak1] Prevent debug crash in subtitle code

### DIFF
--- a/goal_src/jak1/pc/subtitle.gc
+++ b/goal_src/jak1/pc/subtitle.gc
@@ -446,7 +446,7 @@
       (set! (-> self cur-channel) (pc-subtitle-channel invalid))
       ;; check what kind of subtitles are running
       (cond
-        ((and (movie?) (-> *art-control* spool-lock) (-> *art-control* active-stream))
+        ((and (movie?) (handle->process (-> *art-control* spool-lock)) (-> *art-control* active-stream))
          ;; there's a cutscene happening and an active spool with a valid owner.
          (set! (-> self spool-name) (-> *art-control* active-stream))
          (set! (-> self cur-channel) (pc-subtitle-channel movie))


### PR DESCRIPTION
fixes this crash https://gist.github.com/dallmeyer/0a5520379a3b96725af152bde66f63e8 which can be reproduced by doing a HUD buffer on the bottom of LPC cell in debug mode