### PR TITLE
fix(gfx): night stars rendered the Dolby logo and stretched (jak2/jak3)

### DIFF
--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -1451,6 +1451,7 @@ void OpenGLRenderer::dispatch_buckets(DmaFollower dma,
 
   m_render_state.version = m_version;
   m_render_state.frame_idx++;
+  m_render_state.texture_pool->set_frame_stamp(m_render_state.frame_idx);
   switch (m_version) {
     case GameVersion::Jak1:
       dispatch_buckets_jak1(dma, prof, sync_after_buckets);

--- a/game/graphics/opengl_renderer/TextureAnimator.cpp
+++ b/game/graphics/opengl_renderer/TextureAnimator.cpp
@@ -1223,6 +1223,7 @@ void TextureAnimator::handle_texture_anim_data(DmaFollower& dma,
   m_in_use_temp_textures.clear();  // reset temp texture allocator.
   m_force_to_gpu.clear();
   m_skip_tbps.clear();
+  m_current_frame_idx = frame_idx;
 
   // loop over DMA, and do the appropriate texture operations.
   // this will fill out m_textures, which is keyed on TBP.
@@ -1486,11 +1487,18 @@ void TextureAnimator::handle_texture_anim_data(DmaFollower& dma,
         entry.needs_pool_update = false;
         dprintf("create texture %d\n", tbp);
       }
-    } else {
+    } else if (entry.last_write_frame == m_current_frame_idx) {
       // ideal case: OpenGL texture modified in place, just have to simulate "upload".
+      // written this frame, so this is a real write claim and may evict another owner.
       auto p = scoped_prof("pool-move");
       texture_pool->move_existing_to_vram(entry.pool_gpu_tex, tbp);
       dprintf("no change %d\n", tbp);
+    } else {
+      // the game has stopped writing this entry: it may keep its slot, but must not evict a
+      // live upload at the same address (see the claim primitives note in TexturePool.h).
+      auto p = scoped_prof("pool-reassert");
+      texture_pool->reassert_in_vram(entry.pool_gpu_tex, tbp);
+      dprintf("reassert %d\n", tbp);
     }
   }
 
@@ -1744,6 +1752,7 @@ void TextureAnimator::handle_upload_clut_16_16(const DmaTransfer& tf, const u8* 
   dprintf("  dest is 0x%x\n", upload->dest);
   auto& vram = m_textures[upload->dest];
   vram.reset();
+  vram.last_write_frame = m_current_frame_idx;
   vram.kind = VramEntry::Kind::CLUT16_16_IN_PSM32;
   vram.data.resize(16 * 16 * 4);
   vram.tex_width = upload->width;
@@ -1766,6 +1775,7 @@ void TextureAnimator::handle_generic_upload(const DmaTransfer& tf, const u8* ee_
   dprintf(" dest is 0x%x\n", upload->dest);
   auto& vram = m_textures[upload->dest];
   vram.reset();
+  vram.last_write_frame = m_current_frame_idx;
 
   switch (upload->format) {
     case (int)GsTex0::PSM::PSMCT32:
@@ -1972,6 +1982,7 @@ void TextureAnimator::handle_draw(DmaFollower& dma, TexturePool& texture_pool) {
     // texture
     auto& dest_te = m_textures.at(m_current_dest_tbp);
     ASSERT(dest_te.kind == VramEntry::Kind::GPU);
+    dest_te.last_write_frame = m_current_frame_idx;
 
     // set up context to draw to this one
     FramebufferTexturePairContext ctxt(*dest_te.tex);
@@ -2347,6 +2358,7 @@ VramEntry* TextureAnimator::setup_vram_entry_for_gpu_texture(int w, int h, int t
   entry->tex_width = w;
   entry->tex_height = h;
   entry->dest_texture_address = tbp;
+  entry->last_write_frame = m_current_frame_idx;
   return entry;
 }
 

--- a/game/graphics/opengl_renderer/TextureAnimator.h
+++ b/game/graphics/opengl_renderer/TextureAnimator.h
@@ -39,6 +39,11 @@ struct VramEntry {
   bool needs_pool_update = false;
   GpuTexture* pool_gpu_tex = nullptr;
 
+  // frame (render frame_idx) when the game last wrote this entry (upload, erase, or draw).
+  // decides write claim vs re-assert when syncing with the texture pool: entries the game
+  // has stopped writing must not keep evicting live uploads at the same address.
+  u64 last_write_frame = 0;
+
   void reset() {
     data.clear();
     kind = Kind::INVALID;
@@ -390,6 +395,8 @@ class TextureAnimator {
   std::vector<GLuint> m_private_output_slots;
   std::vector<GLuint> m_public_output_slots;
   std::vector<int> m_skip_tbps;
+  // the frame_idx of the current handle_texture_anim_data run, for stamping entry writes.
+  u64 m_current_frame_idx = 0;
 
   struct Bool {
     bool b = false;

--- a/game/graphics/texture/TexturePool.cpp
+++ b/game/graphics/texture/TexturePool.cpp
@@ -111,6 +111,29 @@ void TexturePool::move_existing_to_vram(GpuTexture* tex, u32 slot_addr) {
   }
 }
 
+/*!
+ * Re-assert that a texture's old output may still be resident at this address, without claiming
+ * a write. Keeps the slot if this texture already owns it (or if nobody ever claimed it), but
+ * never steals it from another owner (see the claim primitives note in TexturePool.h).
+ */
+void TexturePool::reassert_in_vram(GpuTexture* tex, u32 slot_addr) {
+  ASSERT(!tex->is_placeholder);
+  ASSERT(!tex->gpu_textures.empty());
+  auto& slot = m_textures[slot_addr];
+  if (slot.source == tex) {
+    return;  // still the owner, nothing to do.
+  }
+  if (slot.source) {
+    return;  // somebody else wrote here since; they own the address now.
+  }
+  // nobody has ever claimed this address, so our old output is still the most recent write.
+  if (std::find(tex->slots.begin(), tex->slots.end(), slot_addr) == tex->slots.end()) {
+    tex->slots.push_back(slot_addr);
+  }
+  slot.source = tex;
+  slot.gpu_texture = tex->gpu_textures.front().gl;
+}
+
 void TexturePool::update_gl_texture(GpuTexture* gpu_texture,
                                     u32 new_w,
                                     u32 new_h,

--- a/game/graphics/texture/TexturePool.cpp
+++ b/game/graphics/texture/TexturePool.cpp
@@ -109,6 +109,7 @@ void TexturePool::move_existing_to_vram(GpuTexture* tex, u32 slot_addr) {
     slot.source = tex;
     slot.gpu_texture = tex->gpu_textures.front().gl;
   }
+  slot.claim_frame = m_frame_stamp.load(std::memory_order_relaxed);
 }
 
 /*!
@@ -275,6 +276,7 @@ void TexturePool::handle_upload_now(const u8* tpage,
             slot.source = get_gpu_texture_for_slot(current_id, tex.dest[mip_idx]);
             ASSERT(slot.gpu_texture != (GLuint)-1);
           }
+          slot.claim_frame = m_frame_stamp.load(std::memory_order_relaxed);
         }
       }
     } else {
@@ -405,6 +407,8 @@ void TexturePool::draw_debug_for_tex(const std::string& name, GpuTexture* tex, u
   }
   if (ImGui::TreeNode(fmt::format("{}) {}", slot, name).c_str())) {
     ImGui::Text("P: %s sz: %d x %d", get_debug_texture_name(tex->tex_id).c_str(), tex->w, tex->h);
+    ImGui::Text("last write claim: frame %llu",
+                static_cast<unsigned long long>(m_textures[slot].claim_frame));
     if (!tex->is_placeholder) {
       ImGui::Image((ImTextureID)(intptr_t)tex->gpu_textures.at(0).gl, ImVec2(tex->w, tex->h));
     } else {

--- a/game/graphics/texture/TexturePool.h
+++ b/game/graphics/texture/TexturePool.h
@@ -289,6 +289,14 @@ struct GoalTexturePage {
  *
  * (note that the above property is only true because we never make a VRAM slot invalid after
  *  it has been loaded once)
+ *
+ * Renderer-side slot claims go through two primitives:
+ * - move_existing_to_vram is a write claim: the texture's contents were just uploaded or
+ *   rendered at this address, so it evicts the current owner, like any VRAM write on PS2.
+ *   (handle_upload_now installs owners the same way for game texture-page uploads.)
+ * - reassert_in_vram is a residency claim: the texture was not rewritten, so it may keep a
+ *   slot it already owns, but never steals one. On PS2, stale VRAM contents lose to whoever
+ *   uploads over them, so a claim that is not backed by a write must not evict one that is.
  */
 class TexturePool {
  public:
@@ -343,6 +351,7 @@ class TexturePool {
     return m_textures;
   }
   void move_existing_to_vram(GpuTexture* tex, u32 slot_addr);
+  void reassert_in_vram(GpuTexture* tex, u32 slot_addr);
 
   std::mutex& mutex() { return m_mutex; }
   PcTextureId allocate_pc_port_texture(GameVersion version);

--- a/game/graphics/texture/TexturePool.h
+++ b/game/graphics/texture/TexturePool.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -189,6 +190,9 @@ struct GpuTexture {
 struct TextureVRAMReference {
   GLuint gpu_texture = -1;  // the OpenGL texture to use when rendering.
   GpuTexture* source = nullptr;
+  // debug bookkeeping: the frame of the most recent write claim that touched this slot.
+  // a stale owner shows up in the debug view as a claim many frames old.
+  u64 claim_frame = 0;
 };
 
 /*!
@@ -352,6 +356,9 @@ class TexturePool {
   }
   void move_existing_to_vram(GpuTexture* tex, u32 slot_addr);
   void reassert_in_vram(GpuTexture* tex, u32 slot_addr);
+  // frame stamp recorded on write claims, for the debug view. Set once per frame by the
+  // renderer; atomic because EE-thread uploads read it while the render thread advances it.
+  void set_frame_stamp(u64 frame) { m_frame_stamp.store(frame, std::memory_order_relaxed); }
 
   std::mutex& mutex() { return m_mutex; }
   PcTextureId allocate_pc_port_texture(GameVersion version);
@@ -365,6 +372,7 @@ class TexturePool {
 
   char m_regex_input[256] = "";
   std::array<TextureVRAMReference, 1024 * 1024 * 4 / 256> m_textures;
+  std::atomic<u64> m_frame_stamp{0};
   struct Mt4hhTexture {
     TextureVRAMReference ref;
     u32 slot;

--- a/goal_src/jak2/engine/gfx/sky/sky-tng.gc
+++ b/goal_src/jak2/engine/gfx/sky/sky-tng.gc
@@ -51,6 +51,10 @@ vf31: cam 0 (premultiplied by hmge)
     (set! (-> *sky-work* moon1-coords 1 x) (* scale-factor 1207.0))
     (set! (-> *sky-work* moon2-coords 0 x) (* scale-factor -232.0))
     (set! (-> *sky-work* moon2-coords 1 x) (* scale-factor 232.0))
+    ;; the night-star quads need the same aspect correction as the other sky billboards,
+    ;; or stars render stretched horizontally on widescreen.
+    (set! (-> *sky-work* star-coords 0 x) (* scale-factor -1.5))
+    (set! (-> *sky-work* star-coords 1 x) (* scale-factor 1.5))
     )
   (none)
   )

--- a/goal_src/jak3/engine/gfx/sky/sky-tng.gc
+++ b/goal_src/jak3/engine/gfx/sky/sky-tng.gc
@@ -37,6 +37,10 @@
     (set! (-> *sky-work* moon2-coords 1 x) (* scale-factor 232.0))
     (set! (-> *sky-work* day-star-coords 0 x) (* scale-factor -126.0))
     (set! (-> *sky-work* day-star-coords 1 x) (* scale-factor 126.0))
+    ;; the night-star quads need the same aspect correction as the other sky billboards,
+    ;; or stars render stretched horizontally on widescreen.
+    (set! (-> *sky-work* star-coords 0 x) (* scale-factor -1.5))
+    (set! (-> *sky-work* star-coords 1 x) (* scale-factor 1.5))
     )
   (none)
   )


### PR DESCRIPTION
## Problem

jak3's night stars (wasteland/Spargus at night) render as small horizontal rectangles instead of round dots. At 8x diagnostic size the rectangles become legible: each star quad is drawing the **Dolby Pro Logic II legal-screen image** instead of the star texture.

<img width="3840" height="2400" alt="gk_jKQRN2jfmS" src="https://github.com/user-attachments/assets/c2ff87c1-c4e7-48d1-8c53-e003ffa6ca44" />

## Root cause

Two independent defects.

The star draw (`stars-dma`, mips2c method 35) looks up GS VRAM address 0, where the per-frame `sky-textures` page upload places `sky-hotdot`. That upload is processed in bucket order on PC just like PS2 (the `tex-lcom-sky-pre` upload handler runs one bucket before the sky draw), but within a TEX bucket uploads are deliberately flushed before the TextureAnimator so that live animator outputs (clouds, fog) can override the page textures they overlay. The animator's end-of-run pool sync then replays a claim for **every** entry in its VRAM map, which is append-only and never pruned, so a dead entry gets the same override privilege as live clouds. The boot sequence leaves a TextureAnimator composite registered at tbp 0 (its GPU texture still holding the Dolby legal screen), and that stale entry out-competed the sky page upload at address 0 every frame, forever. On PS2 this cannot happen: VRAM contents persist only until someone uploads over them, and a texture nobody writes anymore never wins the address back. (This corrects the first revision's description of the mechanism: the runtime slot-ownership traces identified the same winner, PC-ANIM/0, but the pool is not racing across threads; it is letting un-written entries re-claim.)

Separately, `update-pc-sky-scaling` aspect-corrects the X extents of every sky billboard (sun, green sun, all moon layers, jak3 day-star) except `star-coords`, so the star quads additionally displayed about 33% wider than tall at 16:9.

## Fix

The texture pool now distinguishes the two kinds of slot claim. `move_existing_to_vram` remains the write claim: it evicts the current owner, like any VRAM write on PS2. Its new partner `reassert_in_vram` is a residency claim: it may keep a slot the texture already owns, but never steals one, because stale VRAM contents lose to whoever uploads over them. The animator's pool sync issues a write claim only for entries the game actually wrote this frame (uploads, erases, and draws all stamp the entry) and a re-assert otherwise. Written-once-displayed-later outputs (bigmap) keep serving while unchallenged; entries the game stopped writing can no longer evict a live upload. The invariant is documented in the TexturePool header contract.

A second commit records the frame of each slot's most recent write claim and shows it in the texture pool debug window, so wrong-texture-served reports (#3050 and #3140 look like this same mechanism) can be diagnosed by inspection.

`update-pc-sky-scaling` (jak2 + jak3) scales the `star-coords` X extents by `relative-x-scale`, matching every other sky billboard.

## Test plan

- [x] Full Windows Release build from scratch on this branch; goalc-test suite (compiles the full jak2/jak3 GOAL trees, covering the sky-tng.gc edits): 1507/1509 passed, the two failures being a local test-environment artifact that reproduces without this branch
- [x] jak2 and jak3 boot smokes through the legal screens (where the stale boot composite is created) into title attract with level streaming
- [x] jak3 Spargus at night: stars sample `sky-hotdot` (round dots, not logos), square proportions at stock size
- [x] jak3 bigmap renders correctly (the written-once, displayed-later animator pattern most exposed to the re-assert path)
- [x] jak3 clouds and fog animate correctly (live per-frame anim claims still override the same-bucket sky page upload)
- [x] jak2 ctywide at night: stars clean
- [x] jak2 clouds, map, and progress screens verified on the prior revision; night sky re-verified on this one

---

I work off a self-hosted forge, so this GitHub account is quiet; the slot-ownership traces (per-frame VRAM slot 0 claims from both upload paths, and renderer-side bind servings) are available if anyone wants the raw data.

(AI-assisted)
