### PR TITLE
fix(runtime): add missing break after JakX goal_main (jakx)

### DIFF
--- a/game/runtime.cpp
+++ b/game/runtime.cpp
@@ -239,6 +239,7 @@ void ee_runner(SystemThreadInterface& iface) {
       break;
     case GameVersion::JakX:
       jakx::goal_main(g_argc, g_argv);
+      break;
     default:
       ASSERT_MSG(false, "Unsupported game version");
   }


### PR DESCRIPTION
## Problem
Any JakX session aborts on exit: when `jakx::goal_main` returns during shutdown, `gk` dies with `Assertion failed: "Unsupported game version"` from `exec_runtime` in `game/runtime.cpp` instead of tearing down cleanly.

## Root cause
The `GameVersion::JakX` case in `exec_runtime`'s `goal_main` dispatch switch is missing a `break`, so control falls through into `default: ASSERT_MSG(false, "Unsupported game version")`. Introduced with the initial JakX scaffolding (#4112). Not visible in CI because nothing boots JakX there yet, and today `gk -g jakx` stops earlier at a separate pre-existing missing-JakX-case `ASSERT(false)` in `kprint.cpp` `init_output`, so the exit path is not yet reachable in practice.

## Fix
Add the missing `break;`, matching the Jak 1/2/3 cases. One line; no behavior change for the other games.

## Test plan
- [x] `gk` builds (Windows, VS 2026 + LLVM 22 clang; only `runtime.cpp` rebuilt and relinked)
- [x] `gk -g jakx --no-display -- -boot -fakeiso` still reaches `jakx::goal_main` and proceeds into kernel init (stops at the pre-existing `init_output` assert, unrelated to this change)
- [ ] Clean JakX shutdown observed end-to-end (blocked until JakX kernel boot works)

---

I work off a self-hosted forge, so this GitHub account is quiet; build log and gk boot trace available on request.

(AI-assisted)
