### PR TITLE
fix(jak3): render menu backdrop slate correctly (prelit translucent merc in menus)

### DIFF
--- a/common/dma/gs.h
+++ b/common/dma/gs.h
@@ -485,7 +485,7 @@ class DrawMode {
     }
   }
 
-  bool get_tcc_enable() const { return m_val & (1 << 6); }
+  bool get_tcc_enable() const { return m_val & (1 << 7); }
   void enable_tcc() { m_val = m_val | (1 << 7); }
   void disable_tcc() { m_val = m_val & (~(1 << 7)); }
   void set_tcc(bool en) {

--- a/decompiler/level_extractor/extract_merc.cpp
+++ b/decompiler/level_extractor/extract_merc.cpp
@@ -836,7 +836,8 @@ ConvertedMercEffect convert_merc_effect(const MercEffect& input_effect,
         process_draw_mode(*input_effect.extra_info.shader, false, false, false, false);
     result.envmap_mode.set_ab(true);
     u32 new_tex = remap_texture(input_effect.extra_info.shader->original_tex, map);
-    ASSERT(result.envmap_mode.get_tcc_enable());
+    // note: don't assert on the static tcc bit here; the game forces tcc=rgba when it
+    // links textures at login, so the pre-login value in the level data is meaningless.
     ASSERT(result.envmap_mode.get_alpha_blend() == DrawMode::AlphaBlend::SRC_0_DST_DST);
 
     // texture the texture page/texture index, and convert to a PC port texture ID
@@ -1001,9 +1002,9 @@ ConvertedMercEffect convert_merc_effect(const MercEffect& input_effect,
       bool fog = true;
       merc_state.merc_draw_mode.mode =
           process_draw_mode(shader, result.has_envmap, use_alpha_blend, depth_write, fog);
-      if (!merc_state.merc_draw_mode.mode.get_tcc_enable()) {
-        ASSERT(false);
-      }
+      // note: the static shader data may say tcc=rgb here, but at runtime the game forces
+      // tcc=rgba when it links textures (adgif-shader<-texture!), so PC merc always renders
+      // tcc=rgba. Translucent effects take vertex alpha via the prelit path in Merc2 instead.
       u32 new_tex = remap_texture(shader.original_tex, map);
 
       // texture the texture page/texture index, and convert to a PC port texture ID

--- a/game/graphics/opengl_renderer/DirectRenderer.cpp
+++ b/game/graphics/opengl_renderer/DirectRenderer.cpp
@@ -537,9 +537,15 @@ void DirectRenderer::update_gl_test() {
     ASSERT(false);
   }
 
+  // ATST=NEVER fails the alpha test for every pixel, so AFAIL decides all writes.
+  // RGB_ONLY means "write only color, never depth or alpha": without this, invisible
+  // alpha-0 quads using the NEVER+RGB_ONLY idiom stamp depth and z-cull 3D drawn after
+  // them (jak3 progress menu backdrop boxes cutting a hole through the menu ring).
+  // FB_ONLY keeps its existing double-draw handling untouched.
   bool alpha_trick_to_disable = m_test_state.alpha_test_enable &&
                                 m_test_state.alpha_test == GsTest::AlphaTest::NEVER &&
-                                m_test_state.afail == GsTest::AlphaFail::FB_ONLY;
+                                (m_test_state.afail == GsTest::AlphaFail::FB_ONLY ||
+                                 m_test_state.afail == GsTest::AlphaFail::RGB_ONLY);
 
   if (m_test_state.afail == GsTest::AlphaFail::FB_ONLY ||
       m_test_state.afail == GsTest::AlphaFail::RGB_ONLY) {

--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -338,6 +338,20 @@ void OpenGLRenderer::init_bucket_renderers_jak3() {
                                                  BucketId::GMERC2_LCOM_PRIS, m_generic2,
                                                  Generic2::Mode::PRIM);
 
+    // 456
+    // lcom-pris2 is used by hud models on the common level: the progress menu's hud-ring
+    // "Screen" membrane is a pris2-category effect and routes here in menu mode.
+    init_bucket_renderer<TextureUploadHandler>("tex-lcom-pris2", BucketCategory::TEX,
+                                               BucketId::TEX_LCOM_PRIS2, m_texture_animator);
+    init_bucket_renderer<Merc2BucketRenderer>("merc-lcom-pris2", BucketCategory::MERC,
+                                              BucketId::MERC_LCOM_PRIS2, m_merc2);
+    init_bucket_renderer<Generic2BucketRenderer>("gmerc-lcom-pris2", BucketCategory::GENERIC,
+                                                 BucketId::GMERC_LCOM_PRIS2, m_generic2,
+                                                 Generic2::Mode::NORMAL);
+    init_bucket_renderer<Generic2BucketRenderer>("gmerc2-lcom-pris2", BucketCategory::GENERIC,
+                                                 BucketId::GMERC2_LCOM_PRIS2, m_generic2,
+                                                 Generic2::Mode::PRIM);
+
     // 461
     init_bucket_renderer<TextureUploadHandler>("tex-lcom-sky-post", BucketCategory::TEX,
                                                BucketId::TEX_LCOM_SKY_POST, m_texture_animator);

--- a/game/graphics/opengl_renderer/foreground/Merc2.cpp
+++ b/game/graphics/opengl_renderer/foreground/Merc2.cpp
@@ -529,7 +529,10 @@ void Merc2::handle_pc_model(const DmaTransfer& setup,
     u64 ignore_alpha_mask;
     u8 effect_count;
     u8 bitflags;
+    u8 pad[6];
+    u64 prelit_mask;  // only valid if bitflags & 32, jak 3 writes it, jak 1/2 don't.
   };
+  static_assert(sizeof(PcMercFlags) == 32);
   auto* flags = (const PcMercFlags*)input_data;
   int num_effects = flags->effect_count;  // mostly just a sanity check
   ASSERT(num_effects < kMaxEffect);
@@ -540,6 +543,7 @@ void Merc2::handle_pc_model(const DmaTransfer& setup,
   bool model_uses_pc_blerc = flags->bitflags & 4;
   bool model_disables_envmap = flags->bitflags & 8;
   bool model_no_texture = flags->bitflags & 16;
+  u64 current_prelit_bits = (flags->bitflags & 32) ? flags->prelit_mask : 0;
   input_data += 32;
 
   float blerc_weights[kMaxBlerc];
@@ -647,6 +651,7 @@ void Merc2::handle_pc_model(const DmaTransfer& setup,
 
     bool ignore_alpha = !!(current_ignore_alpha_bits & (1ull << ei));
     args.ignore_alpha = ignore_alpha;
+    args.prelit = !!(current_prelit_bits & (1ull << ei));
     auto& effect = model->effects[ei];
 
     bool should_envmap = effect.has_envmap && !model_disables_envmap;
@@ -745,6 +750,7 @@ void Merc2::init_shader_common(Shader& shader, Uniforms* uniforms, bool include_
 
   uniforms->fog = glGetUniformLocation(id, "fog_constants");
   uniforms->decal = glGetUniformLocation(id, "decal_enable");
+  uniforms->prelit = glGetUniformLocation(id, "prelit_enable");
 
   uniforms->fog_color = glGetUniformLocation(id, "fog_color");
   uniforms->perspective_matrix = glGetUniformLocation(id, "perspective_matrix");
@@ -1113,6 +1119,9 @@ Merc2::Draw* Merc2::alloc_normal_draw(const tfrag3::MercDraw& mdraw, const DrawA
   if (args.no_texture) {
     draw->flags |= NO_TEXTURE;
   }
+  if (args.prelit) {
+    draw->flags |= PRELIT;
+  }
   for (int i = 0; i < 4; i++) {
     draw->fade[i] = 0;
   }
@@ -1306,6 +1315,7 @@ void Merc2::do_draws(const Draw* draw_array,
     }
 
     glUniform1i(uniforms.decal, draw.mode.get_decal());
+    glUniform1i(uniforms.prelit, (draw.flags & PRELIT) != 0);
     glUniform1i(uniforms.gfx_hack_no_tex, (draw.flags & NO_TEXTURE) != 0);
 
     if (set_fade) {

--- a/game/graphics/opengl_renderer/foreground/Merc2.h
+++ b/game/graphics/opengl_renderer/foreground/Merc2.h
@@ -131,6 +131,7 @@ class Merc2 {
 
     GLuint ignore_alpha;
     GLuint decal;
+    GLuint prelit;
 
     GLuint gfx_hack_no_tex;
 
@@ -178,6 +179,7 @@ class Merc2 {
     IGNORE_ALPHA = 1,
     MOD_VTX = 2,
     NO_TEXTURE = 4,
+    PRELIT = 8,
   };
 
   struct Draw {
@@ -217,6 +219,7 @@ class Merc2 {
     bool ignore_alpha;
     bool disable_fog;
     bool no_texture;
+    bool prelit;
     u64 hash;
     u32 lights;
     u32 first_bone;

--- a/game/graphics/opengl_renderer/shaders/merc2.vert
+++ b/game/graphics/opengl_renderer/shaders/merc2.vert
@@ -21,6 +21,8 @@ uniform vec4 light_ambient;
 uniform vec4 hvdf_offset;
 uniform vec4 fog_constants;
 
+uniform int prelit_enable;
+
 uniform mat4 perspective_matrix;
 
 // output
@@ -98,6 +100,13 @@ void main() {
   gl_Position = transformed;
 
 
-  vtx_color = rgba * light_color;
+  if (prelit_enable == 1) {
+    // translucent merc effects are prelit: the PS2 mercneric translucent pipeline skips
+    // lighting and submits the neutral chain color doubled (128 -> 255), so the GS sees
+    // white with the vertex alpha. GS dumps of the menu membrane show rgba (255,255,255,128).
+    vtx_color = vec4(1.0, 1.0, 1.0, rgba.a);
+  } else {
+    vtx_color = rgba * light_color;
+  }
   vtx_st = st_in;
 }

--- a/goal_src/jak3/engine/gfx/foreground/foreground.gc
+++ b/goal_src/jak3/engine/gfx/foreground/foreground.gc
@@ -1635,6 +1635,7 @@
   (pc-blerc 2)
   (disable-envmap 3)
   (no-textures 4)
+  (prelit-valid 5) ;; set when prelit-mask is populated (jak 3 writes it, jak 1/2 don't)
   )
 
 (deftype pc-merc-flags (structure)
@@ -1642,6 +1643,7 @@
    (ignore-alpha-mask uint64)
    (effect-count uint8)
    (bit-flags pc-merc-bits)
+   (prelit-mask uint64 :offset 24)
    )
   )
 
@@ -1757,6 +1759,23 @@
               )
             (set! (-> flags enable-mask) enable-mask)
             (set! (-> flags ignore-alpha-mask) ignore-alpha-mask)
+            ;; translucent effects (effect-bits no-fade-out) take the generic renderer's
+            ;; translucent path on PS2 (mercneric-convert selects a separate pipeline
+            ;; config for them): vertex rgba passes through with no lighting. gameplay
+            ;; translucents render lit through VU1 merc, so this only applies in menu
+            ;; mode, the one mode that renders exclusively through generic on PS2.
+            ;; PC renders menus through merc, so flag the effects for the PC renderer.
+            (logior! (-> flags bit-flags) (pc-merc-bits prelit-valid))
+            (let ((prelit-mask 0))
+              (when (-> *blit-displays-work* screen-copied)
+                (dotimes (i (-> merc-ctrl header effect-count))
+                  (if (logtest? (-> merc-ctrl effect i effect-bits) (effect-bits no-fade-out))
+                      (logior! prelit-mask (ash 1 i))
+                      )
+                  )
+                )
+              (set! (-> flags prelit-mask) prelit-mask)
+              )
             )
           (&+! dma-buf (* 16 2))
           (+! qwc-total 2)


### PR DESCRIPTION
## Problem

All jak3 menu backdrops (title screen and in-game pause alike) are missing the blue-teal slate the PS2 renders behind the menu text. On PC the backdrop region reads dark green-black behind the scanline effect, so menu panels look like holes instead of screens. The previous revision of this PR also rendered the in-game panel opaque where PS2 renders it translucent.

## Root cause

Two independent defects, both needed for the slate to appear:

**Merc renders the membrane lit and dark.** The slate is the hud-ring model's `Screen` membrane, a translucent (`effect-bits no-fade-out`) merc effect. On PS2, menu mode renders exclusively through the **generic** renderer (`blit-displays.gc` still carries the "was generic in the original" note), and the generic path treats translucent effects specially: `mercneric-convert` selects a separate pipeline config for records staged with `use-translucent` (set from the effect's `no-fade-out` bit), which skips lighting and submits the neutral chain color doubled, so the GS receives the membrane quad with vertex rgba (255,255,255,128). GS dumps of both the settled title menu and an in-game pause menu show exactly that (with fge=1 but per-vertex F=254, so fog contributes under 1 percent). PC renders menus through merc, which lights the fr3 vertex color (113,121,123,128) through vu-lights instead, leaving the slate at under half the PS2 brightness per channel (GS modulate is Ct*Cv/128: white gives x1.992, the lit color gave ~x0.4). Alpha is not part of the delta: the PS2 draw carries tcc=1, so As stays texture alpha x vertex alpha, exactly upstream's existing math (the earlier revision of this PR overrode alpha from the vertex; that was wrong and made the in-game panel opaque, as the review screenshot showed).

**The invisible progress boxes z-cull the membrane.** The GS idiom ATST=NEVER + AFAIL=RGB_ONLY draws color while never writing Z, but `DirectRenderer` only recognized the FB_ONLY variant when deciding to disable depth writes. The alpha-gated progress backdrop boxes use RGB_ONLY, so their alpha-0 (invisible) draws stamp near depth over the panel rectangle and z-cull the membrane drawn later in merc-lcom-water. Without this fix the merc correction renders nothing; it is also what cut a rectangular hole through the ring during the title menu's opening animation.

Gameplay translucents are unaffected on PS2: they render lit through VU1 merc (verified for the mission-destination light column, whose additive beam depends on lighting and washes out if rendered unlit). Menus are the only mode that is generic-only, which bounds the fix.

Two latent defects surfaced during the investigation:
- `DrawMode::get_tcc_enable()` reads bit 6 (the filt flag) instead of bit 7, which the setters use, so every consumer saw tcc as enabled whenever filtering was on, and extract_merc's tcc asserts passed vacuously. The static tcc bit is meaningless at runtime anyway: `adgif-shader<-texture!` hardcodes tcc=rgba into every shader at texture login (verified against live post-login shader data in a PCSX2 savestate).
- The jak3 renderer init skips the lcom-pris2 bucket block (456-460) entirely, so any DMA routed there hits an `EmptyBucketRenderer` assert; pris2-category hud models on the common level hit this as soon as the menu texture masks include all-pris. The block appears to have been left unwired when the progress buckets were reworked (see open-goal/jak-project#3655 for that history).

## Fix

Four commits, each independently revertable:

1. `get_tcc_enable()` reads bit 7, and the now-vacuous-by-design extract_merc tcc asserts are dropped (with a comment documenting the login behavior).
2. Register the jak3 lcom-pris2 bucket renderers (456-460; emerc 458 left empty for parity with the other emerc buckets).
3. Per-effect prelit mask in the `pc-merc-flags` DMA: a spare u64 in the existing 32-byte flags block, gated by a new bit-flag so jak1/jak2 DMA is bit-identical to before. jak3's `pc-merc-draw-request` populates it from `no-fade-out` effects only while the menu screen-copy is active (`*blit-displays-work* screen-copied`), matching the PS2 scoping. Merc2 tags those draws and the vertex shader emits white with the vertex alpha for them; the fragment shader is unchanged from upstream.
4. NEVER+RGB_ONLY afail draws no longer write depth in `DirectRenderer`. The double-draw path for textured afail draws is deliberately left untouched.

## Before/after (updated)
Re-recorded against the current build:

https://github.com/user-attachments/assets/48391d9e-9008-4c18-9eb2-1bf5348571e4

### About the comparison footage

As the disclaimer in the video notes, the "after" side was captured on my integration build, which carries this PR plus a few other in-flight fixes of mine. They are visible in the frame but are **not part of this diff**; each is (or will be) its own PR:

- **Progress bucket restoration**: restores bucket drains the progress-menu rework left unwired (Sprite3, ocean), so the scene visible through and around the slate draws all of its layers.
- **DirectRenderer blend with GS alpha above 0x80**: the menu darken fill draws with alpha 0x90, which the GS scales to 1.125x but GL blend factors clamp at 1.0; premultiplying in the shader makes the panel darkening depth match PS2. This is why the "after" panel interior reads PS2-dark rather than only PS2-tinted.
- **Title dust storm density**: a PC frame throttle starved the title dust storm's spawn bursts to roughly a tenth of PS2 density.

This PR's slate fix renders as described without any of them; they only change the surrounding scene.

Old opaque before/after (not proper fix):

~~https://github.com/user-attachments/assets/f7cf54df-e68c-4c43-b165-3a2918601b4e~~

## Test plan

- [x] jak3 title menu slate translucent teal over the black capture, tint matches PCSX2 (verified by screenshot on this exact branch build; without commit 4 the panel is provably black)
- [x] jak3 in-game pause menu submenus (Secrets, Restart/Quit, Load Game) render the slate with the frozen scene showing through; sample comparison vs a fresh PS2 GS dump of the same menu puts the header band within a few units per channel
- [x] jak3 title ring no longer cut by the backdrop boxes during the opening animation
- [x] Gameplay translucents unchanged: mission-destination light column renders identically to master
- [x] jak1 title screen (subtitle plate alpha mask) and menus unaffected by the tcc getter change
- [x] jak1/jak2/jak3 boot smokes pass; full jak3 GOAL tree recompiles; fresh C++ build from clean configure

---

I work off a self-hosted forge, so this GitHub account is quiet; the full evidence chain (RenderDoc captures, PCSX2 GS dump parses, and savestate EE/scratchpad analysis of the live merc data and generic chain records) is available if anyone wants the raw data.

(AI-assisted)