### PR TITLE
replace naive `StallLoaderStage` implementation

### DIFF
--- a/game/graphics/opengl_renderer/loader/LoaderStages.cpp
+++ b/game/graphics/opengl_renderer/loader/LoaderStages.cpp
@@ -547,17 +547,32 @@ class StallLoaderStage : public LoaderStage {
  public:
   StallLoaderStage() : LoaderStage("stall") {}
   bool run(Timer&, LoaderInput& /*data*/) override {
-    m_count++;
-    if (m_count > 10) {
+    if (!m_fence) {
+      m_fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+      ASSERT(m_fence);
+      glFlush();
+    }
+
+    const GLenum wait_result = glClientWaitSync(m_fence, 0, 0);
+    ASSERT(wait_result != GL_WAIT_FAILED);
+
+    if (wait_result == GL_ALREADY_SIGNALED || wait_result == GL_CONDITION_SATISFIED) {
+      glDeleteSync(m_fence);
+      m_fence = nullptr;
       return true;
     }
     return false;
   }
 
-  void reset() override { m_count = 0; }
+  void reset() override {
+    if (m_fence) {
+      glDeleteSync(m_fence);
+      m_fence = nullptr;
+    }
+  }
 
  private:
-  int m_count = 0;
+  GLsync m_fence = nullptr;
 };
 
 class HfragLoaderStage : public LoaderStage {


### PR DESCRIPTION
pull request #1768 "added a 10 frame delay in the loader in between finishing the last opengl buffer upload and making the Level available to renderers"

the implementation outlined in the referenced pull request is rather naive and can be both too conservative on high end computers.

this pull request improves on this by using [glFenceSync](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glFenceSync.xhtml) to determine when the gpu has finished instead of an arbitrary 10 frame delay.

in my testing on mac and windows i measured an order of magnitude decrease in the stall time. i measured the original fixed stall to be around ~150 ms and after this change i measured the stall to be ~30 ms.