### PR TITLE
[Jak 3]: Fixing spelling of precursor in french.

### DIFF
--- a/game/assets/jak3/game_text.gp
+++ b/game/assets/jak3/game_text.gp
@@ -11,7 +11,7 @@
   (file "$DECOMP/assets/game_text.txt") ;; this is the decompiler-generated file!
   ;; built-in languages
   (file-json 0 jak3 "common" '("game/assets/jak3/text/game_custom_text_en-US.json"))
-  (file-json 1 jak3 "common" '("game/assets/jak3/text/game_custom_text_fr-FR.json"))
+  (file-json 1 jak3 "common" '("game/assets/jak3/text/game_custom_text_fr-FR.json" "game/assets/jak3/text/game_base_text_fr-FR.json"))
   (file-json 2 jak3 "common" '("game/assets/jak3/text/game_custom_text_de-DE.json"))
   (file-json 3 jak2 "common" '("game/assets/jak3/text/game_custom_text_es-ES.json"))
   (file-json 4 jak3 "common" '("game/assets/jak3/text/game_custom_text_it-IT.json"))

--- a/game/assets/jak3/text/game_base_text_fr-FR.json
+++ b/game/assets/jak3/text/game_base_text_fr-FR.json
@@ -1,0 +1,4 @@
+{
+    "568": "Atteins le Cœur des Précurseurs",
+    "863": "Objets des Précurseurs utilisés"
+}

--- a/game/assets/jak3/text/game_custom_text_fr-FR.json
+++ b/game/assets/jak3/text/game_custom_text_fr-FR.json
@@ -2,8 +2,6 @@
   "a4": "Sauvegarde en cours. Veillez à ne retirer ou n'insérer aucun périphérique, ni éteindre votre système ou arrêter le jeu.",
   "b6": "Lorsque cette icône apparait, ne retirez ou n'insérez aucun périphérique, ni éteindre votre système ou arrêter le jeu.",
   "7c8": "<FLAG_DUTCH> Dutch",
-  "863": "Objets des Précurseurs utilisés",
-  "568": "Atteins le Cœur des Précurseurs",
   "11fe": "Pas en mission",
   "11ff": "Jouer une mission bonus",
   "1200": "Mode d'affichage",

--- a/game/assets/jak3/text/game_custom_text_fr-FR.json
+++ b/game/assets/jak3/text/game_custom_text_fr-FR.json
@@ -2,6 +2,8 @@
   "a4": "Sauvegarde en cours. Veillez à ne retirer ou n'insérer aucun périphérique, ni éteindre votre système ou arrêter le jeu.",
   "b6": "Lorsque cette icône apparait, ne retirez ou n'insérez aucun périphérique, ni éteindre votre système ou arrêter le jeu.",
   "7c8": "<FLAG_DUTCH> Dutch",
+  "863": "Objets des Précurseurs utilisés",
+  "568": "Atteins le Cœur des Précurseurs",
   "11fe": "Pas en mission",
   "11ff": "Jouer une mission bonus",
   "1200": "Mode d'affichage",


### PR DESCRIPTION
Fixed spelling mistake that occurs in the original game. précuseur -> précurseur