### PR TITLE
goalc: arm64 vector float ops were not float ops

### DIFF
--- a/goalc/emitter/IGenARM64.cpp
+++ b/goalc/emitter/IGenARM64.cpp
@@ -2702,10 +2702,10 @@ InstructionARM64 sub_vf(Register dst, Register src1, Register src2) {
 }
 
 InstructionARM64 add_vf(Register dst, Register src1, Register src2) {
-  // https://www.scs.stanford.edu/~zyedidia/arm64/add_advsimd.html
-  // ADD <Vd>.<T>, <Vn>.<T>, <Vm>.<T>
+  // https://www.scs.stanford.edu/~zyedidia/arm64/fadd_advsimd_vec.html
+  // FADD <Vd>.<T>, <Vn>.<T>, <Vm>.<T>
   // 4 single precision floats
-  return InstructionARM64(Base(0b0100111010100000100001, 22), Rn(src1.id()), Rm(src2.id()),
+  return InstructionARM64(Base(0b0100111000100000110101, 22), Rn(src1.id()), Rm(src2.id()),
                           Rd(dst.id()));
 }
 
@@ -2718,18 +2718,18 @@ InstructionARM64 mul_vf(Register dst, Register src1, Register src2) {
 }
 
 InstructionARM64 max_vf(Register dst, Register src1, Register src2) {
-  // https://www.scs.stanford.edu/~zyedidia/arm64/famax_advsimd.html
-  // FAMAX <Vd>.<T>, <Vn>.<T>, <Vm>.<T>
+  // https://www.scs.stanford.edu/~zyedidia/arm64/fmax_advsimd_vec.html
+  // FMAX <Vd>.<T>, <Vn>.<T>, <Vm>.<T>
   // 4 single precision floats
-  return InstructionARM64(Base(0b0100111010100000110111, 22), Rn(src1.id()), Rm(src2.id()),
+  return InstructionARM64(Base(0b0100111000100000111101, 22), Rn(src1.id()), Rm(src2.id()),
                           Rd(dst.id()));
 }
 
 InstructionARM64 min_vf(Register dst, Register src1, Register src2) {
-  // https://www.scs.stanford.edu/~zyedidia/arm64/famin_advsimd.html
-  // FAMIN <Vd>.<T>, <Vn>.<T>, <Vm>.<T>
+  // https://www.scs.stanford.edu/~zyedidia/arm64/fmin_advsimd_vec.html
+  // FMIN <Vd>.<T>, <Vn>.<T>, <Vm>.<T>
   // 4 single precision floats
-  return InstructionARM64(Base(0b0110111010100000110111, 22), Rn(src1.id()), Rm(src2.id()),
+  return InstructionARM64(Base(0b0100111010100000111101, 22), Rn(src1.id()), Rm(src2.id()),
                           Rd(dst.id()));
 }
 

--- a/goalc/emitter/IGenARM64.cpp
+++ b/goalc/emitter/IGenARM64.cpp
@@ -2702,7 +2702,7 @@ InstructionARM64 sub_vf(Register dst, Register src1, Register src2) {
 }
 
 InstructionARM64 add_vf(Register dst, Register src1, Register src2) {
-  // https://www.scs.stanford.edu/~zyedidia/arm64/fadd_advsimd_vec.html
+  // https://www.scs.stanford.edu/~zyedidia/arm64/fadd_advsimd.html
   // FADD <Vd>.<T>, <Vn>.<T>, <Vm>.<T>
   // 4 single precision floats
   return InstructionARM64(Base(0b0100111000100000110101, 22), Rn(src1.id()), Rm(src2.id()),
@@ -2718,7 +2718,7 @@ InstructionARM64 mul_vf(Register dst, Register src1, Register src2) {
 }
 
 InstructionARM64 max_vf(Register dst, Register src1, Register src2) {
-  // https://www.scs.stanford.edu/~zyedidia/arm64/fmax_advsimd_vec.html
+  // https://www.scs.stanford.edu/~zyedidia/arm64/fmax_advsimd.html
   // FMAX <Vd>.<T>, <Vn>.<T>, <Vm>.<T>
   // 4 single precision floats
   return InstructionARM64(Base(0b0100111000100000111101, 22), Rn(src1.id()), Rm(src2.id()),
@@ -2726,7 +2726,7 @@ InstructionARM64 max_vf(Register dst, Register src1, Register src2) {
 }
 
 InstructionARM64 min_vf(Register dst, Register src1, Register src2) {
-  // https://www.scs.stanford.edu/~zyedidia/arm64/fmin_advsimd_vec.html
+  // https://www.scs.stanford.edu/~zyedidia/arm64/fmin_advsimd.html
   // FMIN <Vd>.<T>, <Vn>.<T>, <Vm>.<T>
   // 4 single precision floats
   return InstructionARM64(Base(0b0100111010100000111101, 22), Rn(src1.id()), Rm(src2.id()),


### PR DESCRIPTION
Alters the opcode constants in Base, so these helpers now emit the correct FADD/FMAX/FMIN machine encodings for 4×f32 vector operations.

Found these while getting OpenGOAL running natively on Apple Silicon.