### PR TITLE
game: the sky blend was compiled out entirely on arm64

### DIFF
--- a/game/graphics/opengl_renderer/SkyBlendCPU.cpp
+++ b/game/graphics/opengl_renderer/SkyBlendCPU.cpp
@@ -5,6 +5,10 @@
 
 #include "game/graphics/opengl_renderer/AdgifHandler.h"
 
+#ifdef __aarch64__
+#include <arm_neon.h>
+#endif
+
 SkyBlendCPU::SkyBlendCPU() {
   for (int i = 0; i < 2; i++) {
     glGenTextures(1, &m_textures[i].gl);
@@ -21,8 +25,26 @@ SkyBlendCPU::~SkyBlendCPU() {
   }
 }
 
+/*!
+ * out[i] = saturate_u8((in[i] * intensity) >> 7)
+ */
 void blend_sky_initial_fast(u8 intensity, u8* out, const u8* in, u32 size) {
-#ifndef __arm64__
+#ifdef __aarch64__
+  // widen u8 to u16, multiply, shift, then narrow with saturation. 255*255 fits in a u16 so
+  // the multiply can't overflow, and vqmovn_u16 clamps at 255 like packus does.
+  const uint16x8_t intensity_vec = vdupq_n_u16(intensity);
+  u32 i = 0;
+  for (; i + 16 <= size; i += 16) {
+    const uint8x16_t tex = vld1q_u8(in + i);
+    const uint16x8_t lo = vshrq_n_u16(vmulq_u16(vmovl_u8(vget_low_u8(tex)), intensity_vec), 7);
+    const uint16x8_t hi = vshrq_n_u16(vmulq_u16(vmovl_u8(vget_high_u8(tex)), intensity_vec), 7);
+    vst1q_u8(out + i, vcombine_u8(vqmovn_u16(lo), vqmovn_u16(hi)));
+  }
+  for (; i < size; i++) {
+    const u32 v = ((u32)in[i] * intensity) >> 7;
+    out[i] = v > 255 ? 255 : (u8)v;
+  }
+#else
   if (get_cpu_info().has_avx2) {
 #ifdef __AVX2__
     __m256i intensity_vec = _mm256_set1_epi16(intensity);
@@ -52,8 +74,29 @@ void blend_sky_initial_fast(u8 intensity, u8* out, const u8* in, u32 size) {
 #endif
 }
 
+/*!
+ * out[i] = saturating_add_u8(out[i], saturate_u8((in[i] * intensity) >> 7))
+ */
 void blend_sky_fast(u8 intensity, u8* out, const u8* in, u32 size) {
-#ifndef __arm64__
+#ifdef __aarch64__
+  const uint16x8_t intensity_vec = vdupq_n_u16(intensity);
+  u32 i = 0;
+  for (; i + 16 <= size; i += 16) {
+    const uint8x16_t tex = vld1q_u8(in + i);
+    const uint8x16_t cur = vld1q_u8(out + i);
+    const uint16x8_t lo = vshrq_n_u16(vmulq_u16(vmovl_u8(vget_low_u8(tex)), intensity_vec), 7);
+    const uint16x8_t hi = vshrq_n_u16(vmulq_u16(vmovl_u8(vget_high_u8(tex)), intensity_vec), 7);
+    // vqmovn_u16 clamps at 255, so it covers both the min and the packus the x86 path does
+    vst1q_u8(out + i, vqaddq_u8(cur, vcombine_u8(vqmovn_u16(lo), vqmovn_u16(hi))));
+  }
+  for (; i < size; i++) {
+    u32 v = ((u32)in[i] * intensity) >> 7;
+    if (v > 255)
+      v = 255;
+    const u32 sum = out[i] + v;
+    out[i] = sum > 255 ? 255 : (u8)sum;
+  }
+#else
   if (get_cpu_info().has_avx2) {
 #ifdef __AVX2__
     __m256i intensity_vec = _mm256_set1_epi16(intensity);

--- a/game/graphics/opengl_renderer/SkyBlendCPU.h
+++ b/game/graphics/opengl_renderer/SkyBlendCPU.h
@@ -6,6 +6,10 @@
 #include "game/graphics/opengl_renderer/SkyBlendCommon.h"
 #include "game/graphics/pipelines/opengl.h"
 
+// declared here so the tests can call them
+void blend_sky_initial_fast(u8 intensity, u8* out, const u8* in, u32 size);
+void blend_sky_fast(u8 intensity, u8* out, const u8* in, u32 size);
+
 class SkyBlendCPU {
  public:
   SkyBlendCPU();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,8 @@ add_executable(goalc-test
         ${CMAKE_CURRENT_LIST_DIR}/test_emitter_x86.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test_emitter_avx.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test_emitter_neon.cpp
+
+        ${CMAKE_CURRENT_LIST_DIR}/test_sky_blend.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test_emitter_arm64.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test_common_util.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test_pretty_print.cpp

--- a/test/test_sky_blend.cpp
+++ b/test/test_sky_blend.cpp
@@ -1,0 +1,98 @@
+// the blend maths, checked against a scalar reference. `out` starts filled with the wrong
+// answer, so a function that writes nothing fails instead of quietly giving a black sky.
+
+#include <cstring>
+#include <vector>
+
+#include "common/common_types.h"
+
+#include "game/graphics/opengl_renderer/SkyBlendCPU.h"
+#include "gtest/gtest.h"
+
+namespace {
+// what the x86 SSE/AVX2 paths compute, spelled out
+u8 ref_initial(u8 in, u8 intensity) {
+  u32 v = ((u32)in * intensity) >> 7;
+  return v > 255 ? 255 : (u8)v;
+}
+u8 ref_blend(u8 out, u8 in, u8 intensity) {
+  u32 v = ((u32)in * intensity) >> 7;
+  if (v > 255) {
+    v = 255;
+  }
+  u32 sum = out + v;
+  return sum > 255 ? 255 : (u8)sum;
+}
+}  // namespace
+
+TEST(SkyBlend, InitialMatchesReferenceAndActuallyWrites) {
+  constexpr u32 kSize = 4096;  // the 32x32 sky buffer, 4 bytes per texel
+  std::vector<u8> in(kSize), out(kSize);
+  u32 st = 12345;
+  for (u32 i = 0; i < kSize; i++) {
+    st = st * 1664525u + 1013904223u;
+    in[i] = u8(st >> 24);
+  }
+
+  for (int intensity : {0, 1, 64, 127, 128, 200, 255}) {
+    // fill the destination with the wrong answer so a function that writes nothing fails
+    std::memset(out.data(), 0xAB, kSize);
+    blend_sky_initial_fast(u8(intensity), out.data(), in.data(), kSize);
+
+    bool wrote_something = false;
+    for (u32 i = 0; i < kSize; i++) {
+      ASSERT_EQ(out[i], ref_initial(in[i], u8(intensity)))
+          << "intensity " << intensity << " byte " << i;
+      if (out[i] != 0xAB) {
+        wrote_something = true;
+      }
+    }
+    EXPECT_TRUE(wrote_something) << "blend_sky_initial_fast wrote nothing at intensity "
+                                 << intensity << ". is it compiled out on this platform?";
+  }
+}
+
+TEST(SkyBlend, BlendMatchesReferenceAndActuallyWrites) {
+  constexpr u32 kSize = 16384;  // the 64x64 cloud buffer
+  std::vector<u8> in(kSize), out(kSize), seed(kSize);
+  u32 st = 999;
+  for (u32 i = 0; i < kSize; i++) {
+    st = st * 1664525u + 1013904223u;
+    in[i] = u8(st >> 24);
+    st = st * 1664525u + 1013904223u;
+    seed[i] = u8(st >> 24);
+  }
+
+  for (int intensity : {0, 1, 64, 127, 128, 200, 255}) {
+    out = seed;
+    blend_sky_fast(u8(intensity), out.data(), in.data(), kSize);
+
+    bool changed = false;
+    for (u32 i = 0; i < kSize; i++) {
+      ASSERT_EQ(out[i], ref_blend(seed[i], in[i], u8(intensity)))
+          << "intensity " << intensity << " byte " << i;
+      if (out[i] != seed[i]) {
+        changed = true;
+      }
+    }
+    if (intensity > 0) {
+      EXPECT_TRUE(changed) << "blend_sky_fast changed nothing at intensity " << intensity
+                           << ". is it compiled out on this platform?";
+    }
+  }
+}
+
+TEST(SkyBlend, SaturatesLikePackus) {
+  // (255 * 255) >> 7 is 508, which has to clamp to 255 the way packus/vqmovn do
+  std::vector<u8> in(16, 255), out(16, 0);
+  blend_sky_initial_fast(255, out.data(), in.data(), 16);
+  for (u8 v : out) {
+    EXPECT_EQ(v, 255);
+  }
+  // and the add saturates too
+  std::vector<u8> in2(16, 255), out2(16, 200);
+  blend_sky_fast(255, out2.data(), in2.data(), 16);
+  for (u8 v : out2) {
+    EXPECT_EQ(v, 255);
+  }
+}


### PR DESCRIPTION
Both sky blend functions have their whole body inside `#ifndef __arm64__`, so on
Apple Silicon they compile to nothing and the sky comes out black.

Added a NEON path and left x86 alone. It does the same maths as the SSE version
and there's a test comparing the two. The test fills the output with junk first,
otherwise an empty function would pass it.