### PR TITLE
fix: three ARM64 runtime bugs found running jak1 natively on Apple Silicon

### DIFF
--- a/game/graphics/opengl_renderer/SkyBlendCPU.cpp
+++ b/game/graphics/opengl_renderer/SkyBlendCPU.cpp
@@ -22,7 +22,6 @@ SkyBlendCPU::~SkyBlendCPU() {
 }
 
 void blend_sky_initial_fast(u8 intensity, u8* out, const u8* in, u32 size) {
-#ifndef __arm64__
   if (get_cpu_info().has_avx2) {
 #ifdef __AVX2__
     __m256i intensity_vec = _mm256_set1_epi16(intensity);
@@ -49,11 +48,9 @@ void blend_sky_initial_fast(u8 intensity, u8* out, const u8* in, u32 size) {
       _mm_storel_epi64((__m128i*)(out + (i * 8)), result);
     }
   }
-#endif
 }
 
 void blend_sky_fast(u8 intensity, u8* out, const u8* in, u32 size) {
-#ifndef __arm64__
   if (get_cpu_info().has_avx2) {
 #ifdef __AVX2__
     __m256i intensity_vec = _mm256_set1_epi16(intensity);
@@ -88,7 +85,6 @@ void blend_sky_fast(u8 intensity, u8* out, const u8* in, u32 size) {
       _mm_storel_epi64((__m128i*)(out + (i * 8)), out_val);
     }
   }
-#endif
 }
 
 SkyBlendStats SkyBlendCPU::do_sky_blends(DmaFollower& dma,

--- a/game/kernel/asm_funcs_arm64.s
+++ b/game/kernel/asm_funcs_arm64.s
@@ -172,10 +172,24 @@ _mips2c_call_arm64:
 _call_goal_asm_arm64:
   stp	x29, x30, [sp, #-16]!
   mov	x29, sp
-  ;; saved registers we need to modify for GOAL should be preserved
+  ;; Save the full AAPCS64 callee-saved set, not just the registers GOAL's
+  ;; own dispatch touches (x20-x22). GOAL's coroutine machinery loads whole
+  ;; register contexts from zero-initialized thread structs when it switches
+  ;; coroutines, so a GOAL call can come back with x19, x23-x28 or d8-d15
+  ;; clobbered even though GOAL-compiled code itself never touches them --
+  ;; and the C caller on the other side of this BLR is entitled to all of
+  ;; them under AAPCS64, same as any other call boundary.
   ; ARM64 requires 16-byte stack pointer alignment
   stp x20, x21, [sp, #-16]!
   str x22, [sp, #-16]!
+  stp x19, x23, [sp, #-16]!
+  stp x24, x25, [sp, #-16]!
+  stp x26, x27, [sp, #-16]!
+  str x28, [sp, #-16]!
+  stp q14, q15, [sp, #-32]!
+  stp q12, q13, [sp, #-32]!
+  stp q10, q11, [sp, #-32]!
+  stp q8, q9, [sp, #-32]!
 
   ;; x0 - first arg
   ;; x1 - second arg
@@ -194,6 +208,14 @@ _call_goal_asm_arm64:
   blr x3
 
   ;; restore saved registers.
+  ldp q8, q9, [sp], #32
+  ldp q10, q11, [sp], #32
+  ldp q12, q13, [sp], #32
+  ldp q14, q15, [sp], #32
+  ldr x28, [sp], #16
+  ldp x26, x27, [sp], #16
+  ldp x24, x25, [sp], #16
+  ldp x19, x23, [sp], #16
   ldr x22, [sp], #16
   ldp x20, x21, [sp], #16
   ldp	x29, x30, [sp], #16
@@ -204,10 +226,19 @@ _call_goal_asm_arm64:
 _call_goal8_asm_arm64:
   stp	x29, x30, [sp, #-16]!
   mov	x29, sp
-  ;; saved registers we need to modify for GOAL should be preserved
+  ;; Save the full AAPCS64 callee-saved set -- see note above the top of
+  ;; _call_goal_asm_arm64.
   ; ARM64 requires 16-byte stack pointer alignment
   stp x20, x21, [sp, #-16]!
   str x22, [sp, #-16]!
+  stp x19, x23, [sp, #-16]!
+  stp x24, x25, [sp, #-16]!
+  stp x26, x27, [sp, #-16]!
+  str x28, [sp, #-16]!
+  stp q14, q15, [sp, #-32]!
+  stp q12, q13, [sp, #-32]!
+  stp q10, q11, [sp, #-32]!
+  stp q8, q9, [sp, #-32]!
 
   ;; x0 - first arg (func)
   ;; x1 - second arg (arg array)
@@ -237,6 +268,14 @@ _call_goal8_asm_arm64:
   blr x8
 
   ;; retore registers.
+  ldp q8, q9, [sp], #32
+  ldp q10, q11, [sp], #32
+  ldp q12, q13, [sp], #32
+  ldp q14, q15, [sp], #32
+  ldr x28, [sp], #16
+  ldp x26, x27, [sp], #16
+  ldp x24, x25, [sp], #16
+  ldp x19, x23, [sp], #16
   ldr x22, [sp], #16
   ldp x20, x21, [sp], #16
   ldp	x29, x30, [sp], #16
@@ -255,24 +294,42 @@ _call_goal_on_stack_asm_arm64:
   ;; x4  - st (goes in x21 and x20)
   ;; x5  - offset (goes in x22)
 
-  ;; saved registers we need to modify for GOAL should be preserved
+  ;; Save the full AAPCS64 callee-saved set on the C stack, BEFORE switching
+  ;; sp to the GOAL stack below -- see note above the top of
+  ;; _call_goal_asm_arm64.
   ; ARM64 requires 16-byte stack pointer alignment
   stp x20, x21, [sp, #-16]!
   ;; also stash the current stack pointer on the stack
   ;; NOTE - you cannot directly store or load the `sp` register in arm64
   mov x9, sp
   stp x22, x9, [sp, #-16]!
+  stp x19, x23, [sp, #-16]!
+  stp x24, x25, [sp, #-16]!
+  stp x26, x27, [sp, #-16]!
+  str x28, [sp, #-16]!
+  stp q14, q15, [sp, #-32]!
+  stp q12, q13, [sp, #-32]!
+  stp q10, q11, [sp, #-32]!
+  stp q8, q9, [sp, #-32]!
 
   ;; switch to new stack
   mov sp, x0
 
-  mov x20, x4 ;; set GOAL function pointer  
+  mov x20, x4 ;; set GOAL function pointer
   mov x21, x4 ;; symbol table
   mov x22, x5 ;; offset
   ;; call GOAL by function pointer
   blr x3
 
   ;; restore registers
+  ldp q8, q9, [sp], #32
+  ldp q10, q11, [sp], #32
+  ldp q12, q13, [sp], #32
+  ldp q14, q15, [sp], #32
+  ldr x28, [sp], #16
+  ldp x26, x27, [sp], #16
+  ldp x24, x25, [sp], #16
+  ldp x19, x23, [sp], #16
   ldp x22, x9, [sp], #16
   mov sp, x9
   ldp x20, x21, [sp], #16

--- a/game/mips2c/mips2c_private.h
+++ b/game/mips2c/mips2c_private.h
@@ -22,6 +22,10 @@ extern u8* g_ee_main_mem;
 extern "C" {
 #ifdef __linux__
 u64 _call_goal8_asm_systemv(void* func, u64* arg_array, u64 zero, u64 pp, u64 st, void* off);
+#elif defined __APPLE__ && defined __aarch64__
+// Native Apple Silicon -- defined in asm_funcs_arm64.s
+u64 _call_goal8_asm_arm64(void* func, u64* arg_array, u64 zero, u64 pp, u64 st, void* off) asm(
+    "_call_goal8_asm_arm64");
 #elif defined __APPLE__ && defined __x86_64__
 u64 _call_goal8_asm_systemv(void* func, u64* arg_array, u64 zero, u64 pp, u64 st, void* off) asm(
     "_call_goal8_asm_systemv");
@@ -356,6 +360,11 @@ struct ExecutionContext {
 #ifdef __linux__
     gprs[v0].du64[0] = _call_goal8_asm_systemv(g_ee_main_mem + addr, args, 0, gprs[s6].du64[0],
                                                gprs[s7].du64[0], g_ee_main_mem);
+#elif defined __APPLE__ && defined __aarch64__
+    // g_ee_main_mem is the exec alias (PROT_READ|PROT_EXEC); the func pointer handed
+    // to the trampoline must point through it so the BLR lands on executable memory.
+    gprs[v0].du64[0] = _call_goal8_asm_arm64(g_ee_main_mem + addr, args, 0, gprs[s6].du64[0],
+                                             gprs[s7].du64[0], g_ee_main_mem);
 #elif defined __APPLE__ && defined __x86_64__
     gprs[v0].du64[0] = _call_goal8_asm_systemv(g_ee_main_mem + addr, args, 0, gprs[s6].du64[0],
                                                gprs[s7].du64[0], g_ee_main_mem);


### PR DESCRIPTION
Hey! :) 

I have been building my own native ARM64 backend for jak-project since May, independently of the ARM64 effort underway here (I actually didn't know there was one when I started, and using Rosetta was driving me nuts lol). 

It reached the finish line this week. I just completed 100% playthrough of jak1 on Apple Silicon, no Rosetta, around 150fps uncapped, with no glitches. I am now working on porting that backend onto this repo's own ARM64 encoder design (it seems much more disciplined than mine) so the two efforts merge instead of diverging; this PR is the first slice of that: three runtime bugs that live on current master, independent of any codegen backend, each found the hard way during real playing tests.

## jalr never calls back into GOAL on ARM64 macOS

`ExecutionContext::jalr` has platform branches for Linux, x86 macOS, and Windows, but none for ARM64 macOS, so every mips2c-to-GOAL callback silently does nothing and returns stale garbage. In practice: the character falls straight through the floor, because collision probes never get their GOAL callbacks answered. The fix wires in `_call_goal8_asm_arm64`, which already exists in `asm_funcs_arm64.s`, following the same convention `kscheme.cpp` uses. Receipt: `WithGameTests.Mips2C_CallGoal` fails on current master built for ARM64 macOS and passes with this fix.

## GOAL entry trampolines save 3 of the 18 callee-saved registers

`_call_goal_asm_arm64`, `_call_goal8_asm_arm64`, and `_call_goal_on_stack_asm_arm64` BLR into JIT code but only preserve x20-x22. GOAL's coroutine machinery loads whole register files from zeroed thread structs, so calls can return with x19, x23-x28, or d8-d15 clobbered, corrupting whatever the C++ caller kept there. I hit it as a null-pointer fault in `KernelCheckAndDispatch`, whose cached `&s7` in x27 got zeroed by the first successful dispatch. The fix extends all three trampolines to the full AAPCS64 callee-saved set. One pre-existing sp-ordering oddity in `_call_goal_on_stack_asm_arm64`'s restore path is flagged in the commit but deliberately not folded in.

## Sky blend functions compile to empty stubs on Apple Silicon

`SkyBlendCPU`'s two blend functions are wrapped in `#ifndef __arm64__`, which Apple clang defines, so both bodies compile to a bare `ret` and the sky uploads as a zero-filled texture every frame. Removing the guards is the whole fix: the SSE2 fallback path already routes through sse2neon and runs correctly. The same symptom was independently hit by the in-flight ARM64 work here this week, so this one is live, not hypothetical.

## What comes next

I'll continue trying to merge the worlds (let me know if this is helpful, I don't mean to step on any toes if this diverges with your decisions), and in my fork there will be some design docs and learnings from my own process iterating through this.

Thanks for the continued effort on this awesome project. I hope this helps!
