### PR TITLE
ci: install `brotli` explicitly on macOS runners

### DIFF
--- a/.github/workflows/macos-build-arm.yaml
+++ b/.github/workflows/macos-build-arm.yaml
@@ -29,9 +29,9 @@ jobs:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_ANALYTICS: 1
         run: |
-          if ! brew install ninja nasm openssl@3; then
+          if ! brew install ninja nasm openssl@3 brotli; then
             brew update
-            brew install ninja nasm openssl@3
+            brew install ninja nasm openssl@3 brotli
           fi
           # keg-only, so give CMake's FindOpenSSL an explicit hint
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -39,9 +39,9 @@ jobs:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_ANALYTICS: 1
         run: |
-          if ! brew install ninja nasm openssl@3; then
+          if ! brew install ninja nasm openssl@3 brotli; then
             brew update
-            brew install ninja nasm openssl@3
+            brew install ninja nasm openssl@3 brotli
           fi
           # keg-only, so give CMake's FindOpenSSL an explicit hint
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,8 +228,8 @@ set(CURL_USE_LIBSSH2 OFF)
 set(CURL_USE_LIBPSL OFF)
 set(CURL_ZLIB OFF)
 # these default to AUTO since curl 8.10 and would silently pick up system libs
-set(CURL_BROTLI OFF)
-set(CURL_ZSTD OFF)
+set(CURL_BROTLI OFF CACHE BOOL "Disable Brotli support" FORCE)
+set(CURL_ZSTD OFF CACHE BOOL "Disable zstd support" FORCE)
 # curl's BUILD_EXAMPLES cache option (default ON) would otherwise leak into
 # discord-rpc's identically named option and break its examples add_subdirectory
 set(BUILD_EXAMPLES OFF)


### PR DESCRIPTION
Another out of no-where regression on the macOS runners... https://github.com/open-goal/jak-project/actions/runs/32795420246
```
ld: library 'brotlidec' not found
```