### PR TITLE
ci: fix another macOS dependency (http2)

### DIFF
--- a/.github/workflows/build-matrix.yaml
+++ b/.github/workflows/build-matrix.yaml
@@ -49,14 +49,14 @@ jobs:
     name: "🍎 MacOS"
     uses: ./.github/workflows/macos-build.yaml
     with:
-      cmakePreset: "Release-macos-x86_64-clang-static"
-      cachePrefix: "static"
+      cmakePreset: "Release-macos-x86_64-clang"
+      cachePrefix: ""
     secrets: inherit
 
   build_macos_arm:
     name: "🍎 MacOS"
     uses: ./.github/workflows/macos-build-arm.yaml
     with:
-      cmakePreset: "Release-macos-x86_64-clang-static"
-      cachePrefix: "static-arm"
+      cmakePreset: "Release-macos-arm64-clang"
+      cachePrefix: ""
     secrets: inherit

--- a/.github/workflows/build-matrix.yaml
+++ b/.github/workflows/build-matrix.yaml
@@ -49,14 +49,14 @@ jobs:
     name: "🍎 MacOS"
     uses: ./.github/workflows/macos-build.yaml
     with:
-      cmakePreset: "Release-macos-x86_64-clang"
-      cachePrefix: ""
+      cmakePreset: "Release-macos-x86_64-clang-static"
+      cachePrefix: "static"
     secrets: inherit
 
   build_macos_arm:
     name: "🍎 MacOS"
     uses: ./.github/workflows/macos-build-arm.yaml
     with:
-      cmakePreset: "Release-macos-arm64-clang"
-      cachePrefix: ""
+      cmakePreset: "Release-macos-x86_64-clang-static"
+      cachePrefix: "static-arm"
     secrets: inherit

--- a/.github/workflows/macos-build-arm.yaml
+++ b/.github/workflows/macos-build-arm.yaml
@@ -29,9 +29,9 @@ jobs:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_ANALYTICS: 1
         run: |
-          if ! brew install ninja nasm openssl@3 brotli; then
+          if ! brew install ninja nasm openssl@3 brotli nghttp2; then
             brew update
-            brew install ninja nasm openssl@3 brotli
+            brew install ninja nasm openssl@3 brotli nghttp2
           fi
           # keg-only, so give CMake's FindOpenSSL an explicit hint
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -39,9 +39,9 @@ jobs:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_ANALYTICS: 1
         run: |
-          if ! brew install ninja nasm openssl@3 brotli; then
+          if ! brew install ninja nasm openssl@3 brotli nghttp2; then
             brew update
-            brew install ninja nasm openssl@3 brotli
+            brew install ninja nasm openssl@3 brotli nghttp2
           fi
           # keg-only, so give CMake's FindOpenSSL an explicit hint
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,7 @@ set(CURL_ZLIB OFF)
 # these default to AUTO since curl 8.10 and would silently pick up system libs
 set(CURL_BROTLI OFF CACHE BOOL "Disable Brotli support" FORCE)
 set(CURL_ZSTD OFF CACHE BOOL "Disable zstd support" FORCE)
+set(USE_NGHTTP2 OFF CACHE BOOL "Disable nghttp2 support" FORCE)
 # curl's BUILD_EXAMPLES cache option (default ON) would otherwise leak into
 # discord-rpc's identically named option and break its examples add_subdirectory
 set(BUILD_EXAMPLES OFF)


### PR DESCRIPTION
These dependencies only crop up under the static build i suppose, brotli was fixed, but now http/2 support is the new failure.  Will actually verify they will work here before merging this time.