### PR TITLE
ci: revert change to compilation check

### DIFF
--- a/.github/workflows/compiler-output-check.yaml
+++ b/.github/workflows/compiler-output-check.yaml
@@ -66,10 +66,9 @@ jobs:
 
       - name: Compile and preserve (master)
         run: |
-          # master predates the .break compiler form, so use its old expansion for the comparison
-          ./build.master/goalc/goalc --game jak1 --cmd '(begin (defmacro .break () (quote (/ 0 0))) (make-group "all-code"))'
-          ./build.master/goalc/goalc --game jak2 --cmd '(begin (defmacro .break () (quote (/ 0 0))) (make-group "all-code"))'
-          ./build.master/goalc/goalc --game jak3 --cmd '(begin (defmacro .break () (quote (/ 0 0))) (make-group "all-code"))'
+          ./build.master/goalc/goalc --game jak1 --cmd '(make-group "all-code")'
+          ./build.master/goalc/goalc --game jak2 --cmd '(make-group "all-code")'
+          ./build.master/goalc/goalc --game jak3 --cmd '(make-group "all-code")'
           mv ./out/jak1/obj ./out/jak1/obj.master
           mv ./out/jak2/obj ./out/jak2/obj.master
           mv ./out/jak3/obj ./out/jak3/obj.master


### PR DESCRIPTION
Not required anymore.

Eventually this test should be ran on the ARM version of the compiler in addition to the x86 one, but im not in a rush, especially since it's likely that the ARM backend will be less stable as it's literally brand new.