### PR TITLE
Added missing <algorithm> header to fix compiler error.

### DIFF
--- a/game/kernel/common/codegen.h
+++ b/game/kernel/common/codegen.h
@@ -13,7 +13,7 @@
 #include "game/runtime.h"
 
 #ifdef __APPLE__
-#include <libkern/OSCacheControl.h>
+#include "libkern/OSCacheControl.h"
 #endif
 
 /*!

--- a/game/runtime.cpp
+++ b/game/runtime.cpp
@@ -9,8 +9,8 @@
 
 #include <sys/mman.h>
 #if defined(__APPLE__) && defined(__aarch64__)
-#include <mach/mach.h>
-#include <mach/mach_vm.h>
+#include "mach/mach.h"
+#include "mach/mach_vm.h"
 #endif
 #elif _WIN32
 #include <io.h>

--- a/goalc/emitter/IGenARM64.cpp
+++ b/goalc/emitter/IGenARM64.cpp
@@ -10,7 +10,8 @@
 #include "goalc/emitter/Instruction.h"
 #include "goalc/emitter/InstructionSet.h"
 #include "goalc/emitter/Register.h"
-#include <fmt/base.h>
+
+#include "fmt/base.h"
 
 // https://armconverter.com/?code=ret
 // https://developer.arm.com/documentation/ddi0487/latest

--- a/test/test_emitter_arm64.cpp
+++ b/test/test_emitter_arm64.cpp
@@ -19,7 +19,7 @@
 #include <capstone/arm.h>
 #include <fmt/base.h>
 #include <fmt/format.h>
-
+#include <algorithm>
 #include "fmt/format.h"
 
 using namespace emitter;

--- a/test/test_emitter_arm64.cpp
+++ b/test/test_emitter_arm64.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdio>
 
 #include "emitter_test_helpers.h"
@@ -6,6 +7,7 @@
 #include "common/link_types.h"
 #include "common/type_system/TypeSystem.h"
 
+#include "capstone/arm.h"
 #include "goalc/compiler/IR.h"
 #include "goalc/debugger/DebugInfo.h"
 #include "goalc/emitter/CodeTester.h"
@@ -16,10 +18,8 @@
 #include "goalc/regalloc/Allocator.h"
 #include "goalc/regalloc/Allocator_v2.h"
 #include "gtest/gtest.h"
-#include <capstone/arm.h>
-#include <fmt/base.h>
-#include <fmt/format.h>
-#include <algorithm>
+
+#include "fmt/base.h"
 #include "fmt/format.h"
 
 using namespace emitter;

--- a/test/test_goal_trampolines_arm64.cpp
+++ b/test/test_goal_trampolines_arm64.cpp
@@ -11,8 +11,8 @@
 #include "game/kernel/common/codegen.h"
 
 #ifdef __APPLE__
-#include <mach/mach.h>
-#include <mach/mach_vm.h>
+#include "mach/mach.h"
+#include "mach/mach_vm.h"
 #include <sys/mman.h>
 #endif
 


### PR DESCRIPTION
When compiling today, I had this error on Arch Linux x86-64 due to the missing <algorithm> header.
<img width="1952" height="1079" alt="Screenshot from 2026-08-27 22-53-33" src="https://github.com/user-attachments/assets/c0101a23-ac2a-40a5-a1b9-b1e926e600a7" />

Adding the header fixes it.