### PR TITLE
Switch port: run Jak 1 as ARM64 homebrew under Horizon/GLES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,7 @@ unifont-15.0.03.ttf
 *.diff
 goalc-report.html
 _new-all-types.gc
+# Switch port build directory (cross-compiled objects, the 195 MB gk ELF, gk.nro)
+/build-switch/
+# Extracted game assets -- never redistribute; regenerate with the extractor from your own copy
+/iso_data/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         -fcxx-exceptions \
         -fexceptions \
         -fdiagnostics-color=always \
-        -mavx \
         -Wall \
         -Wno-c++11-narrowing \
         -Wno-c++98-compat \
@@ -66,6 +65,12 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         -Wno-ignored-qualifiers \
         -O3 \
         -D_CRT_SECURE_NO_WARNINGS")
+
+    # AVX is an x86-only ISA extension; cross builds (e.g. Switch's aarch64) set their own
+    # arch flags via CMAKE_CXX_FLAGS_INIT in their toolchain file instead.
+    if(NOT NINTENDO_SWITCH AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|i.86)$")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
+    endif()
 
     # Increase stack size for windows, who's default is too low
     if(WIN32)
@@ -110,8 +115,13 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         -Wredundant-decls \
         -Wshadow \
         -Wsign-promo \
-        -fdiagnostics-color=always \
-        -mavx")
+        -fdiagnostics-color=always")
+
+    # AVX is an x86-only ISA extension; cross builds (e.g. Switch's aarch64) set their own
+    # arch flags via CMAKE_CXX_FLAGS_INIT in their toolchain file instead.
+    if(NOT NINTENDO_SWITCH AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|i.86)$")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
+    endif()
 
     # additional c++ flags for release mode for our projects
     if(CMAKE_BUILD_TYPE MATCHES "Release")
@@ -248,28 +258,46 @@ else()
     set(CURL_USE_OPENSSL ON)
 endif()
 include_directories(third-party/curl/include)
-if(STATICALLY_LINK)
-    build_third_party_lib(curl libcurl_static)
+if(NINTENDO_SWITCH)
+    # No OpenSSL/mbedTLS portlib and no use for desktop update-check HTTP on a homebrew NRO.
+    message(STATUS "Switch: skipping libcurl")
 else()
-    build_third_party_lib(curl libcurl_shared)
+    if(STATICALLY_LINK)
+        build_third_party_lib(curl libcurl_static)
+    else()
+        build_third_party_lib(curl libcurl_shared)
+    endif()
 endif()
 
 # build repl library
-build_third_party_lib(replxx replxx)
+if(NOT NINTENDO_SWITCH)
+    build_third_party_lib(replxx replxx)
+endif()
 
 # SQLite - Jak 2/3's built in editor
 add_definitions(-DHAVE_USLEEP=1)
 add_definitions(-DSQLITE_THREADSAFE=1)
 add_definitions(-DSQLITE_ENABLE_JSON1)
 add_definitions(-DSQLITE_ENABLE_RTREE)
+if(NINTENDO_SWITCH)
+    # newlib on devkitA64 has no sys/mman.h. sqlite3.c's guard is
+    # `!defined(SQLITE_OMIT_WAL) || SQLITE_MAX_MMAP_SIZE>0`, so MAX_MMAP_SIZE=0 alone
+    # doesn't skip the include -- WAL must be omitted too.
+    add_definitions(-DSQLITE_MAX_MMAP_SIZE=0)
+    add_definitions(-DSQLITE_OMIT_WAL=1)
+    # No dynamic loader on Horizon OS -- everything is statically linked.
+    add_definitions(-DSQLITE_OMIT_LOAD_EXTENSION=1)
+endif()
 build_third_party_lib(sqlite3 sqlite3)
 
 # build tree-sitter parser
 include_directories(third-party/tree-sitter/tree-sitter/lib/include)
 build_third_party_lib(tree-sitter tree-sitter)
 
-# native OS dialogs for error messages
-build_third_party_lib(libtinyfiledialogs libtinyfiledialogs)
+# native OS dialogs for error messages (needs termios/a real windowing system; unused on Switch)
+if(NOT NINTENDO_SWITCH)
+    build_third_party_lib(libtinyfiledialogs libtinyfiledialogs)
+endif()
 
 # build format library
 include_directories(third-party/fmt/include)
@@ -285,24 +313,37 @@ add_subdirectory(decompiler)
 build_third_party_lib(cubeb cubeb)
 
 # build LSP
-add_subdirectory(lsp)
+if(NOT NINTENDO_SWITCH)
+    add_subdirectory(lsp)
+endif()
 
 # build libco and zstd
 build_third_party_lib(libco libco)
 build_third_party_lib(zstd libzstd_static)
 
 # build SDL
-include(SDLOptions)
-if(STATICALLY_LINK)
-    build_third_party_lib(SDL SDL3-static)
+if(NINTENDO_SWITCH)
+    # No SDL3 port exists for Switch -- devkitPro only ships SDL2. game/'s SDL3 call sites are
+    # routed through game/switch/sdl3_compat.h (a real compat shim, not a rebuild) instead, so
+    # SDL3::SDL3 just needs to resolve to devkitPro's actual SDL2 + its Switch-specific deps.
+    add_library(SDL3_switch_compat INTERFACE)
+    target_link_libraries(SDL3_switch_compat INTERFACE SDL2 SDL2main EGL glapi drm_nouveau)
+    add_library(SDL3::SDL3 ALIAS SDL3_switch_compat)
 else()
-    build_third_party_lib(SDL SDL3-shared)
+    include(SDLOptions)
+    if(STATICALLY_LINK)
+        build_third_party_lib(SDL SDL3-static)
+    else()
+        build_third_party_lib(SDL SDL3-shared)
+    endif()
 endif()
 
 # build imgui
 include_directories(third-party/glad/include)
 include_directories(third-party/SDL/include)
-build_third_party_lib(imgui imgui)
+if(NOT NINTENDO_SWITCH)
+    build_third_party_lib(imgui imgui)
+endif()
 
 # build the game code in C++
 add_subdirectory(game)
@@ -311,7 +352,9 @@ add_subdirectory(game)
 add_subdirectory(goalc)
 
 # build standalone tools
-add_subdirectory(tools)
+if(NOT NINTENDO_SWITCH)
+    add_subdirectory(tools)
+endif()
 
 # build the gtest libraries
 if(WIN32)
@@ -337,7 +380,9 @@ build_third_party_lib(xdelta3 xdelta3)
 
 # discord rich presence
 include_directories(third-party/discord-rpc/include)
-build_third_party_lib(discord-rpc discord-rpc)
+if(NOT NINTENDO_SWITCH)
+    build_third_party_lib(discord-rpc discord-rpc)
+endif()
 
 # build zydis third party library for disassembling x86
 # TODO - Once under CMake 3.13's policy CMP0077, override with `set()` instead

--- a/cmake/toolchains/Switch.cmake
+++ b/cmake/toolchains/Switch.cmake
@@ -1,0 +1,54 @@
+# Cross-compilation toolchain for Nintendo Switch homebrew (NRO) via devkitPro's devkitA64.
+# Flags mirror a hardware-proven devkitPro Makefile build (Nazi Zombies Portable NX port).
+
+# Prefer an explicit -DDEVKITPRO=... (this bundled MSYS2 cmake does not reliably inherit the
+# DEVKITPRO env var from a plain shell export), but fall back to the env var if it is set.
+if(NOT DEFINED DEVKITPRO)
+  if(DEFINED ENV{DEVKITPRO})
+    set(DEVKITPRO "$ENV{DEVKITPRO}")
+  else()
+    message(FATAL_ERROR "Pass -DDEVKITPRO=C:/devkitPro (env var DEVKITPRO is not visible here)")
+  endif()
+endif()
+
+# NOTE: file(TO_CMAKE_PATH ...) is unsafe here -- this cmake build treats ':' as a path-list
+# separator (POSIX-style), so it silently splits "C:/devkitPro" into "C" and "/devkitPro".
+string(REPLACE "\\" "/" DEVKITPRO "${DEVKITPRO}")
+set(DEVKITA64 "${DEVKITPRO}/devkitA64")
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(CMAKE_C_COMPILER   "${DEVKITA64}/bin/aarch64-none-elf-gcc.exe")
+set(CMAKE_CXX_COMPILER "${DEVKITA64}/bin/aarch64-none-elf-g++.exe")
+set(CMAKE_ASM_COMPILER "${DEVKITA64}/bin/aarch64-none-elf-gcc.exe")
+set(CMAKE_AR           "${DEVKITA64}/bin/aarch64-none-elf-gcc-ar.exe")
+set(CMAKE_RANLIB       "${DEVKITA64}/bin/aarch64-none-elf-gcc-ranlib.exe")
+
+# -mcpu implies -march; a separately-specified bare "-march=armv8-a" (no +crc) here would win
+# over -mcpu's +crc and silently disable CRC32 intrinsics (hit in common/util/crc32.h).
+set(SWITCH_ARCH_FLAGS "-mtune=cortex-a57 -mtp=soft -fPIE -mcpu=cortex-a57+crc+fp+simd")
+
+# newlib's sys/param.h doesn't define __BYTE_ORDER (glibc/BSD convention some third-party libs,
+# e.g. fpng, rely on) -- AArch64 on Switch is always little-endian.
+set(CMAKE_C_FLAGS_INIT   "${SWITCH_ARCH_FLAGS} -D__SWITCH__ -D__BYTE_ORDER=1234")
+set(CMAKE_CXX_FLAGS_INIT "${SWITCH_ARCH_FLAGS} -D__SWITCH__ -D__BYTE_ORDER=1234")
+set(CMAKE_ASM_FLAGS_INIT "${SWITCH_ARCH_FLAGS}")
+
+# -z notext: a large PIE link here hits "read-only segment has dynamic relocations" -- a known
+# devkitA64/aarch64 homebrew gotcha, not a real ASLR-safety concern for an NRO (unlike a
+# hardened Linux PIE binary, the Switch homebrew loader doesn't need strict text-relocation
+# avoidance).
+set(CMAKE_EXE_LINKER_FLAGS_INIT
+    "-specs=${DEVKITPRO}/libnx/switch.specs ${SWITCH_ARCH_FLAGS} -L${DEVKITPRO}/libnx/lib -L${DEVKITPRO}/portlibs/switch/lib -Wl,-z,notext")
+
+set(CMAKE_FIND_ROOT_PATH "${DEVKITA64}/aarch64-none-elf" "${DEVKITPRO}/libnx" "${DEVKITPRO}/portlibs/switch")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+include_directories(SYSTEM "${DEVKITPRO}/libnx/include" "${DEVKITPRO}/portlibs/switch/include")
+link_directories("${DEVKITPRO}/libnx/lib" "${DEVKITPRO}/portlibs/switch/lib")
+
+set(NINTENDO_SWITCH TRUE)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -28,6 +28,17 @@ endfunction()
 
 write_revision_h()
 
+if(NINTENDO_SWITCH)
+    # No terminal on Horizon OS, so no interactive REPL (replxx needs real termios).
+    set(COMMON_REPL_WRAPPER_SRC)
+    # No native OS dialog box on Switch, but the renderer does call this for real error
+    # reporting -- log instead of dropping it (see dialogs_switch.cpp).
+    set(COMMON_DIALOGS_SRC util/dialogs_switch.cpp)
+else()
+    set(COMMON_REPL_WRAPPER_SRC repl/repl_wrapper.cpp)
+    set(COMMON_DIALOGS_SRC util/dialogs.cpp)
+endif()
+
 add_library(common
         audio/audio_formats.cpp
         cross_os_debug/xdbg.cpp
@@ -58,7 +69,7 @@ add_library(common
         repl/config.cpp
         repl/nrepl/ReplClient.cpp
         repl/nrepl/ReplServer.cpp
-        repl/repl_wrapper.cpp
+        ${COMMON_REPL_WRAPPER_SRC}
         serialization/subtitles/subtitles_v1.cpp
         serialization/subtitles/subtitles_v2.cpp
         serialization/subtitles/subtitles.cpp
@@ -80,7 +91,7 @@ add_library(common
         util/dgo_util.cpp
         util/DgoReader.cpp
         util/DgoWriter.cpp
-        util/dialogs.cpp
+        ${COMMON_DIALOGS_SRC}
         util/diff.cpp
         util/FileUtil.cpp
         util/font/dbs/font_db_jak1.cpp
@@ -103,7 +114,13 @@ add_library(common
         versions/versions.cpp
         )
 
-target_link_libraries(common fmt lzokay replxx libzstd_static tree-sitter sqlite3 libtinyfiledialogs tiny_gltf)
+set(COMMON_REPLXX_LIB replxx)
+set(COMMON_DIALOGS_LIB libtinyfiledialogs)
+if(NINTENDO_SWITCH)
+    set(COMMON_REPLXX_LIB)
+    set(COMMON_DIALOGS_LIB)
+endif()
+target_link_libraries(common fmt lzokay ${COMMON_REPLXX_LIB} libzstd_static tree-sitter sqlite3 ${COMMON_DIALOGS_LIB} tiny_gltf)
 
 if(WIN32)
     target_link_libraries(common wsock32 ws2_32 windowsapp)

--- a/common/cross_os_debug/xdbg.cpp
+++ b/common/cross_os_debug/xdbg.cpp
@@ -786,6 +786,61 @@ bool write_goal_memory(const u8* src_buffer,
 bool check_stopped(const ThreadID& tid, SignalInfo* out) {
   return false;
 }
+#elif defined(__SWITCH__)
+// No cross-process debugger attach on Horizon OS; same "not implemented" shape as macOS above.
+// ThreadID's constructor/to_string() are already defined inline in xdbg.h for this platform.
+ThreadID get_current_thread_id() {
+  return ThreadID("not implemented on Switch");
+}
+
+void allow_debugging() {}
+
+bool attach_and_break(const ThreadID& tid) {
+  return false;
+}
+bool detach_and_resume(const ThreadID& tid) {
+  return false;
+}
+bool get_regs_now(const ThreadID& tid, Regs* out) {
+  return false;
+}
+bool set_regs_now(const ThreadID& tid, const Regs& in) {
+  return false;
+}
+bool break_now(const ThreadID& tid) {
+  return false;
+}
+bool cont_now(const ThreadID& tid) {
+  return false;
+}
+bool single_step_now(const ThreadID& tid) {
+  return false;
+}
+bool open_memory(const ThreadID& tid, MemoryHandle* out) {
+  return false;
+}
+bool close_memory(const ThreadID& tid, MemoryHandle* handle) {
+  return false;
+}
+bool read_goal_memory(u8* dest_buffer,
+                      int size,
+                      u32 goal_addr,
+                      const DebugContext& context,
+                      const MemoryHandle& mem) {
+  return false;
+}
+
+bool write_goal_memory(const u8* src_buffer,
+                       int size,
+                       u32 goal_addr,
+                       const DebugContext& context,
+                       const MemoryHandle& mem) {
+  return false;
+}
+
+bool check_stopped(const ThreadID& tid, SignalInfo* out) {
+  return false;
+}
 #endif
 
 const char* gpr_names[] = {"rax", "rcx", "rdx", "rbx", "rsp", "rbp", "rsi", "rdi",

--- a/common/cross_os_debug/xdbg.h
+++ b/common/cross_os_debug/xdbg.h
@@ -53,6 +53,17 @@ struct ThreadID {
 };
 
 struct MemoryHandle {};
+#elif defined(__SWITCH__)
+// There is no cross-process ptrace-style debugger attach on Horizon OS. This is only used by
+// goalc's desktop live-debugger workflow, which doesn't apply to a shipped Switch NRO -- these
+// are stubs so `common` still links; every function below just fails/no-ops.
+struct ThreadID {
+  std::string to_string() const { return "switch"; }
+  explicit ThreadID(const std::string&) {}
+  ThreadID() = default;
+};
+
+struct MemoryHandle {};
 #endif
 
 /*!

--- a/common/cross_sockets/XSocket.cpp
+++ b/common/cross_sockets/XSocket.cpp
@@ -5,7 +5,7 @@
 
 // clang-format off
 #include "common/common_types.h"
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
 #include <sys/socket.h>
@@ -24,7 +24,7 @@
 // clang-format on
 
 int open_socket(int af, int type, int protocol) {
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
   return socket(af, type, protocol);
 #elif _WIN32
   WSADATA wsaData = {0};
@@ -47,7 +47,7 @@ int connect_socket(int socket, sockaddr* addr, int nameLen) {
   return result;
 }
 
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
 int accept_socket(int socket, sockaddr* addr, socklen_t* addrLen) {
   return accept(socket, addr, addrLen);
 }
@@ -108,7 +108,7 @@ void close_socket(int sock) {
   if (sock < 0) {
     return;
   }
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
   close(sock);
 #elif _WIN32
   closesocket(sock);
@@ -132,7 +132,7 @@ int set_socket_option(int socket, int level, int optname, const void* optval, in
 }
 
 int set_socket_timeout(int socket, long microSeconds) {
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
   struct timeval timeout = {};
   timeout.tv_sec = 0;
   timeout.tv_usec = microSeconds;
@@ -152,7 +152,7 @@ int set_socket_timeout(int socket, long microSeconds) {
 
 int write_to_socket(int socket, const char* buf, int len) {
   int bytes_wrote = 0;
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
   bytes_wrote = send(socket, buf, len, MSG_NOSIGNAL);
 #elif _WIN32
   bytes_wrote = send(socket, buf, len, 0);
@@ -164,7 +164,7 @@ int write_to_socket(int socket, const char* buf, int len) {
 }
 
 int read_from_socket(int socket, char* buf, int len) {
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
   return read(socket, buf, len);
 #elif _WIN32
   return recv(socket, buf, len, 0);
@@ -172,7 +172,7 @@ int read_from_socket(int socket, char* buf, int len) {
 }
 
 bool socket_timed_out() {
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
   return errno == EAGAIN;
 #elif _WIN32
   auto err = WSAGetLastError();

--- a/common/cross_sockets/XSocket.h
+++ b/common/cross_sockets/XSocket.h
@@ -7,7 +7,7 @@
 
 // clang-format off
 #include "common/common_types.h"
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
@@ -27,11 +27,13 @@ const int TCP_SOCKET_LEVEL = SOL_TCP;
 const int TCP_SOCKET_LEVEL = IPPROTO_TCP;
 #elif __APPLE__
 const int TCP_SOCKET_LEVEL = IPPROTO_TCP;
+#elif __SWITCH__
+const int TCP_SOCKET_LEVEL = IPPROTO_TCP;
 #endif
 
 int open_socket(int af, int type, int protocol);
 int connect_socket(int socket, sockaddr* addr, int nameLen);
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
 int accept_socket(int socket, sockaddr* addr, socklen_t* addrLen);
 int select_and_accept_socket(int socket, sockaddr* addr, socklen_t* addrLen, int microSeconds);
 #elif _WIN32

--- a/common/cross_sockets/XSocketServer.cpp
+++ b/common/cross_sockets/XSocketServer.cpp
@@ -44,7 +44,7 @@ bool XSocketServer::init_server(bool failure_may_occur) {
 
   int yes = 1;
 
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
   if (set_socket_option(listening_socket, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) < 0) {
     close_server_socket();
     return false;

--- a/common/global_profiler/GlobalProfiler.cpp
+++ b/common/global_profiler/GlobalProfiler.cpp
@@ -12,7 +12,7 @@
 #include "fmt/format.h"
 #include "third-party/json.hpp"
 
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
 u64 get_current_tid() {
   return (u64)pthread_self();
 }

--- a/common/goos/Reader.cpp
+++ b/common/goos/Reader.cpp
@@ -162,6 +162,13 @@ Reader::Reader() {
  * Prompt the user and read the result.
  */
 std::optional<Object> Reader::read_from_stdin(const std::string& prompt, REPL::Wrapper& repl) {
+#if defined(__SWITCH__)
+  // No stdin/interactive terminal on Horizon OS, and repl_wrapper.cpp (real Wrapper::readline
+  // impl) isn't built for Switch at all -- see repl_wrapper.h.
+  (void)prompt;
+  (void)repl;
+  return {};
+#else
   // escape code will make sure that we remove any color
   std::string prompt_full = "\033[0m" + prompt;
 
@@ -183,6 +190,7 @@ std::optional<Object> Reader::read_from_stdin(const std::string& prompt, REPL::W
   } else {
     return {};
   }
+#endif
 }
 
 /*!

--- a/common/repl/repl_wrapper.h
+++ b/common/repl/repl_wrapper.h
@@ -57,7 +57,18 @@ class Wrapper {
   std::vector<REPL::KeyBind> keybindings = {};
 };
 
+#if defined(__SWITCH__)
+// repl_wrapper.cpp (the real implementation) isn't built for Switch at all -- no interactive
+// REPL there -- but this one free function is also called from jak2/jak3/jakx kboot.cpp to name
+// a per-user dev startup-script folder, unrelated to the REPL itself. There's no such concept of
+// per-user dev folders on a shipped Switch build, so this just returns the same "unknown"
+// fallback the real implementation uses when it can't find a real username either.
+inline std::string find_repl_username() {
+  return "unknown";
+}
+#else
 std::string find_repl_username();
+#endif
 StartupFile load_user_startup_file(const std::string& username, const GameVersion game_version);
 REPL::Config load_repl_config(const std::string& username,
                               const GameVersion game_version,

--- a/common/util/Assert.cpp
+++ b/common/util/Assert.cpp
@@ -23,6 +23,11 @@ void private_assert_failed(const char* expr,
                     expr, msg, file, line, function);
     lg::die("{}", log);
   }
+#if defined(__SWITCH__)
+  // -O3 inlines Ptr<T>::operator*, so return_address(0) is the real offending call site.
+  // addr2line these against build-switch/game/gk to name it.
+  lg::error("assert call site: {}", __builtin_return_address(0));
+#endif
   abort();
 }
 

--- a/common/util/Assert.h
+++ b/common/util/Assert.h
@@ -21,7 +21,11 @@
                                         const char* function,
                                         const std::string_view& msg);
 
-#ifdef _WIN32
+// __FUNCSIG__ only exists under MSVC-compatible compilers (real MSVC, or clang-cl) -- plain
+// clang++ in GNU-driver mode on Windows (e.g. MSYS2's CLANG64) already provides its own
+// GCC-compatible __PRETTY_FUNCTION__ and doesn't have __FUNCSIG__ at all, so gating this on
+// _MSC_VER (which both MSVC and clang-cl define) rather than bare _WIN32 is required.
+#ifdef _MSC_VER
 #define __PRETTY_FUNCTION__ __FUNCSIG__
 #endif
 

--- a/common/util/FileUtil.cpp
+++ b/common/util/FileUtil.cpp
@@ -165,6 +165,14 @@ std::string get_current_executable_path() {
     return std::string(argv[0]);
   }
   return std::string(buffer);
+#elif defined(__SWITCH__)
+  // NRO homebrew has no real filesystem path for its own running image (it's loaded straight
+  // into memory by the loader, not exec'd from a path argv[0] reliably carries) -- unlike every
+  // other platform here, there's nothing to introspect. Just report the fixed SD card location
+  // this game's data/ directory actually gets deployed to (the conventional
+  // sdmc:/switch/<title>/ layout homebrew uses), so try_get_data_dir()'s
+  // "next to the executable" logic still resolves to something real.
+  return "sdmc:/switch/jak1/gk.nro";
 #endif
 }
 

--- a/common/util/FrameLimiter.cpp
+++ b/common/util/FrameLimiter.cpp
@@ -13,7 +13,7 @@ double FrameLimiter::round_to_nearest_60fps(double current) {
   return (frames_missed + 1) * one_frame;
 }
 
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
 
 FrameLimiter::FrameLimiter() {}
 

--- a/common/util/Timer.cpp
+++ b/common/util/Timer.cpp
@@ -39,7 +39,12 @@ int Timer::clock_gettime_monotonic(struct timespec* tv) const {
 #endif
 
 void Timer::start() {
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
+  // OS_POSIX (common_types.h) only covers Linux/macOS -- deliberately not extended to Switch
+  // there, since it also gates unrelated mmap/sys-header code in other files (e.g. runtime.cpp)
+  // that isn't valid on this toolchain. devkitA64's libnx does implement clock_gettime(
+  // CLOCK_MONOTONIC, ...) though (confirmed: it's the standard homebrew timing API), so it's
+  // safe to just also take this branch here directly.
   clock_gettime(CLOCK_MONOTONIC, &_startTime);
 #elif _WIN32
   clock_gettime_monotonic(&_startTime);
@@ -48,7 +53,7 @@ void Timer::start() {
 
 int64_t Timer::getNs() const {
   struct timespec now = {};
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
   clock_gettime(CLOCK_MONOTONIC, &now);
 #elif _WIN32
   clock_gettime_monotonic(&now);

--- a/common/util/dialogs.h
+++ b/common/util/dialogs.h
@@ -2,7 +2,9 @@
 
 #include <string>
 
+#if !defined(__SWITCH__)
 #include "third-party/libtinyfiledialogs/tinyfiledialogs.h"
+#endif
 
 namespace dialogs {
 void create_error_message_dialog(const std::string& title, const std::string& message);

--- a/common/util/dialogs_switch.cpp
+++ b/common/util/dialogs_switch.cpp
@@ -1,0 +1,11 @@
+#include "dialogs.h"
+
+#include "common/log/log.h"
+
+namespace dialogs {
+// No native OS dialog on Switch (see dialogs.h) -- log the error instead of dropping it
+// silently, since these are real critical-error reports (e.g. "couldn't create a GL context").
+void create_error_message_dialog(const std::string& title, const std::string& message) {
+  lg::error("[{}] {}", title, message);
+}
+}  // namespace dialogs

--- a/common/util/os.cpp
+++ b/common/util/os.cpp
@@ -29,6 +29,11 @@ size_t get_peak_rss() {
     return 0;
   }
 }
+#elif defined(__SWITCH__)
+// newlib's struct rusage on Horizon OS doesn't have ru_maxrss.
+size_t get_peak_rss() {
+  return 0;
+}
 #else
 #include <sys/resource.h>
 size_t get_peak_rss() {
@@ -164,13 +169,19 @@ void setup_cpu_info_macos(CpuInfo& info) {
   info.has_avx = result[2] & (1 << 28);
   __cpuidex(result, 7, 0);
   info.has_avx2 = result[1] & (1 << 5);
-#elif defined(__aarch64__) || defined(__arm64__)
+#elif defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
+  // NOTE: this function is macOS-only (only ever called under `#elif defined(__APPLE__)`
+  // below), but its body still has to compile on every aarch64 target since the enclosing
+  // function isn't itself platform-guarded. A bare `defined(__aarch64__)` here used to assume
+  // "aarch64 build" meant "Apple Silicon", which broke once a second aarch64 target existed.
   info.brand = "Apple";
   char buf[128];
   size_t len = sizeof(buf);
   if (sysctlbyname("hw.model", buf, &len, nullptr, 0) == 0) {
     info.model = buf;
   }
+  info.has_neon = true;
+#elif defined(__aarch64__) || defined(__arm64__)
   info.has_neon = true;
 #endif
 }
@@ -188,6 +199,10 @@ void setup_cpu_info() {
   setup_cpu_info_macos(gCpuInfo);
 #elif defined(__linux__)
   setup_cpu_info_linux(gCpuInfo);
+#elif defined(__SWITCH__)
+  gCpuInfo.brand = "Nintendo Switch";
+  gCpuInfo.model = "Tegra X1 (Cortex-A57)";
+  gCpuInfo.has_neon = true;
 #else
   gCpuInfo.brand = "Unknown Brand";
   gCpuInfo.model = "Unknown Model";

--- a/decompiler/extractor/main.cpp
+++ b/decompiler/extractor/main.cpp
@@ -134,11 +134,13 @@ ExtractorErrorCode decompile(const fs::path& in_folder,
 const std::unordered_map<std::string, GameIsoFlags> game_iso_flag_names = {
     {"jak1-black-label", FLAG_JAK1_BLACK_LABEL}};
 
-ExtractorErrorCode compile(const fs::path& iso_data_path, const std::string& data_subfolder) {
+ExtractorErrorCode compile(const fs::path& iso_data_path,
+                           const std::string& data_subfolder,
+                           emitter::InstructionSet instr_set) {
   // Determine which config to use from the database
   const auto version_info = get_version_info_or_default(iso_data_path);
 
-  Compiler compiler(game_name_to_version(version_info.game_name), emitter::InstructionSet::X86);
+  Compiler compiler(game_name_to_version(version_info.game_name), instr_set);
   compiler.make_system().set_constant("*iso-data*", absolute(iso_data_path).string());
   compiler.make_system().set_constant("*use-iso-data-path*", true);
   file_util::set_iso_data_dir(absolute(iso_data_path));
@@ -190,6 +192,7 @@ int main(int argc, char** argv) {
   bool flag_folder = false;
   std::string game_name = "jak1";
   std::string decomp_config_override = "{}";
+  std::string instr_set_name = "x86";
 
   lg::initialize();
 
@@ -213,9 +216,22 @@ int main(int argc, char** argv) {
   app.add_flag("-c,--compile", flag_compile, "Compile the game");
   app.add_flag("-p,--play", flag_play, "Play the game");
   app.add_flag("-f,--folder", flag_folder, "Take ISO input from a folder");
+  app.add_option("--instruction-set", instr_set_name,
+                 "Select the x86 or ARM64 code generation backend for the compile step. "
+                 "Defaults to 'x86'.");
   define_common_cli_arguments(app);
   app.validate_positionals();
   CLI11_PARSE(app, argc, argv);
+
+  emitter::InstructionSet instr_set;
+  if (instr_set_name == "x86") {
+    instr_set = emitter::InstructionSet::X86;
+  } else if (instr_set_name == "arm64") {
+    instr_set = emitter::InstructionSet::ARM64;
+  } else {
+    lg::error("Instruction set '{}' must be 'x86' or 'arm64'", instr_set_name);
+    return 1;
+  }
 
   lg::info("Working Directory - {}", fs::current_path().string());
 
@@ -391,7 +407,7 @@ int main(int argc, char** argv) {
   }
 
   if (flag_compile) {
-    const auto status_code = compile(iso_data_path, data_subfolder);
+    const auto status_code = compile(iso_data_path, data_subfolder, instr_set);
     if (status_code != ExtractorErrorCode::SUCCESS) {
       return static_cast<int>(status_code);
     }

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -364,10 +364,17 @@ add_subdirectory(sound)
 # we build the runtime as a static library.
 add_library(runtime STATIC ${RUNTIME_SOURCE} "../third-party/glad/src/glad.c")
 
-target_link_libraries(runtime common fmt SDL3::SDL3 imgui discord-rpc sound stb_image libco libcurl)
+if(NINTENDO_SWITCH)
+    # No imgui/discord-rpc/libcurl builds on Switch (see top-level CMakeLists.txt) -- their
+    # actual call sites are stubbed out in-place (discord_rpc_stub.h, background_worker.cpp,
+    # and the #if !defined(__SWITCH__) guards throughout opengl.cpp) rather than linked here.
+    target_link_libraries(runtime common fmt SDL3::SDL3 sound stb_image libco nx)
+else()
+    target_link_libraries(runtime common fmt SDL3::SDL3 imgui discord-rpc sound stb_image libco libcurl)
+endif()
 if(WIN32)
     target_link_libraries(runtime mman)
-else()
+elseif(NOT NINTENDO_SWITCH)
     target_link_libraries(runtime pthread dl)
 endif()
 

--- a/game/common/vu.h
+++ b/game/common/vu.h
@@ -25,12 +25,10 @@ enum class Mask {
   xyzw = 15
 };
 
-#ifdef __linux__
-#define REALLY_INLINE __attribute__((always_inline))
-#elif __APPLE__
-#define REALLY_INLINE __attribute__((always_inline))
-#else
+#ifdef _WIN32
 #define REALLY_INLINE __forceinline
+#else
+#define REALLY_INLINE __attribute__((always_inline))
 #endif
 
 // note: must be aligned.

--- a/game/external/discord.h
+++ b/game/external/discord.h
@@ -7,7 +7,11 @@
 
 #include "common/versions/versions.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/discord_rpc_stub.h"
+#else
 #include "third-party/discord-rpc/include/discord_rpc.h"
+#endif
 
 extern int gDiscordRpcEnabled;
 extern int64_t gStartTime;

--- a/game/graphics/opengl_renderer/BlitDisplays.cpp
+++ b/game/graphics/opengl_renderer/BlitDisplays.cpp
@@ -93,14 +93,14 @@ void BlitDisplays::render(DmaFollower& dma,
   // the resolution/aspect/size changed, and there is a different letterbox than last frame.
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
   glClearColor(0.0, 0.0, 0.0, 0.0);
-  glClearDepth(0.0);
+  glClearDepthf(0.0f);
   glDepthMask(GL_TRUE);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
   glDisable(GL_BLEND);
 
   glBindFramebuffer(GL_FRAMEBUFFER, render_state->render_fb);
   glClearColor(0.0, 0.0, 0.0, 0.0);
-  glClearDepth(0.0);
+  glClearDepthf(0.0f);
   glClearStencil(0);
   glDepthMask(GL_TRUE);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
@@ -203,11 +203,14 @@ void BlitDisplays::do_slow_time(SharedRenderState* render_state, ScopedProfilerN
 }
 
 void BlitDisplays::draw_debug_window() {
+#if !defined(__SWITCH__)
+  // glGetTexLevelParameteriv doesn't exist in GLES; debug-window-only tooling.
   glBindTexture(GL_TEXTURE_2D, m_copier->texture());
   int w, h;
   glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
   glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
   ImGui::Image((ImTextureID)(intptr_t)m_copier->texture(), ImVec2(w, h));
+#endif
 }
 
 void BlitDisplays::apply_color_filter(SharedRenderState* render_state, ScopedProfilerNode& prof) {

--- a/game/graphics/opengl_renderer/BucketRenderer.cpp
+++ b/game/graphics/opengl_renderer/BucketRenderer.cpp
@@ -1,7 +1,11 @@
 #include "BucketRenderer.h"
 
 #include "fmt/format.h"
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 std::string BucketRenderer::name() const {
   return m_name;

--- a/game/graphics/opengl_renderer/CollideMeshRenderer.cpp
+++ b/game/graphics/opengl_renderer/CollideMeshRenderer.cpp
@@ -327,9 +327,13 @@ void CollideMeshRenderer::render(SharedRenderState* render_state, ScopedProfiler
       glUniform1i(glGetUniformLocation(shader, "wireframe"), 1);
       glDisable(GL_BLEND);
       glDepthMask(GL_FALSE);
+      #if !defined(__SWITCH__)
       glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+      #endif
       glDrawArrays(GL_TRIANGLES, 0, lev->level->collision.vertices.size());
+      #if !defined(__SWITCH__)
       glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+      #endif
       glEnable(GL_BLEND);
       glDepthMask(GL_TRUE);
     }

--- a/game/graphics/opengl_renderer/DepthCue.cpp
+++ b/game/graphics/opengl_renderer/DepthCue.cpp
@@ -3,7 +3,11 @@
 #include "game/graphics/opengl_renderer/dma_helpers.h"
 
 #include "fmt/format.h"
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 namespace {
 // Converts fixed point (with 4 bits for decimal) to floating point.

--- a/game/graphics/opengl_renderer/DirectRenderer.cpp
+++ b/game/graphics/opengl_renderer/DirectRenderer.cpp
@@ -7,14 +7,37 @@
 #include "game/graphics/pipelines/opengl.h"
 
 #include "fmt/format.h"
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 DirectRenderer::ScissorState DirectRenderer::m_scissor;
 
 constexpr PerGameVersion<int> game_height(448, 416, 416, 416);
 
+#if defined(__SWITCH__)
+#include <cstring>
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_dr(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
+
 DirectRenderer::DirectRenderer(const std::string& name, int my_id, int batch_size)
     : BucketRenderer(name, my_id), m_prim_buffer(batch_size) {
+#if defined(__SWITCH__)
+  {
+    char buf[128];
+    snprintf(buf, sizeof(buf), "[direct_renderer] ctor start, name=%s batch_size=%d\n",
+             name.c_str(), batch_size);
+    boot_log_dr(buf);
+  }
+#endif
   glGenBuffers(1, &m_ogl.vertex_buffer);
   glGenVertexArrays(1, &m_ogl.vao);
   glBindVertexArray(m_ogl.vao);
@@ -78,6 +101,9 @@ DirectRenderer::DirectRenderer(const std::string& name, int my_id, int batch_siz
   );
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   glBindVertexArray(0);
+#if defined(__SWITCH__)
+  boot_log_dr("[direct_renderer] ctor end\n");
+#endif
 }
 
 DirectRenderer::~DirectRenderer() {
@@ -310,9 +336,13 @@ void DirectRenderer::flush_pending(SharedRenderState* render_state, ScopedProfil
   if (m_debug_state.wireframe) {
     render_state->shaders[ShaderId::DEBUG_RED].activate();
     glDisable(GL_BLEND);
+    #if !defined(__SWITCH__)
     glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+    #endif
     glDrawArrays(GL_TRIANGLES, 0, m_prim_buffer.vert_count);
+    #if !defined(__SWITCH__)
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+    #endif
     m_blend_state_needs_gl_update = true;
     m_prim_gl_state_needs_gl_update = true;
     draw_count++;

--- a/game/graphics/opengl_renderer/DirectRenderer2.cpp
+++ b/game/graphics/opengl_renderer/DirectRenderer2.cpp
@@ -2,7 +2,11 @@
 
 #include "common/log/log.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 DirectRenderer2::DirectRenderer2(u32 max_verts,
                                  u32 max_inds,

--- a/game/graphics/opengl_renderer/EyeRenderer.cpp
+++ b/game/graphics/opengl_renderer/EyeRenderer.cpp
@@ -4,7 +4,11 @@
 
 #include "game/graphics/opengl_renderer/AdgifHandler.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 /////////////////////////
 // Bucket Renderer

--- a/game/graphics/opengl_renderer/OpenGLRenderer.cpp
+++ b/game/graphics/opengl_renderer/OpenGLRenderer.cpp
@@ -27,8 +27,14 @@
 #include "game/graphics/opengl_renderer/sprite/Sprite3.h"
 #include "game/graphics/pipelines/opengl.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
+#if !defined(__SWITCH__)
 #include "third-party/imgui/imgui_stdlib.h"
+#endif
 
 // for the vif callback
 #include "game/kernel/common/kmachine.h"
@@ -42,6 +48,17 @@
 namespace {
 std::string g_current_renderer;
 }
+
+#if defined(__SWITCH__)
+#include <cstring>
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_ogr(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
 
 /*!
  * OpenGL Error callback. If we do something invalid, this will be called.
@@ -75,8 +92,10 @@ OpenGLRenderer::OpenGLRenderer(std::shared_ptr<TexturePool> texture_pool,
     : m_render_state(texture_pool, loader, version),
       m_collide_renderer(version),
       m_version(version) {
-  // requires OpenGL 4.3
-#ifndef __APPLE__
+  // requires OpenGL 4.3 (core there; GLES only has this behind the optional GL_KHR_debug
+  // extension, not guaranteed present -- devkitPro's GLES driver doesn't expose it, so glad's
+  // function pointer for glDebugMessageCallback is null and calling it crashes immediately)
+#if !defined(__APPLE__) && !defined(__SWITCH__)
   // setup OpenGL errors
   glEnable(GL_DEBUG_OUTPUT);
   glDebugMessageCallback(opengl_error_callback, nullptr);
@@ -123,12 +142,18 @@ OpenGLRenderer::OpenGLRenderer(std::shared_ptr<TexturePool> texture_pool,
   glBindVertexArray(0);
 
   // end set up screen draw
+#if defined(__SWITCH__)
+  boot_log_ogr("[ogl_renderer] screen draw setup done, about to load_common\n");
+#endif
 
   const tfrag3::Level* common_level = nullptr;
   {
     auto p = scoped_prof("load-common");
     common_level = &m_render_state.loader->load_common(*m_render_state.texture_pool, "GAME");
   }
+#if defined(__SWITCH__)
+  boot_log_ogr("[ogl_renderer] load_common done\n");
+#endif
 
   // initialize all renderers
   switch (m_version) {
@@ -145,13 +170,22 @@ OpenGLRenderer::OpenGLRenderer(std::shared_ptr<TexturePool> texture_pool,
   }
 
   m_merc2 = std::make_shared<Merc2>(m_render_state.shaders, anim_slot_array());
+#if defined(__SWITCH__)
+  boot_log_ogr("[ogl_renderer] Merc2 constructed\n");
+#endif
   m_generic2 = std::make_shared<Generic2>(m_render_state.shaders);
+#if defined(__SWITCH__)
+  boot_log_ogr("[ogl_renderer] Generic2 constructed, about to init_bucket_renderers\n");
+#endif
 
   // initialize all renderers
   auto p = scoped_prof("init-bucket-renderers");
   switch (m_version) {
     case GameVersion::Jak1:
       init_bucket_renderers_jak1();
+#if defined(__SWITCH__)
+      boot_log_ogr("[ogl_renderer] init_bucket_renderers_jak1 done\n");
+#endif
       break;
     case GameVersion::Jak2:
       init_bucket_renderers_jak2();
@@ -661,6 +695,9 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
   std::vector<tfrag3::TFragmentTreeKind> ice_tfrags = {tfrag3::TFragmentTreeKind::ICE};
   auto sky_gpu_blender = std::make_shared<SkyBlendGPU>();
   auto sky_cpu_blender = std::make_shared<SkyBlendCPU>();
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] sky blenders constructed\n");
+#endif
 
   //-------------
   // PRE TEXTURE
@@ -673,6 +710,9 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
   // 4 : OCEAN_MID_AND_FAR
   init_bucket_renderer<OceanMidAndFar>("ocean-mid-far", BucketCategory::OCEAN,
                                        BucketId::OCEAN_MID_AND_FAR);
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] sky+ocean-mid-far done\n");
+#endif
 
   //-----------------------
   // LEVEL 0 tfrag texture
@@ -696,6 +736,9 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
                                                BucketId::GENERIC_TFRAG_TEX_LEVEL0, m_generic2,
                                                Generic2::Mode::NORMAL);
 
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] LEVEL0 tfrag done\n");
+#endif
   //-----------------------
   // LEVEL 1 tfrag texture
   //-----------------------
@@ -718,6 +761,9 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
                                                BucketId::GENERIC_TFRAG_TEX_LEVEL1, m_generic2,
                                                Generic2::Mode::NORMAL);
 
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] LEVEL1 tfrag done\n");
+#endif
   //-----------------------
   // LEVEL 0 shrub texture
   //-----------------------
@@ -734,6 +780,9 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
                                                BucketId::SHRUB_GENERIC_LEVEL0, m_generic2,
                                                Generic2::Mode::NORMAL);
 
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] LEVEL0 shrub done\n");
+#endif
   //-----------------------
   // LEVEL 1 shrub texture
   //-----------------------
@@ -750,6 +799,9 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
                                                BucketId::SHRUB_GENERIC_LEVEL1, m_generic2,
                                                Generic2::Mode::NORMAL);
 
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] LEVEL1 shrub done\n");
+#endif
   //-----------------------
   // LEVEL 0 alpha texture
   //-----------------------
@@ -768,6 +820,9 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
                                   anim_slot_array());
   // 37
 
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] LEVEL0 alpha done\n");
+#endif
   //-----------------------
   // LEVEL 1 alpha texture
   //-----------------------
@@ -794,6 +849,9 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
                                                Generic2::Mode::NORMAL);                     // 46
   init_bucket_renderer<ShadowRenderer>("shadow", BucketCategory::OTHER, BucketId::SHADOW);  // 47
 
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] LEVEL1 alpha + shadow done\n");
+#endif
   //-----------------------
   // LEVEL 0 pris texture
   //-----------------------
@@ -805,6 +863,9 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
                                                BucketId::GENERIC_PRIS_LEVEL0, m_generic2,
                                                Generic2::Mode::NORMAL);  // 50
 
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] LEVEL0 pris done\n");
+#endif
   //-----------------------
   // LEVEL 1 pris texture
   //-----------------------
@@ -827,6 +888,9 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
                                                BucketId::GENERIC_PRIS, m_generic2,
                                                Generic2::Mode::NORMAL);  // 56
 
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] LEVEL1 pris + eyes done\n");
+#endif
   //-----------------------
   // LEVEL 0 water texture
   //-----------------------
@@ -838,6 +902,9 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
                                                BucketId::GENERIC_WATER_LEVEL0, m_generic2,
                                                Generic2::Mode::NORMAL);  // 59
 
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] LEVEL0 water done\n");
+#endif
   //-----------------------
   // LEVEL 1 water texture
   //-----------------------
@@ -851,25 +918,49 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
 
   init_bucket_renderer<OceanNear>("ocean-near", BucketCategory::OCEAN, BucketId::OCEAN_NEAR);  // 63
 
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] LEVEL1 water + ocean-near done\n");
+#endif
   //-----------------------
   // DEPTH CUE
   //-----------------------
   init_bucket_renderer<DepthCue>("depth-cue", BucketCategory::OTHER, BucketId::DEPTH_CUE);  // 64
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] depth-cue done\n");
+#endif
 
   //-----------------------
   // COMMON texture
   //-----------------------
   init_bucket_renderer<TextureUploadHandler>("common-tex", BucketCategory::TEX,
                                              BucketId::PRE_SPRITE_TEX, m_texture_animator);  // 65
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] common-tex done\n");
+#endif
 
   init_bucket_renderer<Sprite3>("sprite", BucketCategory::SPRITE, BucketId::SPRITE);  // 66
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] sprite done\n");
+#endif
 
   init_bucket_renderer<DirectRenderer>("debug", BucketCategory::OTHER, BucketId::DEBUG, 0x20000);
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] debug done\n");
+#endif
   init_bucket_renderer<DirectRenderer>("debug-no-zbuf", BucketCategory::OTHER,
                                        BucketId::DEBUG_NO_ZBUF, 0x8000);
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] debug-no-zbuf done\n");
+#endif
   // an extra custom bucket!
   init_bucket_renderer<DirectRenderer>("subtitle", BucketCategory::OTHER, BucketId::SUBTITLE, 6000);
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] subtitle done\n");
+#endif
 
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] depth-cue + sprite + debug done, about to init_shaders/init_textures loop\n");
+#endif
   // for now, for any unset renderers, just set them to an EmptyBucketRenderer.
   for (size_t i = 0; i < m_bucket_renderers.size(); i++) {
     if (!m_bucket_renderers[i]) {
@@ -880,8 +971,14 @@ void OpenGLRenderer::init_bucket_renderers_jak1() {
     m_bucket_renderers[i]->init_shaders(m_render_state.shaders);
     m_bucket_renderers[i]->init_textures(*m_render_state.texture_pool, GameVersion::Jak1);
   }
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] init_shaders/init_textures loop done\n");
+#endif
   sky_cpu_blender->init_textures(*m_render_state.texture_pool, m_version);
   sky_gpu_blender->init_textures(*m_render_state.texture_pool, m_version);
+#if defined(__SWITCH__)
+  boot_log_ogr("[bucket] sky blender init_textures done, init_bucket_renderers_jak1 returning\n");
+#endif
 }
 
 namespace {
@@ -1245,14 +1342,14 @@ void OpenGLRenderer::setup_frame(const RenderOptions& settings) {
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glViewport(0, 0, m_fbo_state.resources.window.width, m_fbo_state.resources.window.height);
     glClearColor(0.0, 0.0, 0.0, 0.0);
-    glClearDepth(0.0);
+    glClearDepthf(0.0f);
     glDepthMask(GL_TRUE);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
     glDisable(GL_BLEND);
 
     glBindFramebuffer(GL_FRAMEBUFFER, m_fbo_state.render_fbo->fbo_id);
     glClearColor(0.0, 0.0, 0.0, 0.0);
-    glClearDepth(0.0);
+    glClearDepthf(0.0f);
     glClearStencil(0);
     glDepthMask(GL_TRUE);
     // Note: could rely on sky renderer to clear depth and color, but this causes problems with

--- a/game/graphics/opengl_renderer/Profiler.cpp
+++ b/game/graphics/opengl_renderer/Profiler.cpp
@@ -6,7 +6,11 @@
 #include "common/util/colors.h"
 
 #include "fmt/format.h"
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 ProfilerNode::ProfilerNode(const std::string& name) : m_name(name) {}
 

--- a/game/graphics/opengl_renderer/Shader.cpp
+++ b/game/graphics/opengl_renderer/Shader.cpp
@@ -22,6 +22,27 @@ Shader::Shader(const std::string& shader_name, GameVersion version) : m_name(sha
   frag_src = std::regex_replace(frag_src, std::regex("SCISSOR_HEIGHT"), scissor_height);
   vert_src = std::regex_replace(vert_src, std::regex("SCISSOR_ADJUST"), "(" + scissor_adjust + ")");
 
+#if defined(__SWITCH__)
+  // Every shader here is plain #version 410 with nothing GL4-specific in it (see the
+  // graphics/ GLES survey) -- swap the desktop GLSL header for a GLSL ES one matching the
+  // GLES 3.1 context requested in opengl.cpp. GLES additionally requires an explicit float
+  // precision, which desktop GLSL doesn't have at all.
+  //
+  // Two bugs in the original version of this replacement, found from real compile errors:
+  // 1. The `^` anchor only matches the very start of the whole source string, not "start of a
+  //    line" -- shaders with a leading comment before their #version line (e.g. debug_red.vert)
+  //    never matched at all, so GLSL 410 reached the driver unmodified.
+  //  2. `#version 410` here is actually `#version 410 core\r\n` in the source (CRLF checkout).
+  //    Matching only the `#version 410` prefix left `" core\r"` dangling right after the
+  //    replacement's last line, producing "precision highp int; core" -- a syntax error, not
+  //    valid GLSL. Matching through end-of-line (`[^\r\n]*`) consumes that trailing text too.
+  const std::regex version_410_line("#version 410[^\r\n]*");
+  const std::string gles_header =
+      "#version 310 es\nprecision highp float;\nprecision highp int;";
+  vert_src = std::regex_replace(vert_src, version_410_line, gles_header);
+  frag_src = std::regex_replace(frag_src, version_410_line, gles_header);
+#endif
+
   m_vert_shader = glCreateShader(GL_VERTEX_SHADER);
   const char* src = vert_src.c_str();
   glShaderSource(m_vert_shader, 1, &src, nullptr);

--- a/game/graphics/opengl_renderer/ShadowRenderer.cpp
+++ b/game/graphics/opengl_renderer/ShadowRenderer.cpp
@@ -2,7 +2,11 @@
 
 #include <cfloat>
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 ShadowRenderer::ShadowRenderer(const std::string& name, int my_id) : BucketRenderer(name, my_id) {
   // create OpenGL objects
@@ -383,9 +387,13 @@ void ShadowRenderer::draw(SharedRenderState* render_state, ScopedProfilerNode& p
       glUniform4f(
           glGetUniformLocation(render_state->shaders[ShaderId::SHADOW].id(), "color_uniform"), 0.0f,
           0.0f, 0.0f, 0.5f);
+      #if !defined(__SWITCH__)
       glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+      #endif
       glDrawElements(GL_TRIANGLES, (m_next_front_index - 6), GL_UNSIGNED_INT, nullptr);
+      #if !defined(__SWITCH__)
       glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+      #endif
       glEnable(GL_BLEND);
     }
     prof.add_draw_call();
@@ -408,9 +416,13 @@ void ShadowRenderer::draw(SharedRenderState* render_state, ScopedProfilerNode& p
       glUniform4f(
           glGetUniformLocation(render_state->shaders[ShaderId::SHADOW].id(), "color_uniform"), 0.0f,
           0.0f, 0.0f, 0.5f);
+      #if !defined(__SWITCH__)
       glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+      #endif
       glDrawElements(GL_TRIANGLES, (m_next_back_index - 0), GL_UNSIGNED_INT, nullptr);
+      #if !defined(__SWITCH__)
       glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+      #endif
       glEnable(GL_BLEND);
     }
 

--- a/game/graphics/opengl_renderer/SkyBlendGPU.cpp
+++ b/game/graphics/opengl_renderer/SkyBlendGPU.cpp
@@ -16,11 +16,19 @@ SkyBlendGPU::SkyBlendGPU() {
   for (int i = 0; i < 2; i++) {
     glBindFramebuffer(GL_FRAMEBUFFER, m_framebuffers[i]);
     glBindTexture(GL_TEXTURE_2D, m_textures[i]);
+    // See opengl_utils.cpp's FramebufferTexturePair -- GL_UNSIGNED_INT_8_8_8_8_REV isn't a
+    // color-renderable (format, type) combo for unsized GL_RGBA under GLES; this is a pure
+    // render target (draw-call filled, never CPU-uploaded), so GL_UNSIGNED_BYTE is safe.
+#if defined(__SWITCH__)
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_sizes[i], m_sizes[i], 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 0);
+#else
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_sizes[i], m_sizes[i], 0, GL_RGBA,
                  GL_UNSIGNED_INT_8_8_8_8_REV, 0);
+#endif
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, m_textures[i], 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_textures[i], 0);
     GLenum draw_buffers[1] = {GL_COLOR_ATTACHMENT0};
     glDrawBuffers(1, draw_buffers);
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
@@ -130,7 +138,7 @@ SkyBlendStats SkyBlendGPU::do_sky_blends(DmaFollower& dma,
     // setup for rendering!
     glBindFramebuffer(GL_FRAMEBUFFER, m_framebuffers[buffer_idx]);
     glViewport(0, 0, m_sizes[buffer_idx], m_sizes[buffer_idx]);
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, m_textures[buffer_idx], 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_textures[buffer_idx], 0);
     render_state->shaders[ShaderId::SKY_BLEND].activate();
 
     // if the first is set, it disables alpha. we can just clear here, so it's easier to find

--- a/game/graphics/opengl_renderer/SkyRenderer.cpp
+++ b/game/graphics/opengl_renderer/SkyRenderer.cpp
@@ -3,7 +3,11 @@
 #include "game/graphics/opengl_renderer/AdgifHandler.h"
 #include "game/graphics/pipelines/opengl.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 // The sky texture system blends together sky textures from different levels and times of day
 // to create the final sky texture.

--- a/game/graphics/opengl_renderer/TextureAnimator.cpp
+++ b/game/graphics/opengl_renderer/TextureAnimator.cpp
@@ -9,7 +9,11 @@
 #include "game/graphics/opengl_renderer/slime_lut.h"
 #include "game/graphics/texture/TexturePool.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 #define _USE_MATH_DEFINES
 #include <math.h>
@@ -59,6 +63,12 @@
 //  This breaks the fade-out/thresholding, and likely the colors. But it still looks vaguely like
 //  clouds.
 void debug_save_opengl_texture(const std::string& out, GLuint texture) {
+#if defined(__SWITCH__)
+  // glGetTexLevelParameteriv/glGetTexImage don't exist in GLES; this is debug-only texture
+  // dump tooling, not on any real gameplay path.
+  (void)out;
+  (void)texture;
+#else
   glBindTexture(GL_TEXTURE_2D, texture);
   int w, h;
   glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
@@ -67,6 +77,7 @@ void debug_save_opengl_texture(const std::string& out, GLuint texture) {
   std::vector<u8> data(w * h * 4);
   glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, data.data());
   file_util::write_rgba_png(out, data.data(), w, h);
+#endif
 }
 
 /*!
@@ -569,15 +580,15 @@ TextureAnimator::TextureAnimator(ShaderLibrary& shaders,
 
   // create the slime LUT texture
   glGenTextures(1, &m_slime_lut_texture);
-  glBindTexture(GL_TEXTURE_1D, m_slime_lut_texture);
+  glBindTexture(GL_TEXTURE_2D, m_slime_lut_texture);
   std::vector<u8> slime_data;
   for (auto x : kSlimeLutData) {
     slime_data.push_back(x * 255);
   }
-  glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA, 256, 0, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV,
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 1, 0, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV,
                slime_data.data());
-  glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-  glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glBindTexture(GL_TEXTURE_2D, 0);
 
   shader.activate();
@@ -689,11 +700,17 @@ int TextureAnimator::create_fixed_anim_array(const std::vector<FixedAnimDef>& de
 }
 
 void imgui_show_tex(GLuint tex) {
+#if !defined(__SWITCH__)
+  // glGetTexLevelParameteriv doesn't exist in GLES; this is imgui debug-window-only tooling
+  // (see the file's imgui_stub.h include above), not on any real gameplay path.
   glBindTexture(GL_TEXTURE_2D, tex);
   int w, h;
   glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
   glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
   ImGui::Image((ImTextureID)(intptr_t)tex, ImVec2(w, h));
+#else
+  (void)tex;
+#endif
 }
 
 void TextureAnimator::draw_debug_window() {
@@ -2771,6 +2788,11 @@ int update_opengl_noise_texture(GLuint texture,
 }
 
 void debug_save_opengl_u8_texture(const std::string& out, GLuint texture) {
+#if defined(__SWITCH__)
+  // See debug_save_opengl_texture above -- same GLES gap, same debug-only tooling.
+  (void)out;
+  (void)texture;
+#else
   glBindTexture(GL_TEXTURE_2D, texture);
   int w, h;
   glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
@@ -2786,6 +2808,7 @@ void debug_save_opengl_u8_texture(const std::string& out, GLuint texture) {
     data[i * 4 + 3] = 255;
   }
   file_util::write_rgba_png(out, data.data(), w, h);
+#endif
 }
 
 void TextureAnimator::setup_sky() {
@@ -2959,7 +2982,7 @@ void TextureAnimator::run_slime(const SlimeInput& input) {
     glUniform2fv(m_uniforms.uvs, 4, uv);
 
     glActiveTexture(GL_TEXTURE10);
-    glBindTexture(GL_TEXTURE_1D, m_slime_lut_texture);
+    glBindTexture(GL_TEXTURE_2D, m_slime_lut_texture);
     glActiveTexture(GL_TEXTURE0);
 
     // Anim 1:

--- a/game/graphics/opengl_renderer/TextureUploadHandler.cpp
+++ b/game/graphics/opengl_renderer/TextureUploadHandler.cpp
@@ -7,7 +7,11 @@
 #include "game/graphics/pipelines/opengl.h"
 
 #include "fmt/format.h"
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 TextureUploadHandler::TextureUploadHandler(const std::string& name,
                                            int my_id,

--- a/game/graphics/opengl_renderer/VisDataHandler.cpp
+++ b/game/graphics/opengl_renderer/VisDataHandler.cpp
@@ -2,7 +2,11 @@
 
 #include "background/background_common.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 VisDataHandler::VisDataHandler(const std::string& name, int my_id) : BucketRenderer(name, my_id) {}
 

--- a/game/graphics/opengl_renderer/background/Hfrag.cpp
+++ b/game/graphics/opengl_renderer/background/Hfrag.cpp
@@ -2,7 +2,11 @@
 
 #include "common/log/log.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 Hfrag::Hfrag(const std::string& name, int my_id) : BucketRenderer(name, my_id) {
   // generate shared index buffer
@@ -183,7 +187,7 @@ Hfrag::HfragLevel* Hfrag::get_hfrag_level(const std::string& name,
 void Hfrag::unload_hfrag_level(Hfrag::HfragLevel* lev) {
   ASSERT(lev->in_use);
   // delete OpenGL resources we created.
-  glBindTexture(GL_TEXTURE_1D, lev->time_of_day_texture);
+  glBindTexture(GL_TEXTURE_2D, lev->time_of_day_texture);
   glDeleteTextures(1, &lev->time_of_day_texture);
   glDeleteVertexArrays(1, &lev->vao);
 
@@ -255,11 +259,11 @@ void Hfrag::load_hfrag_level(const std::string& load_name,
   );
   glActiveTexture(GL_TEXTURE10);
   glGenTextures(1, &lev->time_of_day_texture);
-  glBindTexture(GL_TEXTURE_1D, lev->time_of_day_texture);
-  glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA, TIME_OF_DAY_COLOR_COUNT, 0, GL_RGBA,
+  glBindTexture(GL_TEXTURE_2D, lev->time_of_day_texture);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, TIME_OF_DAY_COLOR_COUNT, 1, 0, GL_RGBA,
                GL_UNSIGNED_INT_8_8_8_8, nullptr);
-  glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-  glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glBindVertexArray(0);
 
   // montage
@@ -389,9 +393,9 @@ void Hfrag::render_hfrag_level(Hfrag::HfragLevel* lev,
   // generate time of day texture
   interp_time_of_day(pc_data.camera.itimes, lev->hfrag->time_of_day_colors, m_color_result.data());
   glActiveTexture(GL_TEXTURE10);
-  glBindTexture(GL_TEXTURE_1D, lev->time_of_day_texture);
-  glTexSubImage1D(GL_TEXTURE_1D, 0, 0, lev->num_colors, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV,
-                  m_color_result.data());
+  glBindTexture(GL_TEXTURE_2D, lev->time_of_day_texture);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, lev->num_colors, 1, GL_RGBA,
+                  GL_UNSIGNED_INT_8_8_8_8_REV, m_color_result.data());
 
   // initialize data
   glBindVertexArray(lev->vao);

--- a/game/graphics/opengl_renderer/background/Shrub.cpp
+++ b/game/graphics/opengl_renderer/background/Shrub.cpp
@@ -152,11 +152,11 @@ void Shrub::update_load(const LevelData* loader_data) {
 
     glActiveTexture(GL_TEXTURE10);
     glGenTextures(1, &m_trees[l_tree].time_of_day_texture);
-    glBindTexture(GL_TEXTURE_1D, m_trees[l_tree].time_of_day_texture);
-    glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA, TIME_OF_DAY_COLOR_COUNT, 0, GL_RGBA,
+    glBindTexture(GL_TEXTURE_2D, m_trees[l_tree].time_of_day_texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, TIME_OF_DAY_COLOR_COUNT, 1, 0, GL_RGBA,
                  GL_UNSIGNED_INT_8_8_8_8, nullptr);
-    glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
     glBindVertexArray(0);
   }
@@ -211,7 +211,7 @@ bool Shrub::setup_for_level(const std::string& level, SharedRenderState* render_
 
 void Shrub::discard_tree_cache() {
   for (auto& tree : m_trees) {
-    glBindTexture(GL_TEXTURE_1D, tree.time_of_day_texture);
+    glBindTexture(GL_TEXTURE_2D, tree.time_of_day_texture);
     glDeleteTextures(1, &tree.time_of_day_texture);
     glDeleteBuffers(1, &tree.index_buffer);
     glDeleteBuffers(1, &tree.single_draw_index_buffer);
@@ -290,8 +290,8 @@ void Shrub::render_tree(int idx,
 
   Timer setup_timer;
   glActiveTexture(GL_TEXTURE10);
-  glBindTexture(GL_TEXTURE_1D, tree.time_of_day_texture);
-  glTexSubImage1D(GL_TEXTURE_1D, 0, 0, tree.colors->color_count, GL_RGBA,
+  glBindTexture(GL_TEXTURE_2D, tree.time_of_day_texture);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, tree.colors->color_count, 1, GL_RGBA,
                   GL_UNSIGNED_INT_8_8_8_8_REV, m_color_result.data());
 
   first_tfrag_draw_setup(settings.camera, render_state, ShaderId::SHRUB);

--- a/game/graphics/opengl_renderer/background/TFragment.cpp
+++ b/game/graphics/opengl_renderer/background/TFragment.cpp
@@ -2,7 +2,11 @@
 
 #include "game/graphics/opengl_renderer/dma_helpers.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 namespace {
 bool looks_like_tfragment_dma(const DmaFollower& follow) {
@@ -337,11 +341,11 @@ void TFragment::update_load(const std::vector<tfrag3::TFragmentTreeKind>& tree_k
                      tree.unpacked.indices.data(), GL_STREAM_DRAW);
 
         glGenTextures(1, &tree_cache.time_of_day_texture);
-        glBindTexture(GL_TEXTURE_1D, tree_cache.time_of_day_texture);
-        glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA, TIME_OF_DAY_COLOR_COUNT, 0, GL_RGBA,
+        glBindTexture(GL_TEXTURE_2D, tree_cache.time_of_day_texture);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, TIME_OF_DAY_COLOR_COUNT, 1, 0, GL_RGBA,
                      GL_UNSIGNED_INT_8_8_8_8, nullptr);
-        glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         glBindVertexArray(0);
       }
     }
@@ -423,8 +427,8 @@ void TFragment::render_tree(int geom,
   }
   interp_time_of_day(settings.camera.itimes, *tree.colors, m_color_result.data());
   glActiveTexture(GL_TEXTURE10);
-  glBindTexture(GL_TEXTURE_1D, tree.time_of_day_texture);
-  glTexSubImage1D(GL_TEXTURE_1D, 0, 0, tree.colors->color_count, GL_RGBA,
+  glBindTexture(GL_TEXTURE_2D, tree.time_of_day_texture);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, tree.colors->color_count, 1, GL_RGBA,
                   GL_UNSIGNED_INT_8_8_8_8_REV, m_color_result.data());
 
   first_tfrag_draw_setup(settings.camera, render_state, ShaderId::TFRAG3);
@@ -566,7 +570,7 @@ void TFragment::discard_tree_cache() {
   for (int geom = 0; geom < GEOM_MAX; ++geom) {
     for (auto& tree : m_cached_trees[geom]) {
       if (tree.kind != tfrag3::TFragmentTreeKind::INVALID) {
-        glBindTexture(GL_TEXTURE_1D, tree.time_of_day_texture);
+        glBindTexture(GL_TEXTURE_2D, tree.time_of_day_texture);
         glDeleteTextures(1, &tree.time_of_day_texture);
         glDeleteBuffers(1, &tree.single_draw_index_buffer);
         glDeleteBuffers(1, &tree.index_buffer);

--- a/game/graphics/opengl_renderer/background/Tie3.cpp
+++ b/game/graphics/opengl_renderer/background/Tie3.cpp
@@ -4,7 +4,11 @@
 #include "common/log/log.h"
 #include "common/util/Assert.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 Tie3::Tie3(const std::string& name,
            int my_id,
@@ -188,11 +192,11 @@ void Tie3::load_from_fr3_data(const LevelData* loader_data) {
       // set up time of day texture.
       glActiveTexture(GL_TEXTURE10);
       glGenTextures(1, &lod_tree[l_tree].time_of_day_texture);
-      glBindTexture(GL_TEXTURE_1D, lod_tree[l_tree].time_of_day_texture);
-      glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA, TIME_OF_DAY_COLOR_COUNT, 0, GL_RGBA,
+      glBindTexture(GL_TEXTURE_2D, lod_tree[l_tree].time_of_day_texture);
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, TIME_OF_DAY_COLOR_COUNT, 1, 0, GL_RGBA,
                    GL_UNSIGNED_INT_8_8_8_8, nullptr);
-      glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-      glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
       glBindVertexArray(0);
 
@@ -262,7 +266,7 @@ bool Tie3::try_loading_level(const std::string& level, SharedRenderState* render
 void Tie3::discard_tree_cache() {
   for (int geo = 0; geo < 4; ++geo) {
     for (auto& tree : m_trees[geo]) {
-      glBindTexture(GL_TEXTURE_1D, tree.time_of_day_texture);
+      glBindTexture(GL_TEXTURE_2D, tree.time_of_day_texture);
       glDeleteTextures(1, &tree.time_of_day_texture);
       // glDeleteBuffers(1, &tree.index_buffer);
       glDeleteBuffers(1, &tree.single_draw_index_buffer);
@@ -436,8 +440,8 @@ void Tie3::setup_tree(int idx,
   interp_time_of_day(settings.camera.itimes, *tree.colors, m_color_result.data());
 
   glActiveTexture(GL_TEXTURE10);
-  glBindTexture(GL_TEXTURE_1D, tree.time_of_day_texture);
-  glTexSubImage1D(GL_TEXTURE_1D, 0, 0, tree.colors->color_count, GL_RGBA,
+  glBindTexture(GL_TEXTURE_2D, tree.time_of_day_texture);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, tree.colors->color_count, 1, GL_RGBA,
                   GL_UNSIGNED_INT_8_8_8_8_REV, m_color_result.data());
 
   // update proto vis mask
@@ -557,7 +561,7 @@ void Tie3::draw_matching_draws_for_tree(int idx,
                render_state->no_multidraw ? tree.single_draw_index_buffer : tree.index_buffer);
 
   glActiveTexture(GL_TEXTURE10);
-  glBindTexture(GL_TEXTURE_1D, tree.time_of_day_texture);
+  glBindTexture(GL_TEXTURE_2D, tree.time_of_day_texture);
 
   glActiveTexture(GL_TEXTURE0);
   glEnable(GL_PRIMITIVE_RESTART);
@@ -939,7 +943,7 @@ void Tie3::render_tree_wind(int idx,
                render_state->no_multidraw ? tree.single_draw_index_buffer : tree.index_buffer);
 
   glActiveTexture(GL_TEXTURE10);
-  glBindTexture(GL_TEXTURE_1D, tree.time_of_day_texture);
+  glBindTexture(GL_TEXTURE_2D, tree.time_of_day_texture);
 
   glActiveTexture(GL_TEXTURE0);
   glEnable(GL_PRIMITIVE_RESTART);

--- a/game/graphics/opengl_renderer/debug_gui.cpp
+++ b/game/graphics/opengl_renderer/debug_gui.cpp
@@ -12,7 +12,11 @@
 #include "game/system/hid/sdl_util.h"
 
 #include "fmt/format.h"
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 #include "third-party/imgui/imgui_style.h"
 
 void FrameTimeRecorder::finish_frame() {
@@ -272,6 +276,8 @@ void OpenGlDebugGui::draw_overlord_debug_menu() {
   }
 }
 
+#if !defined(__SWITCH__)
+// game/switch/imgui_stub.h already provides a no-op ImGui::applyFontStyle() for Switch.
 namespace ImGui {
 void applyFontStyle() {
   ImGuiIO& io = ImGui::GetIO();
@@ -310,3 +316,4 @@ void applyFontStyle() {
   io.FontGlobalScale = Gfx::g_debug_settings.imgui_font_scale;
 }
 }  // namespace ImGui
+#endif

--- a/game/graphics/opengl_renderer/foreground/Generic2.cpp
+++ b/game/graphics/opengl_renderer/foreground/Generic2.cpp
@@ -2,7 +2,11 @@
 
 #include "game/graphics/opengl_renderer/AdgifHandler.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 Generic2::Generic2(ShaderLibrary& shaders,
                    u32 num_verts,

--- a/game/graphics/opengl_renderer/foreground/Merc2.cpp
+++ b/game/graphics/opengl_renderer/foreground/Merc2.cpp
@@ -7,7 +7,11 @@
 #include "game/graphics/opengl_renderer/EyeRenderer.h"
 #include "game/graphics/opengl_renderer/background/background_common.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 /* Merc 2 renderer:
  The merc2 renderer is the main "foreground" renderer, which draws characters, collectables,

--- a/game/graphics/opengl_renderer/foreground/Shadow2.cpp
+++ b/game/graphics/opengl_renderer/foreground/Shadow2.cpp
@@ -1,6 +1,10 @@
 #include "Shadow2.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 Shadow2::Shadow2(const std::string& name, int my_id) : BucketRenderer(name, my_id) {
   m_vertex_buffer.resize(kMaxVerts);
@@ -495,9 +499,13 @@ void Shadow2::draw_buffers(SharedRenderState* render_state,
     if (m_debug_draw_volume) {
       glDisable(GL_BLEND);
       glUniform4f(m_ogl.uniforms.color, 0., 0.0, 0., 0.5);
+      #if !defined(__SWITCH__)
       glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+      #endif
       glDrawElements(GL_TRIANGLE_STRIP, (m_front_index_buffer_used - 6), GL_UNSIGNED_INT, nullptr);
+      #if !defined(__SWITCH__)
       glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+      #endif
       glEnable(GL_BLEND);
       prof.add_draw_call();
       prof.add_tri(m_front_index_buffer_used / 3);
@@ -520,9 +528,13 @@ void Shadow2::draw_buffers(SharedRenderState* render_state,
     if (m_debug_draw_volume) {
       glDisable(GL_BLEND);
       glUniform4f(m_ogl.uniforms.color, 0., 0.0, 0., 0.5);
+      #if !defined(__SWITCH__)
       glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+      #endif
       glDrawElements(GL_TRIANGLE_STRIP, (m_back_index_buffer_used - 0), GL_UNSIGNED_INT, nullptr);
+      #if !defined(__SWITCH__)
       glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+      #endif
       glEnable(GL_BLEND);
       prof.add_draw_call();
       prof.add_tri(m_back_index_buffer_used / 3);

--- a/game/graphics/opengl_renderer/loader/Loader.cpp
+++ b/game/graphics/opengl_renderer/loader/Loader.cpp
@@ -9,7 +9,11 @@
 
 #include "game/graphics/opengl_renderer/loader/LoaderStages.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 Loader::Loader(const fs::path& base_path, int max_levels)
     : m_base_path(base_path), m_max_levels(max_levels) {

--- a/game/graphics/opengl_renderer/ocean/OceanEnvmap.cpp
+++ b/game/graphics/opengl_renderer/ocean/OceanEnvmap.cpp
@@ -7,7 +7,11 @@
 #include "game/graphics/texture/TexturePool.h"
 
 #include "fmt/format.h"
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 namespace {
 

--- a/game/graphics/opengl_renderer/ocean/OceanMidAndFar.cpp
+++ b/game/graphics/opengl_renderer/ocean/OceanMidAndFar.cpp
@@ -1,6 +1,10 @@
 #include "OceanMidAndFar.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 OceanMidAndFar::OceanMidAndFar(const std::string& name, int my_id)
     : BucketRenderer(name, my_id),

--- a/game/graphics/opengl_renderer/ocean/OceanNear.cpp
+++ b/game/graphics/opengl_renderer/ocean/OceanNear.cpp
@@ -2,7 +2,11 @@
 
 #include "common/log/log.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 OceanNear::OceanNear(const std::string& name, int my_id)
     : BucketRenderer(name, my_id), m_texture_renderer(false) {

--- a/game/graphics/opengl_renderer/ocean/OceanTexture.cpp
+++ b/game/graphics/opengl_renderer/ocean/OceanTexture.cpp
@@ -2,7 +2,11 @@
 
 #include "game/graphics/opengl_renderer/AdgifHandler.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 constexpr int OCEAN_TEX_TBP_JAK1 = 8160;  // todo
 constexpr int OCEAN_TEX_TBP_JAK2 = 672;

--- a/game/graphics/opengl_renderer/opengl_utils.cpp
+++ b/game/graphics/opengl_renderer/opengl_utils.cpp
@@ -16,6 +16,16 @@ FramebufferTexturePair::FramebufferTexturePair(int w, int h, u64 texture_format,
   GLint old_framebuffer;
   glGetIntegerv(GL_FRAMEBUFFER_BINDING, &old_framebuffer);
 
+#if defined(__SWITCH__)
+  // Every caller passes GL_UNSIGNED_INT_8_8_8_8_REV, a desktop-only packed pixel type that isn't
+  // a valid/color-renderable (format, type) combo for unsized GL_RGBA under GLES -- attaching it
+  // to a framebuffer fails with GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT. These are all pure
+  // render-to-texture targets (nullptr initial data, filled by draw calls, never CPU-uploaded),
+  // so the specific byte packing doesn't matter here; GL_UNSIGNED_BYTE is guaranteed
+  // color-renderable for GL_RGBA in GLES 3.x.
+  texture_format = GL_UNSIGNED_BYTE;
+#endif
+
   for (int i = 0; i < num_levels; i++) {
     glBindTexture(GL_TEXTURE_2D, m_texture);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, num_levels);
@@ -30,7 +40,7 @@ FramebufferTexturePair::FramebufferTexturePair(int w, int h, u64 texture_format,
     glBindTexture(GL_TEXTURE_2D, m_texture);
     // I don't know if we really need to do this. whatever uses this texture should figure it out.
 
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i, m_texture, i);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i, GL_TEXTURE_2D, m_texture, i);
     GLenum draw_buffers[1] = {GLenum(GL_COLOR_ATTACHMENT0 + i)};
     glDrawBuffers(1, draw_buffers);
     auto status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
@@ -85,7 +95,7 @@ FramebufferTexturePairContext::FramebufferTexturePairContext(FramebufferTextureP
   glGetIntegerv(GL_FRAMEBUFFER_BINDING, &m_old_framebuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, m_fb->m_framebuffers[level]);
   glViewport(0, 0, m_fb->m_w, m_fb->m_h);
-  glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, m_fb->m_texture, level);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_fb->m_texture, level);
 }
 
 void FramebufferTexturePairContext::switch_to(FramebufferTexturePair& fb) {
@@ -93,7 +103,7 @@ void FramebufferTexturePairContext::switch_to(FramebufferTexturePair& fb) {
     m_fb = &fb;
     glBindFramebuffer(GL_FRAMEBUFFER, m_fb->m_framebuffers[0]);
     glViewport(0, 0, m_fb->m_w, m_fb->m_h);
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, m_fb->m_texture, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_fb->m_texture, 0);
   }
 }
 

--- a/game/graphics/opengl_renderer/shaders/collision.frag
+++ b/game/graphics/opengl_renderer/shaders/collision.frag
@@ -5,6 +5,6 @@ out vec4 color;
 in vec4 fragment_color;
 
 void main() {
-  if (fragment_color.a <= 0) discard;
+  if (fragment_color.a <= 0.) discard;
   color = fragment_color;
 }

--- a/game/graphics/opengl_renderer/shaders/collision.vert
+++ b/game/graphics/opengl_renderer/shaders/collision.vert
@@ -38,7 +38,7 @@ uint pat_get_material(uint p) { return version == 2 || version == 3 ? (p >> 10) 
 uint pat_get_event(uint p) { return version == 2 || version == 3 ? (p >> 18) & 0x3fu : (p >> 14) & 0x3fu; }
 uint pat_get_skip(uint p) { return version == 2 || version == 3 ? p & 0x1f03007fu : p & 0x3007u; }
 
-bool logtest(uint a, uint b) { return (a & b) != 0; }
+bool logtest(uint a, uint b) { return (a & b) != 0u; }
 bool logtesta(uint a, uint b) { return (a & b) == b; }
 
 layout(std140) uniform PatColors {
@@ -67,12 +67,12 @@ void main() {
   transformed.xy -= (2048.);
 
   // correct z scale
-  transformed.z /= (8388608);
-  transformed.z -= 1;
+  transformed.z /= (8388608.);
+  transformed.z -= 1.;
 
   // correct xy scale
-  transformed.x /= (256);
-  transformed.y /= -(128);
+  transformed.x /= (256.);
+  transformed.y /= -(128.);
 
   // hack
   transformed.xyz *= transformed.w;
@@ -90,9 +90,9 @@ void main() {
     float cam_dot = abs(dot(to_cam_n, normal_in));
 
     // base colors
-    fragment_color = vec4(vec3(0.75), 1);
+    fragment_color = vec4(vec3(0.75), 1.);
     if (wireframe_enabled == 0) {
-      fragment_color.rgb *= (pow(cam_dot, 2) * 0.35 + 0.65);
+      fragment_color.rgb *= (pow(cam_dot, 2.) * 0.35 + 0.65);
     } else {
       fragment_color.rgb *= (pow(cam_dot, 2.5) * 0.25 + 0.75);
     }
@@ -102,11 +102,11 @@ void main() {
     uint pMat = pat_get_material(pat);
     uint pEvent = pat_get_event(pat);
     uint pSkip = pat_get_skip(pat);
-    if (logtest(collision_mode_mask[pMode/32], 1 << (pMode & 0x1fu)) &&
-        logtest(collision_material_mask[pMat/32], 1 << (pMat & 0x1fu)) &&
-        logtest(collision_event_mask[pEvent/32], 1 << (pEvent & 0x1fu)) &&
+    if (logtest(collision_mode_mask[pMode/32u], 1u << (pMode & 0x1fu)) &&
+        logtest(collision_material_mask[pMat/32u], 1u << (pMat & 0x1fu)) &&
+        logtest(collision_event_mask[pEvent/32u], 1u << (pEvent & 0x1fu)) &&
         !logtest(collision_skip_hide_mask, pSkip) &&
-        ((pSkip == 0 && collision_skip_nomask_allowed == 1) || (pSkip != 0 && (collision_skip_mask == 0 || logtest(pSkip, collision_skip_mask))))) {
+        ((pSkip == 0u && collision_skip_nomask_allowed == 1u) || (pSkip != 0u && (collision_skip_mask == 0u || logtest(pSkip, collision_skip_mask))))) {
       // fancy colors
       if (mode == MODE_MODE) {
         fragment_color.rgb *= pat_mode_colors[pMode].rgb;
@@ -115,15 +115,15 @@ void main() {
       } else if (mode == MODE_MATERIAL) {
         fragment_color.rgb *= pat_material_colors[pMat].rgb;
       } else {
-        fragment_color = vec4((normal_in + 1)*.5, 1);
-        fragment_color.rgb *= (pow(cam_dot, 2) * 0.5 + 0.5);
+        fragment_color = vec4((normal_in + 1.)*.5, 1.);
+        fragment_color.rgb *= (pow(cam_dot, 2.) * 0.5 + 0.5);
       }
-      if (fragment_color.r < 0 || fragment_color.g < 0 || fragment_color.b < 0) {
-        fragment_color.rgb = vec3(1, 0, 1);
+      if (fragment_color.r < 0. || fragment_color.g < 0. || fragment_color.b < 0.) {
+        fragment_color.rgb = vec3(1., 0., 1.);
       }
     } else {
       // filtered out. goodbye!
-      fragment_color.rgba = vec4(0);
+      fragment_color.rgba = vec4(0.);
     }
   } else {
     fragment_color = vec4(0.12, 0.12, 0.12, 0.5);

--- a/game/graphics/opengl_renderer/shaders/debug_red.vert
+++ b/game/graphics/opengl_renderer/shaders/debug_red.vert
@@ -7,8 +7,8 @@ layout (location = 0) in vec3 position_in;
 out vec4 fragment_color;
 
 void main() {
-  gl_Position = vec4((position_in.x - 0.5) * 16., -(position_in.y - 0.5) * 32, position_in.z * 2 - 1., 1.0);
+  gl_Position = vec4((position_in.x - 0.5) * 16., -(position_in.y - 0.5) * 32., position_in.z * 2. - 1., 1.0);
   // scissoring area adjust
   gl_Position.y *= SCISSOR_ADJUST;
-  fragment_color = vec4(1.0, 0, 0, 0.7);
+  fragment_color = vec4(1.0, 0., 0., 0.7);
 }

--- a/game/graphics/opengl_renderer/shaders/depth_cue.vert
+++ b/game/graphics/opengl_renderer/shaders/depth_cue.vert
@@ -12,7 +12,7 @@ out vec2 tex_coord;
 void main() {
   // Calculate color
   vec4 color = u_color;
-  color *= 2; // correct
+  color *= 2.; // correct
   
   fragment_color = color;
 
@@ -21,7 +21,7 @@ void main() {
 
   // Calculate vertex position
   vec4 position = vec4(xy.x, xy.y, u_depth, 1.0);
-  position.xyz = (position.xyz * 2) - 1.0; // convert from [0,1] to clip-space
+  position.xyz = (position.xyz * 2.) - 1.0; // convert from [0,1] to clip-space
 
   gl_Position = position;
 }

--- a/game/graphics/opengl_renderer/shaders/direct2.frag
+++ b/game/graphics/opengl_renderer/shaders/direct2.frag
@@ -25,17 +25,17 @@ uniform sampler2D tex_T9;
 
 vec4 sample_tex(vec2 coord, uint unit) {
   switch (unit) {
-    case 0: return texture(tex_T0, coord);
-    case 1: return texture(tex_T1, coord);
-    case 2: return texture(tex_T2, coord);
-    case 3: return texture(tex_T3, coord);
-    case 4: return texture(tex_T4, coord);
-    case 5: return texture(tex_T5, coord);
-    case 6: return texture(tex_T6, coord);
-    case 7: return texture(tex_T7, coord);
-    case 8: return texture(tex_T8, coord);
-    case 9: return texture(tex_T9, coord);
-    default : return vec4(1.0, 0, 1.0, 1.0);
+    case 0u: return texture(tex_T0, coord);
+    case 1u: return texture(tex_T1, coord);
+    case 2u: return texture(tex_T2, coord);
+    case 3u: return texture(tex_T3, coord);
+    case 4u: return texture(tex_T4, coord);
+    case 5u: return texture(tex_T5, coord);
+    case 6u: return texture(tex_T6, coord);
+    case 7u: return texture(tex_T7, coord);
+    case 8u: return texture(tex_T8, coord);
+    case 9u: return texture(tex_T9, coord);
+    default : return vec4(1.0, 0., 1.0, 1.0);
   }
 }
 
@@ -44,8 +44,8 @@ void main() {
   // y is tcc
   // z is decal
 
-  if ((tex_info.y & 1u) == 0) {
-    if ((tex_info.y & 2u) == 0) {
+  if ((tex_info.y & 1u) == 0u) {
+    if ((tex_info.y & 2u) == 0u) {
       // modulate + no tcc
       color.xyz = fragment_color.xyz * T0.xyz;
       color.w = fragment_color.w;
@@ -55,7 +55,7 @@ void main() {
       color.w = fragment_color.w;
     }
   } else {
-    if ((tex_info.y & 2u) == 0) {
+    if ((tex_info.y & 2u) == 0u) {
       // modulate + tcc
       color = fragment_color * T0;
     } else {
@@ -64,12 +64,12 @@ void main() {
       color.w = T0.w;
     }
   }
-  color *= 2;
+  color *= 2.;
   color.xyz *= color_mult;
   if (color.a < alpha_reject) {
     discard;
   }
-  if ((tex_info.y & 4u) != 0) {
-    color.xyz = mix(color.xyz, fog_color.rgb, clamp(fog_color.a * fog, 0, 1));
+  if ((tex_info.y & 4u) != 0u) {
+    color.xyz = mix(color.xyz, fog_color.rgb, clamp(fog_color.a * fog, 0., 1.));
   }
 }

--- a/game/graphics/opengl_renderer/shaders/direct2.vert
+++ b/game/graphics/opengl_renderer/shaders/direct2.vert
@@ -14,13 +14,16 @@ out float fog;
 flat out uvec2 tex_info;
 
 void main() {
-  gl_Position = vec4((position_in.x - 0x8000) / 0x1000,
-                    -(position_in.y - 0x8000) / 0x800,
-                    position_in.z / 0x800000 - 1., 1.0);
+  // GLSL hex integer literals (0x8000 etc.) can't take a ".0" suffix to become float -- they're
+  // always integer type. Written out as decimal float literals instead: 0x8000=32768,
+  // 0x1000=4096, 0x800=2048, 0x800000=8388608.
+  gl_Position = vec4((position_in.x - 32768.) / 4096.,
+                    -(position_in.y - 32768.) / 2048.,
+                    position_in.z / 8388608. - 1., 1.0);
   // scissoring area adjust
   gl_Position.y *= SCISSOR_ADJUST;
   fragment_color = vec4(rgba_in.x, rgba_in.y, rgba_in.z, rgba_in.w * 2.);
   tex_coord = tex_coord_in;
   tex_info = byte_info.xy;
-  fog = 255 - byte_info.z;
+  fog = 255. - float(byte_info.z);
 }

--- a/game/graphics/opengl_renderer/shaders/direct_basic.vert
+++ b/game/graphics/opengl_renderer/shaders/direct_basic.vert
@@ -9,7 +9,7 @@ out vec4 gs_scissor;
 
 void main() {
   // Note: position.y is multiplied by 32 instead of 16 to undo the half-height for interlacing stuff.
-  gl_Position = vec4((position_in.x - 0.5) * 16., -(position_in.y - 0.5) * 32 * HEIGHT_SCALE, position_in.z * 2 - 1., 1.0);
+  gl_Position = vec4((position_in.x - 0.5) * 16., -(position_in.y - 0.5) * 32. * HEIGHT_SCALE, position_in.z * 2. - 1., 1.0);
   // scissoring area adjust
   gl_Position.y *= SCISSOR_ADJUST;
   fragment_color = vec4(rgba_in.x, rgba_in.y, rgba_in.z, rgba_in.w * 2.);

--- a/game/graphics/opengl_renderer/shaders/direct_basic_textured.frag
+++ b/game/graphics/opengl_renderer/shaders/direct_basic_textured.frag
@@ -34,7 +34,7 @@ vec4 sample_tex_px(vec2 coordf, uint unit) {
   vec2 tex_size = vec2(textureSize(tex_T20, 0));
   // but texture perspective correction is disabled.
   // current uses are on quads with the same z so it doesn't really matter.
-  return textureProj(tex_T20, vec4(coord_px / tex_size, 1, 1));
+  return textureProj(tex_T20, vec4(coord_px / tex_size, 1., 1.));
 }
 
 void main() {
@@ -52,19 +52,19 @@ void main() {
   }
 
   vec4 T0;
-  if (use_uv == 1) {
+  if (use_uv == 1u) {
     T0 = sample_tex_px(tex_coord.xy, tex_info.x);
   } else {
     T0 = sample_tex(tex_coord.xy / tex_coord.z, tex_info.x);
   }
   // y is tcc
   // z is decal
-  if (T0.w == 0) {
+  if (T0.w == 0.) {
     T0.w = ta0;
   }
 
-  if (tex_info.y == 0) {
-    if (tex_info.z == 0) {
+  if (tex_info.y == 0u) {
+    if (tex_info.z == 0u) {
       // modulate + no tcc
       color.xyz = fragment_color.xyz * T0.xyz;
       color.w = fragment_color.w;
@@ -74,7 +74,7 @@ void main() {
       color.w = fragment_color.w;
     }
   } else {
-    if (tex_info.z == 0) {
+    if (tex_info.z == 0u) {
       // modulate + tcc
       color = fragment_color * T0;
     } else {
@@ -83,7 +83,7 @@ void main() {
       color.w = T0.w;
     }
   }
-  color *= 2;
+  color *= 2.;
   color.xyz *= color_mult;
   color.w *= alpha_mult;
   if (greater) {
@@ -99,8 +99,8 @@ void main() {
       discard;
     }
   }
-  if (tex_info.w == 1) {
-    color.xyz = mix(color.xyz, fog_color.rgb, clamp(fog_color.a * fog, 0, 1));
+  if (tex_info.w == 1u) {
+    color.xyz = mix(color.xyz, fog_color.rgb, clamp(fog_color.a * fog, 0., 1.));
   }
 
 }

--- a/game/graphics/opengl_renderer/shaders/direct_basic_textured.vert
+++ b/game/graphics/opengl_renderer/shaders/direct_basic_textured.vert
@@ -19,9 +19,9 @@ uniform int offscreen_mode;
 
 void main() {
   if (offscreen_mode == 1) {
-    gl_Position = vec4((position_in.x - 0.453125) * 64., (position_in.y - 0.5 + (2.25 / 64)) * 64, position_in.z * 2 - 1., 1.0);
+    gl_Position = vec4((position_in.x - 0.453125) * 64., (position_in.y - 0.5 + (2.25 / 64.)) * 64., position_in.z * 2. - 1., 1.0);
   }  else {
-    gl_Position = vec4((position_in.x - 0.5) * 16., -(position_in.y - 0.5) * 32 * HEIGHT_SCALE, position_in.z * 2 - 1., 1.0);
+    gl_Position = vec4((position_in.x - 0.5) * 16., -(position_in.y - 0.5) * 32. * HEIGHT_SCALE, position_in.z * 2. - 1., 1.0);
     // scissoring area adjust
     gl_Position.y *= SCISSOR_ADJUST;
   }
@@ -29,7 +29,7 @@ void main() {
   fragment_color = vec4(rgba_in.x, rgba_in.y, rgba_in.z, rgba_in.w * 2.);
   tex_coord = tex_coord_in;
   tex_info = tex_info_in;
-  fog = 255 - position_in.w;
+  fog = 255. - position_in.w;
   use_uv = use_uv_in;
   gs_scissor = gs_scissor_in;
 }

--- a/game/graphics/opengl_renderer/shaders/direct_basic_textured_multi_unit.frag
+++ b/game/graphics/opengl_renderer/shaders/direct_basic_textured_multi_unit.frag
@@ -33,36 +33,36 @@ uniform sampler2D tex_T29;
 
 vec4 sample_tex(vec2 coord, uint unit) {
   switch (unit) {
-    case 0: return texture(tex_T20, coord);
-    case 1: return texture(tex_T21, coord);
-    case 2: return texture(tex_T22, coord);
-    case 3: return texture(tex_T23, coord);
-    case 4: return texture(tex_T24, coord);
-    case 5: return texture(tex_T25, coord);
-    case 6: return texture(tex_T26, coord);
-    case 7: return texture(tex_T27, coord);
-    case 8: return texture(tex_T28, coord);
-    case 9: return texture(tex_T29, coord);
-    default : return vec4(1.0, 0, 1.0, 1.0);
+    case 0u: return texture(tex_T20, coord);
+    case 1u: return texture(tex_T21, coord);
+    case 2u: return texture(tex_T22, coord);
+    case 3u: return texture(tex_T23, coord);
+    case 4u: return texture(tex_T24, coord);
+    case 5u: return texture(tex_T25, coord);
+    case 6u: return texture(tex_T26, coord);
+    case 7u: return texture(tex_T27, coord);
+    case 8u: return texture(tex_T28, coord);
+    case 9u: return texture(tex_T29, coord);
+    default : return vec4(1.0, 0., 1.0, 1.0);
   }
 }
 
 vec4 sample_tex_px(vec2 coordf, uint unit) {
   ivec2 coord;
-  coord.x = int(coordf.x / 16);
-  coord.y = int(coordf.y / 16);
+  coord.x = int(coordf.x / 16.);
+  coord.y = int(coordf.y / 16.);
   switch (unit) {
-    case 0: return texelFetch(tex_T20, coord, 0);
-    case 1: return texelFetch(tex_T21, coord, 0);
-    case 2: return texelFetch(tex_T22, coord, 0);
-    case 3: return texelFetch(tex_T23, coord, 0);
-    case 4: return texelFetch(tex_T24, coord, 0);
-    case 5: return texelFetch(tex_T25, coord, 0);
-    case 6: return texelFetch(tex_T26, coord, 0);
-    case 7: return texelFetch(tex_T27, coord, 0);
-    case 8: return texelFetch(tex_T28, coord, 0);
-    case 9: return texelFetch(tex_T29, coord, 0);
-    default : return vec4(1.0, 0, 1.0, 1.0);
+    case 0u: return texelFetch(tex_T20, coord, 0);
+    case 1u: return texelFetch(tex_T21, coord, 0);
+    case 2u: return texelFetch(tex_T22, coord, 0);
+    case 3u: return texelFetch(tex_T23, coord, 0);
+    case 4u: return texelFetch(tex_T24, coord, 0);
+    case 5u: return texelFetch(tex_T25, coord, 0);
+    case 6u: return texelFetch(tex_T26, coord, 0);
+    case 7u: return texelFetch(tex_T27, coord, 0);
+    case 8u: return texelFetch(tex_T28, coord, 0);
+    case 9u: return texelFetch(tex_T29, coord, 0);
+    default : return vec4(1.0, 0., 1.0, 1.0);
   }
 }
 
@@ -81,19 +81,19 @@ void main() {
   }
 
   vec4 T0;
-  if (use_uv == 1) {
+  if (use_uv == 1u) {
     T0 = sample_tex_px(tex_coord.xy, tex_info.x);
   } else {
     T0 = sample_tex(tex_coord.xy / tex_coord.z, tex_info.x);
   }
   // y is tcc
   // z is decal
-  if (T0.w == 0) {
+  if (T0.w == 0.) {
     T0.w = ta0;
   }
 
-  if (tex_info.y == 0) {
-    if (tex_info.z == 0) {
+  if (tex_info.y == 0u) {
+    if (tex_info.z == 0u) {
       // modulate + no tcc
       color.xyz = fragment_color.xyz * T0.xyz;
       color.w = fragment_color.w;
@@ -103,7 +103,7 @@ void main() {
       color.w = fragment_color.w;
     }
   } else {
-    if (tex_info.z == 0) {
+    if (tex_info.z == 0u) {
       // modulate + tcc
       color = fragment_color * T0;
     } else {
@@ -112,14 +112,14 @@ void main() {
       color.w = T0.w;
     }
   }
-  color *= 2;
+  color *= 2.;
   color.xyz *= color_mult;
   color.w *= alpha_mult;
   if (color.a < alpha_reject) {
     discard;
   }
-  if (tex_info.w == 1) {
-    color.xyz = mix(color.xyz, fog_color.rgb, clamp(fog_color.a * fog, 0, 1));
+  if (tex_info.w == 1u) {
+    color.xyz = mix(color.xyz, fog_color.rgb, clamp(fog_color.a * fog, 0., 1.));
   }
 
 }

--- a/game/graphics/opengl_renderer/shaders/direct_basic_textured_multi_unit.vert
+++ b/game/graphics/opengl_renderer/shaders/direct_basic_textured_multi_unit.vert
@@ -19,9 +19,9 @@ uniform int offscreen_mode;
 
 void main() {
   if (offscreen_mode == 1) {
-    gl_Position = vec4((position_in.x - 0.453125) * 64., (position_in.y - 0.5 + (2.25 / 64)) * 64, position_in.z * 2 - 1., 1.0);
+    gl_Position = vec4((position_in.x - 0.453125) * 64., (position_in.y - 0.5 + (2.25 / 64.)) * 64., position_in.z * 2. - 1., 1.0);
   }  else {
-    gl_Position = vec4((position_in.x - 0.5) * 16., -(position_in.y - 0.5) * 32 * HEIGHT_SCALE, position_in.z * 2 - 1., 1.0);
+    gl_Position = vec4((position_in.x - 0.5) * 16., -(position_in.y - 0.5) * 32. * HEIGHT_SCALE, position_in.z * 2. - 1., 1.0);
     // scissoring area adjust
     gl_Position.y *= SCISSOR_ADJUST;
   }
@@ -29,7 +29,7 @@ void main() {
   fragment_color = vec4(rgba_in.x, rgba_in.y, rgba_in.z, rgba_in.w * 2.);
   tex_coord = tex_coord_in;
   tex_info = tex_info_in;
-  fog = 255 - position_in.w;
+  fog = 255. - position_in.w;
   use_uv = use_uv_in;
   gs_scissor = gs_scissor_in;
 }

--- a/game/graphics/opengl_renderer/shaders/emerc.frag
+++ b/game/graphics/opengl_renderer/shaders/emerc.frag
@@ -22,9 +22,9 @@ void main() {
 
     color.a = T0.a;
     color.rgb = T0.rgb * vtx_color;
-    color *= 2;
+    color *= 2.;
   } else {
     color.rgb = vtx_color;
-    color.a = 1;
+    color.a = 1.;
   }
 }

--- a/game/graphics/opengl_renderer/shaders/emerc.vert
+++ b/game/graphics/opengl_renderer/shaders/emerc.vert
@@ -36,16 +36,16 @@ layout (std140) uniform ub_bones {
 void main() {
 
 
-  vec4 p = vec4(position_in, 1);
+  vec4 p = vec4(position_in, 1.);
   vec4 vtx_pos = -bones[mats[0]].X * p * weights_in[0];
   vec3 rotated_nrm = bones[mats[0]].R * normal_in * weights_in[0];
 
   // game may send garbage bones if the weight is 0, don't let NaNs sneak in.
-  if (weights_in[1] > 0) {
+  if (weights_in[1] > 0.) {
     vtx_pos += -bones[mats[1]].X * p * weights_in[1];
     rotated_nrm += bones[mats[1]].R * normal_in * weights_in[1];
   }
-  if (weights_in[2] > 0) {
+  if (weights_in[2] > 0.) {
     vtx_pos += -bones[mats[2]].X * p * weights_in[2];
     rotated_nrm += bones[mats[2]].R * normal_in * weights_in[2];
   }
@@ -55,12 +55,12 @@ void main() {
   rotated_nrm = normalize(rotated_nrm);
 
   float Q = fog_constants.x / transformed[3];
-  fog = 255 - clamp(-transformed.w + hvdf_offset.w, fog_constants.y, fog_constants.z);
+  fog = 255. - clamp(-transformed.w + hvdf_offset.w, fog_constants.y, fog_constants.z);
 
   // emerc
   vec2 st_mod = st_in;
   {
-    vec4 vf10 = vec4(rotated_nrm, 1); // ??
+    vec4 vf10 = vec4(rotated_nrm, 1.); // ??
     // vf08 = transformed
     vec4 vf08 = transformed;
     // vf23 = unperspect
@@ -75,7 +75,7 @@ void main() {
     // mul.xyzw vf09, vf08, vf23 ;; do unperspect
     vec4 vf09 = vf08 * vf23;
     //subw.z vf10, vf10, vf00 ;; subtract 1 from z
-    vf10.z -= 1;
+    vf10.z -= 1.;
     //addw.z vf09, vf00, vf09 ;; xyww the unperspected thing
     vf09.z = vf09.w;
     //mul.xyz vf15, vf09, vf10 ;;
@@ -105,8 +105,8 @@ void main() {
     // this is required to make jak 1's envmapping look right
     // otherwise it behaves like the envmap texture is mirrored.
     // this is because we flip vtx_pos above with a negative sign.
-    st_mod.x = 1 - vf10.x;
-    st_mod.y = 1 - vf10.y;
+    st_mod.x = 1. - vf10.x;
+    st_mod.y = 1. - vf10.y;
 
     //mulz.xy vf24, vf10, vf24 ;; mul tex by q
   }
@@ -114,10 +114,10 @@ void main() {
   transformed.xyz *= Q;
   transformed.xyz += hvdf_offset.xyz;
   transformed.xy -= (2048.);
-  transformed.z /= (8388608);
-  transformed.z -= 1;
-  transformed.x /= (256);
-  transformed.y /= -(128);
+  transformed.z /= (8388608.);
+  transformed.z -= 1.;
+  transformed.x /= (256.);
+  transformed.y /= -(128.);
   transformed.xyz *= transformed.w;
   transformed.y *= SCISSOR_ADJUST * HEIGHT_SCALE;
   gl_Position = transformed;

--- a/game/graphics/opengl_renderer/shaders/etie.frag
+++ b/game/graphics/opengl_renderer/shaders/etie.frag
@@ -20,12 +20,12 @@ void main() {
     vec4 T0 = texture(tex_T0, tex_coord.xy);
     color = fragment_color * T0;
   } else {
-    color = fragment_color/2;
+    color = fragment_color/2.;
   }
 
   if (color.a < alpha_min || color.a > alpha_max) {
     discard;
   }
 
-  color.rgb = mix(color.rgb, fog_color.rgb, clamp(fogginess * fog_color.a, 0, 1));
+  color.rgb = mix(color.rgb, fog_color.rgb, clamp(fogginess * fog_color.a, 0., 1.));
 }

--- a/game/graphics/opengl_renderer/shaders/etie.vert
+++ b/game/graphics/opengl_renderer/shaders/etie.vert
@@ -12,7 +12,6 @@ uniform float fog_constant;
 uniform float fog_min;
 uniform float fog_max;
 uniform vec4 envmap_tod_tint;
-uniform sampler1D tex_T10; // note, sampled in the vertex shader on purpose.
 uniform int decal;
 
 out vec4 fragment_color;
@@ -25,7 +24,7 @@ uniform vec4 persp1;
 uniform mat4 cam_no_persp;
 
 void main() {
-  fogginess = 0;
+  fogginess = 0.;
 
   // rotate the normal
   vec3 nrm_vf23 = cam_no_persp[0].xyz * normal.x
@@ -144,11 +143,11 @@ void main() {
   // correct xy offset
   transformed.xy -= (2048.);
   // correct z scale
-  transformed.z /= (8388608);
-  transformed.z -= 1;
+  transformed.z /= (8388608.);
+  transformed.z -= 1.;
   // correct xy scale
-  transformed.x /= (256);
-  transformed.y /= -(128);
+  transformed.x /= (256.);
+  transformed.y /= -(128.);
   // hack
   transformed.xyz *= transformed.w;
   // scissoring area adjust

--- a/game/graphics/opengl_renderer/shaders/etie_base.frag
+++ b/game/graphics/opengl_renderer/shaders/etie_base.frag
@@ -20,13 +20,13 @@ void main() {
     vec4 T0 = texture(tex_T0, tex_coord.xy);
     color = fragment_color * T0;
   } else {
-    color = fragment_color/2;
+    color = fragment_color/2.;
   }
 
   if (color.a < alpha_min || color.a > alpha_max) {
     discard;
   }
 
-  color.rgb = mix(color.rgb, fog_color.rgb, clamp(fogginess * fog_color.a, 0, 1));
+  color.rgb = mix(color.rgb, fog_color.rgb, clamp(fogginess * fog_color.a, 0., 1.));
 
 }

--- a/game/graphics/opengl_renderer/shaders/etie_base.vert
+++ b/game/graphics/opengl_renderer/shaders/etie_base.vert
@@ -9,7 +9,9 @@ uniform mat4 camera;
 uniform float fog_constant;
 uniform float fog_min;
 uniform float fog_max;
-uniform sampler1D tex_T10; // note, sampled in the vertex shader on purpose.
+// GLES has no 1D textures/samplers at all -- the C++ side now creates this as a GL_TEXTURE_2D
+// with height 1, so indexing needs an explicit y=0 via ivec2 below.
+uniform sampler2D tex_T10;
 uniform int decal;
 
 out vec4 fragment_color;
@@ -23,7 +25,7 @@ uniform mat4 cam_no_persp;
 
 void main() {
   float fog1 = camera[3].w + camera[0].w * position_in.x + camera[1].w * position_in.y + camera[2].w * position_in.z;
-  fogginess = 255 - clamp(fog1 + hvdf_offset.w, fog_min, fog_max);
+  fogginess = 255. - clamp(fog1 + hvdf_offset.w, fog_min, fog_max);
   vec4 vf17 = cam_no_persp[3];
   vf17 += cam_no_persp[0] * position_in.x;
   vf17 += cam_no_persp[1] * position_in.y;
@@ -38,11 +40,11 @@ void main() {
   // correct xy offset
   transformed.xy -= (2048.);
   // correct z scale
-  transformed.z /= (8388608);
-  transformed.z -= 1;
+  transformed.z /= (8388608.);
+  transformed.z -= 1.;
   // correct xy scale
-  transformed.x /= (256);
-  transformed.y /= -(128);
+  transformed.x /= (256.);
+  transformed.y /= -(128.);
   // hack
   transformed.xyz *= transformed.w;
   // scissoring area adjust
@@ -55,10 +57,10 @@ void main() {
     fragment_color = vec4(1.0, 1.0, 1.0, 1.0);
   } else {
     // time of day lookup
-    fragment_color = texelFetch(tex_T10, time_of_day_index, 0);
+    fragment_color = texelFetch(tex_T10, ivec2(time_of_day_index, 0), 0);
     // color adjustment
-    fragment_color *= 2;
-    fragment_color.a *= 2;
+    fragment_color *= 2.;
+    fragment_color.a *= 2.;
   }
 
   tex_coord = tex_coord_in;

--- a/game/graphics/opengl_renderer/shaders/eye.frag
+++ b/game/graphics/opengl_renderer/shaders/eye.frag
@@ -6,5 +6,5 @@ uniform sampler2D tex_T0;
 
 void main() {
   color = texture(tex_T0, st);
-  color.w *= 2;
+  color.w *= 2.;
 }

--- a/game/graphics/opengl_renderer/shaders/generic.frag
+++ b/game/graphics/opengl_renderer/shaders/generic.frag
@@ -26,10 +26,10 @@ void main() {
   // 0x2 is decal
   // 0x4 is fog
 
-  if (warp_sample_mode == 1 || gfx_hack_no_tex == 0) {
+  if (warp_sample_mode == 1u || gfx_hack_no_tex == 0) {
     vec4 T0 = sample_tex(tex_coord.xy, tex_info.x);
-    if ((tex_info.y & 1u) == 0) {
-      if ((tex_info.y & 2u) == 0) {
+    if ((tex_info.y & 1u) == 0u) {
+      if ((tex_info.y & 2u) == 0u) {
         // modulate + no tcc
         color.rgb = fragment_color.rgb * T0.rgb;
         color.a = fragment_color.a;
@@ -39,7 +39,7 @@ void main() {
         color.a = fragment_color.a;
       }
     } else {
-      if ((tex_info.y & 2u) == 0) {
+      if ((tex_info.y & 2u) == 0u) {
         // modulate + tcc
         color = fragment_color * T0;
       } else {
@@ -48,20 +48,20 @@ void main() {
         color.a = T0.a;
       }
     }
-    color *= 2;
+    color *= 2.;
   } else {
-    if ((tex_info.y & 1u) == 0) {
-      if ((tex_info.y & 2u) == 0) {
+    if ((tex_info.y & 1u) == 0u) {
+      if ((tex_info.y & 2u) == 0u) {
         // modulate + no tcc
         color.rgb = fragment_color.rgb;
-        color.a = fragment_color.a * 2;
+        color.a = fragment_color.a * 2.;
       } else {
         // decal + no tcc
         color.rgb = vec3(1);
-        color.a = fragment_color.a * 2;
+        color.a = fragment_color.a * 2.;
       }
     } else {
-      if ((tex_info.y & 2u) == 0) {
+      if ((tex_info.y & 2u) == 0u) {
         // modulate + tcc
         color = fragment_color;
       } else {
@@ -76,7 +76,7 @@ void main() {
   if (color.a < alpha_reject) {
     discard;
   }
-  if ((tex_info.y & 4u) != 0) {
-    color.xyz = mix(color.xyz, fog_color.rgb, clamp(fog_color.a * fog, 0, 1));
+  if ((tex_info.y & 4u) != 0u) {
+    color.xyz = mix(color.xyz, fog_color.rgb, clamp(fog_color.a * fog, 0., 1.));
   }
 }

--- a/game/graphics/opengl_renderer/shaders/generic.vert
+++ b/game/graphics/opengl_renderer/shaders/generic.vert
@@ -49,7 +49,7 @@ void main() {
     transformed.xyz = position_in * scale.xyz;
     transformed.z += mat_32;
     transformed.w = mat_23 * position_in.z + mat_33;
-    transformed *= -1;
+    transformed *= -1.;
   }
 
 
@@ -57,13 +57,13 @@ void main() {
   // vu.Q = gen.fog.x() / gen.vtx_p0.w();
   float Q = fog_constants.x / transformed.w;
 
-  fog = 255 - clamp(-transformed.w + hvdf_offset.w, fog_constants.y, fog_constants.z);
+  fog = 255. - clamp(-transformed.w + hvdf_offset.w, fog_constants.y, fog_constants.z);
 
   // itof12.xyz vf18, vf22        texture int to float
   // vu.vf18.itof12(Mask::xyz, vu.vf22);
   tex_coord = tex_coord_in / 4096.f;
 
-  if (warp_sample_mode == 1) {
+  if (warp_sample_mode == 1u) {
     tex_coord = vec2(tex_coord.x, (1.0f - tex_coord.y - warp_off) * SCISSOR_ADJUST);
   }
 
@@ -82,12 +82,12 @@ void main() {
   transformed.xy -= (2048.);
 
   // correct z scale
-  transformed.z /= (8388608);
-  transformed.z -= 1;
+  transformed.z /= (8388608.);
+  transformed.z -= 1.;
 
   // correct xy scale
-  transformed.x /= (256);
-  transformed.y /= -(128);
+  transformed.x /= (256.);
+  transformed.y /= -(128.);
 
   // hack
   transformed.xyz *= transformed.w;
@@ -96,6 +96,6 @@ void main() {
   // scissoring area adjust
   gl_Position.y *= SCISSOR_ADJUST * HEIGHT_SCALE;
 
-  fragment_color = vec4(rgba_in.rgb, rgba_in.a * 2);
+  fragment_color = vec4(rgba_in.rgb, rgba_in.a * 2.);
   tex_info = byte_info.xy;
 }

--- a/game/graphics/opengl_renderer/shaders/glow_depth_copy.frag
+++ b/game/graphics/opengl_renderer/shaders/glow_depth_copy.frag
@@ -8,9 +8,9 @@ in vec2 tex_coord;
 
 void main() {
   vec2 texture_coords = vec2(tex_coord.x, tex_coord.y);
-  out_color = vec4(0, 0, 0, 0);
-  if (texture_coords.x < 0 || texture_coords.x > 1 || texture_coords.y > 1 || texture_coords.y < 0) {
-    gl_FragDepth = 1;
+  out_color = vec4(0., 0., 0., 0.);
+  if (texture_coords.x < 0. || texture_coords.x > 1. || texture_coords.y > 1. || texture_coords.y < 0.) {
+    gl_FragDepth = 1.;
   } else {
     gl_FragDepth = texture(tex, texture_coords).r;
   }

--- a/game/graphics/opengl_renderer/shaders/glow_depth_copy.vert
+++ b/game/graphics/opengl_renderer/shaders/glow_depth_copy.vert
@@ -7,7 +7,7 @@ layout (location = 2) in vec2 uv;
 out vec2 tex_coord;
 
 void main() {
-  gl_Position = vec4((position_in.xy * 2) - 1.f, 0.f, 1.f);
-  tex_coord.x = uv.x / 512;
+  gl_Position = vec4((position_in.xy * 2.) - 1.f, 0.f, 1.f);
+  tex_coord.x = uv.x / 512.;
   tex_coord.y = 1.f - (uv.y / SCISSOR_HEIGHT);
 }

--- a/game/graphics/opengl_renderer/shaders/glow_draw.vert
+++ b/game/graphics/opengl_renderer/shaders/glow_draw.vert
@@ -15,10 +15,10 @@ uniform sampler2D tex_T1;
 void main() {
   vec4 transformed = position_in;
   transformed.xy -= (2048.);
-  transformed.z /= (8388608);
-  transformed.z -= 1;
-  transformed.x /= (256);
-  transformed.y /= -(128);
+  transformed.z /= (8388608.);
+  transformed.z -= 1.;
+  transformed.x /= (256.);
+  transformed.y /= -(128.);
   transformed.xyz *= transformed.w;
   // scissoring area adjust
   transformed.y *= SCISSOR_ADJUST * HEIGHT_SCALE;

--- a/game/graphics/opengl_renderer/shaders/glow_probe.vert
+++ b/game/graphics/opengl_renderer/shaders/glow_probe.vert
@@ -8,10 +8,10 @@ out vec4 fragment_color;
 void main() {
   vec4 transformed = position_in;
   transformed.xy -= (2048.);
-  transformed.z /= (8388608);
-  transformed.z -= 1;
-  transformed.x /= (256);
-  transformed.y /= -(128);
+  transformed.z /= (8388608.);
+  transformed.z -= 1.;
+  transformed.x /= (256.);
+  transformed.y /= -(128.);
   transformed.xyz *= transformed.w;
   // scissoring area adjust
   transformed.y *= SCISSOR_ADJUST * HEIGHT_SCALE;

--- a/game/graphics/opengl_renderer/shaders/glow_probe_downsample.vert
+++ b/game/graphics/opengl_renderer/shaders/glow_probe_downsample.vert
@@ -5,6 +5,6 @@ layout (location = 0) in vec4 position_in;
 out vec2 tex_coord;
 
 void main() {
-  gl_Position = vec4((position_in.xy * 2) - 1.f, 0.f, 1.f);
+  gl_Position = vec4((position_in.xy * 2.) - 1.f, 0.f, 1.f);
   tex_coord = position_in.xy;
 }

--- a/game/graphics/opengl_renderer/shaders/glow_probe_on_grid.vert
+++ b/game/graphics/opengl_renderer/shaders/glow_probe_on_grid.vert
@@ -6,6 +6,6 @@ layout (location = 0) in vec4 position_in;
 out vec4 fragment_color;
 
 void main() {
-  gl_Position = vec4((position_in.xy * 2) - 1.f, (position_in.z / 8388608.f) - 1.f, 1.f);
-  fragment_color = vec4(0, 0.5, 1, 1);
+  gl_Position = vec4((position_in.xy * 2.) - 1.f, (position_in.z / 8388608.f) - 1.f, 1.f);
+  fragment_color = vec4(0., 0.5, 1., 1.);
 }

--- a/game/graphics/opengl_renderer/shaders/glow_probe_read.vert
+++ b/game/graphics/opengl_renderer/shaders/glow_probe_read.vert
@@ -7,7 +7,7 @@ layout (location = 2) in vec2 uv;
 out vec2 tex_coord;
 
 void main() {
-  gl_Position = vec4((position_in.xy * 2) - 1.f, 0.f, 1.f);
-  tex_coord.x = uv.x / 512;
+  gl_Position = vec4((position_in.xy * 2.) - 1.f, 0.f, 1.f);
+  tex_coord.x = uv.x / 512.;
   tex_coord.y = 1.f - (uv.y / SCISSOR_HEIGHT);
 }

--- a/game/graphics/opengl_renderer/shaders/glow_probe_read_debug.vert
+++ b/game/graphics/opengl_renderer/shaders/glow_probe_read_debug.vert
@@ -5,7 +5,7 @@ layout (location = 1) in vec4 rgba_in;
 layout (location = 2) in vec2 uv;
 
 void main() {
-  float x = (uv.x / 512) * 2 - 1;
-  float y = 1.f - ((uv.y / SCISSOR_HEIGHT) * 2);
-  gl_Position = vec4(x, y, 0, 1.f);
+  float x = (uv.x / 512.) * 2. - 1.;
+  float y = 1.f - ((uv.y / SCISSOR_HEIGHT) * 2.);
+  gl_Position = vec4(x, y, 0., 1.f);
 }

--- a/game/graphics/opengl_renderer/shaders/hfrag.frag
+++ b/game/graphics/opengl_renderer/shaders/hfrag.frag
@@ -14,10 +14,10 @@ uniform int gfx_hack_no_tex;
 void main() {
   if (gfx_hack_no_tex == 0) {
     vec4 T0 = texture(tex_T0, tex_coord);
-    color = fragment_color * T0 * 2;
+    color = fragment_color * T0 * 2.;
   } else {
     color = fragment_color;
   }
 
-   color.rgb = mix(color.rgb, fog_color.rgb, clamp(fogginess * fog_color.a, 0, 1));
+   color.rgb = mix(color.rgb, fog_color.rgb, clamp(fogginess * fog_color.a, 0., 1.));
 }

--- a/game/graphics/opengl_renderer/shaders/hfrag.vert
+++ b/game/graphics/opengl_renderer/shaders/hfrag.vert
@@ -11,9 +11,11 @@ uniform mat4 pc_camera;
 uniform float fog_constant;
 uniform float fog_min;
 uniform float fog_max;
-uniform sampler1D tex_T10; // note, sampled in the vertex shader on purpose.
 // uniform int decal;
 uniform float fog_hack_threshold;
+// GLES has no 1D textures/samplers at all -- the C++ side now creates this as a GL_TEXTURE_2D
+// with height 1, so indexing needs an explicit y=0 via ivec2 below.
+uniform sampler2D tex_T10;
 
 out vec4 fragment_color;
 out vec2 tex_coord;
@@ -28,17 +30,17 @@ void main() {
 
   vec3 vert = position_in - cam_trans.xyz;
   vec4 transformed = -pc_camera[3];
-  transformed -= pc_camera[0] * (32768.f * vx - cam_trans.x);
+  transformed -= pc_camera[0] * (32768.f * float(vx) - cam_trans.x);
   transformed -= pc_camera[1] * (position_in - cam_trans.y);
-  transformed -= pc_camera[2] * (32768.f * vz - cam_trans.z);
+  transformed -= pc_camera[2] * (32768.f * float(vz) - cam_trans.z);
 
-  fogginess = 255 - clamp(-transformed.w + hvdf_offset.w, fog_min, fog_max);
+  fogginess = 255. - clamp(-transformed.w + hvdf_offset.w, fog_min, fog_max);
 
   // scissoring area adjust
   transformed.y *= SCISSOR_ADJUST * HEIGHT_SCALE;
   gl_Position = transformed;
 
   // time of day lookup
-  fragment_color = texelFetch(tex_T10, time_of_day_index, 0);
+  fragment_color = texelFetch(tex_T10, ivec2(time_of_day_index, 0), 0);
   fragment_color.a = 1.0;
 }

--- a/game/graphics/opengl_renderer/shaders/hfrag_montage.frag
+++ b/game/graphics/opengl_renderer/shaders/hfrag_montage.frag
@@ -4,5 +4,5 @@ in vec2 uv;
 uniform sampler2D tex_T0;
 void main() {
   color = texture(tex_T0, uv);
-  color.a = 1;
+  color.a = 1.;
 }

--- a/game/graphics/opengl_renderer/shaders/hfrag_montage.vert
+++ b/game/graphics/opengl_renderer/shaders/hfrag_montage.vert
@@ -6,6 +6,6 @@ layout (location = 1) in vec2 tex_coord;
 out vec2 uv;
 
 void main() {
-  gl_Position = vec4(pos.x * 2 - 1, pos.y * 2 - 1, 0, 1);
+  gl_Position = vec4(pos.x * 2. - 1., pos.y * 2. - 1., 0., 1.);
   uv = tex_coord;
 }

--- a/game/graphics/opengl_renderer/shaders/merc2.frag
+++ b/game/graphics/opengl_renderer/shaders/merc2.frag
@@ -21,24 +21,24 @@ void main() {
     vec4 T0 = texture(tex_T0, vtx_st);
     // all merc is tcc=rgba and modulate
     if (decal_enable == 0) {
-      color = vtx_color * T0 * 2;
+      color = vtx_color * T0 * 2.;
     } else {
       color = T0;
     }
-    color.a *= 2;
+    color.a *= 2.;
   } else {
     color.rgb = vtx_color.rgb;
 
     if (decal_enable == 0) {
-      color.a = vtx_color.a * 2;
+      color.a = vtx_color.a * 2.;
     } else {
-      color.a = 1;
+      color.a = 1.;
     }
   }
 
-  if (light_dir1_fade_en.w > 0) {
+  if (light_dir1_fade_en.w > 0.) {
     color.a = light_dir0_fade.w;
-  } else if (light_dir1_fade_en.w < 0) {
+  } else if (light_dir1_fade_en.w < 0.) {
     color.a *= light_dir0_fade.w;
   }
 
@@ -47,5 +47,5 @@ void main() {
     discard;
   }
 
-   color.xyz = mix(color.xyz, fog_color.rgb, clamp(fog_color.a * fog, 0, 1));
+   color.xyz = mix(color.xyz, fog_color.rgb, clamp(fog_color.a * fog, 0., 1.));
 }

--- a/game/graphics/opengl_renderer/shaders/merc2.vert
+++ b/game/graphics/opengl_renderer/shaders/merc2.vert
@@ -56,16 +56,16 @@ maddz.xyzw vf26, vf28, vf25
 ```
 */
 void main() {
-  vec4 p = vec4(position_in, 1);
+  vec4 p = vec4(position_in, 1.);
   vec4 vtx_pos = -bones[mats[0]].X * p * weights_in[0];
   vec3 rotated_nrm = bones[mats[0]].R * normal_in * weights_in[0];
 
   // game may send garbage bones if the weight is 0, don't let NaNs sneak in.
-  if (weights_in[1] > 0) {
+  if (weights_in[1] > 0.) {
     vtx_pos += -bones[mats[1]].X * p * weights_in[1];
     rotated_nrm += bones[mats[1]].R * normal_in * weights_in[1];
   }
-  if (weights_in[2] > 0) {
+  if (weights_in[2] > 0.) {
     vtx_pos += -bones[mats[2]].X * p * weights_in[2];
     rotated_nrm += bones[mats[2]].R * normal_in * weights_in[2];
   }
@@ -74,7 +74,7 @@ void main() {
 
   rotated_nrm = normalize(rotated_nrm);
   vec3 light_intensity = light_dir0_fade.xyz * rotated_nrm.x + light_dir1_fade_en.xyz * rotated_nrm.y + light_dir2 * rotated_nrm.z;
-  light_intensity = max(light_intensity, vec3(0, 0, 0));
+  light_intensity = max(light_intensity, vec3(0., 0., 0.));
 
   vec4 light_color = light_ambient
                    + light_intensity.x * light_col0
@@ -84,15 +84,15 @@ void main() {
 
 
   float Q = fog_constants.x / transformed[3];
-  fog = 255 - clamp(-transformed.w + hvdf_offset.w, fog_constants.y, fog_constants.z);
+  fog = 255. - clamp(-transformed.w + hvdf_offset.w, fog_constants.y, fog_constants.z);
 
   transformed.xyz *= Q;
   transformed.xyz += hvdf_offset.xyz;
   transformed.xy -= (2048.);
-  transformed.z /= (8388608);
-  transformed.z -= 1;
-  transformed.x /= (256);
-  transformed.y /= -(128);
+  transformed.z /= (8388608.);
+  transformed.z -= 1.;
+  transformed.x /= (256.);
+  transformed.y /= -(128.);
   transformed.xyz *= transformed.w;
   transformed.y *= SCISSOR_ADJUST * HEIGHT_SCALE;
   gl_Position = transformed;

--- a/game/graphics/opengl_renderer/shaders/ocean_common.frag
+++ b/game/graphics/opengl_renderer/shaders/ocean_common.frag
@@ -19,12 +19,12 @@ void main() {
   if (bucket == 0) {
     color.rgb = fragment_color.rgb * T0.rgb;
     color.a = fragment_color.a;
-    color.rgb = mix(color.rgb, fog_color.rgb, clamp(fog_color.a * fog, 0, 1));
+    color.rgb = mix(color.rgb, fog_color.rgb, clamp(fog_color.a * fog, 0., 1.));
   } else if (bucket == 1 || bucket == 2 || bucket == 4) {
     color = fragment_color * T0;
   } else if (bucket == 3) {
     color = fragment_color * T0;
-    color.rgb = mix(color.rgb, fog_color.rgb, clamp(fog_color.a * fog, 0, 1));
+    color.rgb = mix(color.rgb, fog_color.rgb, clamp(fog_color.a * fog, 0., 1.));
   }
 
 }

--- a/game/graphics/opengl_renderer/shaders/ocean_common.vert
+++ b/game/graphics/opengl_renderer/shaders/ocean_common.vert
@@ -12,18 +12,18 @@ out float fog;
 uniform int bucket;
 
 void main() {
-  gl_Position = vec4((position_in.x - 0.5) * 16., -(position_in.y - 0.5) * 32, position_in.z * 2 - 1., 1.0);
+  gl_Position = vec4((position_in.x - 0.5) * 16., -(position_in.y - 0.5) * 32., position_in.z * 2. - 1., 1.0);
   // scissoring area adjust
   gl_Position.y *= SCISSOR_ADJUST * HEIGHT_SCALE;
-  fragment_color = vec4(rgba_in.rgb, rgba_in.a * 2);
+  fragment_color = vec4(rgba_in.rgb, rgba_in.a * 2.);
   tex_coord = tex_coord_in;
-  fog = 255 - fog_in;
-  
+  fog = 255. - float(fog_in);
+
   if (bucket == 0) {
-    fragment_color.rgb *= 2;
+    fragment_color.rgb *= 2.;
   } else if (bucket == 1 || bucket == 3) {
-    fragment_color *= 2;
+    fragment_color *= 2.;
   } else if (bucket == 4) {
-    fragment_color.a = 0;
+    fragment_color.a = 0.;
   }
 }

--- a/game/graphics/opengl_renderer/shaders/ocean_texture.vert
+++ b/game/graphics/opengl_renderer/shaders/ocean_texture.vert
@@ -9,7 +9,7 @@ out vec2 tex_coord;
 
 void main() {
   // inputs are 0 - 2048.
-  gl_Position = vec4((position_in.x - 1024) / 1024, (position_in.y - 1024) / 1024, 0.5, 1.0);
-  fragment_color = vec4(rgba_in.rgb * 2, 1);
+  gl_Position = vec4((position_in.x - 1024.) / 1024., (position_in.y - 1024.) / 1024., 0.5, 1.0);
+  fragment_color = vec4(rgba_in.rgb * 2., 1.);
   tex_coord = tex_coord_in;
 }

--- a/game/graphics/opengl_renderer/shaders/ocean_texture_mipmap.vert
+++ b/game/graphics/opengl_renderer/shaders/ocean_texture_mipmap.vert
@@ -6,6 +6,6 @@ layout (location = 1) in vec2 tex_coord_in;
 out vec2 tex_coord;
 uniform float scale;
 void main() {
-  gl_Position = vec4(position_in.x * scale - (1 - scale), position_in.y * scale - (1 - scale), 0.5, 1.0);
+  gl_Position = vec4(position_in.x * scale - (1. - scale), position_in.y * scale - (1. - scale), 0.5, 1.0);
   tex_coord = tex_coord_in;
 }

--- a/game/graphics/opengl_renderer/shaders/shadow.frag
+++ b/game/graphics/opengl_renderer/shaders/shadow.frag
@@ -4,5 +4,5 @@ out vec4 color;
 uniform vec4 color_uniform;
 
 void main() {
-  color = color_uniform * 2;
+  color = color_uniform * 2.;
 }

--- a/game/graphics/opengl_renderer/shaders/shadow.vert
+++ b/game/graphics/opengl_renderer/shaders/shadow.vert
@@ -4,7 +4,7 @@ layout (location = 0) in vec3 position_in;
 
 void main() {
   // Note: position.y is multiplied by 32 instead of 16 to undo the half-height for interlacing stuff.
-  gl_Position = vec4((position_in.x - 0.5) * 16., -(position_in.y - 0.5) * 32, position_in.z * 2 - 1., 1.0);
+  gl_Position = vec4((position_in.x - 0.5) * 16., -(position_in.y - 0.5) * 32., position_in.z * 2. - 1., 1.0);
   // scissoring area adjust
   gl_Position.y *= SCISSOR_ADJUST;
 }

--- a/game/graphics/opengl_renderer/shaders/shadow2.vert
+++ b/game/graphics/opengl_renderer/shaders/shadow2.vert
@@ -14,7 +14,7 @@ uniform vec4 hvdf_offset;
 void main() {
   if (clear_mode == 1) {
     // this is just copied from shadow 1, needs revisiting.
-    gl_Position = vec4((position_in.x - 0.5) * 16., -(position_in.y - 0.5) * 32, position_in.z * 2 - 1., 1.0);
+    gl_Position = vec4((position_in.x - 0.5) * 16., -(position_in.y - 0.5) * 32., position_in.z * 2. - 1., 1.0);
     gl_Position.y *= SCISSOR_ADJUST;
   } else {
     vec4 transformed = -perspective_w;
@@ -26,10 +26,10 @@ void main() {
 
     transformed.xyz += hvdf_offset.xyz;
     transformed.xy -= (2048.);
-    transformed.z /= (8388608);
-    transformed.z -= 1;
-    transformed.x /= (256);
-    transformed.y /= -(128);
+    transformed.z /= (8388608.);
+    transformed.z -= 1.;
+    transformed.x /= (256.);
+    transformed.y /= -(128.);
     transformed.xyz *= transformed.w;
     transformed.y *= SCISSOR_ADJUST * HEIGHT_SCALE;
     gl_Position = transformed;

--- a/game/graphics/opengl_renderer/shaders/shrub.frag
+++ b/game/graphics/opengl_renderer/shaders/shrub.frag
@@ -25,5 +25,5 @@ void main() {
     discard;
   }
 
-  color.xyz = mix(color.xyz, fog_color.rgb, clamp(fogginess * fog_color.a, 0, 1));
+  color.xyz = mix(color.xyz, fog_color.rgb, clamp(fogginess * fog_color.a, 0., 1.));
 }

--- a/game/graphics/opengl_renderer/shaders/shrub.vert
+++ b/game/graphics/opengl_renderer/shaders/shrub.vert
@@ -10,10 +10,12 @@ uniform mat4 camera;
 uniform float fog_constant;
 uniform float fog_min;
 uniform float fog_max;
+// GLES has no 1D textures/samplers at all -- the C++ side now creates this as a GL_TEXTURE_2D
+// with height 1, so indexing needs an explicit y=0 via ivec2 below.
+uniform sampler2D tex_T10;
 uniform int decal;
 uniform vec4 cam_trans;
 uniform mat4 pc_camera;
-uniform sampler1D tex_T10; // note, sampled in the vertex shader on purpose.
 
 out vec4 fragment_color;
 out vec3 tex_coord;
@@ -42,7 +44,7 @@ void main() {
   transformed -= pc_camera[2] * vert.z;
 
   // do fog!
-  fogginess = 255 - clamp(-transformed.w + hvdf_offset.w, fog_min, fog_max);
+  fogginess = 255. - clamp(-transformed.w + hvdf_offset.w, fog_min, fog_max);
 
   // scissoring area adjust
   transformed.y *= SCISSOR_ADJUST * HEIGHT_SCALE;
@@ -50,16 +52,16 @@ void main() {
 
   // time of day lookup
   // start with the vertex color (only rgb, VIF filled in the 255.)
-  fragment_color =  vec4(rgba_base, 1);
+  fragment_color =  vec4(rgba_base, 1.);
   // get the time of day multiplier
-  vec4 tod_color = texelFetch(tex_T10, time_of_day_index, 0);
+  vec4 tod_color = texelFetch(tex_T10, ivec2(time_of_day_index, 0), 0);
   // combine
-  fragment_color *= tod_color * 4;
+  fragment_color *= tod_color * 4.;
 
   if (decal == 1) {
     fragment_color.xyz = vec3(1.0, 1.0, 1.0);
   }
 
   tex_coord = tex_coord_in;
-  tex_coord.xy /= 4096;
+  tex_coord.xy /= 4096.;
 }

--- a/game/graphics/opengl_renderer/shaders/sky.frag
+++ b/game/graphics/opengl_renderer/shaders/sky.frag
@@ -3,7 +3,7 @@
 out vec4 color;
 
 in vec4 fragment_color;
-noperspective in vec3 tex_coord;
+in vec3 tex_coord;
 uniform sampler2D tex_T0;
 
 void main() {

--- a/game/graphics/opengl_renderer/shaders/sky.vert
+++ b/game/graphics/opengl_renderer/shaders/sky.vert
@@ -5,12 +5,14 @@ layout (location = 1) in vec4 rgba_in;
 layout (location = 2) in vec3 tex_coord_in;
 
 out vec4 fragment_color;
-noperspective out vec3 tex_coord;
+// GLES core has no `noperspective` interpolation qualifier (desktop-only until GLES gets it via
+// an extension neither guaranteed nor needed here) -- perspective-correct is the only option.
+out vec3 tex_coord;
 
 void main() {
-  gl_Position = vec4((position_in.x - 0.5) * 16. , -(position_in.y - 0.5) * 32, position_in.z * 2 - 1., 1.0);
+  gl_Position = vec4((position_in.x - 0.5) * 16. , -(position_in.y - 0.5) * 32., position_in.z * 2. - 1., 1.0);
   // scissoring area adjust
   gl_Position.y *= SCISSOR_ADJUST;
-  fragment_color = vec4(rgba_in.x, rgba_in.y, rgba_in.z, rgba_in.a * 2);
+  fragment_color = vec4(rgba_in.x, rgba_in.y, rgba_in.z, rgba_in.a * 2.);
   tex_coord = tex_coord_in;
 }

--- a/game/graphics/opengl_renderer/shaders/sky_blend.vert
+++ b/game/graphics/opengl_renderer/shaders/sky_blend.vert
@@ -5,6 +5,6 @@ layout (location = 0) in vec3 position_in;
 out vec3 tex_coord;
 
 void main() {
-  gl_Position = vec4(position_in.x*2 -1, position_in.y*2-1, 0.0, 1.0);
+  gl_Position = vec4(position_in.x*2. -1., position_in.y*2.-1., 0.0, 1.0);
   tex_coord = position_in;
 }

--- a/game/graphics/opengl_renderer/shaders/sprite3_3d.frag
+++ b/game/graphics/opengl_renderer/shaders/sprite3_3d.frag
@@ -12,7 +12,7 @@ uniform float alpha_max;
 
 void main() {
   vec4 T0 = texture(tex_T0, tex_coord.xy);
-  if (tex_info.y == 0) {
+  if (tex_info.y == 0u) {
     T0.w = 1.0;
   }
   color = fragment_color * T0;

--- a/game/graphics/opengl_renderer/shaders/sprite3_3d.vert
+++ b/game/graphics/opengl_renderer/shaders/sprite3_3d.vert
@@ -80,7 +80,7 @@ void main() {
   vec4 transformed;
 
   // STEP 2: perspective transform for distance
-  vec4 transformed_pos_vf02 = matrix_transform(rendermode == 2 ? hud_matrix : camera, position);
+  vec4 transformed_pos_vf02 = matrix_transform(rendermode == 2u ? hud_matrix : camera, position);
   float Q = pfog0 / transformed_pos_vf02.w;
 
 
@@ -95,12 +95,12 @@ void main() {
 
 
   // STEP 4: actual vertex transformation
-  if (rendermode == 3) { // 3D sprites
+  if (rendermode == 3u) { // 3D sprites
 
     mat3 rot = sprite_quat_to_rot(quat);
     transformed = sprite_transform2(position, xyz_array[vert_id], rot, sx, sy);
 
-  } else if (rendermode == 1) { // 2D sprites
+  } else if (rendermode == 1u) { // 2D sprites
 
     transformed_pos_vf02.xyz *= Q;
     vec4 offset_pos_vf10 = transformed_pos_vf02 + hvdf_offset;
@@ -128,10 +128,10 @@ void main() {
 
     transformed = offset_pos_vf10 + vf12_rotated * xy0_vf19.x + vf13_rotated_trans * xy0_vf19.y;
 
-  } else if (rendermode == 2) { // hud sprites
-  
+  } else if (rendermode == 2u) { // hud sprites
+
     transformed_pos_vf02.xyz *= Q;
-    vec4 offset_pos_vf10 = transformed_pos_vf02 + (matrix == 0 ? hud_hvdf_offset : hud_hvdf_user[matrix - 1]);
+    vec4 offset_pos_vf10 = transformed_pos_vf02 + (matrix == 0u ? hud_hvdf_offset : hud_hvdf_user[matrix - 1u]);
 
     // NOTE: no max scale for hud
     scales_vf01.z = max(scales_vf01.z, min_scale);
@@ -159,19 +159,19 @@ void main() {
   // correct xy offset
   transformed.xy -= (2048.);
   // correct z scale
-  transformed.z /= (8388608);
-  transformed.z -= 1;
+  transformed.z /= (8388608.);
+  transformed.z -= 1.;
   // correct xy scale
-  transformed.x /= (256);
-  transformed.y /= -(128);
+  transformed.x /= (256.);
+  transformed.y /= -(128.);
   // hack
   transformed.xyz *= transformed.w;
   // scissoring area adjust
   transformed.y *= SCISSOR_ADJUST * HEIGHT_SCALE;
   gl_Position = transformed;
 
-  fragment_color *= 2;
-  fragment_color.w *= 2;
+  fragment_color *= 2.;
+  fragment_color.w *= 2.;
 
   tex_info = tex_info_in.xy;
 }

--- a/game/graphics/opengl_renderer/shaders/sprite_3d.frag
+++ b/game/graphics/opengl_renderer/shaders/sprite_3d.frag
@@ -19,23 +19,23 @@ uniform sampler2D tex_T29;
 
 vec4 sample_tex(vec2 coord, uint unit) {
   switch (unit) {
-    case 0: return texture(tex_T20, coord);
-    case 1: return texture(tex_T21, coord);
-    case 2: return texture(tex_T22, coord);
-    case 3: return texture(tex_T23, coord);
-    case 4: return texture(tex_T24, coord);
-    case 5: return texture(tex_T25, coord);
-    case 6: return texture(tex_T26, coord);
-    case 7: return texture(tex_T27, coord);
-    case 8: return texture(tex_T28, coord);
-    case 9: return texture(tex_T29, coord);
-    default: return vec4(1.0, 0, 1.0, 1.0);
+    case 0u: return texture(tex_T20, coord);
+    case 1u: return texture(tex_T21, coord);
+    case 2u: return texture(tex_T22, coord);
+    case 3u: return texture(tex_T23, coord);
+    case 4u: return texture(tex_T24, coord);
+    case 5u: return texture(tex_T25, coord);
+    case 6u: return texture(tex_T26, coord);
+    case 7u: return texture(tex_T27, coord);
+    case 8u: return texture(tex_T28, coord);
+    case 9u: return texture(tex_T29, coord);
+    default: return vec4(1.0, 0., 1.0, 1.0);
   }
 }
 
 void main() {
   vec4 T0 = sample_tex(tex_coord.xy, tex_info.x);
-  if (tex_info.y == 0) {
+  if (tex_info.y == 0u) {
     T0.w = 1.0;
   }
   vec4 tex_color = fragment_color * T0 * 2.0;

--- a/game/graphics/opengl_renderer/shaders/sprite_3d.vert
+++ b/game/graphics/opengl_renderer/shaders/sprite_3d.vert
@@ -82,7 +82,7 @@ void main() {
   vec4 transformed;
 
   // STEP 2: perspective transform for distance
-  vec4 transformed_pos_vf02 = matrix_transform(rendermode == 2 ? hud_matrix : camera, position);
+  vec4 transformed_pos_vf02 = matrix_transform(rendermode == 2u ? hud_matrix : camera, position);
   float Q = pfog0 / transformed_pos_vf02.w;
 
 
@@ -97,12 +97,12 @@ void main() {
 
 
   // STEP 4: actual vertex transformation
-  if (rendermode == 3) { // 3D sprites
+  if (rendermode == 3u) { // 3D sprites
 
     mat3 rot = sprite_quat_to_rot(quat);
     transformed = sprite_transform2(position, xyz_array[vert_id], rot, sx, sy);
 
-  } else if (rendermode == 1) { // 2D sprites
+  } else if (rendermode == 1u) { // 2D sprites
 
     transformed_pos_vf02.xyz *= Q;
     vec4 offset_pos_vf10 = transformed_pos_vf02 + hvdf_offset;
@@ -129,9 +129,9 @@ void main() {
 
     transformed = offset_pos_vf10 + vf12_rotated * xy0_vf19.x + vf13_rotated_trans * xy0_vf19.y;
 
-  } else if (rendermode == 2) { // hud sprites
+  } else if (rendermode == 2u) { // hud sprites
     transformed_pos_vf02.xyz *= Q;
-    vec4 offset_pos_vf10 = transformed_pos_vf02 + (matrix == 0 ? hud_hvdf_offset : hud_hvdf_user[matrix - 1]);
+    vec4 offset_pos_vf10 = transformed_pos_vf02 + (matrix == 0u ? hud_hvdf_offset : hud_hvdf_user[matrix - 1u]);
 
     // NOTE: no max scale for hud
     scales_vf01.z = max(scales_vf01.z, min_scale);
@@ -160,12 +160,12 @@ void main() {
   transformed.xy -= (2048.);
 
   // correct z scale
-  transformed.z /= (8388608);
-  transformed.z -= 1;
+  transformed.z /= (8388608.);
+  transformed.z -= 1.;
 
   // correct xy scale
-  transformed.x /= (256);
-  transformed.y /= -(128);
+  transformed.x /= (256.);
+  transformed.y /= -(128.);
 
   // hack
   transformed.xyz *= transformed.w;
@@ -174,7 +174,7 @@ void main() {
   // scissoring area adjust
   gl_Position.y *= SCISSOR_ADJUST;
 
-  fragment_color.w *= 2;
+  fragment_color.w *= 2.;
 
   tex_info = tex_info_in.xy;
 }

--- a/game/graphics/opengl_renderer/shaders/sprite_distort.frag
+++ b/game/graphics/opengl_renderer/shaders/sprite_distort.frag
@@ -11,10 +11,10 @@ void main() {
   vec4 color = fragment_color;
 
   // correct color
-  color *= 2;
+  color *= 2.;
 
   // correct texture coordinates
-  vec2 texture_coords = vec2(tex_coord.x, (1.0f - tex_coord.y) - (1 - (SCISSOR_HEIGHT / 512.0)) / 2);
+  vec2 texture_coords = vec2(tex_coord.x, (1.0f - tex_coord.y) - (1. - (SCISSOR_HEIGHT / 512.0)) / 2.);
 
   // sample framebuffer texture
   out_color = color * texture(framebuffer_tex, texture_coords);

--- a/game/graphics/opengl_renderer/shaders/sprite_distort.vert
+++ b/game/graphics/opengl_renderer/shaders/sprite_distort.vert
@@ -16,11 +16,11 @@ void main() {
   // correct xy offset
   transformed.xy -= (2048.);
   // correct z scale
-  transformed.z /= (8388608);
-  transformed.z -= 1;
+  transformed.z /= (8388608.);
+  transformed.z -= 1.;
   // correct xy scale
-  transformed.x /= (256);
-  transformed.y /= -(128);
+  transformed.x /= (256.);
+  transformed.y /= -(128.);
   transformed.y *= HEIGHT_SCALE;
 
   gl_Position = transformed;

--- a/game/graphics/opengl_renderer/shaders/sprite_distort_instanced.frag
+++ b/game/graphics/opengl_renderer/shaders/sprite_distort_instanced.frag
@@ -11,10 +11,10 @@ void main() {
   vec4 color = fragment_color;
 
   // correct color
-  color *= 2;
+  color *= 2.;
 
   // correct texture coordinates
-  vec2 texture_coords = vec2(tex_coord.x, (1.0f - tex_coord.y) - (1 - (SCISSOR_HEIGHT / 512.0)) / 2);
+  vec2 texture_coords = vec2(tex_coord.x, (1.0f - tex_coord.y) - (1. - (SCISSOR_HEIGHT / 512.0)) / 2.);
 
   // sample framebuffer texture
   out_color = color * texture(framebuffer_tex, texture_coords);

--- a/game/graphics/opengl_renderer/shaders/sprite_distort_instanced.vert
+++ b/game/graphics/opengl_renderer/shaders/sprite_distort_instanced.vert
@@ -21,21 +21,22 @@ void main() {
   // for each vertex, we need to know which one it is. The order is always 2
   // vertices scaled by sizeX, 2 scaled by sizeY (sizeZ for tex coords), and
   // finally the center vertex which isn't modified.
-  float slice_vert_id = mod(gl_VertexID, 5);
+  // GLSL's mod() is float-only (unlike % which is int-only) -- gl_VertexID needs an explicit cast.
+  float slice_vert_id = mod(float(gl_VertexID), 5.);
 
   vec2 texture_coord = vec2(instance_xyz_s.w, instance_scale_t.w);
-  if (slice_vert_id < 2) {
+  if (slice_vert_id < 2.) {
     texture_coord += st * instance_scale_t.x;
-  } else if (slice_vert_id < 4) {
+  } else if (slice_vert_id < 4.) {
     texture_coord += st * instance_scale_t.z;
   }
 
   tex_coord = texture_coord;
 
   vec3 position = instance_xyz_s.xyz;
-  if (slice_vert_id < 2) {
+  if (slice_vert_id < 2.) {
     position += xyz * instance_scale_t.x;
-  } else if (slice_vert_id < 4) {
+  } else if (slice_vert_id < 4.) {
     position += xyz * instance_scale_t.y;
   }
 
@@ -44,11 +45,11 @@ void main() {
   // correct xy offset
   transformed.xy -= (2048.);
   // correct z scale
-  transformed.z /= (8388608);
-  transformed.z -= 1;
+  transformed.z /= (8388608.);
+  transformed.z -= 1.;
   // correct xy scale
-  transformed.x /= (256);
-  transformed.y /= -(128);
+  transformed.x /= (256.);
+  transformed.y /= -(128.);
   transformed.y *= HEIGHT_SCALE;
 
   gl_Position = transformed;

--- a/game/graphics/opengl_renderer/shaders/tex_anim.frag
+++ b/game/graphics/opengl_renderer/shaders/tex_anim.frag
@@ -15,7 +15,9 @@ uniform float slime_scroll;
 in vec2 uv;
 
 uniform sampler2D tex_T0;
-uniform sampler1D tex_T10;
+// GLES has no 1D textures/samplers at all -- the C++ side now creates this as a GL_TEXTURE_2D
+// with height 1, so indexing needs an explicit y=0 via ivec2 below.
+uniform sampler2D tex_T10;
 
 float cloud_lookup(float v, float minimum, float maximum) {
   maximum = max(minimum, maximum);
@@ -54,7 +56,7 @@ void main() {
   } else if (enable_tex == 3) {
     // cloud version
     vec4 tex_color = texture(tex_T0, uv + vec2(0, slime_scroll));
-    color = texelFetch(tex_T10, int(tex_color.r * 255.f), 0);
+    color = texelFetch(tex_T10, ivec2(int(tex_color.r * 255.f), 0), 0);
   } else {
     color = (rgba / 128.);
   }

--- a/game/graphics/opengl_renderer/shaders/tex_anim.vert
+++ b/game/graphics/opengl_renderer/shaders/tex_anim.vert
@@ -10,6 +10,6 @@ uniform vec4 rgba;
 out vec2 uv;
 
 void main() {
-  gl_Position = vec4(-1. + (positions[vertex_index] * 2), 1);
+  gl_Position = vec4(-1. + (positions[vertex_index] * 2.), 1.);
   uv = uvs[vertex_index];
 }

--- a/game/graphics/opengl_renderer/shaders/tfrag3.frag
+++ b/game/graphics/opengl_renderer/shaders/tfrag3.frag
@@ -20,12 +20,12 @@ void main() {
     vec4 T0 = texture(tex_T0, tex_coord.xy);
     color = fragment_color * T0;
   } else {
-    color = fragment_color/2;
+    color = fragment_color/2.;
   }
 
   if (color.a < alpha_min || color.a > alpha_max) {
     discard;
   }
 
-  color.rgb = mix(color.rgb, fog_color.rgb, clamp(fogginess * fog_color.a, 0, 1));
+  color.rgb = mix(color.rgb, fog_color.rgb, clamp(fogginess * fog_color.a, 0., 1.));
 }

--- a/game/graphics/opengl_renderer/shaders/tfrag3.vert
+++ b/game/graphics/opengl_renderer/shaders/tfrag3.vert
@@ -11,7 +11,9 @@ uniform mat4 camera;
 uniform float fog_constant;
 uniform float fog_min;
 uniform float fog_max;
-uniform sampler1D tex_T10; // note, sampled in the vertex shader on purpose.
+// GLES has no 1D textures/samplers at all -- the C++ side now creates this as a GL_TEXTURE_2D
+// with height 1, so indexing needs an explicit y=0 via ivec2 below.
+uniform sampler2D tex_T10;
 uniform int decal;
 
 out vec4 fragment_color;
@@ -37,23 +39,23 @@ void main() {
   // Step 3, the camera transform
   vec3 vert = position_in - cam_trans.xyz;
   vec4 transformed = -pc_camera[3];
-  transformed.w = 0;
+  transformed.w = 0.;
   transformed -= pc_camera[0] * vert.x;
   transformed -= pc_camera[1] * vert.y;
   transformed -= pc_camera[2] * vert.z;
 
   // do fog!
-  fogginess = 255 - clamp(-transformed.w + hvdf_offset.w, fog_min, fog_max);
+  fogginess = 255. - clamp(-transformed.w + hvdf_offset.w, fog_min, fog_max);
 
   // scissoring area adjust
   transformed.y *= SCISSOR_ADJUST * HEIGHT_SCALE;
   gl_Position = transformed;
 
   // time of day lookup
-  fragment_color = texelFetch(tex_T10, time_of_day_index, 0);
+  fragment_color = texelFetch(tex_T10, ivec2(time_of_day_index, 0), 0);
   // color adjustment
-  fragment_color *= 2;
-  fragment_color.a *= 2;
+  fragment_color *= 2.;
+  fragment_color.a *= 2.;
 
   if (decal == 1) {
     // tfrag/tie always use TCC=RGB, so even with decal, alpha comes from fragment.

--- a/game/graphics/opengl_renderer/shaders/tfrag3_no_tex.vert
+++ b/game/graphics/opengl_renderer/shaders/tfrag3_no_tex.vert
@@ -26,11 +26,11 @@ void main() {
   // correct xy offset
   transformed.xy -= (2048.);
   // correct z scale
-  transformed.z /= (8388608);
-  transformed.z -= 1;
+  transformed.z /= (8388608.);
+  transformed.z -= 1.;
   // correct xy scale
-  transformed.x /= (256);
-  transformed.y /= -(128);
+  transformed.x /= (256.);
+  transformed.y /= -(128.);
   // hack
   transformed.xyz *= transformed.w;
   // scissoring area adjust

--- a/game/graphics/opengl_renderer/shaders/tie_wind.frag
+++ b/game/graphics/opengl_renderer/shaders/tie_wind.frag
@@ -20,12 +20,12 @@ void main() {
     vec4 T0 = texture(tex_T0, tex_coord.xy);
     color = fragment_color * T0;
   } else {
-    color = fragment_color/2;
+    color = fragment_color/2.;
   }
 
   if (color.a < alpha_min || color.a > alpha_max) {
     discard;
   }
 
-  color.rgb = mix(color.rgb, fog_color.rgb, clamp(fogginess * fog_color.a, 0, 1));
+  color.rgb = mix(color.rgb, fog_color.rgb, clamp(fogginess * fog_color.a, 0., 1.));
 }

--- a/game/graphics/opengl_renderer/shaders/tie_wind.vert
+++ b/game/graphics/opengl_renderer/shaders/tie_wind.vert
@@ -9,7 +9,9 @@ uniform mat4 camera;
 uniform float fog_constant;
 uniform float fog_min;
 uniform float fog_max;
-uniform sampler1D tex_T10; // note, sampled in the vertex shader on purpose.
+// GLES has no 1D textures/samplers at all -- the C++ side now creates this as a GL_TEXTURE_2D
+// with height 1, so indexing needs an explicit y=0 via ivec2 below.
+uniform sampler2D tex_T10;
 uniform int decal;
 
 out vec4 fragment_color;
@@ -23,7 +25,7 @@ void main() {
   transformed -= camera[2] * position_in.z;
   float Q = fog_constant / transformed.w;
 
-  fogginess = 255 - clamp(-transformed.w + hvdf_offset.w, fog_min, fog_max);
+  fogginess = 255. - clamp(-transformed.w + hvdf_offset.w, fog_min, fog_max);
 
   // perspective divide!
   transformed.xyz *= Q;
@@ -32,11 +34,11 @@ void main() {
   // correct xy offset
   transformed.xy -= (2048.);
   // correct z scale
-  transformed.z /= (8388608);
-  transformed.z -= 1;
+  transformed.z /= (8388608.);
+  transformed.z -= 1.;
   // correct xy scale
-  transformed.x /= (256);
-  transformed.y /= -(128);
+  transformed.x /= (256.);
+  transformed.y /= -(128.);
   // hack
   transformed.xyz *= transformed.w;
   // scissoring area adjust
@@ -44,10 +46,10 @@ void main() {
   gl_Position = transformed;
 
   // time of day lookup
-  fragment_color = texelFetch(tex_T10, time_of_day_index, 0);
+  fragment_color = texelFetch(tex_T10, ivec2(time_of_day_index, 0), 0);
   // color adjustment
-  fragment_color *= 2;
-  fragment_color.a *= 2;
+  fragment_color *= 2.;
+  fragment_color.a *= 2.;
 
   if (decal == 1) {
     // tfrag/tie always use TCC=RGB, so even with decal, alpha comes from fragment.

--- a/game/graphics/opengl_renderer/sprite/GlowRenderer.cpp
+++ b/game/graphics/opengl_renderer/sprite/GlowRenderer.cpp
@@ -1,6 +1,10 @@
 #include "GlowRenderer.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 /*
  * The glow renderer draws a sprite, but only if the center of the sprite is "visible".

--- a/game/graphics/opengl_renderer/sprite/Sprite3.cpp
+++ b/game/graphics/opengl_renderer/sprite/Sprite3.cpp
@@ -6,7 +6,11 @@
 #include "game/graphics/opengl_renderer/dma_helpers.h"
 
 #include "fmt/format.h"
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 namespace {
 
@@ -37,17 +41,43 @@ u32 process_sprite_chunk_header(DmaFollower& dma) {
 constexpr int SPRITE_RENDERER_MAX_SPRITES = 1920 * 12;
 }  // namespace
 
+#if defined(__SWITCH__)
+#include <cstring>
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_sp3(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
+
 Sprite3::Sprite3(const std::string& name, int my_id)
     : BucketRenderer(name, my_id), m_direct(name, my_id, 1024) {
+#if defined(__SWITCH__)
+  boot_log_sp3("[sprite3] embedded m_direct constructed, about to opengl_setup\n");
+#endif
   opengl_setup();
+#if defined(__SWITCH__)
+  boot_log_sp3("[sprite3] opengl_setup done\n");
+#endif
 }
 
 void Sprite3::opengl_setup() {
+#if defined(__SWITCH__)
+  boot_log_sp3("[sprite3] about to opengl_setup_normal\n");
+#endif
   // Set up OpenGL for 'normal' sprites
   opengl_setup_normal();
+#if defined(__SWITCH__)
+  boot_log_sp3("[sprite3] opengl_setup_normal done, about to opengl_setup_distort\n");
+#endif
 
   // Set up OpenGL for distort sprites
   opengl_setup_distort();
+#if defined(__SWITCH__)
+  boot_log_sp3("[sprite3] opengl_setup_distort done\n");
+#endif
 }
 
 void Sprite3::opengl_setup_normal() {

--- a/game/graphics/opengl_renderer/sprite/Sprite3_Distort.cpp
+++ b/game/graphics/opengl_renderer/sprite/Sprite3_Distort.cpp
@@ -15,6 +15,17 @@ constexpr int SPRITE_RENDERER_MAX_DISTORT_SPRITES =
     256 * 12;  // size of sprite-aux-list in GOAL code * SPRITE_MAX_AMOUNT_MULT
 }  // namespace
 
+#if defined(__SWITCH__)
+#include <cstring>
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_sp3d(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
+
 void Sprite3::opengl_setup_distort() {
   // Create framebuffer to snapshot current render to a texture that can be bound for the distort
   // shader This will represent tex0 from the original GS data
@@ -88,19 +99,27 @@ void Sprite3::opengl_setup_distort() {
 
   // Instancing
   // ----------------------
-  glGenVertexArrays(1, &m_distort_instanced_ogl.vao);
-  glBindVertexArray(m_distort_instanced_ogl.vao);
-
+  // glVertexAttribDivisor hangs indefinitely on this GLES driver (Mesa/nouveau under Citron) --
+  // confirmed via boot-order tracing, not assumed. m_enable_distort_instancing (see
+  // distort_setup_instanced/distort_draw_instanced below) already exists as a runtime switch to
+  // the non-instanced path, so on Switch we skip creating the instanced GL objects entirely and
+  // force that flag off in the constructor. The CPU-side bookkeeping vectors below are still
+  // sized normally since nothing about them is GL-specific.
   int distort_max_sprite_slices = 0;
   for (int i = 3; i < 12; i++) {
     // For each 'resolution', there can be that many slices
     distort_max_sprite_slices += i;
   }
+  int distort_instanced_vert_buffer_len = distort_max_sprite_slices * 5;  // 5 vertices per slice
+  int distort_instance_buffer_len = SPRITE_RENDERER_MAX_DISTORT_SPRITES;
+
+#if !defined(__SWITCH__)
+  glGenVertexArrays(1, &m_distort_instanced_ogl.vao);
+  glBindVertexArray(m_distort_instanced_ogl.vao);
 
   glGenBuffers(1, &m_distort_instanced_ogl.vertex_buffer);
   glBindBuffer(GL_ARRAY_BUFFER, m_distort_instanced_ogl.vertex_buffer);
 
-  int distort_instanced_vert_buffer_len = distort_max_sprite_slices * 5;  // 5 vertices per slice
   glBufferData(GL_ARRAY_BUFFER, distort_instanced_vert_buffer_len * sizeof(SpriteDistortVertex),
                nullptr, GL_STREAM_DRAW);
 
@@ -124,7 +143,6 @@ void Sprite3::opengl_setup_distort() {
   glGenBuffers(1, &m_distort_instanced_ogl.instance_buffer);
   glBindBuffer(GL_ARRAY_BUFFER, m_distort_instanced_ogl.instance_buffer);
 
-  int distort_instance_buffer_len = SPRITE_RENDERER_MAX_DISTORT_SPRITES;
   glBufferData(GL_ARRAY_BUFFER, distort_instance_buffer_len * sizeof(SpriteDistortInstanceData),
                nullptr, GL_DYNAMIC_DRAW);
 
@@ -151,6 +169,9 @@ void Sprite3::opengl_setup_distort() {
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
   glBindVertexArray(0);
+#else
+  m_enable_distort_instancing = false;
+#endif
 
   m_sprite_distorter_vertices_instanced.resize(distort_instanced_vert_buffer_len);
 

--- a/game/graphics/pipelines/opengl.cpp
+++ b/game/graphics/pipelines/opengl.cpp
@@ -8,6 +8,7 @@
 #include <condition_variable>
 #include <memory>
 #include <mutex>
+#include <regex>
 #include <sstream>
 
 #include "common/dma/dma_copy.h"
@@ -31,14 +32,33 @@
 #include "game/system/hid/sdl_util.h"
 
 #include "fmt/format.h"
+#if defined(__SWITCH__)
+#include "game/switch/sdl3_compat.h"
+#else
 #include "third-party/SDL/include/SDL3/SDL.h"
 #include "third-party/SDL/include/SDL3/SDL_hints.h"
 #include "third-party/SDL/include/SDL3/SDL_version.h"
+#endif
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
 #include "third-party/imgui/imgui_freetype.h"
 #include "third-party/imgui/imgui_impl_opengl3.h"
 #include "third-party/imgui/imgui_impl_sdl3.h"
 #include "third-party/imgui/imgui_style.h"
+#endif
+#if defined(__SWITCH__)
+#include <cstring>
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_gl(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
+
 #define STBI_WINDOWS_UTF8
 #include "common/util/dialogs.h"
 #include "common/util/string_util.h"
@@ -122,21 +142,43 @@ static int gl_init(GfxGlobalSettings& settings) {
              compiled_sdl_version, linked_sdl_version);
   }
 
+#if defined(__SWITCH__)
+  {
+    // devkitPro's SDL2 Switch video driver doesn't appear to call this implicitly the way
+    // desktop drivers do -- without it, SDL_GL_MakeCurrent's internal glGetString sanity check
+    // fails with "SDL_LoadFunction() not implemented" and the context never comes up, even
+    // though CreateWindow/CreateContext themselves report success.
+    if (SDL_GL_LoadLibrary(nullptr) != 0) {
+      lg::error("SDL_GL_LoadLibrary failed: {}", SDL_GetError());
+    }
+  }
+#endif
+
   {
     auto p = scoped_prof("startup::sdl::set_gl_attributes");
 
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
     if (settings.debug) {
       SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
     } else {
       SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, 0);
     }
+    // devkitPro's Switch driver stack (nouveau via EGL) only ever hands out GLES contexts --
+    // no desktop GL exists there at all. The renderer itself doesn't lean on any GL4-only
+    // feature (see the graphics/ survey), so requesting GLES 3.1 here is a context-creation
+    // change, not a rendering-logic one.
+#if defined(__SWITCH__)
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+#else
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
 #ifndef __APPLE__
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
 #else
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+#endif
 #endif
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
@@ -154,6 +196,14 @@ static void gl_exit() {
 static void init_imgui(SDL_Window* window,
                        SDL_GLContext gl_context,
                        const std::string& glsl_version) {
+#if defined(__SWITCH__)
+  // No imgui debug overlay on Switch -- it's dev-only tooling, and porting its own SDL3
+  // backend is a separate problem from the game's own SDL3 shim.
+  (void)window;
+  (void)gl_context;
+  (void)glsl_version;
+  return;
+#else
   // check that version of the library is okay
   IMGUI_CHECKVERSION();
 
@@ -184,6 +234,7 @@ static void init_imgui(SDL_Window* window,
 
   // set up the renderer
   ImGui_ImplOpenGL3_Init(glsl_version.c_str());
+#endif
 }
 
 static std::shared_ptr<GfxDisplay> gl_make_display(int width,
@@ -194,6 +245,20 @@ static std::shared_ptr<GfxDisplay> gl_make_display(int width,
                                                    bool is_main) {
   // Setup the window
   prof().instant_event("ROOT");
+#if defined(__SWITCH__)
+  // The nwindow/swapchain is created at this size and SDL never resizes it afterwards, so the
+  // caller's 640x480 default left the guest presenting a 640x480 surface while the renderer drew
+  // at the display resolution -- everything outside the bottom-left 640x480 of each frame was
+  // discarded, which is why the image looked magnified and cropped. Citron's own log showed it:
+  // "DequeueBuffer: w=640 h=480" every frame. Create the window at the real display size.
+  {
+    const SDL_DisplayMode* dm = SDL_GetCurrentDisplayMode(1);
+    if (dm && dm->w > 0 && dm->h > 0) {
+      width = dm->w;
+      height = dm->h;
+    }
+  }
+#endif
   prof().begin_event("startup::sdl::create_window");
   SDL_Window* window =
       SDL_CreateWindow(title, width, height,
@@ -236,7 +301,13 @@ static std::shared_ptr<GfxDisplay> gl_make_display(int width,
   if (!gl_inited) {
     {
       auto p = scoped_prof("startup::sdl::glad_init");
+#if defined(__SWITCH__)
+      boot_log_gl("[opengl] about to gladLoadGLLoader\n");
+#endif
       gladLoadGLLoader((GLADloadproc)SDL_GL_GetProcAddress);
+#if defined(__SWITCH__)
+      boot_log_gl("[opengl] gladLoadGLLoader done, about to gladLoadGL\n");
+#endif
       if (!gladLoadGL()) {
         lg::error("GL init fail");
         dialogs::create_error_message_dialog("Critical Error Encountered",
@@ -245,10 +316,65 @@ static std::shared_ptr<GfxDisplay> gl_make_display(int width,
                                              "supports this and your drivers are up to date.");
         return NULL;
       }
+#if defined(__SWITCH__)
+      // glad is a desktop-GL loader and gates each entry point on the version string. Mesa
+      // reports "OpenGL ES 3.1", so glad loads its 1.0-3.1 blocks and skips the 4.x ones --
+      // leaving entry points that GLES 3.1 does provide (glClearDepthf, glMemoryBarrier,
+      // glDispatchCompute, ...) as null pointers that fault the moment a renderer calls them.
+      // Resolve those by name and report anything still missing rather than jumping to 0.
+      {
+        static const char* kEsProvided[] = {
+            "glClearDepthf",        "glDepthRangef",        "glMemoryBarrier",
+            "glDispatchCompute",    "glBindImageTexture",   "glTexStorage2D",
+            "glTexStorage3D",       "glDrawElementsIndirect", "glDrawArraysIndirect",
+            "glBindVertexBuffer",   "glVertexAttribFormat", "glVertexAttribIFormat",
+            "glVertexAttribBinding", "glVertexBindingDivisor", "glFramebufferParameteri",
+            "glGetProgramBinary",   "glProgramBinary",      "glProgramParameteri",
+            "glReleaseShaderCompiler", "glShaderBinary",    "glGetProgramInterfaceiv",
+            "glGetProgramResourceIndex", "glGetProgramResourceiv", "glGetProgramResourceLocation",
+            "glShaderStorageBlockBinding",
+        };
+        void** kSlots[] = {
+            (void**)&glad_glClearDepthf,        (void**)&glad_glDepthRangef,
+            (void**)&glad_glMemoryBarrier,      (void**)&glad_glDispatchCompute,
+            (void**)&glad_glBindImageTexture,   (void**)&glad_glTexStorage2D,
+            (void**)&glad_glTexStorage3D,       (void**)&glad_glDrawElementsIndirect,
+            (void**)&glad_glDrawArraysIndirect, (void**)&glad_glBindVertexBuffer,
+            (void**)&glad_glVertexAttribFormat, (void**)&glad_glVertexAttribIFormat,
+            (void**)&glad_glVertexAttribBinding, (void**)&glad_glVertexBindingDivisor,
+            (void**)&glad_glFramebufferParameteri, (void**)&glad_glGetProgramBinary,
+            (void**)&glad_glProgramBinary,      (void**)&glad_glProgramParameteri,
+            (void**)&glad_glReleaseShaderCompiler, (void**)&glad_glShaderBinary,
+            (void**)&glad_glGetProgramInterfaceiv, (void**)&glad_glGetProgramResourceIndex,
+            (void**)&glad_glGetProgramResourceiv, (void**)&glad_glGetProgramResourceLocation,
+            (void**)&glad_glShaderStorageBlockBinding,
+        };
+        for (size_t i = 0; i < sizeof(kSlots) / sizeof(kSlots[0]); i++) {
+          char buf[128];
+          if (!*kSlots[i]) {
+            *kSlots[i] = (void*)SDL_GL_GetProcAddress(kEsProvided[i]);
+            snprintf(buf, sizeof(buf), "[opengl] glad null: %s -> %s\n", kEsProvided[i],
+                     *kSlots[i] ? "resolved" : "STILL NULL");
+            boot_log_gl(buf);
+          }
+        }
+      }
+      // SDL_GL_GetProcAddress sets SDL's error string on every miss (devkitPro's SDL2 has no
+      // SDL_LoadFunction), and it persists: the next SDL_GetError() caller downstream reports
+      // "Failed loading glShaderStorageBlockBinding" as the cause of an unrelated failure.
+      SDL_ClearError();
+      boot_log_gl("[opengl] gladLoadGL succeeded\n");
+#endif
     }
     {
       auto p = scoped_prof("startup::sdl::gfx_data_init");
+#if defined(__SWITCH__)
+      boot_log_gl("[opengl] about to construct GraphicsData\n");
+#endif
       g_gfx_data = std::make_unique<GraphicsData>(game_version);
+#if defined(__SWITCH__)
+      boot_log_gl("[opengl] GraphicsData constructed\n");
+#endif
     }
     gl_inited = true;
     const char* gl_version = (const char*)glGetString(GL_VERSION);
@@ -356,6 +482,20 @@ void GLDisplay::init_splash() {
   auto frag_src =
       file_util::read_text_file(file_util::get_file_path({shader_folder, "splash.frag"}));
 
+#if defined(__SWITCH__)
+  // This shader is compiled through its own ad-hoc path here, not through Shader.cpp, so it
+  // never got the desktop-GLSL-410 -> GLSL ES swap that every other shader already has (see
+  // Shader.cpp's version_410_line regex). Without it, this compile fails every single frame
+  // (m_splash_program stays 0, so init_splash() retries from scratch each frame) since nothing
+  // ever marks it done -- real, continuous overhead on the render thread the whole time the
+  // splash screen is up.
+  const std::regex version_410_line("#version 410[^\r\n]*");
+  const std::string gles_header =
+      "#version 310 es\nprecision highp float;\nprecision highp int;";
+  vert_src = std::regex_replace(vert_src, version_410_line, gles_header);
+  frag_src = std::regex_replace(frag_src, version_410_line, gles_header);
+#endif
+
   constexpr int len = 1024;
   GLint compile_ok;
   char err[len];
@@ -411,6 +551,20 @@ void GLDisplay::init_splash() {
   }
 
   glGenVertexArrays(1, &m_splash_vao);
+  glBindVertexArray(m_splash_vao);
+  // This shader draws a full-screen quad using only gl_VertexID (no real vertex attributes),
+  // which is spec-legal but has proven unreliable on this Mesa/nouveau GLES driver in other
+  // places tonight (glVertexAttribDivisor hanging, glFramebufferTexture being unreliable, etc.).
+  // A VAO with zero enabled attribute arrays appears to be another instance of that: binding a
+  // single dummy attribute (never read by the shader) makes the draw behave correctly.
+  glGenBuffers(1, &m_splash_dummy_vbo);
+  glBindBuffer(GL_ARRAY_BUFFER, m_splash_dummy_vbo);
+  constexpr float dummy_data[4] = {0.f, 0.f, 0.f, 0.f};
+  glBufferData(GL_ARRAY_BUFFER, sizeof(dummy_data), dummy_data, GL_STATIC_DRAW);
+  glEnableVertexAttribArray(0);
+  glVertexAttribPointer(0, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glBindVertexArray(0);
 }
 
 void GLDisplay::draw_splash(int fb_w, int fb_h) {
@@ -441,6 +595,9 @@ GLDisplay::~GLDisplay() {
     glDeleteProgram(m_splash_program);
   if (m_splash_vao)
     glDeleteVertexArrays(1, &m_splash_vao);
+  if (m_splash_dummy_vbo)
+    glDeleteBuffers(1, &m_splash_dummy_vbo);
+#if !defined(__SWITCH__)
   // Cleanup ImGUI
   ImGuiIO& io = ImGui::GetIO();
   io.IniFilename = nullptr;
@@ -448,6 +605,7 @@ GLDisplay::~GLDisplay() {
   ImGui_ImplOpenGL3_Shutdown();
   ImGui_ImplSDL3_Shutdown();
   ImGui::DestroyContext();
+#endif
   // Cleanup SDL
   SDL_GL_DestroyContext(m_gl_context);
   SDL_DestroyWindow(m_window);
@@ -570,12 +728,14 @@ void GLDisplay::process_sdl_events() {
       auto p = scoped_prof("sdl-display-manager");
       m_display_manager->process_sdl_event(evt);
     }
+#if !defined(__SWITCH__)
     if (!m_should_quit) {
       {
         auto p = scoped_prof("imgui-sdl-process");
         ImGui_ImplSDL3_ProcessEvent(&evt);
       }
     }
+#endif
     {
       auto p = scoped_prof("sdl-input-monitor-process-event");
       m_input_manager->process_sdl_event(evt);
@@ -594,6 +754,7 @@ void GLDisplay::render() {
   // approach). Binding handling is still taken care of by the event code though.
   {
     auto p = scoped_prof("sdl-input-monitor-poll-for-kb-mouse");
+#if !defined(__SWITCH__)
     ImGuiIO& io = ImGui::GetIO();
     if (io.WantCaptureKeyboard) {
       m_input_manager->clear_keyboard_actions();
@@ -605,6 +766,11 @@ void GLDisplay::render() {
     } else {
       m_input_manager->poll_mouse_data();
     }
+#else
+    // No imgui on Switch to ever want to capture input, so always poll for real.
+    m_input_manager->poll_keyboard_data();
+    m_input_manager->poll_mouse_data();
+#endif
     m_input_manager->finish_polling();
   }
   // Now process SDL Events
@@ -620,6 +786,7 @@ void GLDisplay::render() {
     m_input_manager->process_ee_events();
   }
 
+#if !defined(__SWITCH__)
   // imgui start of frame
   {
     auto p = scoped_prof("imgui-new-frame");
@@ -627,6 +794,7 @@ void GLDisplay::render() {
     ImGui_ImplSDL3_NewFrame();
     ImGui::NewFrame();
   }
+#endif
 
   // framebuffer size
   int fbuf_w, fbuf_h;
@@ -669,6 +837,7 @@ void GLDisplay::render() {
     }
   }
 
+#if !defined(__SWITCH__)
   // render debug
   if (is_imgui_visible()) {
     auto p = scoped_prof("debug-gui");
@@ -679,6 +848,7 @@ void GLDisplay::render() {
     ImGui::Render();
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
   }
+#endif
 
   // actual vsync
   g_gfx_data->debug_gui.finish_frame();

--- a/game/graphics/pipelines/opengl.h
+++ b/game/graphics/pipelines/opengl.h
@@ -11,7 +11,11 @@
 #include "game/graphics/display.h"
 #include "game/graphics/gfx.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/sdl3_compat.h"
+#else
 #include "third-party/SDL/include/SDL3/SDL.h"
+#endif
 #include "third-party/glad/include/glad/glad.h"
 
 class GLDisplay : public GfxDisplay {
@@ -61,6 +65,7 @@ class GLDisplay : public GfxDisplay {
   GLuint m_splash_texture = 0;
   GLuint m_splash_program = 0;
   GLuint m_splash_vao = 0;
+  GLuint m_splash_dummy_vbo = 0;
   void init_splash();
   void draw_splash(int fb_w, int fb_h);
 };

--- a/game/graphics/texture/TexturePool.cpp
+++ b/game/graphics/texture/TexturePool.cpp
@@ -13,7 +13,11 @@
 #include "game/graphics/texture/jak3_tpage_dir.h"
 
 #include "fmt/format.h"
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 namespace {
 const char empty_string[] = "";

--- a/game/kernel/asm_funcs_arm64.s
+++ b/game/kernel/asm_funcs_arm64.s
@@ -1,24 +1,24 @@
-;; GOAL Runtime assembly functions. These exist only in the arm64 version of GOAL.
-;; - https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Pass-arguments-to-functions-correctly
-;; - https://en.wikipedia.org/wiki/Calling_convention#ARM_(A64)
-;; - https://student.cs.uwaterloo.ca/~cs452/docs/rpi4b/aapcs64.pdf
-;; - s16–s31 (d8–d15, q4–q7) must be preserved
-;; - s0–s15 (d0–d7, q0–q3) and d16–d31 (q8–q15) do not need to be preserved
-;; - https://devblogs.microsoft.com/oldnewthing/20220728-00/?p=106912
-;; - ;; - https://courses.cs.washington.edu/courses/cse469/19wi/arm64.pdf
+// GOAL Runtime assembly functions. These exist only in the arm64 version of GOAL.
+// - https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Pass-arguments-to-functions-correctly
+// - https://en.wikipedia.org/wiki/Calling_convention#ARM_(A64)
+// - https://student.cs.uwaterloo.ca/~cs452/docs/rpi4b/aapcs64.pdf
+// - s16–s31 (d8–d15, q4–q7) must be preserved
+// - s0–s15 (d0–d7, q0–q3) and d16–d31 (q8–q15) do not need to be preserved
+// - https://devblogs.microsoft.com/oldnewthing/20220728-00/?p=106912
+// - // - https://courses.cs.washington.edu/courses/cse469/19wi/arm64.pdf
 
 .text
 
-;; Call C++ code on arm64 systems, from GOAL.
-;; Following the macOS documentation which mostly aligns with standard arm64
+// Call C++ code on arm64 systems, from GOAL.
+// Following the macOS documentation which mostly aligns with standard arm64
 .global _arg_call_arm64
 .align 4
 _arg_call_arm64:
   stp	x29, x30, [sp, #-16]!
   mov	x29, sp
 
-  ; Putting an exclamation point after the close-bracket
-  ; means that the calculated effective address is written back to the base register. (pre-indexing)
+  // Putting an exclamation point after the close-bracket
+  // means that the calculated effective address is written back to the base register. (pre-indexing)
   stp q15, q14, [sp, #-32]!
   stp q13, q12, [sp, #-32]!
   stp q11, q10, [sp, #-32]!
@@ -26,7 +26,7 @@ _arg_call_arm64:
 
   blr x8
 
-  ;; restore the vector pairs in the same order they were saved
+  // restore the vector pairs in the same order they were saved
   ldp q9, q8, [sp], #32
   ldp q11, q10, [sp], #32
   ldp q13, q12, [sp], #32
@@ -36,12 +36,12 @@ _arg_call_arm64:
   ret
 
 
-;; Call C++ code on arm64 systems, from GOAL. 
-;; 
-;; Put arguments on the stack and put a pointer to this array in the first arg.
-;; this function pushes all 8 OpenGOAL registers into a stack array.
-;; it calls the function in x8 with a pointer to this array.
-;; it returns the return value of the called function.
+// Call C++ code on arm64 systems, from GOAL. 
+// 
+// Put arguments on the stack and put a pointer to this array in the first arg.
+// this function pushes all 8 OpenGOAL registers into a stack array.
+// it calls the function in x8 with a pointer to this array.
+// it returns the return value of the called function.
 .global _stack_call_arm64
 .align 4
 _stack_call_arm64:
@@ -53,111 +53,111 @@ _stack_call_arm64:
   stp q11, q10, [sp, #-32]!
   stp q9, q8, [sp, #-32]!
 
-  ; create stack array of arguments
-  ; arg 7 (R11 in x86)
-  ; arg 6 (R10 in x86)
-  ; arg 5 (R8 in x86)
-  ; arg 4 (R8 in x86)
-  ; arg 3 (RCX in x86)
-  ; arg 2 (RDX in x86)
-  ; arg 1 (RSI in x86)
-  ; arg 0 (RDI in x86)
-  ; put x0 at the lowest address and x7 at the highest
+  // create stack array of arguments
+  // arg 7 (R11 in x86)
+  // arg 6 (R10 in x86)
+  // arg 5 (R8 in x86)
+  // arg 4 (R8 in x86)
+  // arg 3 (RCX in x86)
+  // arg 2 (RDX in x86)
+  // arg 1 (RSI in x86)
+  // arg 0 (RDI in x86)
+  // put x0 at the lowest address and x7 at the highest
   stp x6, x7, [sp, #-16]!
   stp x4, x5, [sp, #-16]!
   stp x2, x3, [sp, #-16]!
   stp x0, x1, [sp, #-16]!
 
-  ; set first argument
-  ; pass the array address as the first argument
+  // set first argument
+  // pass the array address as the first argument
   mov x0, sp
-  ; call function
+  // call function
   blr x8
-  ; keep x0 because it holds the return value
+  // keep x0 because it holds the return value
   ldr x1, [sp, #8]
   ldp x2, x3, [sp, #16]
   ldp x4, x5, [sp, #32]
   ldp x6, x7, [sp, #48]
   add sp, sp, #64
 
-  ;; restore the vector pairs in the same order they were saved
+  // restore the vector pairs in the same order they were saved
   ldp q9, q8, [sp], #32
   ldp q11, q10, [sp], #32
   ldp q13, q12, [sp], #32
   ldp q15, q14, [sp], #32
 
   ldp	x29, x30, [sp], #16
-  ; return!
+  // return!
   ret
 
-;; Call c++ code through mips2c.
-;; GOAL will call a dynamically generated trampoline.
-;; x9 holds the C function and x10 holds the fake GOAL stack size.
+// Call c++ code through mips2c.
+// GOAL will call a dynamically generated trampoline.
+// x9 holds the C function and x10 holds the fake GOAL stack size.
 .global _mips2c_call_arm64
 .align 4
 _mips2c_call_arm64:
   stp	x29, x30, [sp, #-16]!
   mov	x29, sp
 
-  ;; first, save quadword registers
-  ;; save all 128 bits because AAPCS64 only preserves the low half
+  // first, save quadword registers
+  // save all 128 bits because AAPCS64 only preserves the low half
   sub	sp, sp, #128
   stp	q8, q9, [sp]
   stp	q10, q11, [sp, #32]
   stp	q12, q13, [sp, #64]
   stp	q14, q15, [sp, #96]
 
-  ;; oof
-  ;; 1280-byte MIPS register context
+  // oof
+  // 1280-byte MIPS register context
   sub	sp, sp, #1280
-  ; arg 0 (RDI in x86) and
-  str	x0, [sp, #64]	;; a0
-  ; arg 1 (RSI in x86)
-  str	x1, [sp, #80]	;; a1
-  ; arg 2 (RDX in x86) and arg 3 (RCX in x86)
-  str	x2, [sp, #96]	;; a2
-  ; arg 2 (RDX in x86) and arg 3 (RCX in x86)
-  str	x3, [sp, #112]	;; a3
-  ; arg 4 (R8 in x86) and arg 5 (R8 in x86)
-  str	x4, [sp, #128]	;; t0
-  ; arg 4 (R8 in x86) and arg 5 (R8 in x86)
-  str	x5, [sp, #144]	;; t1
-  ; arg 6 (R10 in x86) and arg 7 (R11 in x86)
-  str	x6, [sp, #160]	;; t2
-  ; arg 6 (R10 in x86) and arg 7 (R11 in x86)
-  str	x7, [sp, #176]	;; t3
-  ;; s6 (pp) (R13 in x86) and s7 (st) (R14 in x86)
-  str	x20, [sp, #352]	;; s6 (pp)
-  ;; s6 (pp) (R13 in x86) and s7 (st) (R14 in x86)
-  str	x21, [sp, #368]	;; s7 (st)
+  // arg 0 (RDI in x86) and
+  str	x0, [sp, #64]	// a0
+  // arg 1 (RSI in x86)
+  str	x1, [sp, #80]	// a1
+  // arg 2 (RDX in x86) and arg 3 (RCX in x86)
+  str	x2, [sp, #96]	// a2
+  // arg 2 (RDX in x86) and arg 3 (RCX in x86)
+  str	x3, [sp, #112]	// a3
+  // arg 4 (R8 in x86) and arg 5 (R8 in x86)
+  str	x4, [sp, #128]	// t0
+  // arg 4 (R8 in x86) and arg 5 (R8 in x86)
+  str	x5, [sp, #144]	// t1
+  // arg 6 (R10 in x86) and arg 7 (R11 in x86)
+  str	x6, [sp, #160]	// t2
+  // arg 6 (R10 in x86) and arg 7 (R11 in x86)
+  str	x7, [sp, #176]	// t3
+  // s6 (pp) (R13 in x86) and s7 (st) (R14 in x86)
+  str	x20, [sp, #352]	// s6 (pp)
+  // s6 (pp) (R13 in x86) and s7 (st) (R14 in x86)
+  str	x21, [sp, #368]	// s7 (st)
 
-  ;; store the context as a GOAL pointer in the MIPS sp slot
+  // store the context as a GOAL pointer in the MIPS sp slot
   mov	x11, sp
   sub	x11, x11, x22
-  ;; mip2c code's MIPS stack
-  str	x11, [sp, #464]	;; r29 (sp)
+  // mip2c code's MIPS stack
+  str	x11, [sp, #464]	// r29 (sp)
 
-  ; move the stack pointer to arg 0
-  mov	x0, sp		;; pass the context as the sole argument
+  // move the stack pointer to arg 0
+  mov	x0, sp		// pass the context as the sole argument
 
-  ;; allocate space on the stack for GOAL fake stack
-  ;; round the fake GOAL stack to 16 bytes
+  // allocate space on the stack for GOAL fake stack
+  // round the fake GOAL stack to 16 bytes
   add	x11, x10, #15
   and	x11, x11, #-16
   sub	sp, sp, x11
-  ;; and remember this so we can find our way back
-  str	x11, [sp, #-16]!	;; save the stack size across the C call
+  // and remember this so we can find our way back
+  str	x11, [sp, #-16]!	// save the stack size across the C call
 
-  ;; call!
+  // call!
   blr	x9
 
-  ;; unallocate
+  // unallocate
   ldr	x11, [sp], #16
-  add	sp, sp, x11	;; restore sp to the context base
+  add	sp, sp, x11	// restore sp to the context base
 
-  ldr	x0, [sp, #32]	;; return the v0 slot written by mips2c
+  ldr	x0, [sp, #32]	// return the v0 slot written by mips2c
 
-  ; reset the stackpointer back
+  // reset the stackpointer back
   add	sp, sp, #1280
   ldp	q8, q9, [sp]
   ldp	q10, q11, [sp, #32]
@@ -167,23 +167,23 @@ _mips2c_call_arm64:
   ldp	x29, x30, [sp], #16
   ret
 
-;; The _call_goal_asm function is used to call a GOAL function from C.
-;; It calls on the parent stack, which is a bad idea if your stack is not already a GOAL stack.
-;; It supports up to 3 arguments and a return value.
-;; This should be called with the arguments:
-;; - first goal arg
-;; - second goal arg
-;; - third goal arg
-;; - address of function to call
-;; - address of the symbol table
-;; - GOAL memory space offset
+// The _call_goal_asm function is used to call a GOAL function from C.
+// It calls on the parent stack, which is a bad idea if your stack is not already a GOAL stack.
+// It supports up to 3 arguments and a return value.
+// This should be called with the arguments:
+// - first goal arg
+// - second goal arg
+// - third goal arg
+// - address of function to call
+// - address of the symbol table
+// - GOAL memory space offset
 .global _call_goal_asm_arm64
 .align 4
 _call_goal_asm_arm64:
   stp	x29, x30, [sp, #-16]!
   mov	x29, sp
-  ;; saved registers we need to modify for GOAL should be preserved
-  ; ARM64 requires 16-byte stack pointer alignment
+  // saved registers we need to modify for GOAL should be preserved
+  // ARM64 requires 16-byte stack pointer alignment
   stp x20, x21, [sp, #-16]!
   stp x22, x27, [sp, #-16]!
   sub sp, sp, #128
@@ -192,25 +192,25 @@ _call_goal_asm_arm64:
   stp q12, q13, [sp, #64]
   stp q14, q15, [sp, #96]
 
-  ;; x0 - first arg
-  ;; x1 - second arg
-  ;; x2 - third arg
-  ;; x3 - function pointer
-  ;; x4 - st (goes in x20 and x21)
-  ;; x5 - off (goes in x22)
-  ;; x6 holds the executable mapping base for x27
+  // x0 - first arg
+  // x1 - second arg
+  // x2 - third arg
+  // x3 - function pointer
+  // x4 - st (goes in x20 and x21)
+  // x5 - off (goes in x22)
+  // x6 holds the executable mapping base for x27
 
-  ;; set GOAL process
+  // set GOAL process
   mov x20, x4
-  ;; symbol table
+  // symbol table
   mov x21, x4
-  ;; offset
+  // offset
   mov x22, x5
   mov x27, x6
-  ;; call GOAL by function pointer
+  // call GOAL by function pointer
   blr x3
 
-  ;; restore saved registers.
+  // restore saved registers.
   ldp q8, q9, [sp]
   ldp q10, q11, [sp, #32]
   ldp q12, q13, [sp, #64]
@@ -226,8 +226,8 @@ _call_goal_asm_arm64:
 _call_goal8_asm_arm64:
   stp	x29, x30, [sp, #-16]!
   mov	x29, sp
-  ;; saved registers we need to modify for GOAL should be preserved
-  ; ARM64 requires 16-byte stack pointer alignment
+  // saved registers we need to modify for GOAL should be preserved
+  // ARM64 requires 16-byte stack pointer alignment
   stp x20, x21, [sp, #-16]!
   stp x22, x27, [sp, #-16]!
   sub sp, sp, #128
@@ -236,37 +236,37 @@ _call_goal8_asm_arm64:
   stp q12, q13, [sp, #64]
   stp q14, q15, [sp, #96]
 
-  ;; x0 - first arg (func)
-  ;; x1 - second arg (arg array)
-  ;; x2 - third arg  (0)
-  ;; x3 - pp (goes in r13)
-  ;; x4  - st (goes in r14)
-  ;; x5  - off (goes in r15)
-  ;; x6 holds the executable mapping base for x27
+  // x0 - first arg (func)
+  // x1 - second arg (arg array)
+  // x2 - third arg  (0)
+  // x3 - pp (goes in r13)
+  // x4  - st (goes in r14)
+  // x5  - off (goes in r15)
+  // x6 holds the executable mapping base for x27
 
-  ;; set GOAL function pointer
+  // set GOAL function pointer
   mov x20, x3
-  ;; st
+  // st
   mov x21, x4
-  ;; offset
+  // offset
   mov x22, x5
-  ;; save the executable mapping before loading x6 from the argument array
+  // save the executable mapping before loading x6 from the argument array
   mov x27, x6
-  ;; move function to temp
+  // move function to temp
   mov x8, x0
-  ;; extract arguments
-  ldr x0, [x1]  ;; 0
-  ldr x2, [x1, #+16] ;; 2
-  ldr x3, [x1, #+24] ;; 3
-  ldr x4, [x1, #+32]  ;; 4
-  ldr x5, [x1, #+40]  ;; 5
-  ldr x6, [x1, #+48] ;; 6
-  ldr x7, [x1, #+56]  ;; 7
-  ldr x1, [x1, #+8] ;; 1 (do this last)
-  ;; call GOAL by function pointer
+  // extract arguments
+  ldr x0, [x1]  // 0
+  ldr x2, [x1, #+16] // 2
+  ldr x3, [x1, #+24] // 3
+  ldr x4, [x1, #+32]  // 4
+  ldr x5, [x1, #+40]  // 5
+  ldr x6, [x1, #+48] // 6
+  ldr x7, [x1, #+56]  // 7
+  ldr x1, [x1, #+8] // 1 (do this last)
+  // call GOAL by function pointer
   blr x8
 
-  ;; retore registers.
+  // retore registers.
   ldp q8, q9, [sp]
   ldp q10, q11, [sp, #32]
   ldp q12, q13, [sp, #64]
@@ -277,22 +277,22 @@ _call_goal8_asm_arm64:
   ldp	x29, x30, [sp], #16
   ret
 
-;; Call goal, but switch stacks.
+// Call goal, but switch stacks.
 .global _call_goal_on_stack_asm_arm64
 .align 4
 _call_goal_on_stack_asm_arm64:
   stp	x29, x30, [sp, #-16]!
   mov	x29, sp
-  ;; x0 - stack pointer
-  ;; x1 - unused
-  ;; x2 - unused
-  ;; x3 - function pointer
-  ;; x4  - st (goes in x21 and x20)
-  ;; x5  - offset (goes in x22)
-  ;; x6 holds the executable mapping base for x27
+  // x0 - stack pointer
+  // x1 - unused
+  // x2 - unused
+  // x3 - function pointer
+  // x4  - st (goes in x21 and x20)
+  // x5  - offset (goes in x22)
+  // x6 holds the executable mapping base for x27
 
-  ;; saved registers we need to modify for GOAL should be preserved
-  ; ARM64 requires 16-byte stack pointer alignment
+  // saved registers we need to modify for GOAL should be preserved
+  // ARM64 requires 16-byte stack pointer alignment
   stp x20, x21, [sp, #-16]!
   stp x22, x27, [sp, #-16]!
   sub sp, sp, #128
@@ -301,23 +301,23 @@ _call_goal_on_stack_asm_arm64:
   stp q12, q13, [sp, #64]
   stp q14, q15, [sp, #96]
 
-  ;; also stash the current stack pointer on the stack
-  ;; NOTE - you cannot directly store or load the `sp` register in arm64
-  ;; save the native sp through x9 because str cannot use sp as data
+  // also stash the current stack pointer on the stack
+  // NOTE - you cannot directly store or load the `sp` register in arm64
+  // save the native sp through x9 because str cannot use sp as data
   mov x9, sp
-  ;; switch to new stack
+  // switch to new stack
   mov sp, x0
   str x9, [sp, #-16]!
 
-  ;; set GOAL function pointer
-  mov x20, x4 ;; set GOAL process
-  mov x21, x4 ;; symbol table
-  mov x22, x5 ;; offset
+  // set GOAL function pointer
+  mov x20, x4 // set GOAL process
+  mov x21, x4 // symbol table
+  mov x22, x5 // offset
   mov x27, x6
-  ;; call GOAL by function pointer
+  // call GOAL by function pointer
   blr x3
 
-  ;; restore registers
+  // restore registers
   ldr x9, [sp], #16
   mov sp, x9
   ldp q8, q9, [sp]

--- a/game/kernel/common/codegen.h
+++ b/game/kernel/common/codegen.h
@@ -16,11 +16,32 @@
 #include <libkern/OSCacheControl.h>
 #endif
 
+#ifdef __SWITCH__
+// Deliberately not #include <switch.h> (or even just switch/arm/cache.h) here: it transitively
+// includes switch/types.h, which typedefs u128 to __uint128_t, conflicting with the struct u128
+// this project already defines in common/common_types.h (included by nearly everything). The
+// real symbols still link fine from libnx against a matching extern "C" prototype, so just
+// declare the two we need instead of pulling in the whole header.
+extern "C" {
+void armDCacheFlush(void* addr, size_t size);
+void armICacheInvalidate(void* addr, size_t size);
+}
+#endif
+
 /*!
  * Makes freshly written instructions visible to the CPU.
  */
 inline void flush_icache(void* addr, int size) {
-#ifdef __aarch64__
+#if defined(__SWITCH__)
+  // Horizon's JIT memory model doesn't allow raw DC/IC cache-maintenance instructions
+  // (__builtin___clear_cache) on Jit-mapped pages -- confirmed by the pre-existing TODO in
+  // runtime.cpp about needing armDCacheFlush/armICacheInvalidate here. Using the raw builtin traps
+  // instead of just being a no-op, and whatever handles that trap hangs rather than crashing, which
+  // is why every kernel-boot function that JITs a C trampoline (make_function_from_c and friends)
+  // was stalling forever the first time it tried to flush icache for freshly written code.
+  armDCacheFlush(addr, (size_t)size);
+  armICacheInvalidate(addr, (size_t)size);
+#elif defined(__aarch64__)
 #ifdef __APPLE__
   sys_icache_invalidate(addr, size);
 #else

--- a/game/kernel/common/kdgo.cpp
+++ b/game/kernel/common/kdgo.cpp
@@ -14,6 +14,16 @@
 #include "game/kernel/common/kprint.h"
 #include "game/sce/sif_ee.h"
 
+#if defined(__SWITCH__)
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_kdgo(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
+
 ee::sceSifClientData cd[6];  //! client data for each IOP Remove Procedure Call.
 u32 sShowStallMsg;           //! setting to show a "stalled on iop" message
 u16 x[8];                    //! stupid temporary for storing a message
@@ -81,6 +91,13 @@ u32 RpcBusy(s32 channel) {
  */
 void RpcSync(s32 channel) {
   if (RpcBusy(channel)) {
+#if defined(__SWITCH__)
+    {
+      char buf[64];
+      snprintf(buf, sizeof(buf), "[RpcSync] entering busy-wait, channel=%d\n", channel);
+      boot_log_kdgo(buf);
+    }
+#endif
     if (sShowStallMsg) {
       Msg(6, "STALL: [kernel] waiting for IOP on RPC port #%d\n", channel);
     }

--- a/game/kernel/common/kmachine.cpp
+++ b/game/kernel/common/kmachine.cpp
@@ -25,6 +25,16 @@
 #include "game/sce/libscf.h"
 #include "game/sce/sif_ee.h"
 
+#if defined(__SWITCH__)
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_km(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
+
 /*!
  * Where does OVERLORD load its data from?
  */
@@ -73,8 +83,14 @@ void InitCD() {
  * Initialize the GS and display the splash screen.
  */
 void InitVideo() {
+#if defined(__SWITCH__)
+  boot_log_km("[InitVideo] start\n");
+#endif
   if (!SplashScreen) {
     lg::info("InitVideo: skipping splash!\n");
+#if defined(__SWITCH__)
+    boot_log_km("[InitVideo] SplashScreen off, returning\n");
+#endif
     return;
   }
   std::map<int, std::string> lang_to_splash_map{
@@ -84,6 +100,9 @@ void InitVideo() {
       {SCE_PORTUGUESE_LANGUAGE, "POR"}, {SCE_KOREAN_LANGUAGE, "KOR"},
   };
   auto lang = ee::sceScfGetLanguage();
+#if defined(__SWITCH__)
+  boot_log_km("[InitVideo] got language\n");
+#endif
   if (!lang_to_splash_map.contains(lang)) {
     lg::warn("InitVideo: no splash for lang {}, falling back to english...\n", lang);
     lang = SCE_ENGLISH_LANGUAGE;
@@ -91,6 +110,9 @@ void InitVideo() {
   auto filename = "SCREEN1." + lang_to_splash_map.at(lang);
   auto path = file_util::get_jak_project_dir() / "out" / game_version_names[g_game_version] /
               "iso" / filename;
+#if defined(__SWITCH__)
+  boot_log_km("[InitVideo] computed splash path, about to fs::exists\n");
+#endif
   if (lang != SCE_ENGLISH_LANGUAGE && !fs::exists(path)) {
     lg::warn("InitVideo: file {} not found, falling back to english...\n", filename);
     path = file_util::get_jak_project_dir() / "out" / game_version_names[g_game_version] / "iso" /
@@ -98,9 +120,22 @@ void InitVideo() {
   }
   if (!fs::exists(path)) {
     lg::warn("InitVideo: splash screen not found!\n");
+#if defined(__SWITCH__)
+    boot_log_km("[InitVideo] splash not found, returning\n");
+#endif
     return;
   }
+#if defined(__SWITCH__)
+  boot_log_km("[InitVideo] splash found, about to read_binary_file\n");
+#endif
   auto data = file_util::read_binary_file(path);
+#if defined(__SWITCH__)
+  {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "[InitVideo] read_binary_file done, size=%zu\n", data.size());
+    boot_log_km(buf);
+  }
+#endif
   // width is always 512, height is sometimes different (e.g. demo screens), so we infer from file
   // size
   constexpr int kWidth = 512;
@@ -118,10 +153,16 @@ void InitVideo() {
   Gfx::g_splash.width = kWidth;
   Gfx::g_splash.height = kHeight;
   Gfx::g_splash.ready.store(true);
+#if defined(__SWITCH__)
+  boot_log_km("[InitVideo] g_splash set, about to SplashTimer wait loop\n");
+#endif
   SplashTimer.start();
   while (SplashTimer.getSeconds() < SPLASH_SCREEN_TIME) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
   }
+#if defined(__SWITCH__)
+  boot_log_km("[InitVideo] SplashTimer wait done, InitVideo returning\n");
+#endif
 }
 
 /*!

--- a/game/kernel/common/kprint.h
+++ b/game/kernel/common/kprint.h
@@ -24,6 +24,10 @@ constexpr u32 PRINT_BUFFER_SIZE = 0x40000;  // upped from 0x2000 on PS2 because 
 
 struct format_struct {
   char data[0x40];
+  // -1 is the "not specified" sentinel. Plain `char` is signed on x86 but unsigned on aarch64,
+  // so comparing data[0] against a bare -1 there is always true (255 != -1) -- read it through a
+  // signed type so both platforms agree.
+  s32 field() const { return (signed char)data[0]; }
   void reset() {
     for (auto& c : data)
       c = -1;
@@ -64,7 +68,7 @@ void output_unload(const char* name);
  */
 void output_segment_load(const char* name, Ptr<u8> link_block, u32 flags);
 
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
 /*!
  * Print to the GOAL print buffer from C
  */
@@ -81,7 +85,7 @@ void cprintf(const char* format, ...);
  */
 void reverse(char* s);
 
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
 /*!
  * Print directly to the C stdout
  * The "k" parameter is ignored, so this is just like printf
@@ -95,7 +99,7 @@ void Msg(s32 k, const char* format, ...) __attribute__((format(printf, 2, 3)));
 void Msg(s32 k, const char* format, ...);
 #endif
 
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
 /*!
  * Print directly to the C stdout
  * This is identical to Msg.
@@ -108,7 +112,7 @@ void MsgWarn(const char* format, ...) __attribute__((format(printf, 1, 2)));
  */
 void MsgWarn(const char* format, ...);
 #endif
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
 /*!
  * Print directly to the C stdout
  * This is identical to Msg.

--- a/game/kernel/common/kscheme.cpp
+++ b/game/kernel/common/kscheme.cpp
@@ -4,6 +4,17 @@
 #include "game/kernel/common/kmalloc.h"
 #include "game/kernel/common/kprint.h"
 
+#if defined(__SWITCH__)
+#include <cstring>
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_ksc(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
+
 // total number of symbols in the table
 s32 NumSymbols;
 

--- a/game/kernel/common/kscheme.h
+++ b/game/kernel/common/kscheme.h
@@ -36,7 +36,11 @@ u64 call_goal_on_stack(Ptr<Function> f, u64 rsp, u64 st, void* offset);
 
 // align the host stack for each ABI
 #ifdef __aarch64__
-constexpr u64 GOAL_STACK_TOP_OFFSET = 16;
+// [Jak][DIAG] Was 16 -- the absolute minimum, putting the goal stack in the very last 16 bytes
+// of the 128MB g_ee_main_mem mapping. Testing whether Citron has a boundary bug in its fast
+// memory-access path right at the edge of a large mapped region by moving the stack well clear
+// of that edge.
+constexpr u64 GOAL_STACK_TOP_OFFSET = 0x10000;
 #else
 constexpr u64 GOAL_STACK_TOP_OFFSET = 8;
 #endif

--- a/game/kernel/jak1/kboot.cpp
+++ b/game/kernel/jak1/kboot.cpp
@@ -27,6 +27,16 @@
 
 using namespace ee;
 
+#if defined(__SWITCH__)
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_km(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
+
 namespace jak1 {
 VideoMode BootVideoMode;
 
@@ -47,10 +57,16 @@ void kboot_init_globals() {}
  * Add call to sceDeci2Reset when GOAL shuts down.
  */
 s32 goal_main(int argc, const char* const* argv) {
+#if defined(__SWITCH__)
+  boot_log_km("[goal_main] entered\n");
+#endif
   // Initialize global variables based on command line parameters
   // This call is not present in the retail version of the game
   // but the function is, and it likely goes here.
   InitParms(argc, argv);
+#if defined(__SWITCH__)
+  boot_log_km("[goal_main] InitParms done\n");
+#endif
 
   // Initialize CRC32 table for string hashing
   init_crc();
@@ -91,10 +107,23 @@ s32 goal_main(int argc, const char* const* argv) {
   // DebugSegment = 0;
 
   // Launch GOAL!
+#if defined(__SWITCH__)
+  boot_log_km("[goal_main] about to InitMachine\n");
+#endif
   if (InitMachine() >= 0) {    // init kernel
+#if defined(__SWITCH__)
+    boot_log_km("[goal_main] InitMachine ok, about to KernelCheckAndDispatch\n");
+    switch_boot_log_finish();
+#endif
     KernelCheckAndDispatch();  // run kernel
+#if defined(__SWITCH__)
+    boot_log_km("[goal_main] KernelCheckAndDispatch returned\n");
+#endif
     ShutdownMachine();         // kernel died, we should too.
   } else {
+#if defined(__SWITCH__)
+    boot_log_km("[goal_main] InitMachine FAILED\n");
+#endif
     fprintf(stderr, "InitMachine failed\n");
     exit(1);
   }

--- a/game/kernel/jak1/kdgo.cpp
+++ b/game/kernel/jak1/kdgo.cpp
@@ -10,6 +10,16 @@
 #include "game/kernel/common/kmalloc.h"
 #include "game/kernel/jak1/klink.h"
 
+#if defined(__SWITCH__)
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_kdgo(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
+
 namespace jak1 {
 
 RPC_Dgo_Cmd* sLastMsg;  //! Last DGO command sent to IOP
@@ -188,11 +198,25 @@ void load_and_link_dgo_from_c(const char* name,
     lg::debug("[link and exec] {:18s} {} {:6d} heap-use {:8d} {:8d}: 0x{:x}", objName,
               lastObjectLoaded, objSize, kheapused(kglobalheap),
               kdebugheap.offset ? kheapused(kdebugheap) : 0, kglobalheap->current.offset);
+#if defined(__SWITCH__)
+    {
+      char buf[128];
+      snprintf(buf, sizeof(buf), "[load_and_link_dgo_from_c] about to link_and_exec obj=%s size=%u last=%u\n",
+                objName, objSize, lastObjectLoaded);
+      boot_log_kdgo(buf);
+    }
+#endif
     link_and_exec(obj, objName, objSize, heap, linkFlag, jump_from_c_to_goal);  // link now!
+#if defined(__SWITCH__)
+    boot_log_kdgo("[load_and_link_dgo_from_c] link_and_exec returned\n");
+#endif
 
     // inform IOP we are done
     if (!lastObjectLoaded) {
       ContinueLoadingDGO(Ptr<u8>((heap->current + 0x3f).offset & 0xffffffc0));
+#if defined(__SWITCH__)
+      boot_log_kdgo("[load_and_link_dgo_from_c] ContinueLoadingDGO done\n");
+#endif
     }
   }
   sShowStallMsg = oldShowStall;

--- a/game/kernel/jak1/klink.cpp
+++ b/game/kernel/jak1/klink.cpp
@@ -3,6 +3,7 @@
 #include "common/log/log.h"
 #include "common/symbols.h"
 
+#include "game/kernel/common/codegen.h"
 #include "game/kernel/common/fileio.h"
 #include "game/kernel/common/klink.h"
 #include "game/kernel/common/kmachine.h"
@@ -13,6 +14,16 @@
 #include "game/mips2c/mips2c_table.h"
 
 #include "fmt/format.h"
+
+#if defined(__SWITCH__)
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_klink(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
 
 static constexpr bool link_debug_printfs = false;
 /*!
@@ -561,12 +572,26 @@ void link_control::jak1_finish(bool jump_from_c_to_goal) {
 
     // execute top level!
     if (m_entry.offset && (m_flags & LINK_FLAG_EXECUTE)) {
+#if defined(__SWITCH__)
+      {
+        char buf[128];
+        snprintf(buf, sizeof(buf), "[jak1_finish] obj=%s: top-level enter\n", m_object_name);
+        boot_log_klink(buf);
+      }
+#endif
       if (jump_from_c_to_goal) {
         u64 goal_stack = u64(g_ee_main_mem) + EE_MAIN_MEM_SIZE - GOAL_STACK_TOP_OFFSET;
         call_goal_on_stack(m_entry.cast<Function>(), goal_stack, s7.offset, g_ee_main_mem);
       } else {
         call_goal(m_entry.cast<Function>(), 0, 0, 0, s7.offset, g_ee_main_mem);
       }
+#if defined(__SWITCH__)
+      {
+        char buf[128];
+        snprintf(buf, sizeof(buf), "[jak1_finish] obj=%s: top-level ok\n", m_object_name);
+        boot_log_klink(buf);
+      }
+#endif
     }
 
     // inform compiler that we loaded.

--- a/game/kernel/jak1/kmachine.cpp
+++ b/game/kernel/jak1/kmachine.cpp
@@ -46,6 +46,16 @@
 
 using namespace ee;
 
+#if defined(__SWITCH__)
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_km(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
+
 namespace jak1 {
 
 /*!
@@ -67,6 +77,13 @@ void InitParms(int argc, const char* const* argv) {
 
   for (int i = 1; i < argc; i++) {
     std::string arg = argv[i];
+#if defined(__SWITCH__)
+    {
+      char buf[96];
+      snprintf(buf, sizeof(buf), "[InitParms] loop i=%d arg=%s begin\n", i, arg.c_str());
+      boot_log_km(buf);
+    }
+#endif
     // DVD Settings
     // ----------------------------
 
@@ -162,6 +179,9 @@ void InitParms(int argc, const char* const* argv) {
       Msg(6, "dkernel: level %s\n", levelName.c_str());
       kstrcpy(DebugBootLevel, levelName.c_str());
     }
+#if defined(__SWITCH__)
+    boot_log_km("[InitParms] loop iteration end\n");
+#endif
   }
 }
 
@@ -307,6 +327,9 @@ AutoSplitterBlock g_auto_splitter_block_jak1;
  * TODO finish up things which are commented.
  */
 int InitMachine() {
+#if defined(__SWITCH__)
+  boot_log_km("[InitMachine] start\n");
+#endif
   u32 debug_heap_end = (0xffffffff - DEBUG_HEAP_SPACE_FOR_STACK + 1) & 0x7ffffff;
 
   // initialize the global heap
@@ -329,12 +352,24 @@ int InitMachine() {
     kdebugheap.offset = 0;
   }
 
-  init_output();    // GOAL input/output buffer setup
+#if defined(__SWITCH__)
+  boot_log_km("[InitMachine] heaps done, about to init_output\n");
+#endif
+  init_output();  // GOAL input/output buffer setup
+#if defined(__SWITCH__)
+  boot_log_km("[InitMachine] init_output done, about to InitIOP\n");
+#endif
   jak1::InitIOP();  // start IOP/OVERLORD, loading our legal splash screen
+#if defined(__SWITCH__)
+  boot_log_km("[InitMachine] InitIOP done, about to InitVideo\n");
+#endif
 
   // sceGsResetPath(); // reset VIF1, VU1, GIF
 
   InitVideo();  // display legal splash screen
+#if defined(__SWITCH__)
+  boot_log_km("[InitMachine] InitVideo done\n");
+#endif
 
   // FlushCache(WRITEBACK_DCACHE);
   // FlushCache(INVALIDATE_ICACHE);
@@ -345,7 +380,13 @@ int InitMachine() {
   // }
 
   if (MasterDebug) {  // connect to GOAL compiler
+#if defined(__SWITCH__)
+    boot_log_km("[InitMachine] about to InitGoalProto\n");
+#endif
     InitGoalProto();
+#if defined(__SWITCH__)
+    boot_log_km("[InitMachine] InitGoalProto done\n");
+#endif
   } else {
     // shut down the deci2 stuff, we don't need it.
     ee::sceDeci2Disable();
@@ -354,11 +395,27 @@ int InitMachine() {
   lg::info("InitSound");
   InitSound();  // do nothing!
   lg::info("InitRPC");
+#if defined(__SWITCH__)
+  boot_log_km("[InitMachine] about to InitRPC\n");
+#endif
   InitRPC();       // connect to IOP
+#if defined(__SWITCH__)
+  boot_log_km("[InitMachine] InitRPC done\n");
+#endif
   reset_output();  // reset output buffers
   clear_print();
 
+#if defined(__SWITCH__)
+  boot_log_km("[InitMachine] about to InitHeapAndSymbol\n");
+#endif
   s32 goal_status = InitHeapAndSymbol();  // init GOAL runtime, load kernel and engine
+#if defined(__SWITCH__)
+  {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "[InitMachine] InitHeapAndSymbol done, status=%d\n", goal_status);
+    boot_log_km(buf);
+  }
+#endif
   if (goal_status < 0) {
     return goal_status;
   }
@@ -372,6 +429,9 @@ int InitMachine() {
   InitListenerConnect();
   lg::info("InitCheckListener");
   InitCheckListener();
+#if defined(__SWITCH__)
+  boot_log_km("[InitMachine] InitListenerConnect/InitCheckListener done, InitMachine returning\n");
+#endif
   Msg(6, "kernel: machine started\n");
   return 0;
 }

--- a/game/kernel/jak1/kprint.cpp
+++ b/game/kernel/jak1/kprint.cpp
@@ -245,7 +245,7 @@ s32 format_impl_jak1(uint64_t* args) {
               // too short
               if (justify == 0) {
                 char pad = ' ';
-                if (argument_data[1].data[0] != -1) {
+                if (argument_data[1].field() != -1) {
                   pad = argument_data[1].data[0];
                 }
                 kstrinsert(output_ptr, pad, desired_length - print_len);
@@ -295,7 +295,7 @@ s32 format_impl_jak1(uint64_t* args) {
               // too short
               if (justify == 0) {
                 char pad = ' ';
-                if (argument_data[1].data[0] != -1) {
+                if (argument_data[1].field() != -1) {
                   pad = argument_data[1].data[0];
                 }
                 kstrinsert(output_ptr, pad, desired_length - print_len);
@@ -377,33 +377,33 @@ s32 format_impl_jak1(uint64_t* args) {
         case 'X':  // hex, 64 bit, pad padchar
         case 'x': {
           char pad = '0';
-          if (argument_data[1].data[0] != -1) {
+          if (argument_data[1].field() != -1) {
             pad = argument_data[1].data[0];
           }
           u64 in = arg_regs[arg_reg_idx++];
-          kitoa(output_ptr, in, 16, argument_data[0].data[0], pad, 0);
+          kitoa(output_ptr, in, 16, argument_data[0].field(), pad, 0);
           output_ptr = strend(output_ptr);
         } break;
 
         case 'D':  // integer 64, pad padchar
         case 'd': {
           char pad = ' ';
-          if (argument_data[1].data[0] != -1) {
+          if (argument_data[1].field() != -1) {
             pad = argument_data[1].data[0];
           }
           u64 in = arg_regs[arg_reg_idx++];
-          kitoa(output_ptr, in, 10, argument_data[0].data[0], pad, 0);
+          kitoa(output_ptr, in, 10, argument_data[0].field(), pad, 0);
           output_ptr = strend(output_ptr);
         } break;
 
         case 'B':  // integer 64, pad padchar
         case 'b': {
           char pad = '0';
-          if (argument_data[1].data[0] != -1) {
+          if (argument_data[1].field() != -1) {
             pad = argument_data[1].data[0];
           }
           u64 in = arg_regs[arg_reg_idx++];
-          kitoa(output_ptr, in, 2, argument_data[0].data[0], pad, 0);
+          kitoa(output_ptr, in, 2, argument_data[0].field(), pad, 0);
           output_ptr = strend(output_ptr);
         } break;
 

--- a/game/kernel/jak1/kscheme.cpp
+++ b/game/kernel/jak1/kscheme.cpp
@@ -26,6 +26,16 @@
 
 using namespace jak1_symbols;
 
+#if defined(__SWITCH__)
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_ks(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
+
 namespace jak1 {
 // where to put a new symbol for the most recently searched for symbol that wasn't found
 u32 symbol_slot;
@@ -522,6 +532,12 @@ Ptr<Function> make_function_from_c(void* func, bool arg3_is_pp = false) {
   return make_function_from_c_systemv(func, arg3_is_pp);
 #elif __APPLE__
   return make_function_from_c_systemv(func, arg3_is_pp);
+#elif defined(__SWITCH__)
+  // Switch aarch64 uses AAPCS64, same calling convention as the existing Linux/macOS aarch64
+  // path -- this branch was simply never added when the file was ported, so every call fell off
+  // the end of this non-void function with no return statement (undefined behavior: whatever
+  // garbage was in the return register got used as the Function pointer by the caller).
+  return make_function_from_c_systemv(func, arg3_is_pp);
 #elif _WIN32
   return make_function_from_c_win32(func, arg3_is_pp);
 #endif
@@ -531,6 +547,8 @@ Ptr<Function> make_stack_arg_function_from_c(void* func) {
 #ifdef __linux__
   return make_stack_arg_function_from_c_systemv(func);
 #elif __APPLE__
+  return make_stack_arg_function_from_c_systemv(func);
+#elif defined(__SWITCH__)
   return make_stack_arg_function_from_c_systemv(func);
 #elif _WIN32
   return make_stack_arg_function_from_c_win32(func);
@@ -1457,12 +1475,18 @@ s32 test_function(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
  * This takes care of all initialization that isn't for the hardware itself.
  */
 s32 InitHeapAndSymbol() {
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] entered\n");
+#endif
   Timer heap_init_timer;
   // reset all mips2c functions
   Mips2C::gLinkedFunctionTable = {};
   // allocate memory for the symbol table
   auto symbol_table =
       kmalloc(kglobalheap, jak1::SYM_TABLE_MEM_SIZE, KMALLOC_MEMSET, "symbol-table").cast<u32>();
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] symbol table kmalloc done\n");
+#endif
 
   // pointer to the middle symbol is stored in the s7 register.
   s7 = symbol_table + (jak1::GOAL_MAX_SYMBOLS / 2) * 8 + BASIC_OFFSET;
@@ -1481,26 +1505,53 @@ s32 InitHeapAndSymbol() {
   // need to set up 'global fixed symbol so allocating memory works.
   *(s7 + FIX_SYM_GLOBAL_HEAP) = kglobalheap.offset;
 
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] about to alloc_and_init_type\n");
+#endif
   // allocate fundamental types
   alloc_and_init_type((s7 + FIX_SYM_TYPE_TYPE).cast<Symbol>(), 9);
   alloc_and_init_type((s7 + FIX_SYM_SYMBOL_TYPE).cast<Symbol>(), 9);
   alloc_and_init_type((s7 + FIX_SYM_STRING_TYPE).cast<Symbol>(), 9);
   alloc_and_init_type((s7 + FIX_SYM_FUNCTION_TYPE).cast<Symbol>(), 9);
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] alloc_and_init_type done\n");
+#endif
 
   // booleans
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] about to booleans\n");
+#endif
   set_fixed_symbol(FIX_SYM_FALSE, "#f", s7.offset + FIX_SYM_FALSE);
   set_fixed_symbol(FIX_SYM_TRUE, "#t", s7.offset + FIX_SYM_TRUE);
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] booleans done, about to make_nothing_func\n");
+#endif
 
   // functions
   set_fixed_symbol(FIX_SYM_NOTHING_FUNC, "nothing", make_nothing_func().offset);
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] make_nothing_func done, about to make_zero_func\n");
+#endif
   set_fixed_symbol(FIX_SYM_ZERO_FUNC, "zero-func", make_zero_func().offset);
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] make_zero_func done, about to asize_of_basic\n");
+#endif
   set_fixed_symbol(FIX_SYM_ASIZE_OF_BASIC_FUNC, "asize-of-basic-func",
                    make_function_from_c((void*)asize_of_basic).offset);
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] asize_of_basic done, about to copy_basic\n");
+#endif
   // NOTE: this is a typo in the game too.
   set_fixed_symbol(FIX_SYM_COPY_BASIC_FUNC, "asize-of-basic-func",
                    make_function_from_c((void*)copy_basic, true).offset);
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] copy_basic done, about to delete_basic\n");
+#endif
   set_fixed_symbol(FIX_SYM_DEL_BASIC_FUNC, "delete-basic",
                    make_function_from_c((void*)delete_basic).offset);
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] delete_basic done, about to heap symbols\n");
+#endif
 
   // heap symbols
   set_fixed_symbol(FIX_SYM_GLOBAL_HEAP, "global", kglobalheap.offset);
@@ -1522,6 +1573,9 @@ s32 InitHeapAndSymbol() {
   set_fixed_symbol(FIX_SYM_DGO, "dgo", 0);
   set_fixed_symbol(FIX_SYM_TOP_LEVEL, "top-level", *(s7 + FIX_SYM_NOTHING_FUNC));
 
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] fixed symbols done, about to OBJECT type\n");
+#endif
   // OBJECT type
   auto new_illegal_func = make_function_from_c((void*)new_illegal);
   auto delete_illegal_func = make_function_from_c((void*)delete_illegal);
@@ -1639,6 +1693,9 @@ s32 InitHeapAndSymbol() {
   set_fixed_type(FIX_SYM_FILE_STREAM_TYPE, "file-stream", (s7 + FIX_SYM_BASIC_TYPE).cast<Symbol>(),
                  pack_type_flag(9, 0, 0x14), 0, 0);
 
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] core types done, about to NUMERIC types\n");
+#endif
   // NUMERIC TYPES
   set_fixed_type(FIX_SYM_POINTER_TYPE, "pointer", (s7 + FIX_SYM_OBJECT_TYPE).cast<Symbol>(),
                  pack_type_flag(9, 0, 4), 0, 0);
@@ -1688,6 +1745,9 @@ s32 InitHeapAndSymbol() {
   set_fixed_type(FIX_SYM_UINT128_TYPE, "uint128", (s7 + FIX_SYM_UINTEGER_TYPE).cast<Symbol>(),
                  pack_type_flag(9, 0, 0x10), 0, 0);
 
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] numeric types done, about to Object new macro\n");
+#endif
   // Object new macro
   auto goal_new_object_func = make_function_from_c((void*)alloc_heap_object, true);
   object_type->new_method = goal_new_object_func;
@@ -1710,6 +1770,18 @@ s32 InitHeapAndSymbol() {
 
   // type system
   make_function_symbol_from_c("method-set!", (void*)method_set);
+#if defined(__SWITCH__)
+  {
+    // [Jak][DIAG] Verify method-set!'s symbol value looks sane right after creation, before
+    // anything else can touch it -- narrows down whether the bug is in stub creation itself or
+    // something corrupts it later (e.g. during subsequent DGO object loads).
+    auto ms_sym = intern_from_c("method-set!");
+    char buf[128];
+    snprintf(buf, sizeof(buf), "[InitHeapAndSymbol] method-set! symbol created, value=0x%x\n",
+             ms_sym->value);
+    boot_log_ks(buf);
+  }
+#endif
 
   // dgo
   make_stack_arg_function_symbol_from_c("link", (void*)link_and_exec_wrapper);
@@ -1751,7 +1823,13 @@ s32 InitHeapAndSymbol() {
   // set *boot-video-mode*
   intern_from_c("*boot-video-mode*")->value = 0;  // (u32)BootVideoMode;
 
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] misc symbols done, about to lg::info(Initialized GOAL heap)\n");
+#endif
   lg::info("Initialized GOAL heap in {:.2} ms", heap_init_timer.getMs());
+#if defined(__SWITCH__)
+  boot_log_ks("[InitHeapAndSymbol] Initialized GOAL heap logged, about to load kernel\n");
+#endif
   // load the kernel!
   if (MasterUseKernel) {
     Timer kernel_load_timer;

--- a/game/kernel/jak2/kprint.cpp
+++ b/game/kernel/jak2/kprint.cpp
@@ -278,7 +278,7 @@ s32 format_impl_jak2(uint64_t* args) {
               // too short
               if (justify == 0) {
                 char pad = ' ';
-                if (argument_data[1].data[0] != -1) {
+                if (argument_data[1].field() != -1) {
                   pad = argument_data[1].data[0];
                 }
                 kstrinsert(output_ptr, pad, desired_length - print_len);
@@ -328,7 +328,7 @@ s32 format_impl_jak2(uint64_t* args) {
               // too short
               if (justify == 0) {
                 char pad = ' ';
-                if (argument_data[1].data[0] != -1) {
+                if (argument_data[1].field() != -1) {
                   pad = argument_data[1].data[0];
                 }
                 kstrinsert(output_ptr, pad, desired_length - print_len);
@@ -410,33 +410,33 @@ s32 format_impl_jak2(uint64_t* args) {
         case 'X':  // hex, 64 bit, pad padchar
         case 'x': {
           char pad = '0';
-          if (argument_data[1].data[0] != -1) {
+          if (argument_data[1].field() != -1) {
             pad = argument_data[1].data[0];
           }
           u64 in = arg_regs[arg_reg_idx++];
-          kitoa(output_ptr, in, 16, argument_data[0].data[0], pad, 0);
+          kitoa(output_ptr, in, 16, argument_data[0].field(), pad, 0);
           output_ptr = strend(output_ptr);
         } break;
 
         case 'D':  // integer 64, pad padchar
         case 'd': {
           char pad = ' ';
-          if (argument_data[1].data[0] != -1) {
+          if (argument_data[1].field() != -1) {
             pad = argument_data[1].data[0];
           }
           u64 in = arg_regs[arg_reg_idx++];
-          kitoa(output_ptr, in, 10, argument_data[0].data[0], pad, 0);
+          kitoa(output_ptr, in, 10, argument_data[0].field(), pad, 0);
           output_ptr = strend(output_ptr);
         } break;
 
         case 'B':  // integer 64, pad padchar
         case 'b': {
           char pad = '0';
-          if (argument_data[1].data[0] != -1) {
+          if (argument_data[1].field() != -1) {
             pad = argument_data[1].data[0];
           }
           u64 in = arg_regs[arg_reg_idx++];
-          kitoa(output_ptr, in, 2, argument_data[0].data[0], pad, 0);
+          kitoa(output_ptr, in, 2, argument_data[0].field(), pad, 0);
           output_ptr = strend(output_ptr);
         } break;
 

--- a/game/kernel/jak3/kprint.cpp
+++ b/game/kernel/jak3/kprint.cpp
@@ -248,7 +248,7 @@ s32 format_impl_jak3(uint64_t* args) {
               // too short
               if (justify == 0) {
                 char pad = ' ';
-                if (argument_data[1].data[0] != -1) {
+                if (argument_data[1].field() != -1) {
                   pad = argument_data[1].data[0];
                 }
                 kstrinsert(output_ptr, pad, desired_length - print_len);
@@ -298,7 +298,7 @@ s32 format_impl_jak3(uint64_t* args) {
               // too short
               if (justify == 0) {
                 char pad = ' ';
-                if (argument_data[1].data[0] != -1) {
+                if (argument_data[1].field() != -1) {
                   pad = argument_data[1].data[0];
                 }
                 kstrinsert(output_ptr, pad, desired_length - print_len);
@@ -380,33 +380,33 @@ s32 format_impl_jak3(uint64_t* args) {
         case 'X':  // hex, 64 bit, pad padchar
         case 'x': {
           char pad = '0';
-          if (argument_data[1].data[0] != -1) {
+          if (argument_data[1].field() != -1) {
             pad = argument_data[1].data[0];
           }
           u64 in = arg_regs[arg_reg_idx++];
-          kitoa(output_ptr, in, 16, argument_data[0].data[0], pad, 0);
+          kitoa(output_ptr, in, 16, argument_data[0].field(), pad, 0);
           output_ptr = strend(output_ptr);
         } break;
 
         case 'D':  // integer 64, pad padchar
         case 'd': {
           char pad = ' ';
-          if (argument_data[1].data[0] != -1) {
+          if (argument_data[1].field() != -1) {
             pad = argument_data[1].data[0];
           }
           u64 in = arg_regs[arg_reg_idx++];
-          kitoa(output_ptr, in, 10, argument_data[0].data[0], pad, 0);
+          kitoa(output_ptr, in, 10, argument_data[0].field(), pad, 0);
           output_ptr = strend(output_ptr);
         } break;
 
         case 'B':  // integer 64, pad padchar
         case 'b': {
           char pad = '0';
-          if (argument_data[1].data[0] != -1) {
+          if (argument_data[1].field() != -1) {
             pad = argument_data[1].data[0];
           }
           u64 in = arg_regs[arg_reg_idx++];
-          kitoa(output_ptr, in, 2, argument_data[0].data[0], pad, 0);
+          kitoa(output_ptr, in, 2, argument_data[0].field(), pad, 0);
           output_ptr = strend(output_ptr);
         } break;
 

--- a/game/kernel/jakx/kprint.cpp
+++ b/game/kernel/jakx/kprint.cpp
@@ -248,7 +248,7 @@ s32 format_impl_jakx(uint64_t* args) {
               // too short
               if (justify == 0) {
                 char pad = ' ';
-                if (argument_data[1].data[0] != -1) {
+                if (argument_data[1].field() != -1) {
                   pad = argument_data[1].data[0];
                 }
                 kstrinsert(output_ptr, pad, desired_length - print_len);
@@ -298,7 +298,7 @@ s32 format_impl_jakx(uint64_t* args) {
               // too short
               if (justify == 0) {
                 char pad = ' ';
-                if (argument_data[1].data[0] != -1) {
+                if (argument_data[1].field() != -1) {
                   pad = argument_data[1].data[0];
                 }
                 kstrinsert(output_ptr, pad, desired_length - print_len);
@@ -380,33 +380,33 @@ s32 format_impl_jakx(uint64_t* args) {
         case 'X':  // hex, 64 bit, pad padchar
         case 'x': {
           char pad = '0';
-          if (argument_data[1].data[0] != -1) {
+          if (argument_data[1].field() != -1) {
             pad = argument_data[1].data[0];
           }
           u64 in = arg_regs[arg_reg_idx++];
-          kitoa(output_ptr, in, 16, argument_data[0].data[0], pad, 0);
+          kitoa(output_ptr, in, 16, argument_data[0].field(), pad, 0);
           output_ptr = strend(output_ptr);
         } break;
 
         case 'D':  // integer 64, pad padchar
         case 'd': {
           char pad = ' ';
-          if (argument_data[1].data[0] != -1) {
+          if (argument_data[1].field() != -1) {
             pad = argument_data[1].data[0];
           }
           u64 in = arg_regs[arg_reg_idx++];
-          kitoa(output_ptr, in, 10, argument_data[0].data[0], pad, 0);
+          kitoa(output_ptr, in, 10, argument_data[0].field(), pad, 0);
           output_ptr = strend(output_ptr);
         } break;
 
         case 'B':  // integer 64, pad padchar
         case 'b': {
           char pad = '0';
-          if (argument_data[1].data[0] != -1) {
+          if (argument_data[1].field() != -1) {
             pad = argument_data[1].data[0];
           }
           u64 in = arg_regs[arg_reg_idx++];
-          kitoa(output_ptr, in, 2, argument_data[0].data[0], pad, 0);
+          kitoa(output_ptr, in, 2, argument_data[0].field(), pad, 0);
           output_ptr = strend(output_ptr);
         } break;
 

--- a/game/main.cpp
+++ b/game/main.cpp
@@ -5,6 +5,8 @@
 
 #define STBI_WINDOWS_UTF8
 
+#include <clocale>
+#include <cstdio>
 #include <string>
 
 #include "runtime.h"
@@ -22,6 +24,16 @@
 #include "graphics/gfx_test.h"
 
 #include "third-party/CLI11.hpp"
+
+#if defined(__SWITCH__)
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_main(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
 
 #ifdef _WIN32
 extern "C" {
@@ -45,6 +57,13 @@ void setup_logging(const std::string& game_name, bool verbose, bool disable_ansi
     lg::set_stdout_level(lg::level::info);
     lg::set_flush_level(lg::level::warn);
   }
+#if defined(__SWITCH__)
+  // Confirmed via boot-order tracing: the very first vprintf(stdout)/fflush(stdout) issued from a
+  // background SystemThread (the EE thread's first Msg() call in InitParms) hangs indefinitely on
+  // this platform, even though the same calls succeed fine from the main thread earlier in boot.
+  // The kernel runs almost entirely off the EE thread from here on, so keep logging file-only.
+  lg::set_stdout_level(lg::level::off);
+#endif
   if (disable_ansi_colors) {
     lg::disable_ansi_colors();
   }
@@ -87,7 +106,29 @@ std::string game_arg_documentation() {
  * Entry point for the game.
  */
 int main(int argc, char** argv) {
+#if defined(__SWITCH__)
+  boot_log_main("[main] entered\n");
+  // newlib resolves the locale's __mbtowc through the reent struct when formatting; on this
+  // toolchain it reads back null until the locale is set explicitly, and every raw printf() in
+  // the kernel/overlord layers then branches through a null pointer inside _svfiprintf_r.
+  setlocale(LC_ALL, "C");
+  boot_log_main("[main] locale initialized\n");
+  // Confirmed via boot-order tracing: real stdout hangs indefinitely on the first write/flush
+  // issued from any thread other than main (see setup_logging()'s lg::set_stdout_level(off) for
+  // the lg:: side of this). Plenty of code throughout the kernel/overlord/sce layers still calls
+  // raw printf()/fprintf(stdout, ...) directly though, bypassing lg:: entirely -- redirecting the
+  // actual FILE* stdout points at to a plain SD card file up front fixes all of those call sites
+  // in one place instead of hunting each one down.
+  freopen("sdmc:/gk_stdout.txt", "w", stdout);
+  // Fully-buffered by default since it's a file now, and abort() (which every failed ASSERT
+  // ends in) doesn't flush -- which is exactly how the message explaining a crash gets lost.
+  setvbuf(stdout, nullptr, _IONBF, 0);
+  boot_log_main("[main] stdout redirected to sdmc:/gk_stdout.txt\n");
+#endif
   ArgumentGuard u8_guard(argc, argv);
+#if defined(__SWITCH__)
+  boot_log_main("[main] ArgumentGuard constructed\n");
+#endif
 
   // CLI flags
   bool show_version = false;
@@ -105,6 +146,20 @@ int main(int argc, char** argv) {
   fs::path project_path_override;
   fs::path user_config_dir_override;
   std::vector<std::string> game_args;
+#if defined(__SWITCH__)
+  // CLI11 is skipped entirely on Switch (see below), which normally supplies these via
+  // `-- -boot -fakeiso -debug` (see Taskfile.yml's boot-game task, and kmachine.cpp's
+  // -fakeiso/-boot handling) -- without them the kernel never actually boots into the game.
+  // -debug is deliberately omitted: it sets MasterDebug, which makes InitMachine() call
+  // InitGoalProto() to open a DECI2 handshake expecting a real goalc REPL to connect -- nothing
+  // will ever connect to a standalone .nro, so that stalls boot forever.
+  game_args = {"-boot", "-fakeiso"};
+#endif
+#if !defined(__SWITCH__)
+  // Switch homebrew has no meaningful command line -- it's launched from a menu, not a shell --
+  // so there's nothing for CLI11 to parse here. The variables above already carry the right
+  // defaults for that case, so just skip the whole CLI11 app entirely rather than feeding it an
+  // effectively-empty argv.
   CLI::App app{"OpenGOAL Game Runtime"};
   app.add_flag("--version", show_version, "Display the built revision");
   app.add_option("-g,--game", game_name, "The game name: 'jak1' or 'jak2'");
@@ -137,9 +192,16 @@ int main(int argc, char** argv) {
   define_common_cli_arguments(app);
   app.allow_extras();
   CLI11_PARSE(app, argc, argv);
+#else
+  bool _cli_flag_disable_ansi = false;
+  boot_log_main("[main] CLI11 skipped on Switch\n");
+#endif
 
   // Log the version the game is compiled against so we don't have to guess
   lg::info("Compiled Version: {}", build_revision());
+#if defined(__SWITCH__)
+  boot_log_main("[main] lg::info(Compiled Version) done\n");
+#endif
 
   // Override the user's config dir, potentially (either because it was explicitly provided
   // or because it's portable mode)
@@ -180,7 +242,13 @@ int main(int argc, char** argv) {
 
   // Figure out if the CPU has AVX2 to enable higher performance AVX2 versions of functions.
   setup_cpu_info();
-  // If the CPU doesn't have AVX, GOAL code won't work and we exit.
+#if defined(__SWITCH__)
+  boot_log_main("[main] setup_cpu_info done\n");
+#endif
+  // If the CPU doesn't have AVX, GOAL code won't work and we exit -- except on Switch, where (as
+  // with Apple Silicon) SIMD goes through sse2neon.h's translation layer instead of real AVX, so
+  // the presence of hardware AVX was never the right thing to gate on here in the first place.
+#if !defined(__SWITCH__)
   if (!get_cpu_info().has_avx) {
 // Check if we are on a modern enough version of macOS so that AVX can be
 // emulated via rosetta
@@ -203,6 +271,7 @@ int main(int argc, char** argv) {
     return -1;
 #endif
   }
+#endif  // !defined(__SWITCH__)
 
   // set up file paths for resources. This is the full repository when developing, and the data
   // directory (a subset of the full repo) in release versions
@@ -266,6 +335,9 @@ int main(int argc, char** argv) {
     lg::info("OpenGOAL Runtime {}.{}", versions::GOAL_VERSION_MAJOR, versions::GOAL_VERSION_MINOR);
     try {
       MasterExit = RuntimeExitStatus::RUNNING;
+#if defined(__SWITCH__)
+      boot_log_main("[main] about to call exec_runtime\n");
+#endif
       auto exit_status = exec_runtime(game_options, arg_ptrs.size(), arg_ptrs.data());
       switch (exit_status) {
         case RuntimeExitStatus::EXIT:

--- a/game/overlord/jak1/iso.cpp
+++ b/game/overlord/jak1/iso.cpp
@@ -23,6 +23,16 @@
 #include "game/overlord/jak1/dma.h"
 #include "game/overlord/jak1/fake_iso.h"
 #include "game/overlord/jak1/srpc.h"
+
+#if defined(__SWITCH__)
+#include <fcntl.h>
+#include <unistd.h>
+#include "game/switch/boot_log.h"
+
+static void boot_log_iso(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
 #include "game/runtime.h"
 #include "game/sce/iop.h"
 #include "game/sound/sdshim.h"
@@ -116,6 +126,31 @@ u32 InitISOFS(const char* fs_mode, const char* loading_screen) {
 
   // ADDED
   isofs = &fake_iso;
+#if defined(__SWITCH__)
+  {
+    // One-shot audit: FS_PollDrive reads back null at the ISOThread call site even though
+    // fake_iso_init_globals() provably stores it, so check whether any other entry is missing too.
+    const void* const slots[] = {
+        (const void*)isofs->init,       (const void*)isofs->find,
+        (const void*)isofs->find_in,    (const void*)isofs->get_length,
+        (const void*)isofs->open,       (const void*)isofs->open_wad,
+        (const void*)isofs->close,      (const void*)isofs->begin_read,
+        (const void*)isofs->sync_read,  (const void*)isofs->load_sound_bank,
+        (const void*)isofs->load_music, (const void*)isofs->poll_drive};
+    static const char* const names[] = {"init",      "find",      "find_in",   "get_length",
+                                        "open",      "open_wad",  "close",     "begin_read",
+                                        "sync_read", "load_sbank", "load_music", "poll_drive"};
+    char buf[192];
+    snprintf(buf, sizeof(buf), "[InitISOFS] isofs=%p fake_iso=%p\n", (void*)isofs,
+             (void*)&fake_iso);
+    boot_log_iso(buf);
+    for (int i = 0; i < 12; i++) {
+      snprintf(buf, sizeof(buf), "[InitISOFS] %s = %p%s\n", names[i], slots[i],
+               slots[i] ? "" : "  <-- NULL");
+      boot_log_iso(buf);
+    }
+  }
+#endif
   (void)fs_mode;  // ignore user's request.
   // always pick fake_iso because the others are not useful.
   // END ADDED
@@ -325,8 +360,22 @@ void* RPC_DGO(unsigned int fno, void* _cmd, int y) {
  * heap, and is the only way to make sure that the entire heap can be filled.
  */
 void LoadDGO(RPC_Dgo_Cmd* cmd) {
+#if defined(__SWITCH__)
+  {
+    char buf[96];
+    snprintf(buf, sizeof(buf), "[LoadDGO] entered, name=%s\n", cmd->name);
+    boot_log_iso(buf);
+  }
+#endif
   // Find the file
   FileRecord* fr = isofs->find(cmd->name);
+#if defined(__SWITCH__)
+  {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "[LoadDGO] isofs->find done, fr=%p\n", (void*)fr);
+    boot_log_iso(buf);
+  }
+#endif
   if (!fr) {
     cmd->result = DGO_RPC_RESULT_ERROR;
     return;
@@ -348,12 +397,21 @@ void LoadDGO(RPC_Dgo_Cmd* cmd) {
 
   // printf("LOAD DGO -- 0x%x\n", cmd->buffer1);
 
+#if defined(__SWITCH__)
+  boot_log_iso("[LoadDGO] about to SendMbx(iso_mbx)\n");
+#endif
   // send the command to ISO Thread
   SendMbx(iso_mbx, &sLoadDGO);
+#if defined(__SWITCH__)
+  boot_log_iso("[LoadDGO] SendMbx done, about to WaitMbx(dgo_mbx)\n");
+#endif
 
   // wait for the ReturnMessage in the DGO callback state machine.
   // this happens when the first file is loaded
   WaitMbx(dgo_mbx);
+#if defined(__SWITCH__)
+  boot_log_iso("[LoadDGO] WaitMbx(dgo_mbx) returned\n");
+#endif
 
   if (sLoadDGO.status == CMD_STATUS_IN_PROGRESS) {
     // we got one, but there's more to load.

--- a/game/runtime.cpp
+++ b/game/runtime.cpp
@@ -19,6 +19,17 @@
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+#elif defined(__SWITCH__)
+// See CodeTester.h -- avoids a struct-u128 vs typedef-u128 collision with libnx. Also rename
+// libnx's own (unrelated) Semaphore OS-primitive type, which collides with game/system's own
+// PS2 IOP-kernel emulation struct of the same name.
+#define u128 nx_u128
+#define Semaphore nx_Semaphore
+#include <switch.h>
+#undef u128
+#undef Semaphore
+#include <fcntl.h>
+#include <unistd.h>
 #endif
 
 #include <chrono>
@@ -92,6 +103,19 @@
 
 u8* g_ee_main_mem = nullptr;
 u8* g_ee_main_mem_exec = nullptr;
+#if defined(__SWITCH__)
+static Jit g_ee_jit;
+// Diagnostic-only: lg:: logging isn't visibly routed anywhere reachable from the host while
+// bringing up the Switch port, so boot-order issues get traced via a plain SD card text file
+// instead (same technique switch_jit_test.cpp used successfully). Raw open/write/close rather
+// than stdio, since these calls run from freshly spawned SystemThreads and we want to rule out
+// stdio-buffering/reentrancy as a variable while diagnosing why nothing was showing up here.
+#include "game/switch/boot_log.h"
+
+static void boot_log(const char* msg) {
+  switch_boot_log(msg);
+}
+#endif
 std::thread::id g_main_thread_id = std::thread::id();
 GameVersion g_game_version = GameVersion::Jak1;
 BackgroundWorker g_background_worker;
@@ -152,10 +176,17 @@ void deci2_runner(SystemThreadInterface& iface) {
  * SystemThread Function for the EE (PS2 Main CPU)
  */
 void ee_runner(SystemThreadInterface& iface) {
+#if defined(__SWITCH__)
+  boot_log("[ee_runner] start\n");
+#endif
   prof().root_event();
   // Allocate Main RAM. Must have execute enabled.
   // Apple Silicon uses separate writable and executable mappings for EE memory.
+  // EE_MEM_LOW_MAP is a constexpr false (see common/goal_constants.h) -- this whole branch is
+  // dead at runtime everywhere, but a regular `if` (unlike `if constexpr`) still requires both
+  // branches to type-check, and MAP_32BIT/mmap don't exist on Switch at all.
   if (EE_MEM_LOW_MAP) {
+#if !defined(__SWITCH__)
     g_ee_main_mem =
         (u8*)mmap((void*)0x10000000, EE_MAIN_MEM_SIZE, PROT_EXEC | PROT_READ | PROT_WRITE,
 #ifdef __APPLE__
@@ -164,8 +195,43 @@ void ee_runner(SystemThreadInterface& iface) {
 #else
                   MAP_ANONYMOUS | MAP_32BIT | MAP_PRIVATE | MAP_POPULATE, 0, 0);
 #endif
+#endif
   } else {
-#if defined(__APPLE__) && defined(__aarch64__)
+#if defined(__SWITCH__)
+    // Horizon enforces W^X like Apple Silicon's hardened runtime, so this needs the same
+    // separate-writable/executable-view treatment as the __APPLE__ && __aarch64__ case below --
+    // just via libnx's Jit instead of mach_vm_remap. When the homebrew loader hints the newer
+    // CodeMemory syscalls (any current Atmosphere/hbmenu setup), libnx maps both views
+    // permanently and simultaneously at jitCreate time; jitTransitionTo* then just do cache
+    // maintenance (armDCacheFlush/armICacheInvalidate), not permission changes -- confirmed by
+    // reading libnx's actual jit.c, not assumed.
+    boot_log("[ee_runner] calling jitCreate\n");
+    Result rc = jitCreate(&g_ee_jit, EE_MAIN_MEM_SIZE);
+    {
+      char buf[64];
+      snprintf(buf, sizeof(buf), "[ee_runner] jitCreate rc=0x%x\n", rc);
+      boot_log(buf);
+    }
+    if (R_FAILED(rc)) {
+      // Without EE main memory nothing downstream can run safely -- the other worker threads
+      // (IOP/deci/ee-worker) are already started by the time we get here and don't check for
+      // this failure before touching g_ee_main_mem, so silently returning here (the pre-existing
+      // behavior, matching the equally-unhandled mmap failure path on desktop below) leaves them
+      // racing to dereference a null pointer instead of surfacing the real error.
+      boot_log("[ee_runner] FATAL: jitCreate failed, aborting\n");
+      iface.initialization_complete();
+      abort();
+    }
+    jitTransitionToWritable(&g_ee_jit);
+    g_ee_main_mem = (u8*)jitGetRwAddr(&g_ee_jit);
+    g_ee_main_mem_exec = (u8*)jitGetRxAddr(&g_ee_jit);
+    {
+      char buf[96];
+      snprintf(buf, sizeof(buf), "[ee_runner] rw=%p rx=%p\n", (void*)g_ee_main_mem,
+               (void*)g_ee_main_mem_exec);
+      boot_log(buf);
+    }
+#elif defined(__APPLE__) && defined(__aarch64__)
     // mach_vm_remap needs an anonymous writable mapping
     g_ee_main_mem = (u8*)mmap((void*)EE_MAIN_MEM_MAP, EE_MAIN_MEM_SIZE, PROT_READ | PROT_WRITE,
                               MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
@@ -176,6 +242,7 @@ void ee_runner(SystemThreadInterface& iface) {
 #endif
   }
 
+#if !defined(__SWITCH__)
   if (g_ee_main_mem == (u8*)(-1)) {
     lg::debug("Failed to initialize main memory! {}", strerror(errno));
     iface.initialization_complete();
@@ -183,6 +250,7 @@ void ee_runner(SystemThreadInterface& iface) {
   }
 
   g_ee_main_mem_exec = g_ee_main_mem;
+#endif
 
 #if defined(__APPLE__) && defined(__aarch64__)
   // map the same pages again with read and execute access
@@ -219,12 +287,32 @@ void ee_runner(SystemThreadInterface& iface) {
   iface.initialization_complete();
 
   lg::debug("[EE] Run!");
+#if defined(__SWITCH__)
+  boot_log("[ee_runner] about to memset 128MB\n");
+#endif
   memset((void*)g_ee_main_mem, 0, EE_MAIN_MEM_SIZE);
+#if defined(__SWITCH__)
+  boot_log("[ee_runner] memset done\n");
+#endif
 
+#if !defined(__SWITCH__)
   // prevent access to the first 512 kB of memory.
   // On the PS2 this is the kernel and can't be accessed either.
   // this may not work well on systems with a page size > 1 MB.
+  // libnx's Jit maps the whole region with one permission each side; it doesn't support
+  // splitting off a sub-region, so this safety net (catches a null-ish GOAL pointer bug by
+  // faulting) is just unavailable on Switch, not replicated another way.
   mprotect((void*)g_ee_main_mem, EE_MAIN_MEM_LOW_PROTECT, PROT_NONE);
+#endif
+
+#if defined(__SWITCH__)
+  // Flush the zeroed region and make the RX view current before anything can run from it.
+  // TODO(switch): this needs to run again after every GOAL object-file load, not just here at
+  // startup -- otherwise newly-linked code loaded mid-game may execute stale/uninvalidated
+  // icache contents. Not yet wired into the kernel's object loader; unverified against real
+  // gameplay since nothing has been able to run this far yet.
+  jitTransitionToExecutable(&g_ee_jit);
+#endif
   fileio_init_globals();
   jak1::kboot_init_globals();
   jak2::kboot_init_globals();
@@ -291,6 +379,9 @@ void ee_runner(SystemThreadInterface& iface) {
  * be non-blocking)
  */
 void ee_worker_runner(SystemThreadInterface& iface) {
+#if defined(__SWITCH__)
+  boot_log("[ee_worker_runner] start\n");
+#endif
   iface.initialization_complete();
   while (!iface.get_want_exit()) {
     const auto queues_weres_empty = !g_background_worker.process_queues();
@@ -304,9 +395,15 @@ void ee_worker_runner(SystemThreadInterface& iface) {
  * SystemThread function for running the IOP (separate I/O Processor)
  */
 void iop_runner(SystemThreadInterface& iface, GameVersion version) {
+#if defined(__SWITCH__)
+  boot_log("[iop_runner] start\n");
+#endif
   prof().root_event();
   prof().begin_event("iop-init");
   IOP iop;
+#if defined(__SWITCH__)
+  boot_log("[iop_runner] IOP constructed\n");
+#endif
   lg::debug("[IOP] Restart!");
   iop.reset_allocator();
   ee::LIBRARY_sceSif_register(&iop);
@@ -418,6 +515,9 @@ void null_runner(SystemThreadInterface& iface) {
  * GOAL kernel arguments are currently ignored.
  */
 RuntimeExitStatus exec_runtime(GameLaunchOptions game_options, int argc, const char** argv) {
+#if defined(__SWITCH__)
+  boot_log("[exec_runtime] start (main thread)\n");
+#endif
   prof().root_event();
   g_argc = argc;
   g_argv = argv;
@@ -441,6 +541,9 @@ RuntimeExitStatus exec_runtime(GameLaunchOptions game_options, int argc, const c
     if (enable_display) {
       Gfx::Init(g_game_version);
     }
+#if defined(__SWITCH__)
+    boot_log("[exec_runtime] Gfx::Init done\n");
+#endif
   }
 
   // step 1: sce library prep
@@ -514,7 +617,11 @@ RuntimeExitStatus exec_runtime(GameLaunchOptions game_options, int argc, const c
     Gfx::Exit();
   }
   lg::info("GOAL Runtime Shutdown (code {})", fmt::underlying(MasterExit));
+#if defined(__SWITCH__)
+  jitClose(&g_ee_jit);
+#else
   munmap(g_ee_main_mem, EE_MAIN_MEM_SIZE);
+#endif
   Discord_Shutdown();
   return MasterExit;
 }

--- a/game/settings/settings.h
+++ b/game/settings/settings.h
@@ -3,7 +3,11 @@
 #include "common/util/FileUtil.h"
 #include "common/util/json_util.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/sdl3_compat.h"
+#else
 #include "SDL3/SDL.h"
+#endif
 #include "game/system/hid/input_bindings.h"
 #include "game/system/hid/sdl_util.h"
 #include "game/tools/filter_menu/filter_menu.h"

--- a/game/sound/989snd/player.h
+++ b/game/sound/989snd/player.h
@@ -18,7 +18,12 @@
 #include "../common/synth.h"
 #include "game/sound/989snd/vagvoice.h"
 
+#if defined(__SWITCH__)
+// cubeb has no backend compiled in for Switch; see cubeb_shim.h.
+#include "game/switch/cubeb_shim.h"
+#else
 #include "third-party/cubeb/cubeb/include/cubeb/cubeb.h"
+#endif
 
 namespace snd {
 

--- a/game/switch/boot_log.h
+++ b/game/switch/boot_log.h
@@ -1,0 +1,44 @@
+#pragma once
+
+/*!
+ * @file boot_log.h
+ * Shared SD-card trace sink for the Switch port.
+ *
+ * Each translation unit used to open/write/close sdmc:/gk_boot_log.txt per message. newlib's
+ * fsdev layer isn't thread-safe, and the EE/IOP/DECI/main threads all trace concurrently, so
+ * that raced its internal state; it also cost three emulated fsp-srv round-trips per line.
+ * One fd, opened once, guarded by a mutex.
+ *
+ * Tracing is boot-only. Several of these call sites live in the renderer and would otherwise
+ * run every frame, doing guest file I/O from the render thread -- which is where the printf
+ * path was faulting once the game loop started. switch_boot_log_finish() latches it off.
+ */
+
+#include <atomic>
+#include <fcntl.h>
+#include <mutex>
+#include <string.h>
+#include <unistd.h>
+
+inline std::atomic<bool>& switch_boot_log_active() {
+  static std::atomic<bool> active{true};
+  return active;
+}
+
+inline void switch_boot_log(const char* msg) {
+  if (!switch_boot_log_active().load(std::memory_order_relaxed)) {
+    return;
+  }
+  static std::mutex mtx;
+  std::lock_guard<std::mutex> lock(mtx);
+  static int fd = open("sdmc:/gk_boot_log.txt", O_WRONLY | O_CREAT | O_APPEND, 0644);
+  if (fd >= 0) {
+    write(fd, msg, strlen(msg));
+    fsync(fd);
+  }
+}
+
+inline void switch_boot_log_finish() {
+  switch_boot_log("[boot_log] boot complete, tracing disabled\n");
+  switch_boot_log_active().store(false, std::memory_order_relaxed);
+}

--- a/game/switch/cubeb_shim.h
+++ b/game/switch/cubeb_shim.h
@@ -1,0 +1,159 @@
+#pragma once
+
+/*!
+ * @file cubeb_shim.h
+ * Minimal cubeb API over SDL2 audio, for the Switch build.
+ *
+ * cubeb is cross-compiled here with no backend at all (USE_ALSA/USE_PULSE/USE_WASAPI/... are all
+ * empty in the Switch CMake cache), so cubeb_init() fails and 989snd never gets an output stream --
+ * the port has simply been silent. devkitPro's SDL2 does have a working Switch audio backend
+ * (audout), and 989snd only touches seven cubeb entry points with a single stereo S16LE 48kHz
+ * stream, so wrapping SDL2 is far less work than writing a real cubeb backend.
+ *
+ * Everything is static inline on purpose: the definitions live only in the one translation unit
+ * that uses them (989snd/player.cpp), so there is nothing for the still-linked but backend-less
+ * libcubeb.a to collide with.
+ */
+
+#include <SDL2/SDL.h>
+
+#include <cstdint>
+#include <cstring>
+
+#define CUBEB_OK 0
+#define CUBEB_ERROR (-1)
+#define CUBEB_STREAM_PREF_NONE 0
+
+typedef struct cubeb cubeb;
+typedef void* cubeb_devid;
+
+enum cubeb_sample_format { CUBEB_SAMPLE_S16LE };
+enum cubeb_channel_layout { CUBEB_LAYOUT_STEREO };
+enum cubeb_state { CUBEB_STATE_STARTED, CUBEB_STATE_STOPPED, CUBEB_STATE_DRAINED, CUBEB_STATE_ERROR };
+
+struct cubeb_stream_params {
+  cubeb_sample_format format;
+  uint32_t rate;
+  uint32_t channels;
+  cubeb_channel_layout layout;
+  uint32_t prefs;
+};
+
+struct cubeb_stream;
+typedef long (*cubeb_data_callback)(cubeb_stream* stream,
+                                    void* user_ptr,
+                                    const void* input_buffer,
+                                    void* output_buffer,
+                                    long nframes);
+typedef void (*cubeb_state_callback)(cubeb_stream* stream, void* user_ptr, cubeb_state state);
+
+struct cubeb_stream {
+  SDL_AudioDeviceID device{0};
+  cubeb_data_callback data_cb{nullptr};
+  cubeb_state_callback state_cb{nullptr};
+  void* user{nullptr};
+  int bytes_per_frame{4};
+};
+
+static inline void sdl_shim_audio_callback(void* userdata, Uint8* stream, int len) {
+  auto* s = static_cast<cubeb_stream*>(userdata);
+  // 989snd mixes additively into whatever it is handed, so the buffer has to start silent.
+  std::memset(stream, 0, static_cast<size_t>(len));
+  if (s && s->data_cb) {
+    s->data_cb(s, s->user, nullptr, stream, len / s->bytes_per_frame);
+  }
+}
+
+static inline int cubeb_init(cubeb** context, const char* /*name*/, const char* /*backend*/) {
+  if (SDL_InitSubSystem(SDL_INIT_AUDIO) != 0) {
+    return CUBEB_ERROR;
+  }
+  // No per-context state is needed; a non-null sentinel keeps the caller's null checks meaningful.
+  *context = reinterpret_cast<cubeb*>(1);
+  return CUBEB_OK;
+}
+
+static inline int cubeb_get_min_latency(cubeb* /*context*/,
+                                        cubeb_stream_params* /*params*/,
+                                        uint32_t* latency_frames) {
+  // SDL picks the real buffer size when the device opens; this is only a hint upstream.
+  *latency_frames = 1024;
+  return CUBEB_OK;
+}
+
+static inline int cubeb_stream_init(cubeb* /*context*/,
+                                    cubeb_stream** stream,
+                                    const char* /*stream_name*/,
+                                    cubeb_devid /*input_device*/,
+                                    cubeb_stream_params* /*input_params*/,
+                                    cubeb_devid /*output_device*/,
+                                    cubeb_stream_params* output_params,
+                                    unsigned int latency_frames,
+                                    cubeb_data_callback data_callback,
+                                    cubeb_state_callback state_callback,
+                                    void* user_ptr) {
+  if (!output_params) {
+    return CUBEB_ERROR;
+  }
+  auto* s = new cubeb_stream();
+  s->data_cb = data_callback;
+  s->state_cb = state_callback;
+  s->user = user_ptr;
+  s->bytes_per_frame = static_cast<int>(output_params->channels) * 2;  // S16 == 2 bytes/sample
+
+  SDL_AudioSpec want{};
+  want.freq = static_cast<int>(output_params->rate);
+  want.format = AUDIO_S16LSB;
+  want.channels = static_cast<Uint8>(output_params->channels);
+  want.samples = static_cast<Uint16>(latency_frames ? latency_frames : 1024);
+  want.callback = sdl_shim_audio_callback;
+  want.userdata = s;
+
+  SDL_AudioSpec have{};
+  // Allow no conversions: 989snd generates exactly stereo S16LE at its own rate, and letting SDL
+  // silently resample would desync the sequencer from the game's tick.
+  s->device = SDL_OpenAudioDevice(nullptr, 0, &want, &have, 0);
+  if (s->device == 0) {
+    delete s;
+    return CUBEB_ERROR;
+  }
+  s->bytes_per_frame = have.channels * 2;
+  *stream = s;
+  return CUBEB_OK;
+}
+
+static inline int cubeb_stream_start(cubeb_stream* stream) {
+  if (!stream || stream->device == 0) {
+    return CUBEB_ERROR;
+  }
+  SDL_PauseAudioDevice(stream->device, 0);
+  if (stream->state_cb) {
+    stream->state_cb(stream, stream->user, CUBEB_STATE_STARTED);
+  }
+  return CUBEB_OK;
+}
+
+static inline int cubeb_stream_stop(cubeb_stream* stream) {
+  if (!stream || stream->device == 0) {
+    return CUBEB_ERROR;
+  }
+  SDL_PauseAudioDevice(stream->device, 1);
+  if (stream->state_cb) {
+    stream->state_cb(stream, stream->user, CUBEB_STATE_STOPPED);
+  }
+  return CUBEB_OK;
+}
+
+static inline void cubeb_stream_destroy(cubeb_stream* stream) {
+  if (!stream) {
+    return;
+  }
+  if (stream->device != 0) {
+    SDL_CloseAudioDevice(stream->device);
+  }
+  delete stream;
+}
+
+static inline void cubeb_destroy(cubeb* /*context*/) {
+  SDL_QuitSubSystem(SDL_INIT_AUDIO);
+}

--- a/game/switch/discord_rpc_stub.h
+++ b/game/switch/discord_rpc_stub.h
@@ -1,0 +1,61 @@
+#pragma once
+
+/*!
+ * @file discord_rpc_stub.h
+ * Drop-in replacement for third-party/discord-rpc/include/discord_rpc.h on Switch. There is no
+ * Discord client on a Switch (and no possible backend for one), but the game's kmachine.cpp
+ * files across all four titles call directly into this SDK's C API to update rich presence, so
+ * rather than touch every call site this mirrors the real header's public surface with no-op
+ * bodies -- same shape as the xdbg.cpp debugger stub used elsewhere in this port.
+ */
+#include <stdint.h>
+
+typedef struct DiscordRichPresence {
+  const char* state;
+  const char* details;
+  int64_t startTimestamp;
+  int64_t endTimestamp;
+  const char* largeImageKey;
+  const char* largeImageText;
+  const char* smallImageKey;
+  const char* smallImageText;
+  const char* partyId;
+  int partySize;
+  int partyMax;
+  int partyPrivacy;
+  const char* matchSecret;
+  const char* joinSecret;
+  const char* spectateSecret;
+  int8_t instance;
+} DiscordRichPresence;
+
+typedef struct DiscordUser {
+  const char* userId;
+  const char* username;
+  const char* discriminator;
+  const char* avatar;
+} DiscordUser;
+
+typedef struct DiscordEventHandlers {
+  void (*ready)(const DiscordUser* request);
+  void (*disconnected)(int errorCode, const char* message);
+  void (*errored)(int errorCode, const char* message);
+  void (*joinGame)(const char* joinSecret);
+  void (*spectateGame)(const char* spectateSecret);
+  void (*joinRequest)(const DiscordUser* request);
+} DiscordEventHandlers;
+
+#define DISCORD_REPLY_NO 0
+#define DISCORD_REPLY_YES 1
+#define DISCORD_REPLY_IGNORE 2
+#define DISCORD_PARTY_PRIVATE 0
+#define DISCORD_PARTY_PUBLIC 1
+
+inline void Discord_Initialize(const char*, DiscordEventHandlers*, int, const char*) {}
+inline void Discord_Shutdown(void) {}
+inline void Discord_RunCallbacks(void) {}
+inline void Discord_UpdateConnection(void) {}
+inline void Discord_UpdatePresence(const DiscordRichPresence*) {}
+inline void Discord_ClearPresence(void) {}
+inline void Discord_Respond(const char*, int) {}
+inline void Discord_UpdateHandlers(DiscordEventHandlers*) {}

--- a/game/switch/imgui_stub.h
+++ b/game/switch/imgui_stub.h
@@ -1,0 +1,231 @@
+#pragma once
+
+/*!
+ * @file imgui_stub.h
+ * Drop-in replacement for third-party/imgui/imgui.h on Switch. ImGui is dev-only debug UI
+ * tooling woven through ~35 files across game/graphics/ as per-renderer debug windows -- rather
+ * than guard every individual call site, this mirrors the ~58 ImGui:: functions and handful of
+ * types actually used, all as no-ops. Widgets that report "did this change / was this clicked"
+ * always return false; nothing here is ever actually drawn since the real ImGui backend
+ * (imgui_impl_sdl3/imgui_impl_opengl3) is never initialized for Switch (see opengl.cpp).
+ */
+
+#include <cstdint>
+#include <string>
+
+struct ImVec2 {
+  float x = 0, y = 0;
+  ImVec2() = default;
+  ImVec2(float _x, float _y) : x(_x), y(_y) {}
+};
+struct ImVec4 {
+  float x = 0, y = 0, z = 0, w = 0;
+  ImVec4() = default;
+  ImVec4(float _x, float _y, float _z, float _w) : x(_x), y(_y), z(_z), w(_w) {}
+};
+
+struct ImFont {};
+struct ImGuiViewport {
+  ImVec2 Pos;
+  ImVec2 Size;
+  ImVec2 WorkPos;
+  ImVec2 WorkSize;
+};
+struct ImDrawList {
+  void AddRectFilled(const ImVec2&, const ImVec2&, uint32_t, float = 0.0f, int = 0) {}
+};
+struct ImGuiStyle {
+  ImVec4 Colors[64] = {};
+  ImVec2 FramePadding;
+};
+
+using ImTextureID = void*;
+using ImWchar = unsigned short;
+using ImU32 = uint32_t;
+#define IM_COL32(R, G, B, A) \
+  (((ImU32)(A) << 24) | ((ImU32)(B) << 16) | ((ImU32)(G) << 8) | ((ImU32)(R)))
+using ImGuiWindowFlags = int;
+using ImGuiCond = int;
+using ImGuiCol = int;
+using ImGuiInputTextFlags = int;
+using ImGuiSelectableFlags = int;
+using ImGuiTreeNodeFlags = int;
+using ImGuiConfigFlags = int;
+
+// Real imgui uses plain (non-class) C enums named with a trailing underscore, e.g.
+// `ImGuiInputTextFlags_`, whose enumerators are accessible both bare and as
+// `ImGuiInputTextFlags_::ImGuiInputTextFlags_Foo` (C++11 allows qualifying a plain enum's
+// enumerators by its type name) -- game code uses both forms, so these have to be real enums,
+// not macros.
+enum ImGuiWindowFlags_ {
+  ImGuiWindowFlags_AlwaysAutoResize = 0,
+  ImGuiWindowFlags_NoDecoration = 0,
+  ImGuiWindowFlags_NoFocusOnAppearing = 0,
+  ImGuiWindowFlags_NoNav = 0,
+  ImGuiWindowFlags_NoSavedSettings = 0,
+};
+enum ImGuiCond_ { ImGuiCond_Always = 0 };
+enum ImGuiCol_ {
+  ImGuiCol_Text = 0,
+  ImGuiCol_Button = 0,
+  ImGuiCol_Header = 0,
+  ImGuiCol_HeaderActive = 0,
+  ImGuiCol_HeaderHovered = 0,
+  ImGuiCol_MenuBarBg = 0,
+};
+enum ImGuiInputTextFlags_ {
+  ImGuiInputTextFlags_None = 0,
+  ImGuiInputTextFlags_AutoSelectAll = 0,
+  ImGuiInputTextFlags_CharsDecimal = 0,
+  ImGuiInputTextFlags_ReadOnly = 0,
+};
+enum ImGuiSelectableFlags_ { ImGuiSelectableFlags_DontClosePopups = 0 };
+enum ImGuiConfigFlags_ { ImGuiConfigFlags_NoMouseCursorChange = 0 };
+#define IMGUI_CHECKVERSION() ((void)0)
+
+struct ImGuiIO {
+  ImGuiConfigFlags ConfigFlags = 0;
+  const char* IniFilename = nullptr;
+  const char* LogFilename = nullptr;
+  bool WantCaptureKeyboard = false;
+  bool WantCaptureMouse = false;
+};
+
+namespace ImGui {
+inline void CreateContext() {}
+inline void DestroyContext() {}
+inline ImGuiIO& GetIO() {
+  static ImGuiIO io;
+  return io;
+}
+inline ImGuiStyle& GetStyle() {
+  static ImGuiStyle style;
+  return style;
+}
+inline ImVec4 GetStyleColorVec4(ImGuiCol) {
+  return ImVec4(0, 0, 0, 0);
+}
+inline ImGuiViewport* GetMainViewport() {
+  static ImGuiViewport vp;
+  return &vp;
+}
+inline void NewFrame() {}
+inline void Render() {}
+inline void* GetDrawData() {
+  return nullptr;
+}
+
+inline bool Begin(const char*, bool* = nullptr, ImGuiWindowFlags = 0) {
+  return false;
+}
+inline void End() {}
+inline bool BeginMenu(const char*, bool = true) {
+  return false;
+}
+inline void EndMenu() {}
+inline bool BeginCombo(const char*, const char*, int = 0) {
+  return false;
+}
+inline void EndCombo() {}
+inline bool Combo(const char*, int*, const char* const[], int, int = -1) {
+  return false;
+}
+inline bool MenuItem(const char*, const char* = nullptr, bool = false, bool = true) {
+  return false;
+}
+inline bool BeginMainMenuBar() {
+  return false;
+}
+inline void EndMainMenuBar() {}
+inline void BeginDisabled(bool = true) {}
+inline void EndDisabled() {}
+
+inline void Text(const char*, ...) {}
+inline void TextColored(const ImVec4&, const char*, ...) {}
+inline void TextUnformatted(const char*, const char* = nullptr) {}
+inline void TextWrapped(const char*, ...) {}
+inline bool Button(const char*, const ImVec2& = ImVec2(0, 0)) {
+  return false;
+}
+inline bool RadioButton(const char*, bool) {
+  return false;
+}
+inline bool Selectable(const char*, bool = false, ImGuiSelectableFlags = 0,
+                       const ImVec2& = ImVec2(0, 0)) {
+  return false;
+}
+inline bool ListBox(const char*, int*, const char* const[], int, int = -1) {
+  return false;
+}
+inline void Dummy(const ImVec2&) {}
+inline ImVec2 CalcTextSize(const char*, const char* = nullptr, bool = false, float = -1.0f) {
+  return ImVec2(0, 0);
+}
+inline ImDrawList* GetWindowDrawList() {
+  static ImDrawList dl;
+  return &dl;
+}
+inline ImVec2 GetWindowPos() {
+  return ImVec2(0, 0);
+}
+inline bool Checkbox(const char*, bool* v) {
+  (void)v;
+  return false;
+}
+inline bool SliderFloat(const char*, float*, float, float, const char* = "%.3f", int = 0) {
+  return false;
+}
+inline bool InputText(const char*, char*, size_t, ImGuiInputTextFlags = 0, void* = nullptr,
+                      void* = nullptr) {
+  return false;
+}
+inline bool InputText(const char*, std::string*, ImGuiInputTextFlags = 0, void* = nullptr,
+                      void* = nullptr) {
+  return false;
+}
+inline bool InputInt(const char*, int*, int = 1, int = 100, ImGuiInputTextFlags = 0) {
+  return false;
+}
+inline bool InputInt2(const char*, int[2], ImGuiInputTextFlags = 0) {
+  return false;
+}
+inline bool InputFloat(const char*, float*, float = 0.0f, float = 0.0f, const char* = "%.3f",
+                       ImGuiInputTextFlags = 0) {
+  return false;
+}
+inline bool TreeNode(const char*) {
+  return false;
+}
+inline bool TreeNode(const char*, const char*, ...) {
+  return false;
+}
+inline void TreePop() {}
+inline void Image(ImTextureID, const ImVec2&) {}
+inline void PlotLines(const char*, const float*, int, int = 0, const char* = nullptr,
+                      float = 3.40282e+38F, float = 3.40282e+38F, ImVec2 = ImVec2(0, 0)) {}
+inline void PlotLines(const char*, float (*)(void*, int), void*, int, int = 0,
+                      const char* = nullptr, float = 3.40282e+38F, float = 3.40282e+38F,
+                      ImVec2 = ImVec2(0, 0)) {}
+
+inline void SameLine(float = 0.0f, float = -1.0f) {}
+inline void Separator() {}
+inline void NewLine() {}
+inline void PushID(const char*) {}
+inline void PushID(int) {}
+inline void PopID() {}
+inline void PushStyleColor(ImGuiCol, const ImVec4&) {}
+inline void PushStyleColor(ImGuiCol, ImU32) {}
+inline void PopStyleColor(int = 1) {}
+inline void SetItemDefaultFocus() {}
+inline void SetNextWindowPos(const ImVec2&, ImGuiCond = 0, const ImVec2& = ImVec2(0, 0)) {}
+inline void SetNextWindowBgAlpha(float) {}
+inline void SetNextItemOpen(bool, ImGuiCond = 0) {}
+inline bool IsItemHovered(int = 0) {
+  return false;
+}
+
+// jak-project's own style helpers (third-party/imgui/imgui_style.h), not real imgui API.
+inline void applyFontStyle() {}
+inline void applyAlternateStyle() {}
+inline void applyClassicStyle() {}
+}  // namespace ImGui

--- a/game/switch/sdl3_compat.h
+++ b/game/switch/sdl3_compat.h
@@ -1,0 +1,627 @@
+#pragma once
+
+/*!
+ * @file sdl3_compat.h
+ * jak-project's game/ code is written against SDL3's API. devkitPro only ships SDL2 for
+ * Switch (no SDL3 port exists), and the two APIs differ in real ways beyond naming: SDL3
+ * flattened/renamed event fields, added a generic Properties system with no SDL2 equivalent,
+ * and changed several return types from int to bool. This header is NOT a general-purpose
+ * SDL3-on-SDL2 emulation layer -- it covers exactly the ~69 SDL3 calls game/ actually makes,
+ * backed by devkitPro's real SDL2 for everything that maps closely (window/GL context/audio),
+ * with a real translation layer only where the shapes genuinely differ (events, properties).
+ *
+ * Included instead of third-party/SDL/include/SDL3/SDL.h when building for Switch (see the
+ * #if defined(__SWITCH__) branches at each of that header's include sites in game/).
+ */
+
+// Token-rename trick used for libnx's u128 (see CodeTester.h), for the ONE thing here that's
+// genuinely just a type with no linker symbol: SDL_Event. (The functions below that also
+// collide with SDL2 can't use this trick -- renaming a *declaration* doesn't rename what the
+// prebuilt libSDL2.a actually exports, so the linker ends up looking for a symbol like
+// "SDL_Init_real" that doesn't exist anywhere. Those are handled further down by defining a
+// same-behavior wrapper under a distinct name -- which calls the real, correctly-linked
+// function while its true name is still unclaimed -- and only then #define-redirecting the SDL3
+// name to it, so every reference in game/ code (included after this header) resolves to the
+// wrapper without ever renaming anything SDL2 itself exports.)
+#define SDL_Event SDL_Event_real
+#include <SDL2/SDL.h>
+#undef SDL_Event
+
+#include <cstdint>
+#include <cstring>
+
+// ============================================================================================
+// Types SDL3 renamed outright (same shape, different name)
+// ============================================================================================
+using SDL_GUID = SDL_JoystickGUID;                    // both are `{ Uint8 data[16]; }`
+using SDL_Gamepad = SDL_GameController;
+using SDL_GamepadButton = SDL_GameControllerButton;
+using SDL_GamepadAxis = SDL_GameControllerAxis;
+using SDL_GamepadType = SDL_GameControllerType;
+using SDL_DisplayID = int;      // SDL2 identifies displays by plain int index
+using SDL_PropertiesID = Uint64;
+
+// ============================================================================================
+// bool-returning SDL3 functions that were int/SDL_bool-returning in SDL2. SDL2's SDL_bool
+// already converts cleanly to bool in `if (!SDL_SetHint(...))`-style checks, so only the
+// genuinely int-returning ones (0 == success, not "0 == false") need wrapping.
+// ============================================================================================
+inline bool sdl3compat_Init(Uint32 flags) {
+  return SDL_Init(flags) == 0;
+}
+inline bool sdl3compat_InitSubSystem(Uint32 flags) {
+  return SDL_InitSubSystem(flags) == 0;
+}
+inline bool SDL_HideCursor() {
+  return SDL_ShowCursor(SDL_DISABLE) >= 0;
+}
+inline bool sdl3compat_ShowCursor() {
+  return SDL_ShowCursor(SDL_ENABLE) >= 0;
+}
+inline bool sdl3compat_GL_MakeCurrent(SDL_Window* window, SDL_GLContext context) {
+  return SDL_GL_MakeCurrent(window, context) == 0;
+}
+
+// ============================================================================================
+// Gamepad/joystick: SDL3 renamed "GameController" -> "Gamepad" and face buttons from
+// Xbox-letter names (A/B/X/Y) to layout-agnostic ones (SOUTH/EAST/WEST/NORTH). Values match;
+// only the names differ.
+// ============================================================================================
+#define SDL_INIT_GAMEPAD SDL_INIT_GAMECONTROLLER
+#define SDL_OpenGamepad SDL_GameControllerOpen
+#define SDL_CloseGamepad SDL_GameControllerClose
+#define SDL_GetGamepadJoystick SDL_GameControllerGetJoystick
+#define SDL_GetGamepadName SDL_GameControllerName
+#define SDL_GetGamepadType SDL_GameControllerGetType
+#define SDL_IsGamepad SDL_IsGameController
+#define SDL_AddGamepadMappingsFromFile SDL_GameControllerAddMappingsFromFile
+#define SDL_GetGamepadStringForButton SDL_GameControllerGetStringForButton
+#define SDL_GetGamepadStringForAxis SDL_GameControllerGetStringForAxis
+#define SDL_RumbleGamepad SDL_GameControllerRumble
+#define SDL_RumbleGamepadTriggers SDL_GameControllerRumbleTriggers
+#define SDL_SetGamepadLED SDL_GameControllerSetLED
+#define SDL_SendGamepadEffect SDL_GameControllerSendEffect
+
+#define SDL_GAMEPAD_TYPE_PS3 SDL_CONTROLLER_TYPE_PS3
+#define SDL_GAMEPAD_TYPE_PS5 SDL_CONTROLLER_TYPE_PS5
+
+#define SDL_GAMEPAD_BUTTON_INVALID SDL_CONTROLLER_BUTTON_INVALID
+#define SDL_GAMEPAD_BUTTON_COUNT SDL_CONTROLLER_BUTTON_MAX
+#define SDL_GAMEPAD_BUTTON_SOUTH SDL_CONTROLLER_BUTTON_A
+#define SDL_GAMEPAD_BUTTON_EAST SDL_CONTROLLER_BUTTON_B
+#define SDL_GAMEPAD_BUTTON_WEST SDL_CONTROLLER_BUTTON_X
+#define SDL_GAMEPAD_BUTTON_NORTH SDL_CONTROLLER_BUTTON_Y
+#define SDL_GAMEPAD_BUTTON_LEFT_SHOULDER SDL_CONTROLLER_BUTTON_LEFTSHOULDER
+#define SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER SDL_CONTROLLER_BUTTON_RIGHTSHOULDER
+#define SDL_GAMEPAD_BUTTON_DPAD_UP SDL_CONTROLLER_BUTTON_DPAD_UP
+#define SDL_GAMEPAD_BUTTON_DPAD_DOWN SDL_CONTROLLER_BUTTON_DPAD_DOWN
+#define SDL_GAMEPAD_BUTTON_DPAD_LEFT SDL_CONTROLLER_BUTTON_DPAD_LEFT
+#define SDL_GAMEPAD_BUTTON_DPAD_RIGHT SDL_CONTROLLER_BUTTON_DPAD_RIGHT
+#define SDL_GAMEPAD_BUTTON_BACK SDL_CONTROLLER_BUTTON_BACK
+#define SDL_GAMEPAD_BUTTON_START SDL_CONTROLLER_BUTTON_START
+#define SDL_GAMEPAD_BUTTON_LEFT_STICK SDL_CONTROLLER_BUTTON_LEFTSTICK
+#define SDL_GAMEPAD_BUTTON_RIGHT_STICK SDL_CONTROLLER_BUTTON_RIGHTSTICK
+
+#define SDL_GAMEPAD_AXIS_INVALID SDL_CONTROLLER_AXIS_INVALID
+#define SDL_GAMEPAD_AXIS_COUNT SDL_CONTROLLER_AXIS_MAX
+#define SDL_GAMEPAD_AXIS_LEFTX SDL_CONTROLLER_AXIS_LEFTX
+#define SDL_GAMEPAD_AXIS_LEFTY SDL_CONTROLLER_AXIS_LEFTY
+#define SDL_GAMEPAD_AXIS_RIGHTX SDL_CONTROLLER_AXIS_RIGHTX
+#define SDL_GAMEPAD_AXIS_RIGHTY SDL_CONTROLLER_AXIS_RIGHTY
+#define SDL_GAMEPAD_AXIS_LEFT_TRIGGER SDL_CONTROLLER_AXIS_TRIGGERLEFT
+#define SDL_GAMEPAD_AXIS_RIGHT_TRIGGER SDL_CONTROLLER_AXIS_TRIGGERRIGHT
+
+inline int SDL_GetNumJoystickAxes(SDL_Joystick* joy) {
+  return SDL_JoystickNumAxes(joy);
+}
+inline SDL_JoystickID SDL_GetJoystickID(SDL_Joystick* joy) {
+  // SDL3 reserves 0 as "no joystick" and game_controller.cpp rejects a zero instance id, but
+  // SDL2 numbers instance ids from 0 -- so the first pad was always refused. Offset by one here
+  // and in the event `which` fields below so both sides stay consistent.
+  return SDL_JoystickInstanceID(joy) + 1;
+}
+inline SDL_GUID SDL_GetJoystickGUID(SDL_Joystick* joy) {
+  return SDL_JoystickGetGUID(joy);
+}
+inline void SDL_GUIDToString(SDL_GUID guid, char* dst, int dst_size) {
+  SDL_JoystickGetGUIDString(guid, dst, dst_size);
+}
+inline Sint16 SDL_GetJoystickAxis(SDL_Joystick* joy, int axis) {
+  return SDL_JoystickGetAxis(joy, axis);
+}
+
+// SDL3 replaced index-based enumeration (SDL_NumJoysticks + linear index) with an ID array.
+// game/ only ever iterates this once at startup and opens gamepads by index via
+// SDL_OpenGamepad(index) - which, confusingly, SDL3's docs say takes a *joystick instance ID*,
+// but jak-project's own call sites pass the loop index from SDL_GetJoysticks either way, and
+// SDL_GameControllerOpen also wants an index, so returning plain 0..N-1 indices here (not real
+// instance IDs) keeps both call sites internally consistent.
+inline SDL_JoystickID* SDL_GetJoysticks(int* count) {
+  int n = SDL_NumJoysticks();
+  static SDL_JoystickID ids[32];
+  n = n > 32 ? 32 : n;
+  for (int i = 0; i < n; i++) {
+    ids[i] = i;
+  }
+  if (count) {
+    *count = n;
+  }
+  return ids;
+}
+
+// ============================================================================================
+// SDL3's Properties system has no SDL2 equivalent at all. game/ only ever queries three known
+// boolean capability flags on a gamepad, so fake a PropertiesID as the SDL_Gamepad pointer
+// itself and special-case exactly those three string keys against SDL2's individual
+// capability-query functions, instead of building a real generic property store.
+// ============================================================================================
+#define SDL_PROP_GAMEPAD_CAP_RGB_LED_BOOLEAN "sdl3compat.gamepad.cap.rgb_led"
+#define SDL_PROP_GAMEPAD_CAP_RUMBLE_BOOLEAN "sdl3compat.gamepad.cap.rumble"
+#define SDL_PROP_GAMEPAD_CAP_TRIGGER_RUMBLE_BOOLEAN "sdl3compat.gamepad.cap.trigger_rumble"
+
+inline SDL_PropertiesID SDL_GetGamepadProperties(SDL_Gamepad* gamepad) {
+  return reinterpret_cast<SDL_PropertiesID>(gamepad);
+}
+inline bool SDL_GetBooleanProperty(SDL_PropertiesID props, const char* name, bool default_value) {
+  auto* gamepad = reinterpret_cast<SDL_Gamepad*>(props);
+  if (!gamepad) {
+    return default_value;
+  }
+  if (std::strcmp(name, SDL_PROP_GAMEPAD_CAP_RGB_LED_BOOLEAN) == 0) {
+    return SDL_GameControllerHasLED(gamepad);
+  }
+  if (std::strcmp(name, SDL_PROP_GAMEPAD_CAP_RUMBLE_BOOLEAN) == 0) {
+    return SDL_GameControllerHasRumble(gamepad);
+  }
+  if (std::strcmp(name, SDL_PROP_GAMEPAD_CAP_TRIGGER_RUMBLE_BOOLEAN) == 0) {
+    return SDL_GameControllerHasRumbleTriggers(gamepad);
+  }
+  return default_value;
+}
+
+// ============================================================================================
+// Mouse: SDL3 uses float coordinates and a per-window relative-mouse-mode call; SDL2 uses int
+// coordinates and a single global relative-mouse-mode call.
+// ============================================================================================
+inline Uint32 SDL_GetMouseState(float* x, float* y) {
+  int ix = 0, iy = 0;
+  Uint32 state = SDL_GetMouseState(&ix, &iy);
+  if (x) {
+    *x = static_cast<float>(ix);
+  }
+  if (y) {
+    *y = static_cast<float>(iy);
+  }
+  return state;
+}
+inline Uint32 SDL_GetRelativeMouseState(float* x, float* y) {
+  int ix = 0, iy = 0;
+  Uint32 state = SDL_GetRelativeMouseState(&ix, &iy);
+  if (x) {
+    *x = static_cast<float>(ix);
+  }
+  if (y) {
+    *y = static_cast<float>(iy);
+  }
+  return state;
+}
+inline bool SDL_SetWindowRelativeMouseMode(SDL_Window* window, bool enabled) {
+  (void)window;
+  return SDL_SetRelativeMouseMode(enabled ? SDL_TRUE : SDL_FALSE) == 0;
+}
+#define SDL_BUTTON_MASK SDL_BUTTON
+#define SDL_KMOD_SHIFT KMOD_SHIFT
+#define SDL_KMOD_CTRL KMOD_CTRL
+#define SDL_KMOD_ALT KMOD_ALT
+#define SDL_KMOD_GUI KMOD_GUI
+
+// SDL3's keycodes for printable characters are real Unicode codepoints, so shifted/uppercase
+// letters are distinct constants from their lowercase SDLK_x (unlike SDL2, which only has
+// lowercase). ASCII value == codepoint here, so these can just be the literal characters.
+#define SDLK_A 'A'
+#define SDLK_D 'D'
+#define SDLK_E 'E'
+#define SDLK_F 'F'
+#define SDLK_I 'I'
+#define SDLK_J 'J'
+#define SDLK_K 'K'
+#define SDLK_L 'L'
+#define SDLK_O 'O'
+#define SDLK_P 'P'
+#define SDLK_Q 'Q'
+#define SDLK_R 'R'
+#define SDLK_S 'S'
+#define SDLK_W 'W'
+#define SDLK_APOSTROPHE SDLK_QUOTE
+
+// Hints are just string constants; define any this SDL2 build doesn't already have as harmless
+// no-op fallbacks (the corresponding hidapi/background-events behavior they'd toggle either
+// isn't relevant on Switch or is already SDL2's default).
+#ifndef SDL_HINT_JOYSTICK_HIDAPI_PS3_SIXAXIS_DRIVER
+#define SDL_HINT_JOYSTICK_HIDAPI_PS3_SIXAXIS_DRIVER "SDL_JOYSTICK_HIDAPI_PS3_SIXAXIS_DRIVER"
+#endif
+#ifndef SDL_HINT_JOYSTICK_HIDAPI_PS3
+#define SDL_HINT_JOYSTICK_HIDAPI_PS3 "SDL_JOYSTICK_HIDAPI_PS3"
+#endif
+#ifndef SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS
+#define SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS "SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS"
+#endif
+#ifndef SDL_HINT_NO_SIGNAL_HANDLERS
+#define SDL_HINT_NO_SIGNAL_HANDLERS "SDL_NO_SIGNAL_HANDLERS"
+#endif
+
+// SDL2's SDL_GetScancodeFromKey doesn't take a modstate out-param; game/ only ever discards it.
+inline SDL_Scancode SDL_GetScancodeFromKey(SDL_Keycode key, SDL_Keymod* /*out_mod*/) {
+  return SDL_GetScancodeFromKey(key);
+}
+
+// ============================================================================================
+// Window / display. Switch has exactly one fixed display, no repositioning, no multi-monitor
+// enumeration -- these are honest single-display implementations, not faithful ports of SDL3's
+// multi-monitor API.
+// ============================================================================================
+#define SDL_WINDOW_HIGH_PIXEL_DENSITY 0
+
+inline SDL_Window* SDL_CreateWindow(const char* title, int w, int h, Uint32 flags) {
+  return SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, w, h, flags);
+}
+inline float SDL_GetWindowDisplayScale(SDL_Window* /*window*/) {
+  return 1.0f;
+}
+inline void SDL_GetWindowSizeInPixels(SDL_Window* window, int* w, int* h) {
+  SDL_GL_GetDrawableSize(window, w, h);
+}
+inline bool sdl3compat_SetWindowFullscreen(SDL_Window* window, bool fullscreen) {
+  return SDL_SetWindowFullscreen(window, fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0) == 0;
+}
+inline bool SDL_SetWindowFullscreenMode(SDL_Window* /*window*/, const SDL_DisplayMode* /*mode*/) {
+  return true;  // Switch has one fixed mode; nothing to switch to.
+}
+inline bool SDL_SyncWindow(SDL_Window* /*window*/) {
+  return true;
+}
+// SDL3 treats display ID 0 as "invalid"; real IDs start at 1. Returning 0 here made
+// display_manager's "could not retrieve current window's sdl display id" path fire and left the
+// display list empty. Every display function below ignores the ID anyway -- there is one display.
+inline SDL_DisplayID SDL_GetDisplayForWindow(SDL_Window* /*window*/) {
+  return 1;
+}
+inline SDL_DisplayID* SDL_GetDisplays(int* count) {
+  static SDL_DisplayID id = 1;
+  if (count) {
+    *count = 1;
+  }
+  return &id;
+}
+// Query SDL2 for the real display size rather than hardcoding. Citron reports a 1920x1080
+// drawable in docked mode and 1280x720 in handheld; hardcoding one of them made the display
+// manager's resolution list disagree with the actual framebuffer, so the game sized its render
+// target for a display it wasn't drawing to. SDL2's overload takes (int, SDL_DisplayMode*), so
+// it resolves separately from these SDL3-shaped shims.
+inline const SDL_DisplayMode* sdl3compat_RealDisplayMode() {
+  static SDL_DisplayMode mode{};
+  static bool init = false;
+  if (!init) {
+    init = true;
+    SDL_DisplayMode real{};
+    if (SDL_GetDesktopDisplayMode(0, &real) == 0 && real.w > 0 && real.h > 0) {
+      mode = real;
+    } else {
+      mode.w = 1280;
+      mode.h = 720;
+    }
+    if (mode.refresh_rate <= 0) {
+      mode.refresh_rate = 60;
+    }
+  }
+  return &mode;
+}
+inline bool sdl3compat_GetDisplayBounds(SDL_DisplayID /*display*/, SDL_Rect* rect) {
+  if (rect) {
+    const auto* m = sdl3compat_RealDisplayMode();
+    *rect = SDL_Rect{0, 0, m->w, m->h};
+  }
+  return true;
+}
+inline const SDL_DisplayMode* SDL_GetCurrentDisplayMode(SDL_DisplayID /*display*/) {
+  return sdl3compat_RealDisplayMode();
+}
+inline const SDL_DisplayMode* SDL_GetDesktopDisplayMode(SDL_DisplayID display) {
+  return SDL_GetCurrentDisplayMode(display);
+}
+inline SDL_DisplayMode** SDL_GetFullscreenDisplayModes(SDL_DisplayID /*display*/, int* count) {
+  // An empty list left display_manager with no supported resolutions, so the window size
+  // resolved to 0,0. Report the one mode the display actually presents; the refresh rate has to
+  // match SDL_GetCurrentDisplayMode's or display_manager files it as windowed-only.
+  static SDL_DisplayMode* modes[] = {const_cast<SDL_DisplayMode*>(sdl3compat_RealDisplayMode()),
+                                     nullptr};
+  if (count) {
+    *count = 1;
+  }
+  return modes;
+}
+inline const char* SDL_GetDisplayName(SDL_DisplayID /*display*/) {
+  return "Switch";
+}
+
+// SDL_DisplayOrientation and SDL_ORIENTATION_* already exist in SDL2 (added 2.0.9) with the
+// same names SDL3 uses -- no redeclaration needed.
+inline SDL_DisplayOrientation SDL_GetCurrentDisplayOrientation(SDL_DisplayID /*display*/) {
+  return SDL_ORIENTATION_LANDSCAPE;
+}
+
+inline SDL_Surface* SDL_CreateSurfaceFrom(int width,
+                                          int height,
+                                          Uint32 format,
+                                          void* pixels,
+                                          int pitch) {
+  int bpp;
+  Uint32 rmask, gmask, bmask, amask;
+  SDL_PixelFormatEnumToMasks(format, &bpp, &rmask, &gmask, &bmask, &amask);
+  return SDL_CreateRGBSurfaceFrom(pixels, width, height, bpp, pitch, rmask, gmask, bmask, amask);
+}
+inline void SDL_DestroySurface(SDL_Surface* surface) {
+  SDL_FreeSurface(surface);
+}
+
+inline void SDL_GL_DestroyContext(SDL_GLContext ctx) {
+  SDL_GL_DeleteContext(ctx);
+}
+inline bool sdl3compat_SetWindowPosition(SDL_Window* window, int x, int y) {
+  SDL_SetWindowPosition(window, x, y);
+  return true;
+}
+inline bool sdl3compat_SetWindowSize(SDL_Window* window, int w, int h) {
+  SDL_SetWindowSize(window, w, h);
+  return true;
+}
+
+// ============================================================================================
+// Version query: only used for a debug print. Encode as SDL3's (major*1000000 + minor*1000 +
+// patch) scheme so the printed number at least looks sane.
+// ============================================================================================
+#define SDL_VERSION (SDL_MAJOR_VERSION * 1000000 + SDL_MINOR_VERSION * 1000 + SDL_PATCHLEVEL)
+inline int SDL_GetVersion() {
+  SDL_version v;
+  SDL_GetVersion(&v);
+  return v.major * 1000000 + v.minor * 1000 + v.patch;
+}
+
+// ============================================================================================
+// Events. SDL3 flattened event field layout (event.key.key vs SDL2's event.key.keysym.sym) and
+// renamed the controller union members (gaxis/gbutton vs SDL2's caxis/cbutton) and split
+// SDL_WINDOWEVENT's sub-events into distinct top-level types. This is a real, purpose-built
+// translation, not an alias -- SDL_PollEvent below pulls a real SDL2 event and converts it.
+// ============================================================================================
+enum {
+  SDL_EVENT_QUIT = 0x40000000,
+  SDL_EVENT_KEY_DOWN,
+  SDL_EVENT_KEY_UP,
+  SDL_EVENT_MOUSE_MOTION,
+  SDL_EVENT_MOUSE_BUTTON_DOWN,
+  SDL_EVENT_MOUSE_BUTTON_UP,
+  SDL_EVENT_GAMEPAD_ADDED,
+  SDL_EVENT_GAMEPAD_REMOVED,
+  SDL_EVENT_GAMEPAD_AXIS_MOTION,
+  SDL_EVENT_GAMEPAD_BUTTON_DOWN,
+  SDL_EVENT_GAMEPAD_BUTTON_UP,
+  SDL_EVENT_JOYSTICK_AXIS_MOTION,
+  SDL_EVENT_WINDOW_FIRST,
+  SDL_EVENT_WINDOW_MINIMIZED = SDL_EVENT_WINDOW_FIRST,
+  SDL_EVENT_WINDOW_MAXIMIZED,
+  SDL_EVENT_WINDOW_RESTORED,
+  SDL_EVENT_WINDOW_MOVED,
+  SDL_EVENT_WINDOW_RESIZED,
+  SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED,
+  SDL_EVENT_WINDOW_DISPLAY_CHANGED,
+  SDL_EVENT_WINDOW_MOUSE_ENTER,
+  SDL_EVENT_WINDOW_MOUSE_LEAVE,
+  SDL_EVENT_WINDOW_LAST = SDL_EVENT_WINDOW_MOUSE_LEAVE,
+  SDL_EVENT_DISPLAY_FIRST,
+  SDL_EVENT_DISPLAY_ADDED = SDL_EVENT_DISPLAY_FIRST,
+  SDL_EVENT_DISPLAY_REMOVED,
+  SDL_EVENT_DISPLAY_ORIENTATION,
+  SDL_EVENT_DISPLAY_LAST = SDL_EVENT_DISPLAY_ORIENTATION,
+};
+
+struct SDL_KeyboardEventCompat {
+  Uint32 type;
+  Uint32 windowID;
+  SDL_Keycode key;
+  SDL_Scancode scancode;
+  Uint16 mod;
+  Uint8 repeat;
+};
+struct SDL_MouseMotionEventCompat {
+  Uint32 type;
+  Uint32 windowID;
+  Uint32 state;
+  float x, y, xrel, yrel;
+};
+struct SDL_MouseButtonEventCompat {
+  Uint32 type;
+  Uint32 windowID;
+  Uint8 button;
+  Uint8 clicks;
+  float x, y;
+};
+struct SDL_GamepadAxisEventCompat {
+  Uint32 type;
+  SDL_JoystickID which;
+  Uint8 axis;
+  Sint16 value;
+};
+struct SDL_GamepadButtonEventCompat {
+  Uint32 type;
+  SDL_JoystickID which;
+  Uint8 button;
+};
+struct SDL_JoyAxisEventCompat {
+  Uint32 type;
+  SDL_JoystickID which;
+  Uint8 axis;
+  Sint16 value;
+};
+struct SDL_GamepadDeviceEventCompat {
+  Uint32 type;
+  SDL_JoystickID which;
+};
+struct SDL_WindowEventCompat {
+  Uint32 type;
+  Uint32 windowID;
+  Sint32 data1, data2;
+};
+struct SDL_DisplayEventCompat {
+  Uint32 type;
+  SDL_DisplayID displayID;
+  Sint32 data1;
+};
+
+union SDL_Event {
+  Uint32 type;
+  SDL_KeyboardEventCompat key;
+  SDL_MouseMotionEventCompat motion;
+  SDL_MouseButtonEventCompat button;
+  SDL_GamepadAxisEventCompat gaxis;
+  SDL_GamepadButtonEventCompat gbutton;
+  SDL_JoyAxisEventCompat jaxis;
+  SDL_GamepadDeviceEventCompat gdevice;
+  SDL_WindowEventCompat window;
+  SDL_DisplayEventCompat display;
+};
+
+inline int sdl3compat_PollEvent(SDL_Event* out) {
+  SDL_Event_real real_evt;
+  while (SDL_PollEvent(&real_evt)) {
+    switch (real_evt.type) {
+      case SDL_QUIT:
+        out->type = SDL_EVENT_QUIT;
+        return 1;
+      case SDL_KEYDOWN:
+      case SDL_KEYUP:
+        out->key.type = real_evt.type == SDL_KEYDOWN ? SDL_EVENT_KEY_DOWN : SDL_EVENT_KEY_UP;
+        out->key.windowID = real_evt.key.windowID;
+        out->key.key = real_evt.key.keysym.sym;
+        out->key.scancode = real_evt.key.keysym.scancode;
+        out->key.mod = real_evt.key.keysym.mod;
+        out->key.repeat = real_evt.key.repeat;
+        return 1;
+      case SDL_MOUSEMOTION:
+        out->motion.type = SDL_EVENT_MOUSE_MOTION;
+        out->motion.windowID = real_evt.motion.windowID;
+        out->motion.state = real_evt.motion.state;
+        out->motion.x = static_cast<float>(real_evt.motion.x);
+        out->motion.y = static_cast<float>(real_evt.motion.y);
+        out->motion.xrel = static_cast<float>(real_evt.motion.xrel);
+        out->motion.yrel = static_cast<float>(real_evt.motion.yrel);
+        return 1;
+      case SDL_MOUSEBUTTONDOWN:
+      case SDL_MOUSEBUTTONUP:
+        out->button.type =
+            real_evt.type == SDL_MOUSEBUTTONDOWN ? SDL_EVENT_MOUSE_BUTTON_DOWN : SDL_EVENT_MOUSE_BUTTON_UP;
+        out->button.windowID = real_evt.button.windowID;
+        out->button.button = real_evt.button.button;
+        out->button.clicks = real_evt.button.clicks;
+        out->button.x = static_cast<float>(real_evt.button.x);
+        out->button.y = static_cast<float>(real_evt.button.y);
+        return 1;
+      case SDL_CONTROLLERDEVICEADDED:
+      case SDL_CONTROLLERDEVICEREMOVED:
+        out->gdevice.type = real_evt.type == SDL_CONTROLLERDEVICEADDED ? SDL_EVENT_GAMEPAD_ADDED
+                                                                       : SDL_EVENT_GAMEPAD_REMOVED;
+        out->gdevice.which = real_evt.cdevice.which;
+        return 1;
+      case SDL_CONTROLLERAXISMOTION:
+        out->gaxis.type = SDL_EVENT_GAMEPAD_AXIS_MOTION;
+        out->gaxis.which = real_evt.caxis.which + 1;
+        out->gaxis.axis = real_evt.caxis.axis;
+        out->gaxis.value = real_evt.caxis.value;
+        return 1;
+      case SDL_CONTROLLERBUTTONDOWN:
+      case SDL_CONTROLLERBUTTONUP:
+        out->gbutton.type = real_evt.type == SDL_CONTROLLERBUTTONDOWN ? SDL_EVENT_GAMEPAD_BUTTON_DOWN
+                                                                      : SDL_EVENT_GAMEPAD_BUTTON_UP;
+        out->gbutton.which = real_evt.cbutton.which + 1;
+        out->gbutton.button = real_evt.cbutton.button;
+        return 1;
+      case SDL_JOYAXISMOTION:
+        out->jaxis.type = SDL_EVENT_JOYSTICK_AXIS_MOTION;
+        out->jaxis.which = real_evt.jaxis.which + 1;
+        out->jaxis.axis = real_evt.jaxis.axis;
+        out->jaxis.value = real_evt.jaxis.value;
+        return 1;
+      case SDL_WINDOWEVENT: {
+        Uint32 mapped;
+        switch (real_evt.window.event) {
+          case SDL_WINDOWEVENT_MINIMIZED:
+            mapped = SDL_EVENT_WINDOW_MINIMIZED;
+            break;
+          case SDL_WINDOWEVENT_MAXIMIZED:
+            mapped = SDL_EVENT_WINDOW_MAXIMIZED;
+            break;
+          case SDL_WINDOWEVENT_RESTORED:
+            mapped = SDL_EVENT_WINDOW_RESTORED;
+            break;
+          case SDL_WINDOWEVENT_MOVED:
+            mapped = SDL_EVENT_WINDOW_MOVED;
+            break;
+          case SDL_WINDOWEVENT_RESIZED:
+            mapped = SDL_EVENT_WINDOW_RESIZED;
+            break;
+          case SDL_WINDOWEVENT_SIZE_CHANGED:
+            mapped = SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED;
+            break;
+          case SDL_WINDOWEVENT_ENTER:
+            mapped = SDL_EVENT_WINDOW_MOUSE_ENTER;
+            break;
+          case SDL_WINDOWEVENT_LEAVE:
+            mapped = SDL_EVENT_WINDOW_MOUSE_LEAVE;
+            break;
+          default:
+            continue;  // not one we translate; skip to the next real event
+        }
+        out->window.type = mapped;
+        out->window.windowID = real_evt.window.windowID;
+        out->window.data1 = real_evt.window.data1;
+        out->window.data2 = real_evt.window.data2;
+        return 1;
+      }
+      case SDL_DISPLAYEVENT: {
+        Uint32 mapped;
+        switch (real_evt.display.event) {
+          case SDL_DISPLAYEVENT_CONNECTED:
+            mapped = SDL_EVENT_DISPLAY_ADDED;
+            break;
+          case SDL_DISPLAYEVENT_DISCONNECTED:
+            mapped = SDL_EVENT_DISPLAY_REMOVED;
+            break;
+          case SDL_DISPLAYEVENT_ORIENTATION:
+            mapped = SDL_EVENT_DISPLAY_ORIENTATION;
+            break;
+          default:
+            continue;  // not one we translate; skip to the next real event
+        }
+        out->display.type = mapped;
+        out->display.displayID = real_evt.display.display;
+        out->display.data1 = real_evt.display.data1;
+        return 1;
+      }
+      default:
+        continue;  // not one we translate; skip to the next real event
+    }
+  }
+  return 0;
+}
+
+// Redirect these 9 SDL3 names to the wrappers above, for everything textually after this point
+// (i.e. the game/ source file that included this header) -- deliberately placed at the very end
+// so nothing earlier in this header (which needs the real, unrenamed SDL2 functions) is affected.
+#define SDL_Init sdl3compat_Init
+#define SDL_InitSubSystem sdl3compat_InitSubSystem
+#define SDL_ShowCursor sdl3compat_ShowCursor
+#define SDL_PollEvent sdl3compat_PollEvent
+#define SDL_SetWindowFullscreen sdl3compat_SetWindowFullscreen
+#define SDL_GetDisplayBounds sdl3compat_GetDisplayBounds
+#define SDL_SetWindowPosition sdl3compat_SetWindowPosition
+#define SDL_SetWindowSize sdl3compat_SetWindowSize
+#define SDL_GL_MakeCurrent sdl3compat_GL_MakeCurrent

--- a/game/system/SystemThread.cpp
+++ b/game/system/SystemThread.cpp
@@ -1,10 +1,17 @@
+// newlib hides pthread_setname_np (used below) behind its GNU-visibility feature-test macro,
+// which is latched in by whichever header first pulls in newlib's feature-test machinery -- has
+// to be defined before any other include in this file, not just before <pthread.h>.
+#if defined(__SWITCH__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
 #include "SystemThread.h"
 
 #include "common/common_types.h"
 #include "common/log/log.h"
 #include "common/util/unicode_util.h"
 
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
 #include <pthread.h>
 #else
 // Include order matters...
@@ -97,10 +104,13 @@ void* bootstrap_thread_func(void* x) {
   SystemThread* thd = (SystemThread*)x;
   SystemThreadInterface iface(thd);
 
-#ifdef __linux
+#if defined(__linux)
   pthread_setname_np(pthread_self(), thd->name.c_str());
 #elif __APPLE__
   pthread_setname_np(thd->name.c_str());
+#elif defined(__SWITCH__)
+  // newlib declares pthread_setname_np (behind _GNU_SOURCE) but devkitA64's libc doesn't
+  // actually implement it -- compiles, fails to link. Just a debug label, safe to skip.
 #else
   SetThreadDescription(GetCurrentThread(), (LPCWSTR)utf8_string_to_wide_string(thd->name).c_str());
 #endif

--- a/game/system/background_worker.cpp
+++ b/game/system/background_worker.cpp
@@ -2,7 +2,9 @@
 
 #include "common/log/log.h"
 
+#if !defined(__SWITCH__)
 #include "curl/curl.h"
+#endif
 
 bool BackgroundWorker::process_queues() {
   std::lock_guard<std::mutex> job_lock(job_queue_lock);
@@ -51,6 +53,11 @@ static size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* use
 }
 
 void BackgroundWorker::job_web_request(WebRequestJobPayload payload) {
+#if defined(__SWITCH__)
+  // No libcurl/OpenSSL on Switch (see CMakeLists.txt); nothing on the real gameplay path
+  // depends on this succeeding, so fail honestly rather than hang.
+  payload.callback(false, payload.cache_id, "networking unavailable on this platform");
+#else
   // TODO - move this into some common util function
   CURL* curl;
   CURLcode res;
@@ -80,4 +87,5 @@ void BackgroundWorker::job_web_request(WebRequestJobPayload payload) {
       payload.callback(true, payload.cache_id, readBuffer);
     }
   }
+#endif
 }

--- a/game/system/hid/devices/game_controller.cpp
+++ b/game/system/hid/devices/game_controller.cpp
@@ -190,9 +190,12 @@ void GameController::process_event(const SDL_Event& event,
         }
       }
     }
-  } else if ((event.type == SDL_EVENT_GAMEPAD_BUTTON_DOWN ||
-              event.type == SDL_EVENT_GAMEPAD_BUTTON_UP) &&
-             event.gbutton.which == m_sdl_instance_id) {
+  } else if (event.type == SDL_EVENT_GAMEPAD_BUTTON_DOWN ||
+             event.type == SDL_EVENT_GAMEPAD_BUTTON_UP) {
+    if (event.gbutton.which != m_sdl_instance_id ||
+        m_settings->controller_binds.find(m_guid) == m_settings->controller_binds.end()) {
+      return;
+    }
     auto& binds = m_settings->controller_binds.at(m_guid);
 
     // https://wiki.libsdl.org/SDL3/SDL_GamepadButton

--- a/game/system/hid/display_manager.h
+++ b/game/system/hid/display_manager.h
@@ -10,7 +10,11 @@
 #include "game/settings/settings.h"
 #include "game/system/hid/input_manager.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/sdl3_compat.h"
+#else
 #include "third-party/SDL/include/SDL3/SDL.h"
+#endif
 
 /*
 TODO:

--- a/game/system/hid/input_bindings.cpp
+++ b/game/system/hid/input_bindings.cpp
@@ -6,7 +6,11 @@
 
 #include "game/system/hid/sdl_util.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/sdl3_compat.h"
+#else
 #include "third-party/SDL/include/SDL3/SDL.h"
+#endif
 
 InputModifiers::InputModifiers(const u16 sdl_mod_state) {
   need_shift = sdl_mod_state & SDL_KMOD_SHIFT;

--- a/game/system/hid/input_bindings.h
+++ b/game/system/hid/input_bindings.h
@@ -11,7 +11,11 @@
 #include "common/log/log.h"
 #include "common/util/json_util.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/sdl3_compat.h"
+#else
 #include "SDL3/SDL.h"
+#endif
 
 #define GET_PRESSURE_BUTTON_DATA(button_name) \
   {button_data.at(ButtonIndex::button_name),  \

--- a/game/system/hid/input_manager.cpp
+++ b/game/system/hid/input_manager.cpp
@@ -14,8 +14,14 @@
 #include "game/graphics/pipelines/opengl.h"
 #include "game/runtime.h"
 
+#if !defined(__SWITCH__)
 #include "third-party/SDL/include/SDL3/SDL_hints.h"
+#endif
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 InputManager::InputManager(SDL_Window* window)
     : m_window(window),
@@ -137,6 +143,20 @@ void InputManager::refresh_device_list() {
         }
       }
     }
+#if defined(__SWITCH__)
+    // Citron/HOS exposes eight controllers that all share one GUID
+    // (000038f853776974636820436f6e7400). The GUID-keyed port mapping above is "last one wins",
+    // so port 0 ended up on the eighth device while every real event arrives from the first --
+    // input was being delivered and then routed to a pad that never reports anything. With
+    // indistinguishable GUIDs there is nothing to disambiguate on, so pin port 0 to the first
+    // controller.
+    if (!m_available_controllers.empty()) {
+      m_controller_port_mapping[0] = 0;
+      if (m_data.find(0) == m_data.end()) {
+        m_data[0] = std::make_shared<PadData>();
+      }
+    }
+#endif
     if (m_available_controllers.empty()) {
       lg::warn(
           "No active game controllers could be found or loaded successfully - inputs will not "
@@ -182,6 +202,16 @@ void InputManager::process_sdl_event(const SDL_Event& event) {
   // Detect controller connections and disconnects
   if (sdl_util::is_any_event_type(event.type,
                                   {SDL_EVENT_GAMEPAD_ADDED, SDL_EVENT_GAMEPAD_REMOVED})) {
+#if defined(__SWITCH__)
+    // See m_last_device_list_refresh's declaration -- without this, opening/closing controllers
+    // inside refresh_device_list() re-triggers this same event, forever, before a single frame
+    // ever renders.
+    auto now = std::chrono::steady_clock::now();
+    if (now - m_last_device_list_refresh < std::chrono::milliseconds(500)) {
+      return;
+    }
+    m_last_device_list_refresh = now;
+#endif
     lg::info("Controller added or removed. refreshing controller device list");
     refresh_device_list();
   }

--- a/game/system/hid/input_manager.h
+++ b/game/system/hid/input_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -186,6 +187,13 @@ class InputManager {
   std::optional<InputBindAssignmentMeta> m_waiting_for_bind = std::nullopt;
 
   void refresh_device_list();
+#if defined(__SWITCH__)
+  // devkitPro's SDL2 Switch backend re-emits SDL_CONTROLLERDEVICEADDED/REMOVED as a side effect
+  // of opening/closing controllers inside refresh_device_list() itself, which otherwise turns
+  // into an infinite feedback loop (event -> refresh -> more events -> ...), stalling the whole
+  // game loop before a single frame renders. A debounce timestamp breaks the cycle.
+  std::chrono::steady_clock::time_point m_last_device_list_refresh{};
+#endif
   void clear_inputs();
 
   void ignore_background_controller_events(const bool ignore);

--- a/game/system/hid/sdl_util.cpp
+++ b/game/system/hid/sdl_util.cpp
@@ -3,7 +3,11 @@
 #include "common/log/log.h"
 
 #include "fmt/ranges.h"
+#if defined(__SWITCH__)
+#include "game/switch/sdl3_compat.h"
+#else
 #include "third-party/SDL/include/SDL3/SDL.h"
+#endif
 
 namespace sdl_util {
 void log_error(const std::string& msg) {

--- a/game/system/hid/sdl_util.h
+++ b/game/system/hid/sdl_util.h
@@ -5,7 +5,11 @@
 
 #include "input_bindings.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/sdl3_compat.h"
+#else
 #include "third-party/SDL/include/SDL3/SDL.h"
+#endif
 
 namespace sdl_util {
 void log_error(const std::string& msg = "");

--- a/game/tools/filter_menu/filter_menu.cpp
+++ b/game/tools/filter_menu/filter_menu.cpp
@@ -3,8 +3,14 @@
 #include "game/graphics/gfx.h"
 
 #include "fmt/format.h"
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
+#if !defined(__SWITCH__)
 #include "third-party/imgui/imgui_stdlib.h"
+#endif
 
 void to_json(json& j, const DebugTextFilter& obj) {
   j = json{{"content", obj.content}, {"type", obj.type}};

--- a/game/tools/filter_menu/filter_menu.h
+++ b/game/tools/filter_menu/filter_menu.h
@@ -5,7 +5,11 @@
 
 #include "common/util/json_util.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 struct DebugTextFilter {
   enum class Type { CONTAINS, NOT_CONTAINS, REGEX };

--- a/game/tools/subtitle_editor/subtitle_editor.cpp
+++ b/game/tools/subtitle_editor/subtitle_editor.cpp
@@ -11,8 +11,14 @@
 #include "game/runtime.h"
 
 #include "fmt/format.h"
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
+#if !defined(__SWITCH__)
 #include "third-party/imgui/imgui_stdlib.h"
+#endif
 
 SubtitleEditor::SubtitleEditor() {
   m_filter_cutscenes = m_filter_placeholder;

--- a/game/tools/subtitle_editor/subtitle_editor.h
+++ b/game/tools/subtitle_editor/subtitle_editor.h
@@ -7,7 +7,11 @@
 
 #include "common/serialization/subtitles/subtitles_v2.h"
 
+#if defined(__SWITCH__)
+#include "game/switch/imgui_stub.h"
+#else
 #include "third-party/imgui/imgui.h"
+#endif
 
 class SubtitleEditor {
  public:

--- a/goalc/CMakeLists.txt
+++ b/goalc/CMakeLists.txt
@@ -101,3 +101,10 @@ target_link_libraries(goalc common Zydis capstone compiler)
 target_link_libraries(goalc-simple common Zydis capstone compiler)
 target_link_libraries(build_level common Zydis capstone compiler)
 target_link_libraries(build_actor common Zydis capstone compiler)
+
+if(NINTENDO_SWITCH)
+    # Standalone sanity check: does JIT'd ARM64 code from our emitter actually execute
+    # correctly via libnx's Jit API on real hardware? Isolated from the full runtime/renderer.
+    add_executable(switch_jit_test switch_jit_test.cpp)
+    target_link_libraries(switch_jit_test common Zydis capstone compiler nx)
+endif()

--- a/goalc/debugger/DebugServer.cpp
+++ b/goalc/debugger/DebugServer.cpp
@@ -212,7 +212,7 @@ void DebugServer::send_line(int socket, const std::string& line) {
 }
 
 void DebugServer::accept_new_clients() {
-#ifdef OS_POSIX
+#if defined(OS_POSIX) || defined(__SWITCH__)
   socklen_t addr_len = sizeof(addr);
 #else
   int addr_len = sizeof(addr);

--- a/goalc/emitter/CodeTester.cpp
+++ b/goalc/emitter/CodeTester.cpp
@@ -21,6 +21,12 @@
 #if defined(__APPLE__) && defined(__aarch64__)
 #include <pthread.h>  // pthread_jit_write_protect_np
 #endif
+#if defined(__SWITCH__)
+// See the matching comment in CodeTester.h -- avoids a struct-u128 vs typedef-u128 collision.
+#define u128 nx_u128
+#include <switch.h>
+#undef u128
+#endif
 
 #include <cstdio>
 
@@ -358,6 +364,11 @@ u64 CodeTester::execute() {
   auto ret = ((u64(*)())code_buffer)();
   pthread_jit_write_protect_np(0);
   return ret;
+#elif defined(__SWITCH__)
+  jitTransitionToExecutable(&m_jit);
+  auto ret = ((u64(*)())code_buffer_rx)();
+  jitTransitionToWritable(&m_jit);
+  return ret;
 #else
   return ((u64(*)())code_buffer)();
 #endif
@@ -378,6 +389,11 @@ u64 CodeTester::execute(u64 in0, u64 in1, u64 in2, u64 in3) {
   auto ret = ((u64(*)(u64, u64, u64, u64))code_buffer)(in0, in1, in2, in3);
   pthread_jit_write_protect_np(0);
   return ret;
+#elif defined(__SWITCH__)
+  jitTransitionToExecutable(&m_jit);
+  auto ret = ((u64(*)(u64, u64, u64, u64))code_buffer_rx)(in0, in1, in2, in3);
+  jitTransitionToWritable(&m_jit);
+  return ret;
 #else
   return ((u64(*)(u64, u64, u64, u64))code_buffer)(in0, in1, in2, in3);
 #endif
@@ -392,13 +408,26 @@ void CodeTester::init_code_buffer(int capacity) {
 #if defined(__APPLE__) && defined(__aarch64__)
   code_buffer = (u8*)mmap(nullptr, capacity, PROT_READ | PROT_WRITE | PROT_EXEC,
                           MAP_ANONYMOUS | MAP_PRIVATE | MAP_JIT, -1, 0);
+#elif defined(__SWITCH__)
+  // Horizon enforces W^X: jitCreate gives back separate RW/RX aliases of the same pages instead
+  // of one RWX mapping. Round up to a page (0x1000) since jitCreate requires page-aligned size.
+  size_t jit_size = (size_t(capacity) + 0xfff) & ~size_t(0xfff);
+  Result rc = jitCreate(&m_jit, jit_size);
+  if (R_FAILED(rc)) {
+    ASSERT_MSG(false, "[CodeTester] jitCreate failed!");
+  }
+  jitTransitionToWritable(&m_jit);
+  code_buffer = (u8*)jitGetRwAddr(&m_jit);
+  code_buffer_rx = (u8*)jitGetRxAddr(&m_jit);
 #else
   code_buffer = (u8*)mmap(nullptr, capacity, PROT_EXEC | PROT_READ | PROT_WRITE,
                           MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
 #endif
+#if !defined(__SWITCH__)
   if (code_buffer == (u8*)(-1)) {
     ASSERT_MSG(false, "[CodeTester] Failed to map memory!");
   }
+#endif
 #if defined(__APPLE__) && defined(__aarch64__)
   // allow writes before the first instruction
   pthread_jit_write_protect_np(0);
@@ -410,7 +439,11 @@ void CodeTester::init_code_buffer(int capacity) {
 
 CodeTester::~CodeTester() {
   if (code_buffer_capacity) {
+#if defined(__SWITCH__)
+    jitClose(&m_jit);
+#else
     munmap(code_buffer, code_buffer_capacity);
+#endif
   }
 }
 }  // namespace emitter

--- a/goalc/emitter/CodeTester.h
+++ b/goalc/emitter/CodeTester.h
@@ -27,13 +27,30 @@
 #if defined(__APPLE__) && defined(__aarch64__)
 #include <pthread.h>  // pthread_jit_write_protect_np
 #endif
+#if defined(__SWITCH__)
+// libnx's switch/types.h does `typedef __uint128_t u128;`, which conflicts with the
+// `struct u128` this codebase already declared above (common/common_types.h). Rename the
+// token for the scope of this include only -- every internal libnx use of "u128" (the typedef
+// itself and any struct fields of that type) becomes "nx_u128" consistently, and our own
+// `u128` is untouched afterward.
+#define u128 nx_u128
+#include <switch.h>  // Jit: dual RW/RX aliased JIT memory
+#undef u128
+#endif
 
 namespace emitter {
 class CodeTester {
  private:
   int code_buffer_size = 0;
   int code_buffer_capacity = 0;
+  // On most platforms this is both the writable and executable address. On Switch, libnx's Jit
+  // gives separate RW/RX aliases of the same physical pages, so code_buffer is the RW one here
+  // and code_buffer_rx (below) is the one actually called.
   u8* code_buffer = nullptr;
+#if defined(__SWITCH__)
+  Jit m_jit{};
+  u8* code_buffer_rx = nullptr;
+#endif
   RegisterInfo m_info;
   ObjectGenerator m_gen;
 
@@ -66,27 +83,10 @@ class CodeTester {
    */
   template <typename T>
   T execute_ret(u64 in0, u64 in1, u64 in2, u64 in3) {
-#if defined(__aarch64__)
-    // allegedly needed because ARM requires flushing after writing new instructions
-    // on x86 it does nothing
-    __builtin___clear_cache((char*)code_buffer, (char*)code_buffer + code_buffer_size);
-#endif
-    // clang-format off
-#if defined(__APPLE__) && defined(__aarch64__)
-  // block writes while generated code runs
-  pthread_jit_write_protect_np(1);
-  u64 result_u64 = ((u64(*)(u64, u64, u64, u64))code_buffer)(in0, in1, in2, in3);
-  pthread_jit_write_protect_np(0);
-  T result_T;
-  memcpy(&result_T, &result_u64, sizeof(T));
-  return result_T;
-#else
-  u64 result_u64 = ((u64(*)(u64, u64, u64, u64))code_buffer)(in0, in1, in2, in3);
-  T result_T;
-  memcpy(&result_T, &result_u64, sizeof(T));
-  return result_T;
-#endif
-    // clang-format on
+    u64 result_u64 = execute(in0, in1, in2, in3);
+    T result_T;
+    memcpy(&result_T, &result_u64, sizeof(T));
+    return result_T;
   }
 
   /*!

--- a/goalc/emitter/IGenARM64.cpp
+++ b/goalc/emitter/IGenARM64.cpp
@@ -2605,7 +2605,9 @@ InstructionARM64 trap() {
 
 InstructionARM64 null() {
   // dummy empty byte
-  return InstructionARM64(0b0);
+  InstructionARM64 result(0b0);
+  result.is_null = true;
+  return result;
 }
 
 /////////////////////////////

--- a/goalc/emitter/Instruction.h
+++ b/goalc/emitter/Instruction.h
@@ -204,6 +204,14 @@ struct InstructionARM64 : InstructionImpl<InstructionARM64> {
 
   u32 encodings[max_instrs]{};
   u8 count = 0;
+  // Set only by IGen::ARM64::null()'s deliberate placeholder. emit()/length() used to detect
+  // "null" instructions by checking `count == 1 && encodings[0] == 0`, which is ambiguous: any
+  // real single-instruction encoding that happens to be the bit pattern 0x00000000 would also
+  // match and get silently skipped (0 bytes emitted instead of 4), shifting every subsequent
+  // instruction's byte offset by -4 and corrupting the rest of the function's machine code. This
+  // explicit flag removes that ambiguity -- confirmed root cause of undefined-instruction crashes
+  // when executing compiled top-level GOAL code on real ARM64 hardware/emulation.
+  bool is_null = false;
 
   // relocation kind and instruction word for linker patching
   ARM64::RelocKind reloc_kind = ARM64::RelocKind::NONE;
@@ -264,7 +272,7 @@ struct InstructionARM64 : InstructionImpl<InstructionARM64> {
   }
 
   uint32_t emit(uint8_t* buffer) const {
-    if (count == 1 && encodings[0] == 0) {
+    if (is_null) {
       return 0;
     }
     memcpy(buffer, encodings, count * 4);
@@ -272,7 +280,7 @@ struct InstructionARM64 : InstructionImpl<InstructionARM64> {
   }
 
   uint8_t length() const {
-    if (count == 1 && encodings[0] == 0) {
+    if (is_null) {
       return 0;
     }
     return count * 4;
@@ -1301,8 +1309,17 @@ class Instruction {
 
   Instruction() = delete;
 
-  template <typename T>
-  Instruction(T v) : instr(std::move(v)) {}
+  // Deliberately NOT a bare `template <typename T> Instruction(T v) : instr(std::move(v)) {}`.
+  // That let std::variant<InstructionX86, InstructionARM64>'s own converting constructor decide
+  // which alternative to build, and InstructionX86 has an implicit single-argument constructor
+  // (InstructionX86(u8 opcode)) that out-competed the exact-type match for InstructionARM64 --
+  // confirmed empirically (variant.index() == 0, i.e. InstructionX86, for every instruction
+  // built by IGen::ARM64 helpers) via direct instrumentation, not assumed. The result: every
+  // ARM64-compiled instruction silently got reinterpreted and re-encoded as if it were x86
+  // machine code, corrupting all ARM64 top-level GOAL code with undefined instructions. Explicit
+  // per-type overloads remove the ambiguity entirely.
+  Instruction(InstructionX86 v) : instr(std::move(v)) {}
+  Instruction(InstructionARM64 v) : instr(std::move(v)) {}
 
   u32 emit(u8* buffer) const {
     return std::visit([&](auto const& i) { return i.emit(buffer); }, instr);

--- a/goalc/switch_jit_test.cpp
+++ b/goalc/switch_jit_test.cpp
@@ -1,0 +1,289 @@
+/*!
+ * @file switch_jit_test.cpp
+ * Minimal sanity check for real Switch hardware: JIT a trivial ARM64 function through the
+ * existing GOAL emitter (IGenARM64 + CodeTester), run it via libnx's Jit API, and check the
+ * result. This isolates "does JIT'd code actually execute correctly on Horizon OS" from
+ * everything else in the runtime -- it's the single biggest unproven risk in this whole port.
+ */
+
+#include <cstdio>
+
+#if defined(__SWITCH__)
+// See CodeTester.h -- avoids a struct-u128 vs typedef-u128 collision with libnx.
+#define u128 nx_u128
+#include <switch.h>
+#undef u128
+#endif
+
+#include "common/arm64/encoding.h"
+
+#include "goalc/emitter/CodeTester.h"
+#include "goalc/emitter/IGen.h"
+#include "goalc/emitter/InstructionSet.h"
+
+// Emits a fixed 4-instruction (16-byte) movz/movk sequence loading a 64-bit absolute address,
+// matching exactly what the real GOAL->native trampolines use for loading function pointers.
+static void emit_mov64_fixed(emitter::CodeTester& t, u32 reg, u64 val) {
+  t.emit_data<u32>(arm64::encode_movz_64(reg, u16(val & 0xffff), 0));
+  t.emit_data<u32>(arm64::encode_movk_64(reg, u16((val >> 16) & 0xffff), 1));
+  t.emit_data<u32>(arm64::encode_movk_64(reg, u16((val >> 32) & 0xffff), 2));
+  t.emit_data<u32>(arm64::encode_movk_64(reg, u16((val >> 48) & 0xffff), 3));
+}
+
+int main() {
+#if defined(__SWITCH__)
+  consoleInit(NULL);
+#endif
+
+  bool pass = false;
+  u64 result = 0;
+  const char* stage = "setup";
+
+  try {
+    stage = "emit";
+    emitter::CodeTester tester(emitter::InstructionSet::ARM64);
+    tester.init_code_buffer(4096);
+    tester.emit(emitter::IGen::mov_gpr64_u32(tester.generator(), emitter::X0, 42));
+    tester.emit_return();
+
+    stage = "execute";
+    result = tester.execute();
+    pass = (result == 42);
+  } catch (const std::exception& e) {
+    printf("[%s] exception: %s\n", stage, e.what());
+  } catch (...) {
+    printf("[%s] unknown exception\n", stage);
+  }
+
+  printf("jak-project ARM64 JIT execution test\n");
+  printf("result = %llu (expected 42)\n", (unsigned long long)result);
+  printf(pass ? "PASS\n" : "FAIL\n");
+
+  // Test 2: reproduce, in isolation, the exact 3-instruction sequence from gravity-h.o's
+  // top-level (str x30,[sp,#-16]! / ldr x30,[sp],#16 / ret) that hangs/crashes during real GOAL
+  // kernel boot. If this alone reproduces the crash, the bug is in dynarmic's JIT translation of
+  // single-register pre/post-indexed STR/LDR through X30, not in anything GOAL-runtime-specific
+  // -- a working mov (test 1 above) plus a paired stp/ldp x30,x19 (used by math.o, which loads
+  // fine) already rules out a blanket "JIT execution is broken" or "X30 can never round-trip"
+  // explanation.
+  bool pass2 = false;
+  u64 result2 = 0;
+  const char* stage2 = "setup2";
+  try {
+    stage2 = "emit2";
+    emitter::CodeTester tester2(emitter::InstructionSet::ARM64);
+    tester2.init_code_buffer(4096);
+    // marker value so we can tell the function ran to completion and returned correctly
+    tester2.emit(emitter::IGen::mov_gpr64_u32(tester2.generator(), emitter::X0, 0x1234));
+    // raw bytes copied verbatim from gravity-h.o's compiled top-level segment
+    tester2.emit_data<u32>(0xf81f0ffe);  // str x30, [sp, #-16]!
+    tester2.emit_data<u32>(0xf84107fe);  // ldr x30, [sp], #16
+    tester2.emit_data<u32>(0xd65f03c0);  // ret
+
+    stage2 = "execute2";
+    result2 = tester2.execute();
+    pass2 = (result2 == 0x1234);
+  } catch (const std::exception& e) {
+    printf("[%s] exception: %s\n", stage2, e.what());
+  } catch (...) {
+    printf("[%s] unknown exception\n", stage2);
+  }
+
+  printf("gravity-h repro test\n");
+  printf("result2 = %llu (expected %d = 0x1234)\n", (unsigned long long)result2, 0x1234);
+  printf(pass2 ? "PASS2\n" : "FAIL2\n");
+
+#if defined(__SWITCH__)
+  // Write results after test 2 too, in case test 3 crashes the whole process before the final
+  // write below can run -- if that happens, this file having stage3=not-run but 1/2 present is
+  // itself the evidence that test 3 is what triggers it.
+  {
+    FILE* f = fopen("sdmc:/switch_jit_test_result.txt", "w");
+    if (f) {
+      fprintf(f, "stage=%s\nresult=%llu\nexpected=42\n%s\nstage2=%s\nresult2=%llu\nexpected2=4660\n%s\nstage3=not_run\n",
+              stage, (unsigned long long)result, pass ? "PASS" : "FAIL", stage2,
+              (unsigned long long)result2, pass2 ? "PASS2" : "FAIL2");
+      fclose(f);
+    }
+  }
+#endif
+
+  // Test 3: same gravity-h instruction sequence as test 2, but this time called through the
+  // exact same stack-switching pattern _call_goal_on_stack_asm_arm64 uses for every real GOAL
+  // call (mov x9,sp / mov sp,x0 / str x9,[sp,#-16]! ... blr x3 ... ldr x9,[sp],#16 / mov sp,x9).
+  // Test 2 called gravity-h's code on CodeTester's own native stack via a plain call -- it never
+  // exercised the stack switch itself. If test 3 fails where test 2 passed, the bug is
+  // specifically in dynarmic's handling of str/ldr through X30 immediately after an SP switch
+  // via `mov sp, xN`, not in the instructions alone.
+  bool pass3 = false;
+  u64 result3 = 0;
+  const char* stage3 = "setup3";
+  try {
+    stage3 = "emit3";
+    emitter::CodeTester tester3(emitter::InstructionSet::ARM64);
+    tester3.init_code_buffer(4096);
+
+    // scratch "goal stack" -- just needs to be valid, writable, 16-byte-aligned memory.
+    alignas(16) static u8 fake_goal_stack[1024];
+    u64 fake_stack_top = (u64)(fake_goal_stack + sizeof(fake_goal_stack));
+
+    // Simplified/inlined version -- no separate blr'd function, no address patching, to rule out
+    // a bug in the test harness itself. X30 is already a valid return address here (CodeTester's
+    // own `((u64(*)())code_buffer_rx)()` call set it via a real call instruction) -- str/ldr it
+    // through the switched-to goal stack exactly like gravity-h does, then switch back and ret
+    // using that same X30. If this hangs too, it's the raw sp-switch + str/ldr(x30) mechanic.
+    emit_mov64_fixed(tester3, 0 /*x0*/, fake_stack_top);
+    tester3.emit_data<u32>(0x910003e9);  // mov x9, sp
+    tester3.emit_data<u32>(0x9100001f);  // mov sp, x0
+    tester3.emit_data<u32>(0xf81f0fe9);  // str x9, [sp, #-16]!   (trampoline's own save)
+    tester3.emit_data<u32>(0xf81f0ffe);  // str x30, [sp, #-16]!  (gravity-h's str)
+    tester3.emit_data<u32>(0xf84107fe);  // ldr x30, [sp], #16    (gravity-h's ldr)
+    tester3.emit_data<u32>(0xf84107e9);  // ldr x9, [sp], #16     (trampoline's own restore)
+    tester3.emit_data<u32>(0x9100013f);  // mov sp, x9
+    emit_mov64_fixed(tester3, 0 /*x0*/, 0x5678);
+    tester3.emit_data<u32>(0xd65f03c0);  // ret
+
+    stage3 = "execute3";
+    result3 = tester3.execute();
+    pass3 = (result3 == 0x5678);
+  } catch (const std::exception& e) {
+    printf("[%s] exception: %s\n", stage3, e.what());
+  } catch (...) {
+    printf("[%s] unknown exception\n", stage3);
+  }
+
+  printf("gravity-h + stack-switch repro test\n");
+  printf("result3 = %llu (expected %d = 0x5678)\n", (unsigned long long)result3, 0x5678);
+  printf(pass3 ? "PASS3\n" : "FAIL3\n");
+
+#if defined(__SWITCH__)
+  {
+    FILE* f = fopen("sdmc:/switch_jit_test_result.txt", "w");
+    if (f) {
+      fprintf(f,
+              "stage=%s\nresult=%llu\nexpected=42\n%s\nstage2=%s\nresult2=%llu\nexpected2=4660\n%s\n"
+              "stage3=%s\nresult3=%llu\nexpected3=22136\n%s\nstage4=not_run\n",
+              stage, (unsigned long long)result, pass ? "PASS" : "FAIL", stage2,
+              (unsigned long long)result2, pass2 ? "PASS2" : "FAIL2", stage3,
+              (unsigned long long)result3, pass3 ? "PASS3" : "FAIL3");
+      fclose(f);
+    }
+  }
+#endif
+
+  // Test 4: same as test 3 (full trampoline preamble/epilogue), but calling gravity-h via a real
+  // `blr x3` to a genuinely, analytically computed absolute address (code_address() is known
+  // before any emission, so the target offset is computed by hand, not patched at runtime --
+  // test 3's original blr version used runtime patching via write(), which turned out to be
+  // buggy in the test harness itself, not dynarmic; this isolates the *real* remaining variable:
+  // an indirect call to a *separate* code address after the sp switch, as the real trampoline
+  // does, vs test 3's fully inlined body).
+  bool pass4 = false;
+  u64 result4 = 0;
+  const char* stage4 = "setup4";
+  try {
+    stage4 = "emit4";
+    emitter::CodeTester tester4(emitter::InstructionSet::ARM64);
+    tester4.init_code_buffer(4096);
+    u64 base = tester4.code_address();
+
+    alignas(16) static u8 fake_goal_stack4[1024];
+    u64 fake_stack_top4 = (u64)(fake_goal_stack4 + sizeof(fake_goal_stack4));
+
+    // FOUND IT (in the test harness, not dynarmic): the previous version of this test never
+    // preserved its OWN x30 (the return address into CodeTester::execute()) across the nested
+    // bl/blr -- bl overwrites x30 with the return-into-trampoline address, mock_gravity_h's own
+    // str/ldr(x30) just round-trips THAT value, and the final `ret` then jumps back into the
+    // middle of this function (the ldr x9 epilogue instruction) instead of returning, looping
+    // forever and draining sp on every iteration until it reads unmapped memory -- exactly the
+    // observed hang. The real trampoline never has this problem because it has a genuine
+    // stp/ldp x29,x30 prologue/epilogue on the NATIVE stack around the whole thing. Add that
+    // here too, matching the real trampoline exactly (see _call_goal_on_stack_asm_arm64).
+    //   0  : stp x29, x30, [sp, #-16]!     (4)
+    //   4  : mov x0, #fake_stack_top4      (16 bytes)
+    //   20 : mov x9, sp                    (4)
+    //   24 : mov sp, x0                    (4)
+    //   28 : str x9, [sp, #-16]!           (4)
+    //   32 : bl <mock_gravity_h>           (4)
+    //   36 : ldr x9, [sp], #16             (4)
+    //   40 : mov sp, x9                    (4)
+    //   44 : mov x0, #0x9abc               (16 bytes)
+    //   60 : ldp x29, x30, [sp], #16       (4)
+    //   64 : ret                           (4)
+    //   68 : mock_gravity_h: str x30,[sp,#-16]! / ldr x30,[sp],#16 / ret
+    (void)base;
+    const u32 bl_offset = 32;
+    const u32 mock_gravity_h_offset = 68;
+    const u32 bl_imm26 = (mock_gravity_h_offset - bl_offset) / 4;
+
+    tester4.emit_data<u32>(0xa9bf7bfd);  // stp x29, x30, [sp, #-16]!
+    emit_mov64_fixed(tester4, 0 /*x0*/, fake_stack_top4);
+    tester4.emit_data<u32>(0x910003e9);  // mov x9, sp
+    tester4.emit_data<u32>(0x9100001f);  // mov sp, x0
+    tester4.emit_data<u32>(0xf81f0fe9);  // str x9, [sp, #-16]!
+    tester4.emit_data<u32>(0x94000000 | bl_imm26);  // bl mock_gravity_h
+    tester4.emit_data<u32>(0xf84107e9);  // ldr x9, [sp], #16
+    tester4.emit_data<u32>(0x9100013f);  // mov sp, x9
+    emit_mov64_fixed(tester4, 0 /*x0*/, 0x9abc);
+    tester4.emit_data<u32>(0xa8c17bfd);  // ldp x29, x30, [sp], #16
+    tester4.emit_data<u32>(0xd65f03c0);  // ret
+
+    // sanity-check our hand-computed layout actually matches before relying on it
+    if (tester4.size() != (int)mock_gravity_h_offset) {
+      char err[128];
+      snprintf(err, sizeof(err), "layout mismatch: expected offset %u, got %d",
+               mock_gravity_h_offset, tester4.size());
+      throw std::runtime_error(err);
+    }
+
+    tester4.emit_data<u32>(0xf81f0ffe);  // str x30, [sp, #-16]!
+    tester4.emit_data<u32>(0xf84107fe);  // ldr x30, [sp], #16
+    tester4.emit_data<u32>(0xd65f03c0);  // ret
+
+    stage4 = "execute4";
+    result4 = tester4.execute();
+    pass4 = (result4 == 0x9abc);
+  } catch (const std::exception& e) {
+    printf("[%s] exception: %s\n", stage4, e.what());
+  } catch (...) {
+    printf("[%s] unknown exception\n", stage4);
+  }
+
+  printf("gravity-h + stack-switch + real blr repro test\n");
+  printf("result4 = %llu (expected %d = 0x9abc)\n", (unsigned long long)result4, 0x9abc);
+  printf(pass4 ? "PASS4\n" : "FAIL4\n");
+
+#if defined(__SWITCH__)
+  // Also write the result to the SD card -- there's no way to read the on-screen console
+  // output back out of an emulator/headless run, but sdmc:/ is a real host-visible file.
+  FILE* f = fopen("sdmc:/switch_jit_test_result.txt", "w");
+  if (f) {
+    fprintf(f,
+            "stage=%s\nresult=%llu\nexpected=42\n%s\nstage2=%s\nresult2=%llu\nexpected2=4660\n%s\n"
+            "stage3=%s\nresult3=%llu\nexpected3=22136\n%s\nstage4=%s\nresult4=%llu\nexpected4=39612\n%s\n",
+            stage, (unsigned long long)result, pass ? "PASS" : "FAIL", stage2,
+            (unsigned long long)result2, pass2 ? "PASS2" : "FAIL2", stage3,
+            (unsigned long long)result3, pass3 ? "PASS3" : "FAIL3", stage4,
+            (unsigned long long)result4, pass4 ? "PASS4" : "FAIL4");
+    fclose(f);
+  }
+
+  consoleUpdate(NULL);
+
+  PadState pad;
+  padConfigureInput(1, HidNpadStyleSet_NpadStandard);
+  padInitializeDefault(&pad);
+  // Auto-exit after ~3 seconds (180 frames) so this can run unattended in an emulator; still
+  // exits early on + if run interactively.
+  for (int frame = 0; frame < 180 && appletMainLoop(); frame++) {
+    padUpdate(&pad);
+    if (padGetButtonsDown(&pad) & HidNpadButton_Plus) {
+      break;
+    }
+    consoleUpdate(NULL);
+  }
+  consoleExit(NULL);
+#endif
+
+  return pass ? 0 : 1;
+}

--- a/third-party/filesystem.hpp
+++ b/third-party/filesystem.hpp
@@ -80,6 +80,8 @@
 #define GHC_OS_QNX
 #elif defined(__HAIKU__)
 #define GHC_OS_HAIKU
+#elif defined(__SWITCH__)
+#define GHC_OS_SWITCH
 #else
 #error "Operating system currently not supported!"
 #endif

--- a/third-party/fmt/include/fmt/format.h
+++ b/third-party/fmt/include/fmt/format.h
@@ -44,6 +44,9 @@
 #  include <cmath>    // std::signbit
 #  include <cstddef>  // std::byte
 #  include <cstdint>  // uint32_t
+#  include <cstdlib>  // malloc/free -- must be visible before detail::allocator below for
+                       // two-phase lookup; some C library header configurations don't make
+                       // free() visible via any earlier transitive include in this file.
 #  include <cstring>  // std::memcpy
 #  include <limits>   // std::numeric_limits
 #  include <new>      // std::bad_alloc

--- a/third-party/glad/include/glad/glad.h
+++ b/third-party/glad/include/glad/glad.h
@@ -4734,4 +4734,42 @@ GLAPI int GLAD_GL_ARB_texture_filter_anisotropic;
 }
 #endif
 
+
+/* Switch (GLES 3.1 via mesa/nouveau) compatibility.
+ *
+ * GL_UNSIGNED_INT_8_8_8_8[_REV] are desktop-GL packed pixel types that GLES 3.x does not accept:
+ * every glTexImage2D/glTexSubImage2D using them fails with GL_INVALID_ENUM, so the upload is
+ * silently dropped and the texture keeps its uninitialised contents. This project uses them for
+ * essentially all texture uploads (TexturePool, the time-of-day palettes, TextureAnimator, ...),
+ * which is why nothing was textured.
+ *
+ * For GL_RGBA on a little-endian host, GL_UNSIGNED_INT_8_8_8_8_REV is byte-for-byte identical to
+ * GL_UNSIGNED_BYTE, so this substitution is value-preserving rather than a reinterpretation.
+ * Overridden here, at the single point every renderer already includes, instead of at ~45 call
+ * sites.
+ */
+#if defined(__SWITCH__)
+#undef GL_UNSIGNED_INT_8_8_8_8_REV
+#define GL_UNSIGNED_INT_8_8_8_8_REV GL_UNSIGNED_BYTE
+#undef GL_UNSIGNED_INT_8_8_8_8
+#define GL_UNSIGNED_INT_8_8_8_8 GL_UNSIGNED_BYTE
+#endif
+
+
+/* GLES 3.x has no GL_PRIMITIVE_RESTART and no glPrimitiveRestartIndex(): glEnable() rejects the
+ * enum with GL_INVALID_ENUM and the restart is simply never applied, so every triangle strip in a
+ * draw runs together into one continuous strip -- the huge stretched polygons spanning the level.
+ *
+ * The GLES equivalent is GL_PRIMITIVE_RESTART_FIXED_INDEX, whose restart index is fixed at
+ * 2^n - 1, i.e. 0xFFFFFFFF for the u32 index buffers used here. Every call site already passes
+ * exactly UINT32_MAX, so remapping the enum and dropping the (now redundant) index setter is
+ * behaviour-preserving.
+ */
+#if defined(__SWITCH__)
+#undef GL_PRIMITIVE_RESTART
+#define GL_PRIMITIVE_RESTART GL_PRIMITIVE_RESTART_FIXED_INDEX
+#undef glPrimitiveRestartIndex
+#define glPrimitiveRestartIndex(index) ((void)(index))
+#endif
+
 #endif

--- a/third-party/glad/src/glad.c
+++ b/third-party/glad/src/glad.c
@@ -25,6 +25,13 @@
 #include <string.h>
 #include <glad/glad.h>
 
+#if !defined(__SWITCH__)
+/* gladLoadGL() (below) auto-opens the system GL library via LoadLibrary/dlopen and is never
+ * called on Switch -- the app always calls gladLoadGLLoader() with an explicit proc-address
+ * getter (SDL_GL_GetProcAddress) instead, which is a separate, independent function further
+ * down in this file. Horizon OS has no dynamic loader at all (everything is statically linked),
+ * so dlfcn.h doesn't exist there; this whole open_gl/close_gl/get_proc/gladLoadGL block is dead
+ * code for Switch and just needs to not be compiled, not reimplemented. */
 static void* get_proc(const char *namez);
 
 #if defined(_WIN32) || defined(__CYGWIN__)
@@ -156,6 +163,14 @@ int gladLoadGL(void) {
 
     return status;
 }
+#else
+/* game/ always calls gladLoadGLLoader(explicit getter) first, which does the real work; this
+ * call is just a redundant post-hoc success check with no dlopen'd GL library to verify, so it
+ * always reports success. */
+int gladLoadGL(void) {
+    return 1;
+}
+#endif /* !defined(__SWITCH__) */
 
 struct gladGLversionStruct GLVersion = { 0, 0 };
 

--- a/third-party/libtinyfiledialogs/tinyfiledialogs.c
+++ b/third-party/libtinyfiledialogs/tinyfiledialogs.c
@@ -588,7 +588,7 @@ static void RGB2HexW(
 	{
 		if (aRGB)
 		{
-#if defined(__GNUC__) && __GNUC__ < 5
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
 swprintf(aoResultHexRGB, L"#%02hhx%02hhx%02hhx", aRGB[0], aRGB[1], aRGB[2]);
 #else
 swprintf(aoResultHexRGB, 8, L"#%02hhx%02hhx%02hhx", aRGB[0], aRGB[1], aRGB[2]);

--- a/third-party/sqlite3/sqlite3.c
+++ b/third-party/sqlite3/sqlite3.c
@@ -162,6 +162,14 @@
 #define SQLITE_OMIT_LOAD_EXTENSION 1
 #define SQLITE_ENABLE_LOCKING_STYLE 0
 #define HAVE_UTIME 1
+#elif defined(__SWITCH__)
+/* Horizon OS: newlib declares fchown/geteuid (from some POSIX-ish header) but devkitA64's libc
+** doesn't actually implement them -- they link-fail, not compile-fail. There's no #ifndef guard
+** on the HAVE_FCHOWN define below to override from the command line, so this needs its own
+** branch here instead. */
+#define OS_VXWORKS 0
+#define HAVE_READLINK 1
+#define HAVE_LSTAT 1
 #else
 /* This is not VxWorks. */
 #define OS_VXWORKS 0

--- a/third-party/zydis/dependencies/zycore/include/Zycore/API/Memory.h
+++ b/third-party/zydis/dependencies/zycore/include/Zycore/API/Memory.h
@@ -40,6 +40,9 @@
 
 #if   defined(ZYAN_WINDOWS)
 #   include <windows.h>
+#elif defined(__SWITCH__)
+// No general mmap/mprotect-style API on Horizon OS (only libnx's paired-alias Jit API), and
+// nothing in this codebase's actual use of zydis calls into Zycore's memory API anyway.
 #elif defined(ZYAN_POSIX)
 #   include <sys/mman.h>
 #else
@@ -62,6 +65,14 @@ typedef enum ZyanMemoryPageProtection_
     ZYAN_PAGE_EXECUTE           = PAGE_EXECUTE,
     ZYAN_PAGE_EXECUTE_READ      = PAGE_EXECUTE_READ,
     ZYAN_PAGE_EXECUTE_READWRITE = PAGE_EXECUTE_READWRITE
+
+#elif defined(__SWITCH__)
+
+    ZYAN_PAGE_READONLY          = 0,
+    ZYAN_PAGE_READWRITE         = 1,
+    ZYAN_PAGE_EXECUTE           = 2,
+    ZYAN_PAGE_EXECUTE_READ      = 3,
+    ZYAN_PAGE_EXECUTE_READWRITE = 4
 
 #elif defined(ZYAN_POSIX)
 

--- a/third-party/zydis/dependencies/zycore/include/Zycore/Defines.h
+++ b/third-party/zydis/dependencies/zycore/include/Zycore/Defines.h
@@ -111,7 +111,13 @@
 /* Platform detection                                                                             */
 /* ============================================================================================== */
 
-#if defined(_WIN32)
+#if defined(__SWITCH__)
+// Horizon OS (Nintendo Switch homebrew, via devkitA64/libnx) has newlib-backed threads,
+// sockets, and file I/O, so it's POSIX-like enough for the rest of Zycore. The one real gap
+// (no general mmap/mprotect) is handled by dedicated __SWITCH__ branches in the memory API
+// itself, which take priority over the generic ZYAN_POSIX path there.
+#   define ZYAN_POSIX
+#elif defined(_WIN32)
 #   define ZYAN_WINDOWS
 #elif defined(__EMSCRIPTEN__)
 #   define ZYAN_EMSCRIPTEN

--- a/third-party/zydis/dependencies/zycore/src/API/Memory.c
+++ b/third-party/zydis/dependencies/zycore/src/API/Memory.c
@@ -30,6 +30,8 @@
 
 #if   defined(ZYAN_WINDOWS)
 
+#elif defined(__SWITCH__)
+// See Memory.h -- no general mmap/mprotect API on Horizon OS, and nothing here is ever called.
 #elif defined(ZYAN_POSIX)
 #   include <unistd.h>
 #else
@@ -53,6 +55,10 @@ ZyanU32 ZyanMemoryGetSystemPageSize(void)
 
     return system_info.dwPageSize;
 
+#elif defined(__SWITCH__)
+
+    return 0x1000;
+
 #elif defined(ZYAN_POSIX)
 
     return sysconf(_SC_PAGE_SIZE);
@@ -68,6 +74,10 @@ ZyanU32 ZyanMemoryGetSystemAllocationGranularity(void)
     GetSystemInfo(&system_info);
 
     return system_info.dwAllocationGranularity;
+
+#elif defined(__SWITCH__)
+
+    return 0x1000;
 
 #elif defined(ZYAN_POSIX)
 
@@ -91,6 +101,13 @@ ZyanStatus ZyanMemoryVirtualProtect(void* address, ZyanUSize size,
         return ZYAN_STATUS_BAD_SYSTEMCALL;
     }
 
+#elif defined(__SWITCH__)
+
+    ZYAN_UNUSED(address);
+    ZYAN_UNUSED(size);
+    ZYAN_UNUSED(protection);
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
+
 #elif defined(ZYAN_POSIX)
 
     if (mprotect(address, size, protection))
@@ -113,6 +130,12 @@ ZyanStatus ZyanMemoryVirtualFree(void* address, ZyanUSize size)
         return ZYAN_STATUS_BAD_SYSTEMCALL;
     }
 
+#elif defined(__SWITCH__)
+
+    ZYAN_UNUSED(address);
+    ZYAN_UNUSED(size);
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
+
 #elif defined(ZYAN_POSIX)
 
     if (munmap(address, size))
@@ -122,7 +145,7 @@ ZyanStatus ZyanMemoryVirtualFree(void* address, ZyanUSize size)
 
 #endif
 
-    return ZYAN_STATUS_SUCCESS;    
+    return ZYAN_STATUS_SUCCESS;
 }
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/third-party/zydis/dependencies/zycore/src/API/Process.c
+++ b/third-party/zydis/dependencies/zycore/src/API/Process.c
@@ -35,6 +35,9 @@
 #else
 #      include <windows.h>
 #endif
+#elif defined(__SWITCH__)
+// No msync/mmap API on Horizon OS; ZyanProcessFlushInstructionCache is unused by anything
+// this codebase's use of zydis actually calls.
 #elif defined(ZYAN_POSIX)
 #   include <sys/mman.h>
 #else
@@ -57,6 +60,12 @@ ZyanStatus ZyanProcessFlushInstructionCache(void* address, ZyanUSize size)
     {
         return ZYAN_STATUS_BAD_SYSTEMCALL;
     }
+
+#elif defined(__SWITCH__)
+
+    ZYAN_UNUSED(address);
+    ZYAN_UNUSED(size);
+    return ZYAN_STATUS_BAD_SYSTEMCALL;
 
 #elif defined(ZYAN_POSIX)
 


### PR DESCRIPTION
Builds gk as a Nintendo Switch .nro via devkitPro/devkitA64 + libnx, targeting the GLES 3.1 context devkitPro's mesa/nouveau provides. GOAL itself is already AOT-compiled to native ARM64 by goalc, so this is about making the runtime, the platform layer and the renderer work under Horizon rather than any new codegen.

Platform layer
- cmake/toolchains/Switch.cmake: devkitA64 toolchain, cortex-a57, -fPIE.
- game/switch/sdl3_compat.h: SDL3 -> SDL2 shim (devkitPro ships SDL2).
- game/switch/{imgui_stub,discord_rpc_stub}.h: no-op stubs for disabled deps.
- game/switch/boot_log.h: single fd, mutex-guarded SD-card boot trace. Per-call open/write/close raced newlib's fsdev across the EE/IOP/DECI threads; latched off once the kernel reaches KernelCheckAndDispatch so it can't run per-frame.
- EE main memory uses libnx jitCreate for its W^X mapping (RW + RX views); flush_icache goes through armDCacheFlush/armICacheInvalidate, since the raw __builtin___clear_cache traps on Jit-mapped pages.

Correctness fixes found bringing this up
- setlocale(LC_ALL, "C") before anything prints: newlib resolves the locale's __mbtowc through the reent struct when formatting, it comes back null until the locale is set, and every raw printf() in the kernel/overlord layers then branched through a null pointer inside _svfiprintf_r.
- kprint format_struct uses -1 as its "unspecified" sentinel, but plain char is signed on x86 and unsigned on aarch64, so `data[0] != -1` was always true and every ~D padded to 255 columns with 0xff. Read the field through a signed accessor. Applies to all four kernels.
- stdout is freopen'd to a file and therefore fully buffered; abort() doesn't flush, which silently ate the message from every failed ASSERT. Unbuffer it.

GLES compatibility
- glad is a desktop-GL loader gating on the version string; mesa reports "OpenGL ES 3.1" so its 4.x blocks never load, leaving 25 entry points that GLES 3.1 does provide (glClearDepthf, glDispatchCompute, glMemoryBarrier, glTexStorage2D, glBindVertexBuffer, ...) as null pointers. Resolve them by name and report anything still missing instead of calling through null.
- GL_UNSIGNED_INT_8_8_8_8[_REV] are desktop-only packed pixel types; GLES rejects them, so ~45 texture uploads (TexturePool, the time-of-day palettes, TextureAnimator) silently dropped their data and everything drew untextured. For GL_RGBA on little-endian they are byte-identical to GL_UNSIGNED_BYTE.
- GL_PRIMITIVE_RESTART / glPrimitiveRestartIndex do not exist in GLES, so glEnable() no-op'd and triangle strips never broke -- every strip welded to the next and threw huge stretched triangles across the level. GLES's GL_PRIMITIVE_RESTART_FIXED_INDEX has its index hardwired to 0xFFFFFFFF, which is exactly the UINT32_MAX every call site already passes.
- sampler1D has no GLES equivalent: the time-of-day palettes become height-1 GL_TEXTURE_2D, indexed with texelFetch(..., ivec2(idx, 0), 0).
- Shaders are rewritten from #version 410 core to #version 310 es with explicit precision, plus the int->float literal strictness GLES requires.

Display, input and audio
- SDL_CreateWindow gets the display size rather than the settings default: the nwindow/swapchain takes its size at creation and is never resized, so a 640x480 default left the renderer drawing 1920x1080 into a 640x480 surface and everything outside the bottom-left corner was discarded.
- Display shim reports the real mode from SDL2 and a valid (1-based) display id; returning 0 left the resolution list empty and window size at 0,0.
- SDL_GetJoystickID returns SDL2's 0-based instance id, which the caller rejects as invalid because SDL3 reserves 0. Offset by one, consistently with the event `which` fields. Horizon also exposes eight controllers sharing one GUID, and the GUID-keyed port mapping is last-one-wins, so port 0 bound to a pad that never reports; pin it to the first controller.
- game/switch/cubeb_shim.h: cubeb is built with no backend for Switch, so 989snd never got an output stream. Back its seven entry points with SDL2 audio (audout). Also fixes FMV, which is driven off the VAG audio stream and aborted immediately without one.