### PR TITLE
cmake: point to correct draco_features.h location

### DIFF
--- a/third-party/draco/cmake/draco_install.cmake
+++ b/third-party/draco/cmake/draco_install.cmake
@@ -60,7 +60,7 @@ macro(draco_setup_install_target)
               DESTINATION "${target_directory}")
     endforeach()
 
-    install(FILES "${draco_build}/draco/draco_features.h"
+    install(FILES "${draco_features_file_name}"
             DESTINATION "${includes_path}/draco/")
 
     install(TARGETS draco_decoder DESTINATION "${bin_path}")


### PR DESCRIPTION
Fixes the following error when running the "Install Jak" option in VS:
```
  CMake Error at third-party/draco/cmake_install.cmake:841 (file):
    file INSTALL cannot find
    "C:/Users/{WindowsUsername}/Documents/Coding/jak-project/out/build/Release/draco/draco_features.h":
    No error.
  Call Stack (most recent call first):
    cmake_install.cmake:48 (include)
  
  
  FAILED: [code=1] CMakeFiles/install.util 
  C:\WINDOWS\system32\cmd.exe /C "cd /D C:\Users\Jack\Documents\Coding\jak-project\out\build\Release && "C:\Program Files\Microsoft Visual Studio\18\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -P cmake_install.cmake"
  ninja: build stopped: subcommand failed.
Install succeeded.
```

The build was still useable but the error was bugging me.

Our version of `draco_features.h` is stored in `third-party/draco/src/draco/draco_features.h` but `draco_install.cmake` was not updated to reflect this change. Use the already defined `${draco_features_file_name}` from `draco_options.cmake` to point to the right place.

Disclosure: I didn't want to spend too much time dealing with cmake so I pointed Qwen at the problem and it found a very simple solution. Using `${draco_features_file_name}` to avoid hardcoding is neat. I fully understand the fix, have tested it and all the descriptions were written by me.
(AI Assisted)